### PR TITLE
perf: Batch clipped, stroked, and gradient-filled runs through pathID bindings

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1032,12 +1032,14 @@ std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevic
 
 }  // namespace
 
-/// Gate for ordered cross-entity batching. Enabled: the deferred flush that
-/// used to reorder a batched draw past a scissor or clip change can no longer
-/// form one, because the eligibility predicate refuses any draw taken while a
-/// clip state, a scissor, or a mask pass is active. The same-entity instanced
-/// path and the solo residence flows are unchanged and still handle
-/// everything a scene batch declines.
+/// Gate for ordered cross-entity batching. Enabled: a batch's single draw can
+/// no longer observe target state that moved on after its instances were
+/// appended. A clip rectangle travels in each instance's record and the
+/// fragment stage applies it, and the eligibility predicate still refuses any
+/// draw taken under a clip polygon, a clip mask, or an open mask pass, which
+/// are the states a deferred draw would otherwise read at flush time. The
+/// same-entity instanced path and the solo residence flows are unchanged and
+/// still handle everything a scene batch declines.
 ///
 /// Kept as a compile-time constant rather than a runtime option so that
 /// turning it off folds the whole eligibility predicate away, leaving the
@@ -2025,11 +2027,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     /// Encoder clip-state version at the batch's first append. A batch
     /// never spans a clip change (one draw carries one clip state).
     uint64_t sceneClipVersion = 0;
-    /// GPU-residence slot for this source entity's fill (captured
-    /// when the batch starts). Used only by the size-1 flush path - a
-    /// size >= 2 flush routes through the instanced arena path, which has
-    /// no per-entity residence.
-    geode::GeodeResidentSlot* residentFillSlot = nullptr;
+    /// GPU-residence slot for the encode this batch started on - the source
+    /// entity's fill slot for a fill, its stroke slot for a stroked outline.
+    /// Used only by the size-1 flush path; a size >= 2 flush routes through
+    /// the instanced arena path, which has no per-entity residence.
+    geode::GeodeResidentSlot* residentSlot = nullptr;
   };
   std::optional<PendingBatch> pendingBatch;
 
@@ -2049,20 +2051,24 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   std::deque<SceneTempRecordSlot> sceneTempRecordSlots;
 
   /// Choose the record slot for a scene-batch instance of `slot` WITHOUT
-  /// marking it used: the primary slot when nothing this frame references
-  /// it yet (nullptr: the ensure uses the cached write path), or a fresh
-  /// temporary slot for same-frame repeats. The primary slot is off-limits
-  /// when an earlier recorded batch references it (`lastSceneFrame`) AND
-  /// when a solo resident draw was recorded against it (`lastResidentFrame`):
-  /// buffer writes are queue-ordered ahead of every draw in the frame's
-  /// submit, so rewriting the record in scene form would retroactively
-  /// retransform the already-recorded solo draw. Callers mark
-  /// `slot.lastSceneFrame = currentFrameIndex` only after a successful
-  /// ensure.
+  /// marking it used: the primary slot when nothing this frame reads it yet
+  /// (nullptr: the ensure uses the cached write path), or a fresh temporary
+  /// slot for a same-frame repeat. The primary is off-limits exactly when an
+  /// earlier recorded BATCH draw references it, because buffer writes are
+  /// queue-ordered ahead of every draw in the frame's submit and rewriting the
+  /// record would retroactively retransform that draw.
+  ///
+  /// A solo resident draw of the same slot is NOT such a reference: it binds
+  /// the device's shared identity record and takes every parameter from the
+  /// slot's uniform, so it never reads the slot's own record. Diverting for it
+  /// cost a fresh temporary record, and its always-write contract, on every
+  /// frame of any document that draws one entity both solo and batched.
+  /// Callers mark `slot.lastSceneFrame = currentFrameIndex` only after a
+  /// successful ensure.
   bool resolveSceneRecordSlot(geode::GeodeResidentSlot& slot,
                               const geode::GeodeRecordSlab::Slot*& outSlot) {
     outSlot = nullptr;
-    if (slot.lastSceneFrame == currentFrameIndex || slot.lastResidentFrame == currentFrameIndex) {
+    if (slot.lastSceneFrame == currentFrameIndex) {
       outSlot = allocateTempRecordSlot(slot.recordSlab);
       return outSlot != nullptr;
     }
@@ -2378,14 +2384,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                            const Transform2d& deviceFromGlyph,
                            const geode::GeodeRecordSlab::Slot* recordSlot,
                            std::vector<uint8_t>* recordCache) {
-    if (!kEnableSceneBatching || recordSlot == nullptr || encoder->hasActiveClipState() ||
-        encoder->hasActiveScissor()) {
+    if (!kEnableSceneBatching || recordSlot == nullptr || encoder->hasActiveClipState()) {
       return false;
     }
     // The ensure both establishes residence on first sight of this glyph and
     // publishes this occurrence's record; a repeat frame writes neither.
-    if (!encoder->ensureResidentSceneRecord(entry.slot, entry.encoded, color, FillRule::NonZero,
-                                            deviceFromGlyph, recordSlot, recordCache)) {
+    if (!encoder->ensureResidentSceneRecord(entry.slot, entry.encoded,
+                                            geode::GeoEncoder::ScenePaint{color},
+                                            FillRule::NonZero, deviceFromGlyph, recordSlot,
+                                            recordCache)) {
       return false;
     }
 
@@ -2549,6 +2556,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     out[7] = 0.0f;
   }
 
+  /// True when the pending batch still points at `encoded`, either as the
+  /// same-entity singleton's encode or as one of an ordered batch's instances.
+  /// Both retain the pointer until the batch flushes, so anything that
+  /// replaces an `EncodedPath` in place has to ask.
+  bool pendingBatchReferences(const geode::EncodedPath* encoded) const {
+    if (!pendingBatch.has_value() || encoded == nullptr) {
+      return false;
+    }
+    if (pendingBatch->encoded == encoded) {
+      return true;
+    }
+    for (const PendingBatch::SceneInstance& instance : pendingBatch->sceneInstances) {
+      if (instance.encoded == encoded) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Emit any pending `<use>` batch. No-op if there's nothing pending.
   /// On size == 1 the batch degrades to a single `fillPath` call so we
   /// don't pay the per-instance-buffer cost when we accumulated
@@ -2634,9 +2660,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // no-op when the record is unchanged.
       for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
         if (inst.slot != nullptr && inst.encoded != nullptr) {
-          (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color, inst.rule,
-                                                   inst.deviceFromLocal, inst.recordSlotOverride,
-                                                   inst.recordCacheOverride);
+          (void)encoder->ensureResidentSceneRecord(
+              *inst.slot, *inst.encoded, geode::GeoEncoder::ScenePaint{inst.color}, inst.rule,
+              inst.deviceFromLocal, inst.recordSlotOverride, inst.recordCacheOverride,
+              /*publishPaint=*/false);
         }
       }
       encoder->fillPathSceneBatch(batchColor, batchRule, binding);
@@ -2665,7 +2692,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // a paint or fill-rule change.
       deviceFromLocalTransform = batch.deviceFromLocalTransforms.front();
       syncTransform();
-      emitSolidFill(*batch.path, batch.color, batch.rule, batch.encoded, batch.residentFillSlot);
+      emitSolidFill(*batch.path, batch.color, batch.rule, batch.encoded, batch.residentSlot);
     } else {
       // Instanced: set encoder transform to identity so the shader's
       // `uniforms.mvp` carries only the orthographic screen-pixel mapping.
@@ -2697,7 +2724,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   void startSameEntitySingleton(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                                 const css::RGBA& color, FillRule rule,
                                 const geode::EncodedPath* encoded,
-                                geode::GeodeResidentSlot* residentFillSlot) {
+                                geode::GeodeResidentSlot* residentSlot) {
     pendingBatch = PendingBatch{};
     pendingBatch->mode = PendingBatch::Mode::SameEntity;
     pendingBatch->sameEntityClipVersion = encoder->clipStateVersion();
@@ -2707,7 +2734,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->rule = rule;
     pendingBatch->encoded = encoded;
     pendingBatch->path = &path;
-    pendingBatch->residentFillSlot = residentFillSlot;
+    pendingBatch->residentSlot = residentSlot;
     pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
   }
 
@@ -2717,21 +2744,49 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// it's been absorbed into a batch). Always returns true on a
   /// non-empty batch state - either appends or flushes + starts new.
   /// The caller is expected to have already verified the draw is
-  /// "batch-compatible" (solid paint, no stroke, has source entity,
-  /// has cached fill encode, no in-flight pattern).
+  /// "batch-compatible" (solid paint, has source entity, has a cached
+  /// encode, no in-flight pattern). Both an element's fill and its stroked
+  /// outline can be offered here, in that order: they are two solid fills of
+  /// two different cached encodes on the same entity, and appending them
+  /// consecutively is exactly the painter order a fill-then-stroke element
+  /// requires.
   ///
   /// \p path is retained until the batch flushes, so it must be storage that outlives this
   /// call - see `PendingBatch::path`.
+  /// @param allowInstancedAppend True when this draw may extend a pending
+  ///   same-entity instanced batch. That batch draws from the per-frame arena
+  ///   and has no residence, so folding an otherwise-resident draw into it
+  ///   trades a draw call for a full geometry re-upload every frame. It is
+  ///   worth it for a run of repeated `<use>` draws, which is what it exists
+  ///   for; it is not worth it for a draw that also has a stroked outline,
+  ///   whose element is going to open an ordered batch anyway.
   bool tryAppendOrStartBatch(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
-                             const css::RGBA& color, FillRule rule,
+                             const geode::GeoEncoder::ScenePaint& paint, FillRule rule,
                              const geode::EncodedPath* encoded,
-                             geode::GeodeResidentSlot* residentFillSlot) {
+                             geode::GeodeResidentSlot* residentSlot,
+                             bool allowInstancedAppend = true) {
+    // The record-sourced paint fields are the only place a gradient can live
+    // in a batch, so a gradient draw is offered to the ordered path and
+    // nothing else: the instanced same-entity path and the size-1 singleton
+    // flush both take their paint from the draw-level uniform, which carries
+    // one colour and no gradient.
+    const css::RGBA& color = paint.color;
+    const bool gradientPaint = paint.isGradient();
+
     // Same-entity mode: consecutive draws of the SAME entity with the
-    // same paint extend the same-entity instanced batch.
-    if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::SameEntity &&
+    // same paint AND the same encode extend the same-entity instanced batch.
+    // The encode comparison separates a repeated `<use>` - one shape at many
+    // transforms, which is exactly what an instanced draw expresses - from an
+    // entity's fill followed by its own stroke outline. Those two share an
+    // entity and can share a colour, but they are different shapes, and
+    // treating the second as another instance of the first would paint the
+    // fill geometry twice instead of painting the outline.
+    if (!gradientPaint && allowInstancedAppend && pendingBatch.has_value() &&
+        pendingBatch->mode == PendingBatch::Mode::SameEntity &&
         pendingBatch->sourceRegistry == sourceRegistry &&
         pendingBatch->sourceEntity == sourceEntity && pendingBatch->color == color &&
-        pendingBatch->rule == rule) {
+        pendingBatch->rule == rule && pendingBatch->encoded == encoded &&
+        pendingBatch->residentSlot == residentSlot) {
       pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
       return true;
     }
@@ -2747,6 +2802,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // ordered batching and are already exact for repeated draws.
     const geode::GeodeRecordSlab::Slot* recordSlotPtr = nullptr;
     const uint64_t clipVersion = encoder->clipStateVersion();
+
+    // Whether this draw has anything to batch WITH. A solid draw with nothing
+    // to join becomes a size-1 same-entity entry, which flushes as a solo
+    // resident draw reading its paint from the slot's uniform and needing no
+    // record at all. Publishing a record for it anyway is not just wasted
+    // work: two such draws from one slot both write the slot's primary record
+    // and neither reads it, so a steady frame rewrites those bytes forever.
+    // The slot is still ALLOCATED below, in draw order, because record indices
+    // are the batch's ordering and a slot handed out late would take a lower
+    // index than a draw that already has one and split the pair.
+    const bool havePendingSceneBatch =
+        pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene;
+    const bool haveConvertibleSingleton =
+        pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::SameEntity &&
+        pendingBatch->deviceFromLocalTransforms.size() == 1 &&
+        pendingBatch->sameEntityClipVersion == clipVersion &&
+        pendingBatch->residentSlot != residentSlot;
+    const bool wantsRecord = gradientPaint || havePendingSceneBatch || haveConvertibleSingleton;
+
     // `kEnableSceneBatching` is the compile-time gate for ordered
     // cross-entity batching; with it off the whole predicate folds away, so
     // no draw allocates a record slot, writes a record, or touches the record
@@ -2758,25 +2832,29 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // batch takes its paint from the uniform and binds the device's shared
     // identity record, so giving it a slot would be pure cost.
     //
-    // The three target-state guards (clip, scissor, mask pass) are what make
-    // deferring a draw to flush time safe: each is state the batch would
-    // observe at flush rather than at draw. Solid fills do not currently
-    // reach here during a mask pass, but the residency helpers all carry the
-    // same three-way guard, and an ordered batch is the one caller for which
-    // getting it wrong silently paints into the wrong target.
+    // The remaining target-state guards - a clip polygon or mask, and an open
+    // mask pass - are what make deferring a draw to flush time safe: each is
+    // state the batch would observe at flush rather than at draw. Solid fills
+    // do not currently reach here during a mask pass, but the residency
+    // helpers all carry the same guard, and an ordered batch is the one caller
+    // for which getting it wrong silently paints into the wrong target.
+    //
+    // A rectangular clip is NOT among them. It travels in the instance record
+    // and the fragment stage applies it, so a deferred draw does not read
+    // raster-stage scissor state that may have moved on by flush time.
     const bool sceneEligible =
-        kEnableSceneBatching && residentFillSlot != nullptr && encoded != nullptr &&
-        !encoder->hasActiveClipState() && !encoder->hasActiveScissor() &&
-        !encoder->hasOpenMaskPass() && residentFillSlot->lastSceneFrame != currentFrameIndex &&
-        residentFillSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
-        ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
-        resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
-    if (sceneEligible &&
-        encoder->ensureResidentSceneRecord(*residentFillSlot, *encoded, color, rule,
+        kEnableSceneBatching && residentSlot != nullptr && encoded != nullptr &&
+        !encoder->hasActiveClipState() && !encoder->hasOpenMaskPass() &&
+        residentSlot->lastSceneFrame != currentFrameIndex &&
+        residentSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
+        ensureRecordSlot(*residentSlot, *sourceRegistry) &&
+        resolveSceneRecordSlot(*residentSlot, recordSlotPtr);
+    if (sceneEligible && wantsRecord &&
+        encoder->ensureResidentSceneRecord(*residentSlot, *encoded, paint, rule,
                                            deviceFromLocalTransform, recordSlotPtr)) {
       const geode::GeodeRecordSlab::Slot& effectiveRecordSlot =
-          recordSlotPtr != nullptr ? *recordSlotPtr : residentFillSlot->recordSlot;
-      const wgpu::Buffer chunk = residentFillSlot->buffer;
+          recordSlotPtr != nullptr ? *recordSlotPtr : residentSlot->recordSlot;
+      const wgpu::Buffer chunk = residentSlot->buffer;
       const wgpu::Buffer recordBuf = effectiveRecordSlot.buffer;
       const uint64_t chunkId = residentFillSlot->bufferId;
       const uint64_t recordBufId = effectiveRecordSlot.bufferId;
@@ -2800,11 +2878,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         if (pendingBatch->sceneChunkBufferId == chunkId &&
             pendingBatch->sceneRecordBufferId == recordBufId &&
             pendingBatch->sceneClipVersion == clipVersion &&
-            pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() == recordIndex) {
-          appendSceneInstance(
-              *pendingBatch,
-              PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color, rule,
-                                          deviceFromLocalTransform, vertexCount, recordSlotPtr});
+            pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
+                recordIndex) {
+          appendSceneInstance(*pendingBatch,
+                              PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
+                                                          rule, deviceFromLocalTransform,
+                                                          vertexCount, recordSlotPtr});
         } else {
           flushPendingBatch();
           pendingBatch = PendingBatch{};
@@ -2816,24 +2895,33 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->sceneFirstInstance = recordIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
-          appendSceneInstance(
-              *pendingBatch,
-              PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color, rule,
-                                          deviceFromLocalTransform, vertexCount, recordSlotPtr});
+          appendSceneInstance(*pendingBatch,
+                              PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
+                                                          rule, deviceFromLocalTransform,
+                                                          vertexCount, recordSlotPtr});
         }
         return true;
       }
 
+      // Converting a pending singleton that draws from the SAME residence
+      // slot as this draw would hand both instances the slot's one primary
+      // record: the two ensures resolve to it independently (neither has
+      // marked the slot yet), the later write wins because every buffer write
+      // in a submit executes before every draw, and the earlier instance is
+      // silently repainted with this draw's colour and transform. Two draws of
+      // one entity that differ only in paint therefore stay unconverted; the
+      // singleton flushes solo and this draw opens a fresh one. Same-encode
+      // same-paint repeats are the instanced same-entity path above and never
+      // reach here.
       if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::SameEntity &&
           pendingBatch->deviceFromLocalTransforms.size() == 1 &&
-          pendingBatch->sameEntityClipVersion == clipVersion) {
+          pendingBatch->sameEntityClipVersion == clipVersion &&
+          pendingBatch->residentSlot != residentSlot) {
         // Convert the pending size-1 same-entity entry into the scene
         // batch's first instance.
-        PendingBatch::SceneInstance first{pendingBatch->residentFillSlot,
-                                          pendingBatch->encoded,
-                                          pendingBatch->path,
-                                          pendingBatch->color,
-                                          pendingBatch->rule,
+        PendingBatch::SceneInstance first{pendingBatch->residentSlot,
+                                          pendingBatch->encoded, pendingBatch->path,
+                                          pendingBatch->color, pendingBatch->rule,
                                           pendingBatch->deviceFromLocalTransforms.front(),
                                           pendingBatch->encoded->boundingDrawVertexCount()};
         // Resolve the first entity's record slot: its primary slot on its
@@ -2849,8 +2937,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sourceRegistry != nullptr &&
             ensureRecordSlot(*first.slot, *pendingBatch->sourceRegistry) &&
             resolveSceneRecordSlot(*first.slot, firstRecordSlotPtr) &&
-            encoder->ensureResidentSceneRecord(*first.slot, *first.encoded, first.color, first.rule,
-                                               first.deviceFromLocal, firstRecordSlotPtr)) {
+            encoder->ensureResidentSceneRecord(
+                *first.slot, *first.encoded, geode::GeoEncoder::ScenePaint{first.color}, first.rule,
+                first.deviceFromLocal, firstRecordSlotPtr)) {
           first.slot->lastSceneFrame = currentFrameIndex;
           // Carry the resolved slot on the instance so the flush-time
           // re-ensure targets the same record this batch draws from.
@@ -2875,10 +2964,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->sceneInstances.push_back(first);
           if (firstChunkId == chunkId && firstRecordBufId == recordBufId &&
               firstIndex + 1 == recordIndex) {
-            appendSceneInstance(
-                *pendingBatch,
-                PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color, rule,
-                                            deviceFromLocalTransform, vertexCount, recordSlotPtr});
+            appendSceneInstance(*pendingBatch,
+                                PendingBatch::SceneInstance{residentSlot, encoded, &path,
+                                                            color, rule,
+                                                            deviceFromLocalTransform,
+                                                            vertexCount, recordSlotPtr});
           } else {
             flushPendingBatch();
             pendingBatch = PendingBatch{};
@@ -2890,32 +2980,37 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneFirstInstance = recordIndex;
             pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
             pendingBatch->sceneClipVersion = clipVersion;
-            appendSceneInstance(
-                *pendingBatch,
-                PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color, rule,
-                                            deviceFromLocalTransform, vertexCount, recordSlotPtr});
+            appendSceneInstance(*pendingBatch,
+                                PendingBatch::SceneInstance{residentSlot, encoded, &path,
+                                                            color, rule,
+                                                            deviceFromLocalTransform,
+                                                            vertexCount, recordSlotPtr});
           }
         } else {
           // The pending singleton could not take scene form: emit it solo
-          // and keep the CURRENT draw as a fresh singleton. Returning
-          // without recording the current draw would silently drop it
-          // (its ensured record is not referenced by any batch).
+          // and keep the CURRENT draw pending. Returning without recording the
+          // current draw would silently drop it (its ensured record is not
+          // referenced by any batch).
           flushPendingBatch();
-          startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
-                                   residentFillSlot);
+          startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
+                       chunk, recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion,
+                       vertexCount, recordSlotPtr);
         }
         return true;
       }
 
       if (!pendingBatch.has_value() || pendingBatch->mode != PendingBatch::Mode::Scene) {
-        // First draw of an entity (or after a flushed pair): start a
-        // same-entity batch of size 1; a different entity converts it
-        // into a scene batch, a repeat extends it as instanced.
+        // First draw of an entity (or after a flushed pair): a solid fill
+        // starts a same-entity batch of size 1, so a different entity can
+        // convert it into a scene batch and a repeat can extend it as
+        // instanced. A gradient has neither of those futures and opens the
+        // scene batch directly.
         if (pendingBatch.has_value()) {
           flushPendingBatch();
         }
-        startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
-                                 residentFillSlot);
+        startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot, chunk,
+                     recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion, vertexCount,
+                     recordSlotPtr);
         return true;
       }
 
@@ -2929,18 +3024,53 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->sceneFirstInstance = recordIndex;
       pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;
-      appendSceneInstance(*pendingBatch, PendingBatch::SceneInstance{
-                                             residentFillSlot, encoded, &path, color, rule,
-                                             deviceFromLocalTransform, vertexCount, recordSlotPtr});
+      appendSceneInstance(*pendingBatch,
+                          PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
+                                                      rule, deviceFromLocalTransform,
+                                                      vertexCount, recordSlotPtr});
       return true;
     }
 
-    // Not scene-eligible: flush whatever's pending, then start a fresh
-    // same-entity batch.
+    // Not scene-eligible. A gradient has no non-ordered batch form, so the
+    // caller emits it through the ordinary gradient path; a solid fill starts
+    // a fresh same-entity batch.
     flushPendingBatch();
+    if (gradientPaint) {
+      return false;
+    }
     startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
-                             residentFillSlot);
+                             residentSlot);
     return true;
+  }
+
+  /// Open a new pending batch holding exactly this draw: a same-entity
+  /// singleton for solid paint, or a scene batch of one instance for gradient
+  /// paint, which the uniform-sourced singleton flush cannot express. The
+  /// caller has already flushed whatever was pending and has already ensured
+  /// this draw's record.
+  void startPending(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
+                    const geode::GeoEncoder::ScenePaint& paint, FillRule rule,
+                    const geode::EncodedPath* encoded, geode::GeodeResidentSlot* residentSlot,
+                    const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer,
+                    uint32_t recordIndex, uint64_t recordOffset, uint64_t clipVersion,
+                    uint32_t vertexCount, const geode::GeodeRecordSlab::Slot* recordSlotPtr) {
+    if (!paint.isGradient()) {
+      startSameEntitySingleton(sourceRegistry, sourceEntity, path, paint.color, rule, encoded,
+                               residentSlot);
+      return;
+    }
+    pendingBatch = PendingBatch{};
+    pendingBatch->mode = PendingBatch::Mode::Scene;
+    pendingBatch->sceneChunkBuffer = chunk;
+    pendingBatch->sceneRecordBuffer = recordBuffer;
+    pendingBatch->sceneFirstInstance = recordIndex;
+    pendingBatch->sceneFirstRecordOffset = recordOffset;
+    pendingBatch->sceneClipVersion = clipVersion;
+    pendingBatch->sceneVertexCount = vertexCount;
+    pendingBatch->sceneInstances.push_back(PendingBatch::SceneInstance{
+        residentSlot, encoded, &path, paint.color, rule, deviceFromLocalTransform, vertexCount,
+        recordSlotPtr});
+    residentSlot->lastSceneFrame = currentFrameIndex;
   }
 
   /// Determine the fill rule for a stroked outline. Each painted interval of
@@ -3003,6 +3133,19 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // keep a dangling encodedKey plus a retained slab range. The
         // GeoEncoder fingerprint guard is a second line of defense; this
         // keeps the invariant obvious at the single mutation site.
+        //
+        // Drain the pending batch first when it still refers to THIS outline.
+        // Both the cached encode and the residence built from it are about to
+        // be replaced: the encode's storage is reused for the new outline, and
+        // resetting the residence lets the flush-time re-ensure land the
+        // geometry in a different slab chunk than the one the batch captured.
+        // Either way an appended-but-unflushed instance would draw the wrong
+        // shape. A run of DIFFERENT elements' strokes is untouched, so the
+        // ordinary first sight of a stroke does not break up a batch.
+        if (cache.strokeSlot.has_value() &&
+            pendingBatchReferences(&cache.strokeSlot->strokedEncode)) {
+          flushPendingBatch();
+        }
         if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
           resident->strokeSlot.reset();
           resident->gradientStrokeSlot.reset();
@@ -3044,6 +3187,46 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     result.strokedPath = &strokeScratchPath;
     result.fillRule = strokeFillRuleFor(strokeScratchPath, strokeStyle);
     return result;
+  }
+
+  /// Resolve a paint-server reference into gradient parameters a batched
+  /// instance can carry. Returns false when the reference is not a usable
+  /// gradient - a pattern, a malformed or empty gradient, a degenerate frame,
+  /// or a radial that collapses to a single stop colour. Those keep the
+  /// ordinary emit path, which owns the fallback-colour handling.
+  ///
+  /// The resolved stops live in `gradientStopScratch`, so the outputs are
+  /// valid only until the next resolve. That is enough: the encoder copies
+  /// everything it needs into the entity's persistent paint block during the
+  /// append, and a batch's flush-time re-ensure reads the paint back off the
+  /// residence slot rather than from the caller.
+  bool resolveBatchGradient(const Path& geometryPath,
+                            const components::ResolvedPaintServer& server, double effectiveOpacity,
+                            std::optional<geode::LinearGradientParams>& outLinear,
+                            std::optional<geode::RadialGradientParams>& outRadial) {
+    const auto* ref = std::get_if<components::PaintResolvedReference>(&server);
+    if (ref == nullptr) {
+      return false;
+    }
+    const css::RGBA currentColor = paint.currentColor.rgba();
+    const float opacity = static_cast<float>(effectiveOpacity);
+    const Box2d geometryBounds = geometryPath.bounds();
+    bool stopsTruncated = false;
+    outLinear = resolveLinearGradientParams(*ref, geometryBounds, paint.viewBox, currentColor,
+                                            opacity, gradientStopScratch, &stopsTruncated);
+    if (!outLinear.has_value()) {
+      auto radial = resolveRadialGradientParams(*ref, geometryBounds, paint.viewBox, currentColor,
+                                                opacity, gradientStopScratch, &stopsTruncated);
+      if (radial.has_value() && radial->gradient.has_value()) {
+        outRadial = std::move(radial->gradient);
+      }
+    }
+    if (stopsTruncated && verbose && !warnedGradient) {
+      std::cerr << "RendererGeode: gradient has more than " << kMaxGradientStopsClient
+                << " stops; truncating (follow-up: texture-based stop lookup)\n";
+      warnedGradient = true;
+    }
+    return outLinear.has_value() || outRadial.has_value();
   }
 
   /// Issue a fill of the given path using the current `paint.fill`. Handles
@@ -4891,25 +5074,55 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   const geode::EncodedPath* fillEncoded =
       impl_->getFillEncode(path.sourceEntity, drawPathGeometry, path.fillRule);
 
-  // Try to append to a pending `<use>`-batch. Preconditions:
+  // Try to append to a pending batch. Preconditions:
   //  - Source entity valid (non-null handle).
   //  - Fill encode cache hit (shared across all instances).
   //  - Solid paint (gradient / pattern need per-draw uniforms today).
   //  - No active pattern-fill handoff from the driver.
-  //  - No stroke (we can't defer a fill while the stroke runs on top).
   //
   // When all hold: append this draw's `deviceFromLocalTransform` into the pending
-  // batch (flushing + restarting if the paint/source key differs) and
-  // return early. A later state change (pushClip, popLayer, endFrame,
-  // setPaint-different-key, non-batchable draw) flushes as one instanced
-  // draw.
+  // batch (flushing + restarting if the paint/source key differs). A later
+  // state change (pushClip, popLayer, endFrame, setPaint-different-key,
+  // non-batchable draw) flushes as one instanced draw.
+  //
+  // Under ordered cross-entity batching, a stroke on the same element is NOT
+  // a blocker. A stroked outline is itself a solid fill of a separately
+  // cached encode, so it is offered to the batcher immediately after the fill
+  // and lands as the next instance - the same painter order a fill-then-stroke
+  // element requires. That matters a lot on stroke-heavy documents: excluding
+  // stroked elements ends the run at every one of them, so a document that
+  // alternates fill and stroke cannot batch anything at all.
+  //
+  // Without ordered batching the only batch a stroked element's fill could
+  // join is the same-entity instanced one, which draws from the per-frame
+  // arena and has no residence. Merging two otherwise-resident solo fills
+  // into it trades a draw call for a full geometry re-upload every frame, so
+  // that configuration keeps the original exclusion.
   const bool hasStroke = !(stroke.strokeWidth <= 0.0 ||
                            std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
-  const bool batchable = !hasStroke && fillEncoded != nullptr &&
-                         path.sourceEntity.entity() != entt::null &&
-                         std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
-                         !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr &&
-                         impl_->paint.drawFillComponent;
+  const bool solidFill = std::holds_alternative<PaintServer::Solid>(impl_->paint.fill);
+  const bool referenceFill =
+      std::holds_alternative<components::PaintResolvedReference>(impl_->paint.fill);
+  const bool fillShapeBatchable = fillEncoded != nullptr &&
+                                  path.sourceEntity.entity() != entt::null &&
+                                  !impl_->patternFillPaint.has_value() &&
+                                  impl_->encoder != nullptr && impl_->paint.drawFillComponent;
+
+  // A gradient fill can batch too: the record carries its stop-ramp reference,
+  // gradient transform and spread, so a run that alternates solid and gradient
+  // paint collapses into one draw instead of one draw per shape plus a
+  // pipeline switch at every boundary. The parameters are resolved here rather
+  // than at emit time because the batcher needs them before it can decide.
+  std::optional<geode::LinearGradientParams> batchLinear;
+  std::optional<geode::RadialGradientParams> batchRadial;
+  if (kEnableSceneBatching && referenceFill && fillShapeBatchable) {
+    impl_->resolveBatchGradient(drawPathGeometry, impl_->paint.fill, impl_->paint.fillOpacity,
+                                batchLinear, batchRadial);
+  }
+  const bool gradientFillBatchable = batchLinear.has_value() || batchRadial.has_value();
+
+  const bool fillBatchable = (kEnableSceneBatching || !hasStroke) && fillShapeBatchable &&
+                             (solidFill || gradientFillBatchable);
 
   // GPU residence: a persistent per-entity fill slot, eligible for
   // any solid fill with a cached encode. Shared by the batch size-1 flush,
@@ -4917,7 +5130,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // solid fill re-uploads zero geometry on an unchanged frame however it
   // ends up being drawn.
   geode::GeodeResidentSlot* residentFill =
-      (fillEncoded != nullptr && std::holds_alternative<PaintServer::Solid>(impl_->paint.fill))
+      (fillEncoded != nullptr && (solidFill || gradientFillBatchable))
           ? impl_->residentFillSlot(path.sourceEntity)
           : nullptr;
 
@@ -4926,29 +5139,45 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // pass through here and simply never use the slot (the resident
   // gradient methods only run for resolved gradients).
   geode::GeodeResidentGradientSlot* residentGradientFill =
-      (fillEncoded != nullptr &&
-       std::holds_alternative<components::PaintResolvedReference>(impl_->paint.fill))
-          ? impl_->residentGradientFillSlot(path.sourceEntity)
-          : nullptr;
+      (fillEncoded != nullptr && referenceFill) ? impl_->residentGradientFillSlot(path.sourceEntity)
+                                                : nullptr;
 
-  if (batchable) {
-    const auto& solid = std::get<PaintServer::Solid>(impl_->paint.fill);
-    const css::RGBA color = solid.color.resolve(impl_->paint.currentColor.rgba(),
-                                                static_cast<float>(impl_->paint.fillOpacity));
-    impl_->tryAppendOrStartBatch(path.sourceEntity.registry(), path.sourceEntity.entity(),
-                                 drawPathGeometry, color, path.fillRule, fillEncoded, residentFill);
-    return;
+  bool fillAbsorbed = false;
+  if (fillBatchable) {
+    geode::GeoEncoder::ScenePaint scenePaint;
+    if (solidFill) {
+      const auto& solid = std::get<PaintServer::Solid>(impl_->paint.fill);
+      scenePaint.color = solid.color.resolve(impl_->paint.currentColor.rgba(),
+                                             static_cast<float>(impl_->paint.fillOpacity));
+    } else {
+      scenePaint.linearGradient = batchLinear.has_value() ? &*batchLinear : nullptr;
+      scenePaint.radialGradient = batchRadial.has_value() ? &*batchRadial : nullptr;
+    }
+    fillAbsorbed = impl_->tryAppendOrStartBatch(
+        path.sourceEntity.registry(), path.sourceEntity.entity(), drawPathGeometry, scenePaint,
+        path.fillRule, fillEncoded, residentFill, /*allowInstancedAppend=*/!hasStroke);
   }
-
-  // Non-batchable: flush whatever's pending, then emit normally.
-  impl_->flushPendingBatch();
-  // Honor the driver's paint-order component switch: when paint-order issues a
-  // per-component pass (RendererInterface PaintParams::drawFillComponent), skip
-  // the fill on stroke-only passes so Geode reorders rather than double-paints.
-  // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
-  if (impl_->paint.drawFillComponent) {
-    impl_->fillResolved(drawPathGeometry, path.fillRule, fillEncoded, residentFill,
-                        residentGradientFill);
+  if (fillAbsorbed) {
+    if (!hasStroke) {
+      return;
+    }
+    // Fall through so the stroke can join the same batch. Every path below
+    // that emits directly flushes first, which drains this fill ahead of the
+    // stroke and preserves painter order.
+  } else {
+    // The fill did not join a batch, either because it could never batch or
+    // because a gradient failed the ordered-path gates (it declines rather
+    // than falling back to a paint form the singleton flush cannot express).
+    // Flush whatever is pending, then emit normally.
+    impl_->flushPendingBatch();
+    // Honor the driver's paint-order component switch: when paint-order issues a
+    // per-component pass (RendererInterface PaintParams::drawFillComponent), skip
+    // the fill on stroke-only passes so Geode reorders rather than double-paints.
+    // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
+    if (impl_->paint.drawFillComponent) {
+      impl_->fillResolved(drawPathGeometry, path.fillRule, fillEncoded, residentFill,
+                          residentGradientFill);
+    }
   }
 
   // Mirror fillResolved's no-op safety: if there's no encoder (headless
@@ -5000,6 +5229,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // Pattern dispatch comes first: a stroke pattern slot was populated by the
   // driver via `endPatternTile(forStroke=true)` and consumed here.
   if (impl_->patternStrokePaint.has_value()) {
+    // This element's fill may still be sitting in the pending batch; drain it
+    // so the pattern stroke lands on top of it rather than under it.
+    impl_->flushPendingBatch();
     impl_->syncTransform();
     const double opacity = impl_->paint.strokeOpacity;
     impl_->encoder->fillPathPattern(strokedOutline, strokeDerived.fillRule,
@@ -5033,6 +5265,35 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
        std::holds_alternative<components::PaintResolvedReference>(strokeServer))
           ? impl_->residentGradientStrokeSlot(path.sourceEntity)
           : nullptr;
+
+  // A solid stroke is a solid fill of the cached stroke encode, so it is
+  // offered to the batcher on the same terms as the fill above. Landing here
+  // right after this element's own fill is what lets a run of stroked
+  // elements collapse: the outline becomes the next instance instead of
+  // ending the run.
+  //
+  // The stroked outline is retained by the batch until it flushes. That is
+  // safe for the same reason the fill geometry is: the outline lives in this
+  // entity's `GeodePathCacheComponent::strokeSlot`, which is only replaced by
+  // a `getStrokeDerived` miss on this same entity, and the pending batch is
+  // always flushed within the frame that started it.
+  if (kEnableSceneBatching && residentStroke != nullptr && strokeDerived.encoded != nullptr &&
+      path.sourceEntity.entity() != entt::null && !impl_->patternStrokePaint.has_value()) {
+    const auto& solidStroke = std::get<PaintServer::Solid>(strokeServer);
+    geode::GeoEncoder::ScenePaint strokePaint;
+    strokePaint.color = solidStroke.color.resolve(impl_->paint.currentColor.rgba(),
+                                                  static_cast<float>(effectiveOpacity));
+    if (impl_->tryAppendOrStartBatch(path.sourceEntity.registry(), path.sourceEntity.entity(),
+                                     strokedOutline, strokePaint, strokeDerived.fillRule,
+                                     strokeDerived.encoded, residentStroke,
+                                     /*allowInstancedAppend=*/false)) {
+      return;
+    }
+  }
+
+  // Non-batchable stroke: drain this element's pending fill first so the
+  // outline paints over it.
+  impl_->flushPendingBatch();
   impl_->drawPaintedPathAgainst(drawPathGeometry, strokedOutline, strokeServer, effectiveOpacity,
                                 strokeDerived.fillRule, strokeDerived.encoded, residentStroke,
                                 residentGradientStroke);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2395,7 +2395,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                            const Transform2d& deviceFromGlyph,
                            const geode::GeodeRecordSlab::Slot* recordSlot,
                            std::vector<uint8_t>* recordCache) {
-    if (!kEnableSceneBatching || recordSlot == nullptr || encoder->hasActiveClipState()) {
+    if (!kEnableSceneBatching || recordSlot == nullptr || encoder->hasActiveClipState() ||
+        encoder->hasOpenMaskPass()) {
       return false;
     }
     // The ensure both establishes residence on first sight of this glyph and

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2905,8 +2905,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         if (pendingBatch->sceneChunkBufferId == chunkId &&
             pendingBatch->sceneRecordBufferId == recordBufId &&
             pendingBatch->sceneClipVersion == clipVersion &&
-            pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
-                recordIndex) {
+            pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() == recordIndex) {
           appendSceneInstance(*pendingBatch, current);
         } else {
           flushPendingBatch();
@@ -3082,10 +3081,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   void startPending(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                     const geode::GeoEncoder::ScenePaint& paint, FillRule rule,
                     const geode::EncodedPath* encoded, geode::GeodeResidentSlot* residentSlot,
-                    const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer,
-                    uint64_t chunkId, uint64_t recordBufferId, uint32_t recordIndex,
-                    uint64_t recordOffset, uint64_t clipVersion,
-                    const PendingBatch::SceneInstance& instance) {
+                    const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer, uint64_t chunkId,
+                    uint64_t recordBufferId, uint32_t recordIndex, uint64_t recordOffset,
+                    uint64_t clipVersion, const PendingBatch::SceneInstance& instance) {
     if (!paint.isGradient()) {
       startSameEntitySingleton(sourceRegistry, sourceEntity, path, paint.color, rule, encoded,
                                residentSlot);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2403,6 +2403,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
 
     const wgpu::Buffer chunk = entry.slot.buffer;
+    const uint64_t chunkId = entry.slot.bufferId;
     const uint32_t vertexCount = entry.encoded.boundingDrawVertexCount();
     const uint64_t clipVersion = encoder->clipStateVersion();
     const PendingBatch::SceneInstance instance{
@@ -2410,8 +2411,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         deviceFromGlyph, vertexCount,    recordSlot,     recordCache, recordState};
 
     if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene &&
-        pendingBatch->sceneChunkBuffer == chunk &&
-        pendingBatch->sceneRecordBuffer == recordSlot->buffer &&
+        pendingBatch->sceneChunkBufferId == chunkId &&
+        pendingBatch->sceneRecordBufferId == recordSlot->bufferId &&
         pendingBatch->sceneClipVersion == clipVersion &&
         pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
             recordSlot->index) {
@@ -2426,6 +2427,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->mode = PendingBatch::Mode::Scene;
     pendingBatch->sceneChunkBuffer = chunk;
     pendingBatch->sceneRecordBuffer = recordSlot->buffer;
+    pendingBatch->sceneChunkBufferId = chunkId;
+    pendingBatch->sceneRecordBufferId = recordSlot->bufferId;
     pendingBatch->sceneFirstInstance = recordSlot->index;
     pendingBatch->sceneFirstRecordOffset = recordSlot->offset;
     pendingBatch->sceneClipVersion = clipVersion;
@@ -2868,7 +2871,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           recordSlotPtr != nullptr ? *recordSlotPtr : residentSlot->recordSlot;
       const wgpu::Buffer chunk = residentSlot->buffer;
       const wgpu::Buffer recordBuf = effectiveRecordSlot.buffer;
-      const uint64_t chunkId = residentFillSlot->bufferId;
+      const uint64_t chunkId = residentSlot->bufferId;
       const uint64_t recordBufId = effectiveRecordSlot.bufferId;
       const uint32_t recordIndex = effectiveRecordSlot.index;
       const uint32_t vertexCount = encoded->boundingDrawVertexCount();
@@ -3001,8 +3004,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           claimSceneSlot(*residentSlot, paint);
           flushPendingBatch();
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
-                       chunk, recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion,
-                       current);
+                       chunk, recordBuf, chunkId, recordBufId, recordIndex,
+                       effectiveRecordSlot.offset, clipVersion, current);
         }
         return true;
       }
@@ -3018,7 +3021,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           flushPendingBatch();
         }
         startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot, chunk,
-                     recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion, current);
+                     recordBuf, chunkId, recordBufId, recordIndex, effectiveRecordSlot.offset,
+                     clipVersion, current);
         return true;
       }
 
@@ -3073,7 +3077,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                     const geode::GeoEncoder::ScenePaint& paint, FillRule rule,
                     const geode::EncodedPath* encoded, geode::GeodeResidentSlot* residentSlot,
                     const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer,
-                    uint32_t recordIndex, uint64_t recordOffset, uint64_t clipVersion,
+                    uint64_t chunkId, uint64_t recordBufferId, uint32_t recordIndex,
+                    uint64_t recordOffset, uint64_t clipVersion,
                     const PendingBatch::SceneInstance& instance) {
     if (!paint.isGradient()) {
       startSameEntitySingleton(sourceRegistry, sourceEntity, path, paint.color, rule, encoded,
@@ -3084,6 +3089,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->mode = PendingBatch::Mode::Scene;
     pendingBatch->sceneChunkBuffer = chunk;
     pendingBatch->sceneRecordBuffer = recordBuffer;
+    pendingBatch->sceneChunkBufferId = chunkId;
+    pendingBatch->sceneRecordBufferId = recordBufferId;
     pendingBatch->sceneFirstInstance = recordIndex;
     pendingBatch->sceneFirstRecordOffset = recordOffset;
     pendingBatch->sceneClipVersion = clipVersion;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2057,12 +2057,17 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   std::deque<SceneTempRecordSlot> sceneTempRecordSlots;
 
   /// Choose the record slot for a scene-batch instance of `slot` WITHOUT
-  /// marking it used: the primary slot when nothing this frame reads it yet
+  /// marking it used: the primary slot when no unsubmitted frame reads it yet
   /// (nullptr: the ensure uses the cached write path), or a fresh temporary
-  /// slot for a same-frame repeat. The primary is off-limits exactly when an
-  /// earlier recorded BATCH draw references it, because buffer writes are
-  /// queue-ordered ahead of every draw in the frame's submit and rewriting the
-  /// record would retroactively retransform that draw.
+  /// slot otherwise. The primary is off-limits exactly when a recorded BATCH
+  /// draw of a still-open frame references it - a repeat earlier in THIS
+  /// frame, or an outer renderer whose frame is still open while an offscreen
+  /// pass renders the same document - because buffer writes are queue-ordered
+  /// ahead of every draw in a frame's submit and rewriting the record (or the
+  /// paint block the ensure republishes with it) would retroactively repaint
+  /// that draw. Generations are device-scoped, so the claim test compares
+  /// against `GeodeDevice::oldestOpenFrameGeneration` rather than our own
+  /// frame index.
   ///
   /// A solo resident draw of the same slot is NOT such a reference: it binds
   /// the device's shared identity record and takes every parameter from the
@@ -2074,7 +2079,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   bool resolveSceneRecordSlot(geode::GeodeResidentSlot& slot,
                               const geode::GeodeRecordSlab::Slot*& outSlot) {
     outSlot = nullptr;
-    if (slot.lastSceneFrame == currentFrameIndex) {
+    if (device->frameStampClaimed(slot.lastSceneFrame)) {
       outSlot = allocateTempRecordSlot(slot.recordSlab);
       return outSlot != nullptr;
     }
@@ -2858,8 +2863,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     const bool sceneEligible =
         kEnableSceneBatching && residentSlot != nullptr && encoded != nullptr &&
         !encoder->hasActiveClipState() && !encoder->hasOpenMaskPass() &&
-        residentSlot->lastSceneFrame != currentFrameIndex &&
-        residentSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
+        !device->frameStampClaimed(residentSlot->lastSceneFrame) &&
+        !device->frameStampClaimed(residentSlot->lastResidentFrame) && sourceRegistry != nullptr &&
         ensureRecordSlot(*residentSlot, *sourceRegistry) &&
         resolveSceneRecordSlot(*residentSlot, recordSlotPtr);
     geode::GeoEncoder::SceneRecordState recordState;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2396,20 +2396,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // The ensure both establishes residence on first sight of this glyph and
     // publishes this occurrence's record; a repeat frame writes neither.
     geode::GeoEncoder::SceneRecordState recordState;
-    if (!encoder->ensureResidentSceneRecord(entry.slot, entry.encoded,
-                                            geode::GeoEncoder::ScenePaint{color},
-                                            FillRule::NonZero, deviceFromGlyph, recordSlot,
-                                            recordCache, &recordState)) {
+    if (!encoder->ensureResidentSceneRecord(
+            entry.slot, entry.encoded, geode::GeoEncoder::ScenePaint{color}, FillRule::NonZero,
+            deviceFromGlyph, recordSlot, recordCache, &recordState)) {
       return false;
     }
 
     const wgpu::Buffer chunk = entry.slot.buffer;
     const uint32_t vertexCount = entry.encoded.boundingDrawVertexCount();
     const uint64_t clipVersion = encoder->clipStateVersion();
-    const PendingBatch::SceneInstance instance{&entry.slot, &entry.encoded,    &entry.outline,
-                                               color,       FillRule::NonZero, deviceFromGlyph,
-                                               vertexCount, recordSlot,        recordCache,
-                                               recordState};
+    const PendingBatch::SceneInstance instance{
+        &entry.slot,     &entry.encoded, &entry.outline, color,       FillRule::NonZero,
+        deviceFromGlyph, vertexCount,    recordSlot,     recordCache, recordState};
 
     if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene &&
         pendingBatch->sceneChunkBuffer == chunk &&
@@ -2826,11 +2824,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // index than a draw that already has one and split the pair.
     const bool havePendingSceneBatch =
         pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene;
-    const bool haveConvertibleSingleton =
-        pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::SameEntity &&
-        pendingBatch->deviceFromLocalTransforms.size() == 1 &&
-        pendingBatch->sameEntityClipVersion == clipVersion &&
-        pendingBatch->residentSlot != residentSlot;
+    const bool haveConvertibleSingleton = pendingBatch.has_value() &&
+                                          pendingBatch->mode == PendingBatch::Mode::SameEntity &&
+                                          pendingBatch->deviceFromLocalTransforms.size() == 1 &&
+                                          pendingBatch->sameEntityClipVersion == clipVersion &&
+                                          pendingBatch->residentSlot != residentSlot;
     const bool wantsRecord = gradientPaint || havePendingSceneBatch || haveConvertibleSingleton;
 
     // `kEnableSceneBatching` is the compile-time gate for ordered
@@ -2877,11 +2875,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // One description of THIS draw, used by every branch below. It carries
       // the record state the ensure just captured, so wherever the instance
       // ends up, its flush replays what was appended.
-      const PendingBatch::SceneInstance current{residentSlot, encoded,
-                                                &path,        color,
-                                                rule,         deviceFromLocalTransform,
-                                                vertexCount,  recordSlotPtr,
-                                                nullptr,      recordState};
+      const PendingBatch::SceneInstance current{
+          residentSlot, encoded,       &path,   color,      rule, deviceFromLocalTransform,
+          vertexCount,  recordSlotPtr, nullptr, recordState};
 
       auto appendSceneInstance = [&](PendingBatch& b, const PendingBatch::SceneInstance& inst) {
         b.sceneInstances.push_back(inst);
@@ -2902,8 +2898,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneClipVersion == clipVersion &&
             pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
                 recordIndex) {
-          appendSceneInstance(*pendingBatch,
-                              current);
+          appendSceneInstance(*pendingBatch, current);
         } else {
           flushPendingBatch();
           pendingBatch = PendingBatch{};
@@ -2915,8 +2910,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->sceneFirstInstance = recordIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
-          appendSceneInstance(*pendingBatch,
-                              current);
+          appendSceneInstance(*pendingBatch, current);
         }
         return true;
       }
@@ -2938,8 +2932,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // Convert the pending size-1 same-entity entry into the scene
         // batch's first instance.
         PendingBatch::SceneInstance first{pendingBatch->residentSlot,
-                                          pendingBatch->encoded, pendingBatch->path,
-                                          pendingBatch->color, pendingBatch->rule,
+                                          pendingBatch->encoded,
+                                          pendingBatch->path,
+                                          pendingBatch->color,
+                                          pendingBatch->rule,
                                           pendingBatch->deviceFromLocalTransforms.front(),
                                           pendingBatch->encoded->boundingDrawVertexCount()};
         // Resolve the first entity's record slot: its primary slot on its
@@ -2983,8 +2979,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->sceneInstances.push_back(first);
           if (firstChunkId == chunkId && firstRecordBufId == recordBufId &&
               firstIndex + 1 == recordIndex) {
-            appendSceneInstance(*pendingBatch,
-                                current);
+            appendSceneInstance(*pendingBatch, current);
           } else {
             flushPendingBatch();
             pendingBatch = PendingBatch{};
@@ -2996,8 +2991,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneFirstInstance = recordIndex;
             pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
             pendingBatch->sceneClipVersion = clipVersion;
-            appendSceneInstance(*pendingBatch,
-                                current);
+            appendSceneInstance(*pendingBatch, current);
           }
         } else {
           // The pending singleton could not take scene form: emit it solo
@@ -3038,8 +3032,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->sceneFirstInstance = recordIndex;
       pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;
-      appendSceneInstance(*pendingBatch,
-                          current);
+      appendSceneInstance(*pendingBatch, current);
       return true;
     }
 
@@ -3065,8 +3058,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// Only a gradient needs it: solid paint publishes nothing a later solid
   /// draw could disturb, and a solid draw that becomes a singleton still wants
   /// its own residence, which the claim would take away.
-  void claimSceneSlot(geode::GeodeResidentSlot& slot,
-                      const geode::GeoEncoder::ScenePaint& paint) {
+  void claimSceneSlot(geode::GeodeResidentSlot& slot, const geode::GeoEncoder::ScenePaint& paint) {
     if (paint.isGradient()) {
       slot.lastSceneFrame = currentFrameIndex;
     }
@@ -3227,8 +3219,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// everything it needs into the entity's persistent paint block during the
   /// append, and a batch's flush-time re-ensure reads the paint back off the
   /// residence slot rather than from the caller.
-  bool resolveBatchGradient(const Path& geometryPath,
-                            const components::ResolvedPaintServer& server, double effectiveOpacity,
+  bool resolveBatchGradient(const Path& geometryPath, const components::ResolvedPaintServer& server,
+                            double effectiveOpacity,
                             std::optional<geode::LinearGradientParams>& outLinear,
                             std::optional<geode::RadialGradientParams>& outRadial) {
     const auto* ref = std::get_if<components::PaintResolvedReference>(&server);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2005,6 +2005,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       /// override write into a skip-when-unchanged write. Null for per-frame
       /// temporary slots, which are always fresh and always written.
       std::vector<uint8_t>* recordCacheOverride = nullptr;
+      /// The record fields that come from encoder-side state - the paint
+      /// scalars published into the slot, and the clip rectangle - captured
+      /// when this instance was appended. The flush-time re-ensure replays
+      /// these rather than re-reading the slot and the encoder, both of which
+      /// can have moved on to a later draw by then.
+      geode::GeoEncoder::SceneRecordState recordState;
     };
     /// Consecutive instances. Each instance's record-slab slot index must
     /// be `firstInstanceIndex + i`, its geometry must live in the same
@@ -2389,10 +2395,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     // The ensure both establishes residence on first sight of this glyph and
     // publishes this occurrence's record; a repeat frame writes neither.
+    geode::GeoEncoder::SceneRecordState recordState;
     if (!encoder->ensureResidentSceneRecord(entry.slot, entry.encoded,
                                             geode::GeoEncoder::ScenePaint{color},
                                             FillRule::NonZero, deviceFromGlyph, recordSlot,
-                                            recordCache)) {
+                                            recordCache, &recordState)) {
       return false;
     }
 
@@ -2401,7 +2408,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     const uint64_t clipVersion = encoder->clipStateVersion();
     const PendingBatch::SceneInstance instance{&entry.slot, &entry.encoded,    &entry.outline,
                                                color,       FillRule::NonZero, deviceFromGlyph,
-                                               vertexCount, recordSlot,        recordCache};
+                                               vertexCount, recordSlot,        recordCache,
+                                               recordState};
 
     if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene &&
         pendingBatch->sceneChunkBuffer == chunk &&
@@ -2658,12 +2666,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // buffer writes execute before all draws at submit). For
       // primary-slot instances the cached-record compare makes this a
       // no-op when the record is unchanged.
-      for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
+      for (PendingBatch::SceneInstance& inst : batch.sceneInstances) {
         if (inst.slot != nullptr && inst.encoded != nullptr) {
           (void)encoder->ensureResidentSceneRecord(
               *inst.slot, *inst.encoded, geode::GeoEncoder::ScenePaint{inst.color}, inst.rule,
               inst.deviceFromLocal, inst.recordSlotOverride, inst.recordCacheOverride,
-              /*publishPaint=*/false);
+              // Replay what the append captured. Re-reading the slot's paint
+              // or the encoder's clip here would take a later draw's state.
+              &inst.recordState, /*publishPaint=*/false);
         }
       }
       encoder->fillPathSceneBatch(batchColor, batchRule, binding);
@@ -2849,9 +2859,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         residentSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
         ensureRecordSlot(*residentSlot, *sourceRegistry) &&
         resolveSceneRecordSlot(*residentSlot, recordSlotPtr);
+    geode::GeoEncoder::SceneRecordState recordState;
     if (sceneEligible && wantsRecord &&
         encoder->ensureResidentSceneRecord(*residentSlot, *encoded, paint, rule,
-                                           deviceFromLocalTransform, recordSlotPtr)) {
+                                           deviceFromLocalTransform, recordSlotPtr,
+                                           /*overrideRecordCache=*/nullptr, &recordState)) {
       const geode::GeodeRecordSlab::Slot& effectiveRecordSlot =
           recordSlotPtr != nullptr ? *recordSlotPtr : residentSlot->recordSlot;
       const wgpu::Buffer chunk = residentSlot->buffer;
@@ -2860,6 +2872,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       const uint64_t recordBufId = effectiveRecordSlot.bufferId;
       const uint32_t recordIndex = effectiveRecordSlot.index;
       const uint32_t vertexCount = encoded->boundingDrawVertexCount();
+      // One description of THIS draw, used by every branch below. It carries
+      // the record state the ensure just captured, so wherever the instance
+      // ends up, its flush replays what was appended.
+      const PendingBatch::SceneInstance current{residentSlot, encoded,
+                                                &path,        color,
+                                                rule,         deviceFromLocalTransform,
+                                                vertexCount,  recordSlotPtr,
+                                                nullptr,      recordState};
 
       auto appendSceneInstance = [&](PendingBatch& b, const PendingBatch::SceneInstance& inst) {
         b.sceneInstances.push_back(inst);
@@ -2881,9 +2901,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
                 recordIndex) {
           appendSceneInstance(*pendingBatch,
-                              PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
-                                                          rule, deviceFromLocalTransform,
-                                                          vertexCount, recordSlotPtr});
+                              current);
         } else {
           flushPendingBatch();
           pendingBatch = PendingBatch{};
@@ -2896,9 +2914,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
           appendSceneInstance(*pendingBatch,
-                              PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
-                                                          rule, deviceFromLocalTransform,
-                                                          vertexCount, recordSlotPtr});
+                              current);
         }
         return true;
       }
@@ -2939,7 +2955,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             resolveSceneRecordSlot(*first.slot, firstRecordSlotPtr) &&
             encoder->ensureResidentSceneRecord(
                 *first.slot, *first.encoded, geode::GeoEncoder::ScenePaint{first.color}, first.rule,
-                first.deviceFromLocal, firstRecordSlotPtr)) {
+                first.deviceFromLocal, firstRecordSlotPtr, /*overrideRecordCache=*/nullptr,
+                &first.recordState)) {
           first.slot->lastSceneFrame = currentFrameIndex;
           // Carry the resolved slot on the instance so the flush-time
           // re-ensure targets the same record this batch draws from.
@@ -2965,10 +2982,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           if (firstChunkId == chunkId && firstRecordBufId == recordBufId &&
               firstIndex + 1 == recordIndex) {
             appendSceneInstance(*pendingBatch,
-                                PendingBatch::SceneInstance{residentSlot, encoded, &path,
-                                                            color, rule,
-                                                            deviceFromLocalTransform,
-                                                            vertexCount, recordSlotPtr});
+                                current);
           } else {
             flushPendingBatch();
             pendingBatch = PendingBatch{};
@@ -2981,20 +2995,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
             pendingBatch->sceneClipVersion = clipVersion;
             appendSceneInstance(*pendingBatch,
-                                PendingBatch::SceneInstance{residentSlot, encoded, &path,
-                                                            color, rule,
-                                                            deviceFromLocalTransform,
-                                                            vertexCount, recordSlotPtr});
+                                current);
           }
         } else {
           // The pending singleton could not take scene form: emit it solo
           // and keep the CURRENT draw pending. Returning without recording the
           // current draw would silently drop it (its ensured record is not
           // referenced by any batch).
+          claimSceneSlot(*residentSlot, paint);
           flushPendingBatch();
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
                        chunk, recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion,
-                       vertexCount, recordSlotPtr);
+                       current);
         }
         return true;
       }
@@ -3005,12 +3017,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // convert it into a scene batch and a repeat can extend it as
         // instanced. A gradient has neither of those futures and opens the
         // scene batch directly.
+        claimSceneSlot(*residentSlot, paint);
         if (pendingBatch.has_value()) {
           flushPendingBatch();
         }
         startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot, chunk,
-                     recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion, vertexCount,
-                     recordSlotPtr);
+                     recordBuf, recordIndex, effectiveRecordSlot.offset, clipVersion, current);
         return true;
       }
 
@@ -3025,9 +3037,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;
       appendSceneInstance(*pendingBatch,
-                          PendingBatch::SceneInstance{residentSlot, encoded, &path, color,
-                                                      rule, deviceFromLocalTransform,
-                                                      vertexCount, recordSlotPtr});
+                          current);
       return true;
     }
 
@@ -3043,6 +3053,23 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return true;
   }
 
+  /// Claim `slot` for a scene batch that is about to be opened, BEFORE any
+  /// flush that could emit a solo draw of the same slot.
+  ///
+  /// Draining the pending batch can flush a same-entity singleton that draws
+  /// from this very slot, and a solo resident draw republishes the slot's paint
+  /// as solid on its way out. Claiming first sends that draw down the arena
+  /// fallback instead, which leaves the paint this draw just published intact.
+  /// Only a gradient needs it: solid paint publishes nothing a later solid
+  /// draw could disturb, and a solid draw that becomes a singleton still wants
+  /// its own residence, which the claim would take away.
+  void claimSceneSlot(geode::GeodeResidentSlot& slot,
+                      const geode::GeoEncoder::ScenePaint& paint) {
+    if (paint.isGradient()) {
+      slot.lastSceneFrame = currentFrameIndex;
+    }
+  }
+
   /// Open a new pending batch holding exactly this draw: a same-entity
   /// singleton for solid paint, or a scene batch of one instance for gradient
   /// paint, which the uniform-sourced singleton flush cannot express. The
@@ -3053,7 +3080,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                     const geode::EncodedPath* encoded, geode::GeodeResidentSlot* residentSlot,
                     const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer,
                     uint32_t recordIndex, uint64_t recordOffset, uint64_t clipVersion,
-                    uint32_t vertexCount, const geode::GeodeRecordSlab::Slot* recordSlotPtr) {
+                    const PendingBatch::SceneInstance& instance) {
     if (!paint.isGradient()) {
       startSameEntitySingleton(sourceRegistry, sourceEntity, path, paint.color, rule, encoded,
                                residentSlot);
@@ -3066,10 +3093,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->sceneFirstInstance = recordIndex;
     pendingBatch->sceneFirstRecordOffset = recordOffset;
     pendingBatch->sceneClipVersion = clipVersion;
-    pendingBatch->sceneVertexCount = vertexCount;
-    pendingBatch->sceneInstances.push_back(PendingBatch::SceneInstance{
-        residentSlot, encoded, &path, paint.color, rule, deviceFromLocalTransform, vertexCount,
-        recordSlotPtr});
+    pendingBatch->sceneVertexCount = instance.vertexCount;
+    pendingBatch->sceneInstances.push_back(instance);
     residentSlot->lastSceneFrame = currentFrameIndex;
   }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2694,9 +2694,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // non-instanced path. Prefer the persistent-residence path so an
       // unbatched solid fill re-uploads zero geometry on an unchanged frame.
       // A fill lands here whenever it never gained a second batch member:
-      // it was scene-ineligible (clipped, scissored, no cached encode, no
-      // residence slot, or a same-frame repeat), or it was eligible but its
-      // record slot did not extend the pending run. Differing paint does NOT
+      // it was scene-ineligible (a clip polygon or mask, an open mask pass, no
+      // cached encode, no residence slot, or a same-frame repeat), or it was
+      // eligible but its record slot did not extend the pending run. A
+      // rectangular clip is NOT among those reasons any more - it travels in
+      // the instance record. Differing paint does NOT
       // land a draw here - a scene batch carries color and fill rule per
       // instance record; only the same-entity instanced mode ends its run on
       // a paint or fill-rule change.
@@ -5140,7 +5142,14 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // than at emit time because the batcher needs them before it can decide.
   std::optional<geode::LinearGradientParams> batchLinear;
   std::optional<geode::RadialGradientParams> batchRadial;
-  if (kEnableSceneBatching && referenceFill && fillShapeBatchable) {
+  //
+  // The state-driven reasons a gradient would be declined are cheap to test up
+  // front, and testing them here keeps the ordinary emit path from re-resolving
+  // a gradient the batcher just discarded. The remaining decline is a
+  // same-frame repeat of one entity, which needs the residence slot to detect
+  // and is rare enough not to be worth fetching one for.
+  if (kEnableSceneBatching && referenceFill && fillShapeBatchable &&
+      !impl_->encoder->hasActiveClipState() && !impl_->encoder->hasOpenMaskPass()) {
     impl_->resolveBatchGradient(drawPathGeometry, impl_->paint.fill, impl_->paint.fillOpacity,
                                 batchLinear, batchRadial);
   }

--- a/donner/svg/renderer/benchmarks/BUILD.bazel
+++ b/donner/svg/renderer/benchmarks/BUILD.bazel
@@ -25,6 +25,7 @@ donner_cc_binary(
     name = "renderer_bench",
     srcs = ["RendererBench.cc"],
     data = [
+        "testdata/gradient_grid.svg",
         "//donner/svg/renderer/testdata",
     ],
     target_compatible_with = select({

--- a/donner/svg/renderer/benchmarks/RendererBench.cc
+++ b/donner/svg/renderer/benchmarks/RendererBench.cc
@@ -462,6 +462,10 @@ int main(int argc, char* argv[]) {
   const std::vector<std::string> defaultFiles = {
       "donner/svg/renderer/testdata/Ghostscript_Tiger.svg",
       "donner/svg/renderer/testdata/lion.svg",
+      // Gradient-heavy grid: 96 shapes, two thirds painted by their own linear
+      // or radial gradient and the rest solid, interleaved. Covers the
+      // paint-heterogeneous run that the solid-and-stroke scenes above do not.
+      "donner/svg/renderer/benchmarks/testdata/gradient_grid.svg",
   };
 
   auto tryAddFile = [&workloads](const std::string& path) {

--- a/donner/svg/renderer/benchmarks/testdata/gradient_grid.svg
+++ b/donner/svg/renderer/benchmarks/testdata/gradient_grid.svg
@@ -1,0 +1,420 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 480" width="720" height="480">
+  <defs>
+    <linearGradient id="g0" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(0, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(90, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(0, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g1" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(37, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(127, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(37, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g3" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(111, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(201, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(111, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g4" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(148, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(238, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(148, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g6" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(222, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(312, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(222, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g7" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(259, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(349, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(259, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g9" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(333, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(63, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(333, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g10" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(10, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(100, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(10, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g12" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(84, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(174, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(84, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g13" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(121, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(211, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(121, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g15" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(195, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(285, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(195, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g16" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(232, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(322, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(232, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g18" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(306, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(36, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(306, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g19" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(343, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(73, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(343, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g21" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(57, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(147, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(57, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g22" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(94, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(184, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(94, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g24" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(168, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(258, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(168, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g25" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(205, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(295, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(205, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g27" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(279, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(9, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(279, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g28" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(316, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(46, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(316, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g30" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(30, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(120, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(30, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g31" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(67, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(157, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(67, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g33" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(141, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(231, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(141, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g34" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(178, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(268, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(178, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g36" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(252, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(342, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(252, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g37" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(289, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(19, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(289, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g39" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(3, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(93, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(3, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g40" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(40, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(130, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(40, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g42" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(114, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(204, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(114, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g43" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(151, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(241, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(151, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g45" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(225, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(315, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(225, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g46" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(262, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(352, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(262, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g48" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(336, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(66, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(336, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g49" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(13, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(103, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(13, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g51" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(87, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(177, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(87, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g52" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(124, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(214, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(124, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g54" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(198, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(288, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(198, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g55" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(235, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(325, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(235, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g57" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(309, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(39, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(309, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g58" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(346, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(76, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(346, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g60" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(60, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(150, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(60, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g61" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(97, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(187, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(97, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g63" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(171, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(261, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(171, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g64" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(208, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(298, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(208, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g66" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(282, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(12, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(282, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g67" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(319, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(49, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(319, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g69" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(33, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(123, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(33, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g70" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(70, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(160, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(70, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g72" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(144, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(234, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(144, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g73" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(181, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(271, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(181, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g75" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(255, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(345, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(255, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g76" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(292, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(22, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(292, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g78" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(6, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(96, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(6, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g79" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(43, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(133, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(43, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g81" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(117, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(207, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(117, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g82" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(154, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(244, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(154, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g84" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(228, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(318, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(228, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g85" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(265, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(355, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(265, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g87" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(339, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(69, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(339, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g88" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(16, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(106, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(16, 70%, 55%)"/>
+    </linearGradient>
+    <linearGradient id="g90" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(90, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(180, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(90, 70%, 55%)"/>
+    </linearGradient>
+    <radialGradient id="g91" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(127, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(217, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(127, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="g93" cx="0.4" cy="0.4" r="0.7" fx="0.3" fy="0.35">
+      <stop offset="0" stop-color="hsl(201, 70%, 55%)"/>
+      <stop offset="0.6" stop-color="hsl(291, 70%, 35%)"/>
+      <stop offset="1" stop-color="hsl(201, 70%, 55%)" stop-opacity="0.6"/>
+    </radialGradient>
+    <linearGradient id="g94" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="hsl(238, 70%, 55%)"/>
+      <stop offset="0.5" stop-color="hsl(328, 70%, 35%)" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="hsl(238, 70%, 55%)"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="48" height="48" rx="6" fill="url(#g0)"/>
+  <circle cx="90" cy="30" r="24" fill="url(#g1)"/>
+  <rect x="126" y="6" width="48" height="48" rx="6" fill="hsl(74, 60%, 45%)"/>
+  <path d="M 186 54 L 210 6 L 234 54 Z" fill="url(#g3)"/>
+  <rect x="246" y="6" width="48" height="48" rx="6" fill="url(#g4)"/>
+  <circle cx="330" cy="30" r="24" fill="hsl(185, 60%, 45%)"/>
+  <rect x="366" y="6" width="48" height="48" rx="6" fill="url(#g6)"/>
+  <path d="M 426 54 L 450 6 L 474 54 Z" fill="url(#g7)"/>
+  <rect x="486" y="6" width="48" height="48" rx="6" fill="hsl(296, 60%, 45%)"/>
+  <circle cx="570" cy="30" r="24" fill="url(#g9)"/>
+  <rect x="606" y="6" width="48" height="48" rx="6" fill="url(#g10)"/>
+  <path d="M 666 54 L 690 6 L 714 54 Z" fill="hsl(47, 60%, 45%)"/>
+  <rect x="6" y="66" width="48" height="48" rx="6" fill="url(#g12)"/>
+  <circle cx="90" cy="90" r="24" fill="url(#g13)"/>
+  <rect x="126" y="66" width="48" height="48" rx="6" fill="hsl(158, 60%, 45%)"/>
+  <path d="M 186 114 L 210 66 L 234 114 Z" fill="url(#g15)"/>
+  <rect x="246" y="66" width="48" height="48" rx="6" fill="url(#g16)"/>
+  <circle cx="330" cy="90" r="24" fill="hsl(269, 60%, 45%)"/>
+  <rect x="366" y="66" width="48" height="48" rx="6" fill="url(#g18)"/>
+  <path d="M 426 114 L 450 66 L 474 114 Z" fill="url(#g19)"/>
+  <rect x="486" y="66" width="48" height="48" rx="6" fill="hsl(20, 60%, 45%)"/>
+  <circle cx="570" cy="90" r="24" fill="url(#g21)"/>
+  <rect x="606" y="66" width="48" height="48" rx="6" fill="url(#g22)"/>
+  <path d="M 666 114 L 690 66 L 714 114 Z" fill="hsl(131, 60%, 45%)"/>
+  <rect x="6" y="126" width="48" height="48" rx="6" fill="url(#g24)"/>
+  <circle cx="90" cy="150" r="24" fill="url(#g25)"/>
+  <rect x="126" y="126" width="48" height="48" rx="6" fill="hsl(242, 60%, 45%)"/>
+  <path d="M 186 174 L 210 126 L 234 174 Z" fill="url(#g27)"/>
+  <rect x="246" y="126" width="48" height="48" rx="6" fill="url(#g28)"/>
+  <circle cx="330" cy="150" r="24" fill="hsl(353, 60%, 45%)"/>
+  <rect x="366" y="126" width="48" height="48" rx="6" fill="url(#g30)"/>
+  <path d="M 426 174 L 450 126 L 474 174 Z" fill="url(#g31)"/>
+  <rect x="486" y="126" width="48" height="48" rx="6" fill="hsl(104, 60%, 45%)"/>
+  <circle cx="570" cy="150" r="24" fill="url(#g33)"/>
+  <rect x="606" y="126" width="48" height="48" rx="6" fill="url(#g34)"/>
+  <path d="M 666 174 L 690 126 L 714 174 Z" fill="hsl(215, 60%, 45%)"/>
+  <rect x="6" y="186" width="48" height="48" rx="6" fill="url(#g36)"/>
+  <circle cx="90" cy="210" r="24" fill="url(#g37)"/>
+  <rect x="126" y="186" width="48" height="48" rx="6" fill="hsl(326, 60%, 45%)"/>
+  <path d="M 186 234 L 210 186 L 234 234 Z" fill="url(#g39)"/>
+  <rect x="246" y="186" width="48" height="48" rx="6" fill="url(#g40)"/>
+  <circle cx="330" cy="210" r="24" fill="hsl(77, 60%, 45%)"/>
+  <rect x="366" y="186" width="48" height="48" rx="6" fill="url(#g42)"/>
+  <path d="M 426 234 L 450 186 L 474 234 Z" fill="url(#g43)"/>
+  <rect x="486" y="186" width="48" height="48" rx="6" fill="hsl(188, 60%, 45%)"/>
+  <circle cx="570" cy="210" r="24" fill="url(#g45)"/>
+  <rect x="606" y="186" width="48" height="48" rx="6" fill="url(#g46)"/>
+  <path d="M 666 234 L 690 186 L 714 234 Z" fill="hsl(299, 60%, 45%)"/>
+  <rect x="6" y="246" width="48" height="48" rx="6" fill="url(#g48)"/>
+  <circle cx="90" cy="270" r="24" fill="url(#g49)"/>
+  <rect x="126" y="246" width="48" height="48" rx="6" fill="hsl(50, 60%, 45%)"/>
+  <path d="M 186 294 L 210 246 L 234 294 Z" fill="url(#g51)"/>
+  <rect x="246" y="246" width="48" height="48" rx="6" fill="url(#g52)"/>
+  <circle cx="330" cy="270" r="24" fill="hsl(161, 60%, 45%)"/>
+  <rect x="366" y="246" width="48" height="48" rx="6" fill="url(#g54)"/>
+  <path d="M 426 294 L 450 246 L 474 294 Z" fill="url(#g55)"/>
+  <rect x="486" y="246" width="48" height="48" rx="6" fill="hsl(272, 60%, 45%)"/>
+  <circle cx="570" cy="270" r="24" fill="url(#g57)"/>
+  <rect x="606" y="246" width="48" height="48" rx="6" fill="url(#g58)"/>
+  <path d="M 666 294 L 690 246 L 714 294 Z" fill="hsl(23, 60%, 45%)"/>
+  <rect x="6" y="306" width="48" height="48" rx="6" fill="url(#g60)"/>
+  <circle cx="90" cy="330" r="24" fill="url(#g61)"/>
+  <rect x="126" y="306" width="48" height="48" rx="6" fill="hsl(134, 60%, 45%)"/>
+  <path d="M 186 354 L 210 306 L 234 354 Z" fill="url(#g63)"/>
+  <rect x="246" y="306" width="48" height="48" rx="6" fill="url(#g64)"/>
+  <circle cx="330" cy="330" r="24" fill="hsl(245, 60%, 45%)"/>
+  <rect x="366" y="306" width="48" height="48" rx="6" fill="url(#g66)"/>
+  <path d="M 426 354 L 450 306 L 474 354 Z" fill="url(#g67)"/>
+  <rect x="486" y="306" width="48" height="48" rx="6" fill="hsl(356, 60%, 45%)"/>
+  <circle cx="570" cy="330" r="24" fill="url(#g69)"/>
+  <rect x="606" y="306" width="48" height="48" rx="6" fill="url(#g70)"/>
+  <path d="M 666 354 L 690 306 L 714 354 Z" fill="hsl(107, 60%, 45%)"/>
+  <rect x="6" y="366" width="48" height="48" rx="6" fill="url(#g72)"/>
+  <circle cx="90" cy="390" r="24" fill="url(#g73)"/>
+  <rect x="126" y="366" width="48" height="48" rx="6" fill="hsl(218, 60%, 45%)"/>
+  <path d="M 186 414 L 210 366 L 234 414 Z" fill="url(#g75)"/>
+  <rect x="246" y="366" width="48" height="48" rx="6" fill="url(#g76)"/>
+  <circle cx="330" cy="390" r="24" fill="hsl(329, 60%, 45%)"/>
+  <rect x="366" y="366" width="48" height="48" rx="6" fill="url(#g78)"/>
+  <path d="M 426 414 L 450 366 L 474 414 Z" fill="url(#g79)"/>
+  <rect x="486" y="366" width="48" height="48" rx="6" fill="hsl(80, 60%, 45%)"/>
+  <circle cx="570" cy="390" r="24" fill="url(#g81)"/>
+  <rect x="606" y="366" width="48" height="48" rx="6" fill="url(#g82)"/>
+  <path d="M 666 414 L 690 366 L 714 414 Z" fill="hsl(191, 60%, 45%)"/>
+  <rect x="6" y="426" width="48" height="48" rx="6" fill="url(#g84)"/>
+  <circle cx="90" cy="450" r="24" fill="url(#g85)"/>
+  <rect x="126" y="426" width="48" height="48" rx="6" fill="hsl(302, 60%, 45%)"/>
+  <path d="M 186 474 L 210 426 L 234 474 Z" fill="url(#g87)"/>
+  <rect x="246" y="426" width="48" height="48" rx="6" fill="url(#g88)"/>
+  <circle cx="330" cy="450" r="24" fill="hsl(53, 60%, 45%)"/>
+  <rect x="366" y="426" width="48" height="48" rx="6" fill="url(#g90)"/>
+  <path d="M 426 474 L 450 426 L 474 474 Z" fill="url(#g91)"/>
+  <rect x="486" y="426" width="48" height="48" rx="6" fill="hsl(164, 60%, 45%)"/>
+  <circle cx="570" cy="450" r="24" fill="url(#g93)"/>
+  <rect x="606" y="426" width="48" height="48" rx="6" fill="url(#g94)"/>
+  <path d="M 666 474 L 690 426 L 714 474 Z" fill="hsl(275, 60%, 45%)"/>
+</svg>

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -878,4 +878,32 @@ donner_multi_transitioned_test(
     text = "true",
 )
 
+# Cross-renderer frame-generation claims on one shared device: the
+# frameStampClaimed contract plus an end-to-end mid-frame offscreen render of
+# the same document that must not repaint an outer frame's recorded gradient.
+donner_cc_test(
+    name = "geode_shared_device_frame_tests_impl",
+    srcs = ["tests/GeodeSharedDeviceFrame_tests.cc"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_device",
+        "//donner/base",
+        "//donner/base:gtest_timeout_main",
+        "//donner/svg",
+        "//donner/svg/components",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_shared_device_frame_tests",
+    size = "small",
+    testonly = 1,
+    dep = ":geode_shared_device_frame_tests_impl",
+    opens_gpu_device = True,
+    renderer_backend = "geode",
+)
+
 donner_package()

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -362,8 +362,8 @@ void writeGradientPaintBlock(float (&rows)[kPaintBlockRows * 4], const ParamsT& 
   rows[6] = static_cast<float>(t.data[5]);
   rows[7] = 0.0f;
 
-  const uint32_t stopCount = std::min<uint32_t>(kMaxGradientStops,
-                                                static_cast<uint32_t>(stops.size()));
+  const uint32_t stopCount =
+      std::min<uint32_t>(kMaxGradientStops, static_cast<uint32_t>(stops.size()));
   for (uint32_t i = 0; i < stopCount; ++i) {
     const auto& s = stops[i];
     float* color = rows + (kPaintStopColorRow + i) * 4u;
@@ -2398,8 +2398,7 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.radialGradient = paint.radialGradient;
   return impl_->ensureResidentSceneRecordImpl(slot, encoded, args, recordTransform,
                                               recordSlotOverride, overrideRecordCache,
-                                              /*bakeTransform=*/false, recordState,
-                                              publishPaint);
+                                              /*bakeTransform=*/false, recordState, publishPaint);
 }
 
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -721,6 +721,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
                                      const FillDrawArgs& args, const Transform2d& recordTransform,
                                      const GeodeRecordSlab::Slot* recordSlotOverride,
                                      std::vector<uint8_t>* overrideRecordCache, bool bakeTransform,
+                                     SceneRecordState* recordState = nullptr,
                                      bool publishPaint = true);
 
   /// Publish `args`' paint into `slot`: write the gradient paint block when
@@ -2102,7 +2103,8 @@ void GeoEncoder::Impl::publishSlotPaint(GeodeResidentSlot& slot, const FillDrawA
 bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
     GeodeResidentSlot& slot, const EncodedPath& encoded, const FillDrawArgs& args,
     const Transform2d& recordTransform, const GeodeRecordSlab::Slot* recordSlotOverride,
-    std::vector<uint8_t>* overrideRecordCache, bool bakeTransform, bool publishPaint) {
+    std::vector<uint8_t>* overrideRecordCache, bool bakeTransform, SceneRecordState* recordState,
+    bool publishPaint) {
   // Ensure the geometry is resident and current AND owned by THIS device.
   // Component removal is the primary invalidation; the pointer + fingerprint
   // guard catches the in-place stroke-slot rebuild (which replaces the encode
@@ -2159,20 +2161,50 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
   record.hRefsBase = static_cast<uint32_t>(slot.hRefs.offset / sizeof(uint32_t));
   record.vRefsBase = static_cast<uint32_t>(slot.vRefs.offset / sizeof(uint32_t));
 
-  // Paint. A gradient's parameters and stop ramp go into the slot's own paint
-  // block, and the record only carries the index of that block plus the two
-  // scalars the shader needs before it reads it. The published paint lives on
-  // the SLOT, not in this call's arguments, because a batch re-derives an
-  // instance's record when it flushes, long after the caller's resolved
-  // gradient is gone: reading it back from the slot is what makes the flush
-  // reproduce byte-identical bytes.
+  // Paint and clip. A gradient's parameters and stop ramp go into the slot's
+  // own paint block, and the record only carries the index of that block plus
+  // the two scalars the shader needs before it reads it.
+  //
+  // Both the paint scalars and the clip rectangle come from state OUTSIDE this
+  // call's arguments - the slot and the encoder - and a batch re-derives an
+  // instance's record when it flushes, arbitrarily far from its append. By then
+  // the slot's paint can belong to a later draw of the same entity and the
+  // encoder's clip can have moved on, so the flush replays exactly what the
+  // append captured instead of re-reading either.
+  SceneRecordState state;
   if (publishPaint) {
     publishSlotPaint(slot, args);
+    state.paintMode = slot.paintMode;
+    state.gradientSpread = slot.gradientSpread;
+    state.gradientStopCount = slot.gradientStopCount;
+    state.clipRectActive = record.clipRectActive;
+    for (size_t i = 0; i < std::size(state.clipRect); ++i) {
+      state.clipRect[i] = record.clipRect[i];
+    }
+    if (recordState != nullptr) {
+      *recordState = state;
+    }
+  } else if (recordState != nullptr) {
+    state = *recordState;
+  } else {
+    state.paintMode = slot.paintMode;
+    state.gradientSpread = slot.gradientSpread;
+    state.gradientStopCount = slot.gradientStopCount;
+    state.clipRectActive = record.clipRectActive;
+    for (size_t i = 0; i < std::size(state.clipRect); ++i) {
+      state.clipRect[i] = record.clipRect[i];
+    }
   }
-  record.paintMode = slot.paintMode;
+  record.paintMode = state.paintMode;
+  // The block's own address is slot state, not append-time state: a re-upload
+  // moves it and the batch's flush-time re-ensure has to bind where it is now.
   record.paintBase = static_cast<uint32_t>(slot.paint.offset / 16u);
-  record.gradientSpread = slot.gradientSpread;
-  record.gradientStopCount = slot.gradientStopCount;
+  record.gradientSpread = state.gradientSpread;
+  record.gradientStopCount = state.gradientStopCount;
+  record.clipRectActive = state.clipRectActive;
+  for (size_t i = 0; i < std::size(record.clipRect); ++i) {
+    record.clipRect[i] = state.clipRect[i];
+  }
 
   if (bakeTransform) {
     // The slot's uniform region belongs exclusively to the solo resident
@@ -2340,7 +2372,7 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
                                            const Transform2d& recordTransform,
                                            const GeodeRecordSlab::Slot* recordSlotOverride,
                                            std::vector<uint8_t>* overrideRecordCache,
-                                           bool publishPaint) {
+                                           SceneRecordState* recordState, bool publishPaint) {
   if (encoded.empty()) {
     return false;
   }
@@ -2366,7 +2398,8 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.radialGradient = paint.radialGradient;
   return impl_->ensureResidentSceneRecordImpl(slot, encoded, args, recordTransform,
                                               recordSlotOverride, overrideRecordCache,
-                                              /*bakeTransform=*/false, publishPaint);
+                                              /*bakeTransform=*/false, recordState,
+                                              publishPaint);
 }
 
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -2300,15 +2300,19 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
     return;
   }
   // A slot's single uniform buffer can only carry one draw's uniform per
-  // frame. If this slot was already drawn resident this frame (markers,
-  // non-adjacent repeated `<use>` at distinct transforms), route the
-  // repeat through the arena path so it gets its own uniform + bind group
-  // instead of clobbering the first draw's transform. The frame counter is
-  // per-renderer, so this same-frame gate only applies when the slot is
-  // already resident ON THIS device; a matching frame index carried over
-  // from a DIFFERENT device that previously rendered this document is not a
-  // same-frame repeat and must re-upload (submitResidentFillDraw re-uploads
-  // on the device-id mismatch) rather than fall back.
+  // frame. If a frame that drew this slot resident is still open - a repeat
+  // earlier in THIS frame (markers, non-adjacent repeated `<use>` at
+  // distinct transforms), or an outer renderer's frame on this device that
+  // recorded a draw against the slot while an offscreen pass renders the
+  // same document - route this draw through the arena path so it gets its
+  // own uniform + bind group instead of clobbering the parameters that
+  // recorded draw reads at submit. Frame stamps are device-scoped
+  // generations, so the claim compares against the device's oldest open
+  // generation; the gate still applies only when the slot is resident ON
+  // THIS device, because a stamp carried over from a DIFFERENT device that
+  // previously rendered this document is not a live claim and must
+  // re-upload (submitResidentFillDraw re-uploads on the device-id
+  // mismatch) rather than fall back.
   // A repeat whose slot was re-uploaded mid-frame (an in-place stroke
   // rebuild clears the device id) is NOT gated here: the re-upload took a
   // fresh slab range with its own uniform region, and a solo resident draw
@@ -2316,7 +2320,8 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   // per-entity record, so the earlier recorded draw of this slot keeps its
   // own parameters at submit time.
   if (slot.owningDeviceId == impl_->device->deviceId() &&
-      (slot.lastResidentFrame == frameId || slot.lastSceneFrame == frameId)) {
+      (impl_->device->frameStampClaimed(slot.lastResidentFrame) ||
+       impl_->device->frameStampClaimed(slot.lastSceneFrame))) {
     submitFillDraw(args);
     return;
   }
@@ -3119,11 +3124,13 @@ void GeoEncoder::fillPathLinearGradientResident(GeodeResidentGradientSlot& slot,
 
   // Residence is only safe (bind group stable, uniform clip flags zero)
   // when no clip mask / clip polygon / mask pass is active, and a slot's
-  // single uniform can only carry one draw per frame. Fall back to the
-  // per-frame arena path in both cases, mirroring `fillPathResident`.
+  // single uniform can only carry one draw per still-open frame (the stamp
+  // claim covers a same-frame repeat and an offscreen pass drawing while an
+  // outer frame on this device has recorded against the slot). Fall back to
+  // the per-frame arena path in both cases, mirroring `fillPathResident`.
   if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen ||
       ((slot.owningDeviceId == impl_->device->deviceId() || slot.owningDeviceId == 0) &&
-       slot.lastResidentFrame == frameId)) {
+       impl_->device->frameStampClaimed(slot.lastResidentFrame))) {
     impl_->submitGradientArenaFallback(u, encoded);
     return;
   }
@@ -3151,7 +3158,7 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
 
   if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen ||
       ((slot.owningDeviceId == impl_->device->deviceId() || slot.owningDeviceId == 0) &&
-       slot.lastResidentFrame == frameId)) {
+       impl_->device->frameStampClaimed(slot.lastResidentFrame))) {
     impl_->submitGradientArenaFallback(u, encoded);
     return;
   }

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -126,8 +126,29 @@ struct alignas(16) Uniforms {
   uint32_t vRefsBase;            // 316 .. 320
   // Two path-space vec2 vertices per vec4, up to eight vertices.
   float boundingVertices[16];  // 320 .. 384
+  // Draw-level copy of the record's clip rectangle, same mirroring contract
+  // as the paint / geometry parameters above.
+  float clipRect[4];           // 384 .. 400
+  uint32_t clipRectActive;     // 400 .. 404
+  uint32_t paintBase;          // 404 .. 408
+  uint32_t gradientSpread;     // 408 .. 412
+  uint32_t gradientStopCount;  // 412 .. 416
 };
-static_assert(sizeof(Uniforms) == 384, "Uniforms struct layout mismatch");
+static_assert(sizeof(Uniforms) == 416, "Uniforms struct layout mismatch");
+
+/// Rows the stop ramp starts at inside a gradient paint block. Must match the
+/// layout documented beside `paintData` in `shaders/slug_fill.wgsl`;
+/// `kGradientPaintBlockRows` is the block's total row count.
+constexpr uint32_t kPaintStopColorRow = 5u;
+constexpr uint32_t kPaintStopOffsetRow = 21u;
+constexpr uint32_t kPaintBlockRows = kGradientPaintBlockRows;
+constexpr uint64_t kPaintBlockBytes = kPaintBlockRows * 16u;
+
+/// Paint modes shared with `shaders/slug_fill.wgsl`.
+constexpr uint32_t kPaintModeSolid = 0u;
+constexpr uint32_t kPaintModePattern = 1u;
+constexpr uint32_t kPaintModeLinearGradient = 2u;
+constexpr uint32_t kPaintModeRadialGradient = 3u;
 
 /// Write the 4x4 identity matrix in column-major order.
 void writeIdentityMvp(float* out16) {
@@ -202,8 +223,12 @@ void affineToMat4(const Transform2d& t, float* out16) {
   out16[15] = 1.0f;
 }
 
-/// Must match `kMaxStops` in `shaders/slug_gradient.wgsl`.
+/// Must match `kMaxStops` in `shaders/slug_gradient.wgsl` and in
+/// `shaders/slug_fill.wgsl`.
 constexpr uint32_t kMaxGradientStops = 16u;
+static_assert(kPaintStopColorRow + kMaxGradientStops <= kPaintStopOffsetRow &&
+                  kPaintStopOffsetRow + kMaxGradientStops / 4u <= kPaintBlockRows,
+              "gradient paint block is too small for its stop ramp");
 
 /// Layout of the gradient per-draw uniform buffer. Must match
 /// `GradientUniforms` in `shaders/slug_gradient.wgsl`.
@@ -310,6 +335,44 @@ void copyRecordParamsToUniform(Uniforms& u, const InstanceRecord& r) {
   u.vGridBase = r.vGridBase;
   u.hRefsBase = r.hRefsBase;
   u.vRefsBase = r.vRefsBase;
+  u.clipRect[0] = r.clipRect[0];
+  u.clipRect[1] = r.clipRect[1];
+  u.clipRect[2] = r.clipRect[2];
+  u.clipRect[3] = r.clipRect[3];
+  u.clipRectActive = r.clipRectActive;
+  u.paintBase = r.paintBase;
+  u.gradientSpread = r.gradientSpread;
+  u.gradientStopCount = r.gradientStopCount;
+}
+
+/// Fill one gradient paint block from resolved gradient parameters. The two
+/// gradient kinds share the block, each leaving the other's geometry rows
+/// zeroed, so a change of kind rewrites the same region.
+template <typename ParamsT>
+void writeGradientPaintBlock(float (&rows)[kPaintBlockRows * 4], const ParamsT& params,
+                             std::span<const typename ParamsT::Stop> stops) {
+  const Transform2d& t = params.gradientFromPath;
+  // Row-vector packing: gx = a*px + c*py + e, gy = b*px + d*py + f.
+  rows[0] = static_cast<float>(t.data[0]);
+  rows[1] = static_cast<float>(t.data[2]);
+  rows[2] = static_cast<float>(t.data[4]);
+  rows[3] = 0.0f;
+  rows[4] = static_cast<float>(t.data[1]);
+  rows[5] = static_cast<float>(t.data[3]);
+  rows[6] = static_cast<float>(t.data[5]);
+  rows[7] = 0.0f;
+
+  const uint32_t stopCount = std::min<uint32_t>(kMaxGradientStops,
+                                                static_cast<uint32_t>(stops.size()));
+  for (uint32_t i = 0; i < stopCount; ++i) {
+    const auto& s = stops[i];
+    float* color = rows + (kPaintStopColorRow + i) * 4u;
+    color[0] = s.rgba[0];
+    color[1] = s.rgba[1];
+    color[2] = s.rgba[2];
+    color[3] = s.rgba[3];
+    rows[kPaintStopOffsetRow * 4u + i] = s.offset;
+  }
 }
 
 /// Byte range covering a resident slot's four grid classes, which share one
@@ -330,11 +393,11 @@ GridRegionSpan gridRegionSpan(const GeodeResidentSlot& slot) {
   return {start, end - start};
 }
 
-/// Rewrite the geometry bases of a solo resident draw's uniform so they are
-/// relative to the sub-ranges its bind group actually binds, rather than to
-/// the slab chunk. Each single-class binding starts at its own region, so
-/// its base is zero; the four grid classes share one binding covering all of
-/// them, so their bases are offsets within that span.
+/// Rewrite the geometry and paint bases of a solo resident draw's uniform so
+/// they are relative to the sub-ranges its bind group actually binds, rather
+/// than to the slab chunk. Each single-class binding starts at its own region,
+/// so its base is zero; the four grid classes share one binding covering all
+/// of them, so their bases are offsets within that span.
 void writeSoloGeometryBases(Uniforms& u, const GeodeResidentSlot& slot) {
   const GridRegionSpan grid = gridRegionSpan(slot);
   u.bandBase = 0u;
@@ -345,6 +408,10 @@ void writeSoloGeometryBases(Uniforms& u, const GeodeResidentSlot& slot) {
   u.vGridBase = static_cast<uint32_t>((slot.vGrid.offset - grid.offset) / sizeof(uint32_t));
   u.hRefsBase = static_cast<uint32_t>((slot.hRefs.offset - grid.offset) / sizeof(uint32_t));
   u.vRefsBase = static_cast<uint32_t>((slot.vRefs.offset - grid.offset) / sizeof(uint32_t));
+  // The paint block is bound as its own tight range too. A solo draw never
+  // reads it - its entry point compiles in no gradient shading at all - but a
+  // base that still pointed into the chunk would be a live lie in the uniform.
+  u.paintBase = 0u;
 }
 
 /// Gradient kind values shared with `shaders/slug_gradient.wgsl`.
@@ -653,7 +720,14 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   bool ensureResidentSceneRecordImpl(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                      const FillDrawArgs& args, const Transform2d& recordTransform,
                                      const GeodeRecordSlab::Slot* recordSlotOverride,
-                                     std::vector<uint8_t>* overrideRecordCache, bool bakeTransform);
+                                     std::vector<uint8_t>* overrideRecordCache, bool bakeTransform,
+                                     bool publishPaint = true);
+
+  /// Publish `args`' paint into `slot`: write the gradient paint block when
+  /// the paint is a gradient, and record the paint mode and gradient scalars
+  /// the instance record reads back. Skipped when the bytes are unchanged, so
+  /// a steady frame writes no paint at all.
+  void publishSlotPaint(GeodeResidentSlot& slot, const FillDrawArgs& args);
 
   /// Publish the solo resident draw's uniform for `slot`, skipping the write
   /// when the bytes are unchanged. Only the solo path calls this: a scene
@@ -932,9 +1006,11 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// no active polygon.
   bool clipPolygonActive = false;
 
-  /// Monotonic version bumped by every clip-polygon / clip-mask mutation.
-  /// The ordered batch machinery snapshots this per batch so a batch never
-  /// spans a clip change (one draw can only carry one clip state).
+  /// Monotonic version bumped by every scissor / clip-polygon / clip-mask
+  /// mutation. The ordered batch machinery snapshots this per batch so a
+  /// batch never spans a clip change: a batch's instances all share the
+  /// polygon and mask state its single draw carries, and all share the one
+  /// clip rectangle their records were written with.
   uint64_t clipStateVersion = 0;
   float clipPolygonPlanes[16] = {0};  // 4 edges × vec4 (xyz + pad)
 
@@ -949,6 +1025,43 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     }
   }
 
+  /// Clamp the requested scissor to the target. Out-of-bounds scissor rects
+  /// would trip WebGPU validation, and a clip rect can legitimately fall
+  /// outside the current viewport (a nested SVG positioned at the edge).
+  void clampedScissor(uint32_t& x, uint32_t& y, uint32_t& w, uint32_t& h) const {
+    x = std::min(scissorX, targetWidth);
+    y = std::min(scissorY, targetHeight);
+    w = std::min(scissorW, targetWidth - x);
+    h = std::min(scissorH, targetHeight - y);
+  }
+
+  /// Publish the current scissor as the record/uniform clip rectangle: the
+  /// half-open integer-pixel range `[x, x+w) x [y, y+h)` the shader tests.
+  /// It is derived from the SAME clamped values `applyScissorIfPassOpen`
+  /// hands the rasterizer, so the data-carried test and the raster test keep
+  /// exactly the same pixels and a draw that uses one, the other, or both is
+  /// pixel-identical.
+  void writeClipRect(float (&outRect)[4], uint32_t& outActive) const {
+    if (!scissorActive) {
+      outRect[0] = 0.0f;
+      outRect[1] = 0.0f;
+      outRect[2] = 0.0f;
+      outRect[3] = 0.0f;
+      outActive = 0u;
+      return;
+    }
+    uint32_t x = 0;
+    uint32_t y = 0;
+    uint32_t w = 0;
+    uint32_t h = 0;
+    clampedScissor(x, y, w, h);
+    outRect[0] = static_cast<float>(x);
+    outRect[1] = static_cast<float>(y);
+    outRect[2] = static_cast<float>(x + w);
+    outRect[3] = static_cast<float>(y + h);
+    outActive = 1u;
+  }
+
   /// Apply the current scissor to the open render pass. No-op if the
   /// pass isn't open yet - `ensurePassOpen` will call this on first
   /// open. Safe to call whenever `scissorActive` / `scissor*` changes.
@@ -957,15 +1070,11 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
       return;
     }
     if (scissorActive) {
-      // Clamp to the target so out-of-bounds scissor rects don't trigger
-      // WebGPU validation errors. Required when the clip rect is outside
-      // the current viewport (e.g., a nested SVG positioned at the edge).
-      uint32_t x = std::min(scissorX, targetWidth);
-      uint32_t y = std::min(scissorY, targetHeight);
-      uint32_t maxW = targetWidth - x;
-      uint32_t maxH = targetHeight - y;
-      uint32_t w = std::min(scissorW, maxW);
-      uint32_t h = std::min(scissorH, maxH);
+      uint32_t x = 0;
+      uint32_t y = 0;
+      uint32_t w = 0;
+      uint32_t h = 0;
+      clampedScissor(x, y, w, h);
       pass.get().setScissorRect(x, y, w, h);
     } else {
       pass.get().setScissorRect(0, 0, targetWidth, targetHeight);
@@ -1565,10 +1674,6 @@ uint64_t GeoEncoder::clipStateVersion() const {
   return impl_->clipStateVersion;
 }
 
-bool GeoEncoder::hasActiveScissor() const {
-  return impl_->scissorActive;
-}
-
 bool GeoEncoder::hasOpenMaskPass() const {
   return impl_->maskPassOpen;
 }
@@ -1616,6 +1721,14 @@ struct GeoEncoder::FillDrawArgs {
   /// transform, so one GPU draw covers all instances with shared geometry
   /// bases.
   uint32_t instanceCount = 1;
+
+  /// Resolved gradient paint, for the record-sourced gradient path only
+  /// (`paintMode` 2 or 3). At most one is set; both null means the paint
+  /// rides in `solidColor` or in the pattern fields. Borrowed for the
+  /// duration of the call - the encoder copies the parameters it needs into
+  /// the residence slot's persistent paint block.
+  const LinearGradientParams* linearGradient = nullptr;
+  const RadialGradientParams* radialGradient = nullptr;
 };
 
 void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rule,
@@ -1719,6 +1832,11 @@ void GeoEncoder::Impl::populateInstanceRecord(InstanceRecord& r, const EncodedPa
   r.vGridBase = 0u;
   r.hRefsBase = 0u;
   r.vRefsBase = 0u;
+  // The clip rectangle is draw state, not geometry, so it is snapshotted
+  // here for every draw form. A solo draw is additionally scissored by the
+  // rasterizer and the two tests agree exactly; a batched draw runs with the
+  // scissor opened to the full target and relies on this value alone.
+  writeClipRect(r.clipRect, r.clipRectActive);
 }
 
 void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded) {
@@ -1765,6 +1883,11 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   place(slot.vGrid, vGridBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.hRefs, hRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vRefs, vRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  // The gradient paint block is reserved unconditionally: paint can change
+  // from solid to gradient without the geometry changing, and re-laying-out
+  // the slot for that would move every region and invalidate the cached bind
+  // group. It stays zero-filled for a solid fill, whose record never reads it.
+  place(slot.paint, kPaintBlockBytes, kStorageOffsetAlignment, /*storageDummy=*/false);
   place(slot.uniform, sizeof(Uniforms), kUniformOffsetAlignment, /*storageDummy=*/false);
 
   // Round the slot up to the slab's allocation alignment so consecutive
@@ -1826,12 +1949,14 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   shift(slot.vRefs);
   shift(slot.hGrid);
   shift(slot.vGrid);
+  shift(slot.paint);
   shift(slot.uniform);
 
   slot.vertexCount = encoded.boundingDrawVertexCount();
   slot.resident = true;
   slot.lastUniform.clear();  // Force the first uniform write below.
   slot.lastRecord.clear();   // Force the first record write below.
+  slot.lastPaint.clear();    // The staging blob left the paint block zeroed.
 
   // Stamp the current device's identity so a later render by a different
   // device re-uploads instead of binding this device's buffer / bind group
@@ -1843,7 +1968,7 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   const wgpu::Device& dev = device->device();
   const wgpu::Buffer& buf = slot.buffer;
 
-  wgpu::BindGroupEntry entries[14] = {};
+  wgpu::BindGroupEntry entries[12] = {};
   auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
     entries[i].binding = binding;
     entries[i].buffer = buf;
@@ -1893,11 +2018,15 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   entries[10].buffer = buf;
   entries[10].offset = grid.offset;
   entries[10].size = grid.size;
+  // This slot's own gradient paint block, on the same tight-range terms, so
+  // the uniform's `paintBase` is zero. A cross-entity batch instead binds the
+  // whole chunk and each record carries a chunk-relative base.
+  bufEntry(11, 11, slot.paint);
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeResidentBindGroup");
   bgDesc.layout = pipeline->bindGroupLayout();
-  bgDesc.entryCount = 11;
+  bgDesc.entryCount = 12;
   bgDesc.entries = entries;
   slot.bindGroup.reset(dev.createBindGroup(bgDesc));
   device->countBindGroup();
@@ -1926,10 +2055,54 @@ bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   return true;
 }
 
+void GeoEncoder::Impl::publishSlotPaint(GeodeResidentSlot& slot, const FillDrawArgs& args) {
+  if (args.linearGradient == nullptr && args.radialGradient == nullptr) {
+    slot.paintMode = args.paintMode;
+    slot.gradientSpread = 0u;
+    slot.gradientStopCount = 0u;
+    return;
+  }
+
+  float rows[kPaintBlockRows * 4] = {};
+  uint32_t stopCount = 0;
+  if (args.linearGradient != nullptr) {
+    const LinearGradientParams& params = *args.linearGradient;
+    writeGradientPaintBlock(rows, params, params.stops);
+    rows[2 * 4 + 0] = static_cast<float>(params.startGrad.x);
+    rows[2 * 4 + 1] = static_cast<float>(params.startGrad.y);
+    rows[2 * 4 + 2] = static_cast<float>(params.endGrad.x);
+    rows[2 * 4 + 3] = static_cast<float>(params.endGrad.y);
+    slot.paintMode = kPaintModeLinearGradient;
+    slot.gradientSpread = params.spreadMode;
+    stopCount = static_cast<uint32_t>(params.stops.size());
+  } else {
+    const RadialGradientParams& params = *args.radialGradient;
+    writeGradientPaintBlock(rows, params, params.stops);
+    rows[3 * 4 + 0] = static_cast<float>(params.center.x);
+    rows[3 * 4 + 1] = static_cast<float>(params.center.y);
+    rows[3 * 4 + 2] = static_cast<float>(params.focalCenter.x);
+    rows[3 * 4 + 3] = static_cast<float>(params.focalCenter.y);
+    rows[4 * 4 + 0] = static_cast<float>(params.radius);
+    rows[4 * 4 + 1] = static_cast<float>(params.focalRadius);
+    slot.paintMode = kPaintModeRadialGradient;
+    slot.gradientSpread = params.spreadMode;
+    stopCount = static_cast<uint32_t>(params.stops.size());
+  }
+  slot.gradientStopCount = std::min<uint32_t>(kMaxGradientStops, stopCount);
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(rows);
+  if (slot.lastPaint.size() != sizeof(rows) ||
+      std::memcmp(slot.lastPaint.data(), bytes, sizeof(rows)) != 0) {
+    device->queue().writeBuffer(slot.buffer, slot.paint.offset, rows, sizeof(rows));
+    device->countBufferWrite(sizeof(rows));
+    slot.lastPaint.assign(bytes, bytes + sizeof(rows));
+  }
+}
+
 bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
     GeodeResidentSlot& slot, const EncodedPath& encoded, const FillDrawArgs& args,
     const Transform2d& recordTransform, const GeodeRecordSlab::Slot* recordSlotOverride,
-    std::vector<uint8_t>* overrideRecordCache, bool bakeTransform) {
+    std::vector<uint8_t>* overrideRecordCache, bool bakeTransform, bool publishPaint) {
   // Ensure the geometry is resident and current AND owned by THIS device.
   // Component removal is the primary invalidation; the pointer + fingerprint
   // guard catches the in-place stroke-slot rebuild (which replaces the encode
@@ -1985,6 +2158,21 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
   record.vGridBase = static_cast<uint32_t>(slot.vGrid.offset / sizeof(uint32_t));
   record.hRefsBase = static_cast<uint32_t>(slot.hRefs.offset / sizeof(uint32_t));
   record.vRefsBase = static_cast<uint32_t>(slot.vRefs.offset / sizeof(uint32_t));
+
+  // Paint. A gradient's parameters and stop ramp go into the slot's own paint
+  // block, and the record only carries the index of that block plus the two
+  // scalars the shader needs before it reads it. The published paint lives on
+  // the SLOT, not in this call's arguments, because a batch re-derives an
+  // instance's record when it flushes, long after the caller's resolved
+  // gradient is gone: reading it back from the slot is what makes the flush
+  // reproduce byte-identical bytes.
+  if (publishPaint) {
+    publishSlotPaint(slot, args);
+  }
+  record.paintMode = slot.paintMode;
+  record.paintBase = static_cast<uint32_t>(slot.paint.offset / 16u);
+  record.gradientSpread = slot.gradientSpread;
+  record.gradientStopCount = slot.gradientStopCount;
 
   if (bakeTransform) {
     // The slot's uniform region belongs exclusively to the solo resident
@@ -2148,13 +2336,15 @@ void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& 
 }
 
 bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const EncodedPath& encoded,
-                                           const css::RGBA& color, FillRule rule,
+                                           const ScenePaint& paint, FillRule rule,
                                            const Transform2d& recordTransform,
                                            const GeodeRecordSlab::Slot* recordSlotOverride,
-                                           std::vector<uint8_t>* overrideRecordCache) {
+                                           std::vector<uint8_t>* overrideRecordCache,
+                                           bool publishPaint) {
   if (encoded.empty()) {
     return false;
   }
+  const css::RGBA& color = paint.color;
   // Build the same solid-fill args fillPath would, so the shared ensure
   // path produces byte-identical uniforms and records.
   FillDrawArgs args = {};
@@ -2172,9 +2362,11 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.patternSampler = impl_->device->dummyPatternSampler();
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
+  args.linearGradient = paint.linearGradient;
+  args.radialGradient = paint.radialGradient;
   return impl_->ensureResidentSceneRecordImpl(slot, encoded, args, recordTransform,
                                               recordSlotOverride, overrideRecordCache,
-                                              /*bakeTransform=*/false);
+                                              /*bakeTransform=*/false, publishPaint);
 }
 
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
@@ -2231,7 +2423,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   const uint64_t recordSpanBytes =
       static_cast<uint64_t>(binding.instanceCount) * sizeof(InstanceRecord);
 
-  wgpu::BindGroupEntry entries[11] = {};
+  wgpu::BindGroupEntry entries[12] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
@@ -2259,6 +2451,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   chunkEntry(8, 8);
   chunkEntry(9, 9);
   chunkEntry(10, 10);
+  chunkEntry(11, 11);
 
   // Buffer IDENTITIES, never handle addresses: the cache lives on the
   // device, which outlives the documents drawn on it, and a destroyed
@@ -2286,7 +2479,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     wgpu::BindGroupDescriptor bgDesc = {};
     bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
     bgDesc.layout = impl_->pipeline->bindGroupLayout();
-    bgDesc.entryCount = 11;
+    bgDesc.entryCount = 12;
     bgDesc.entries = entries;
     wgpu::BindGroup created = impl_->device->device().createBindGroup(bgDesc);
     impl_->device->countBindGroup();
@@ -2303,12 +2496,28 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     }
   }
 
+  // Open the rasterizer scissor to the whole target for the duration of this
+  // draw. The batch is recorded when it flushes, which can be after the
+  // encoder's scissor has already moved to the next clip, so pass state is
+  // not a sound source for this draw's clipping. Each instance's record
+  // instead carries the rectangle that was live when the instance was
+  // appended, and the fragment stage applies it. Restoring afterwards leaves
+  // the pass exactly as the surrounding solo draws expect to find it.
+  const bool neutralizeScissor = impl_->scissorActive;
+  if (neutralizeScissor) {
+    impl_->pass.get().setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
+  }
+
   // The binding covers the span of consecutive record slots starting at
   // `firstInstance`; the shader's instance_index therefore runs 0..N-1
   // (the draw's firstInstance must NOT add the slot offset again).
   impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
   impl_->pass.get().draw(binding.vertexCount, binding.instanceCount, 0, 0);
   impl_->device->countDraw();
+
+  if (neutralizeScissor) {
+    impl_->applyScissorIfPassOpen();
+  }
 }
 
 void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint,
@@ -2465,11 +2674,11 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
     recordSize = sizeof(InstanceRecord);
   }
 
-  // 3. Bind group - eleven entries: uniforms, H bands SSBO, H curves SSBO,
+  // 3. Bind group - twelve entries: uniforms, H bands SSBO, H curves SSBO,
   // pattern texture, pattern sampler, clip-mask texture, clip-mask sampler,
-  // per-instance records SSBO, V bands SSBO, V curves SSBO, and the combined
-  // dense grid storage.
-  wgpu::BindGroupEntry entries[11] = {};
+  // per-instance records SSBO, V bands SSBO, V curves SSBO, the combined
+  // dense grid storage, and the gradient paint blocks.
+  wgpu::BindGroupEntry entries[12] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
@@ -2507,11 +2716,18 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   entries[10].buffer = gridSpan.alloc.buffer;
   entries[10].offset = gridSpan.alloc.offset;
   entries[10].size = gridSpan.alloc.size;
+  // The per-frame arena path never carries a record-sourced gradient - a
+  // gradient without residence goes to the dedicated gradient pipeline - so it
+  // binds the device's zero-filled block and the shader never reads it.
+  entries[11].binding = 11;
+  entries[11].buffer = impl_->device->dummyPaintDataBuffer();
+  entries[11].offset = 0;
+  entries[11].size = impl_->device->dummyPaintDataBuffer().getSize();
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeBindGroup");
   bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 11;
+  bgDesc.entryCount = 12;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -561,7 +561,7 @@ public:
     const LinearGradientParams* linearGradient = nullptr;
     const RadialGradientParams* radialGradient = nullptr;
 
-      /// True when this instance paints with a gradient rather than a colour.
+    /// True when this instance paints with a gradient rather than a colour.
     bool isGradient() const { return linearGradient != nullptr || radialGradient != nullptr; }
   };
 
@@ -628,8 +628,7 @@ public:
                                  const Transform2d& recordTransform,
                                  const GeodeRecordSlab::Slot* recordSlotOverride = nullptr,
                                  std::vector<uint8_t>* overrideRecordCache = nullptr,
-                                 SceneRecordState* recordState = nullptr,
-                                 bool publishPaint = true);
+                                 SceneRecordState* recordState = nullptr, bool publishPaint = true);
 
   /// One cross-entity ordered batch: consecutive resident slots of one
   /// slab chunk plus a run of consecutive record-slab slots.

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -561,8 +561,29 @@ public:
     const LinearGradientParams* linearGradient = nullptr;
     const RadialGradientParams* radialGradient = nullptr;
 
-    /// True when this instance paints with a gradient rather than a colour.
+      /// True when this instance paints with a gradient rather than a colour.
     bool isGradient() const { return linearGradient != nullptr || radialGradient != nullptr; }
+  };
+
+  /**
+   * The record fields a batched instance takes from encoder-side state rather
+   * than from its own arguments: the paint scalars published into its slot and
+   * the clip rectangle live at the time it was appended.
+   *
+   * A batch re-derives every instance's record when it flushes, which can be
+   * arbitrarily far from the append: other draws of the same entity, and other
+   * clip changes, can happen in between. Reading these back off the slot or off
+   * the encoder at that point reads the LATEST state, not the appended one. The
+   * caller therefore captures them at append and hands the same values back at
+   * flush, which is what makes the re-derivation reproduce byte-identical
+   * bytes.
+   */
+  struct SceneRecordState {
+    uint32_t paintMode = 0;
+    uint32_t gradientSpread = 0;
+    uint32_t gradientStopCount = 0;
+    uint32_t clipRectActive = 0;
+    float clipRect[4] = {0.0f, 0.0f, 0.0f, 0.0f};
   };
 
   /**
@@ -589,11 +610,17 @@ public:
    *   lets a persistent per-occurrence record reach a zero-write steady
    *   state. Null means the override slot is per-frame scratch and is always
    *   written. Ignored when `recordSlotOverride` is null.
+   * @param recordState Carries the record fields that come from encoder-side
+   *   state. When `publishPaint` is true this is an OUT parameter: `paint` is
+   *   published into the slot and the resulting scalars, plus the live clip
+   *   rectangle, are written here. When it is false this is an IN parameter:
+   *   the record takes these exact values and neither the slot's paint nor the
+   *   encoder's current clip is consulted. Null on either side falls back to
+   *   the slot's and the encoder's current state.
    * @param publishPaint True to publish `paint` into the slot's paint block
-   *   and paint scalars; false to keep whatever the slot already holds. A
-   *   batch's flush-time re-ensure passes false: it runs after the caller's
-   *   resolved gradient is gone and has to reproduce the record the append
-   *   wrote, which reading the paint back off the slot does exactly.
+   *   and paint scalars; false to replay `recordState` instead. A batch's
+   *   flush-time re-ensure passes false, because by then the slot's paint may
+   *   belong to a later draw and the encoder's clip may have moved on.
    * @return True when the slot is resident and current.
    */
   bool ensureResidentSceneRecord(GeodeResidentSlot& slot, const EncodedPath& encoded,
@@ -601,6 +628,7 @@ public:
                                  const Transform2d& recordTransform,
                                  const GeodeRecordSlab::Slot* recordSlotOverride = nullptr,
                                  std::vector<uint8_t>* overrideRecordCache = nullptr,
+                                 SceneRecordState* recordState = nullptr,
                                  bool publishPaint = true);
 
   /// One cross-entity ordered batch: consecutive resident slots of one

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -81,10 +81,13 @@ struct LinearGradientParams {
   /// fixed-size uniform buffer layout in `slug_gradient.wgsl`. Stops beyond
   /// the cap are silently truncated - a follow-up will move stop storage to
   /// a texture lookup (`GeodeGradientCacheComponent`) to lift this limit.
-  /// A single gradient stop: normalized offset and premultiplied linear RGBA.
+  /// A single gradient stop: normalized offset and STRAIGHT-alpha RGBA.
+  /// Not premultiplied: the resolver writes r/g/b/a each divided by 255, and
+  /// both gradient shaders interpolate stops in straight alpha and
+  /// premultiply only at output (stop-opacity conformance depends on it).
   struct Stop {
     float offset = 0.0f;                       ///< Stop offset in [0, 1].
-    float rgba[4] = {0.0f, 0.0f, 0.0f, 1.0f};  ///< Premultiplied linear RGBA color.
+    float rgba[4] = {0.0f, 0.0f, 0.0f, 1.0f};  ///< Straight-alpha RGBA color.
   };
   /// Gradient stops (capped at 16 entries by the underlying uniform buffer).
   std::span<const Stop> stops;

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -253,16 +253,10 @@ public:
   /// zero clip flags).
   bool hasActiveClipState() const;
 
-  /// Monotonic clip-state version: every clip-polygon / clip-mask
-  /// mutation bumps it. The ordered batch machinery snapshots it per
-  /// batch so a batch never spans a clip change.
+  /// Monotonic clip-state version: every scissor, clip-polygon, and
+  /// clip-mask mutation bumps it. The ordered batch machinery snapshots it
+  /// per batch so a batch never spans a clip change.
   uint64_t clipStateVersion() const;
-
-  /// True when a rectangular scissor rect is active. The ordered batch
-  /// gate excludes scissor-clipped draws (the scissor is raster-stage
-  /// state applied per draw; a deferred batch draw would observe the
-  /// scissor at flush time instead of at draw time).
-  bool hasActiveScissor() const;
 
   /// True while a mask pass is open, i.e. draws are being recorded into a
   /// mask texture through the mask pipeline rather than into the main pass.
@@ -557,6 +551,21 @@ public:
                          std::span<const float> instanceTransforms);
 
   /**
+   * Paint carried by one cross-entity batch instance: a solid colour, or a
+   * resolved gradient whose parameters and stop ramp the encoder copies into
+   * the slot's persistent paint block. The gradient pointers are borrowed for
+   * the duration of the call only.
+   */
+  struct ScenePaint {
+    css::RGBA color = css::RGBA(0, 0, 0, 255);
+    const LinearGradientParams* linearGradient = nullptr;
+    const RadialGradientParams* radialGradient = nullptr;
+
+    /// True when this instance paints with a gradient rather than a colour.
+    bool isGradient() const { return linearGradient != nullptr || radialGradient != nullptr; }
+  };
+
+  /**
    * Ensure a resident slot's geometry is uploaded and its instance record
    * (record-slab slot, chunk-relative bases, transform-bearing) is current
    * WITHOUT drawing. Used by the cross-entity ordered-batch path, which
@@ -580,13 +589,19 @@ public:
    *   lets a persistent per-occurrence record reach a zero-write steady
    *   state. Null means the override slot is per-frame scratch and is always
    *   written. Ignored when `recordSlotOverride` is null.
+   * @param publishPaint True to publish `paint` into the slot's paint block
+   *   and paint scalars; false to keep whatever the slot already holds. A
+   *   batch's flush-time re-ensure passes false: it runs after the caller's
+   *   resolved gradient is gone and has to reproduce the record the append
+   *   wrote, which reading the paint back off the slot does exactly.
    * @return True when the slot is resident and current.
    */
   bool ensureResidentSceneRecord(GeodeResidentSlot& slot, const EncodedPath& encoded,
-                                 const css::RGBA& color, FillRule rule,
+                                 const ScenePaint& paint, FillRule rule,
                                  const Transform2d& recordTransform,
                                  const GeodeRecordSlab::Slot* recordSlotOverride = nullptr,
-                                 std::vector<uint8_t>* overrideRecordCache = nullptr);
+                                 std::vector<uint8_t>* overrideRecordCache = nullptr,
+                                 bool publishPaint = true);
 
   /// One cross-entity ordered batch: consecutive resident slots of one
   /// slab chunk plus a run of consecutive record-slab slots.

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -183,6 +183,10 @@ struct GeodeDevice::Impl {
   ScopedWgpuHandle<wgpu::TextureView> dummyClipMaskTextureView;
   ScopedWgpuHandle<wgpu::Sampler> dummyClipMaskSampler;
 
+  // Zero-filled gradient paint block bound by draws with no residence slot.
+  // See `GeodeDevice::dummyPaintDataBuffer()`.
+  ScopedWgpuHandle<wgpu::Buffer> dummyPaintDataBuffer;
+
   // 1-element instance-transform buffer bound by every
   // non-instanced solid fill. Uploaded once at CreateHeadless time,
   // never modified. Layout matches the WGSL `InstanceRecord` struct, whose
@@ -633,6 +637,9 @@ const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
 const wgpu::Buffer& GeodeDevice::identityInstanceRecordBuffer() const {
   return impl_->identityInstanceRecordBuffer.get();
 }
+const wgpu::Buffer& GeodeDevice::dummyPaintDataBuffer() const {
+  return impl_->dummyPaintDataBuffer.get();
+}
 
 GeodePipeline& GeodeDevice::pipeline() const {
   return *impl_->pipeline;
@@ -903,6 +910,21 @@ void GeodeDevice::initSharedResources() {
     queue_.writeBuffer(impl_->identityInstanceRecordBuffer.get(), 0, identityRecord,
                        sizeof(identityRecord));
   }
+
+  {
+    // One zero-filled gradient paint block, sized from the shared row count so
+    // it cannot drift from the layout the encoder writes and the fill shader
+    // reads. A whole block, rather than a single element, keeps any accidental
+    // read inside the binding.
+    constexpr size_t kPaintBlockFloats = kGradientPaintBlockRows * 4;
+    const float zeroPaint[kPaintBlockFloats] = {};
+    wgpu::BufferDescriptor bd = {};
+    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPaintData"}};
+    bd.size = sizeof(zeroPaint);
+    bd.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+    impl_->dummyPaintDataBuffer.reset(device_.createBuffer(bd));
+    queue_.writeBuffer(impl_->dummyPaintDataBuffer.get(), 0, zeroPaint, sizeof(zeroPaint));
+  }
 }
 
 void GeodeDevice::initSharedPipelines() {
@@ -925,10 +947,16 @@ wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(
 
 void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
                                            wgpu::BindGroup group) {
-  if (sceneBatchBindGroups_.size() >= kSceneBatchBindGroupCacheCap) {
-    sceneBatchBindGroups_.clear();
+  while (sceneBatchBindGroups_.size() >= kSceneBatchBindGroupCacheCap &&
+         !sceneBatchBindGroupOrder_.empty()) {
+    sceneBatchBindGroups_.erase(sceneBatchBindGroupOrder_.front());
+    sceneBatchBindGroupOrder_.pop_front();
   }
-  sceneBatchBindGroups_[key] = ScopedWgpuHandle<wgpu::BindGroup>(std::move(group));
+  if (sceneBatchBindGroups_
+          .insert_or_assign(key, ScopedWgpuHandle<wgpu::BindGroup>(std::move(group)))
+          .second) {
+    sceneBatchBindGroupOrder_.push_back(key);
+  }
 }
 
 void GeodeDevice::deferDestroy(wgpu::Buffer buffer) {

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -8,6 +8,7 @@
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -947,6 +948,11 @@ wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(
 
 void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
                                            wgpu::BindGroup group) {
+  // The deque holds one entry per live map key, in insertion order: a key is
+  // pushed only when it was newly inserted, and popped only together with the
+  // erase of that same key. Nothing else touches either container, so the two
+  // stay the same size and eviction always finds a key that is really there.
+  assert(sceneBatchBindGroupOrder_.size() == sceneBatchBindGroups_.size());
   while (sceneBatchBindGroups_.size() >= kSceneBatchBindGroupCacheCap &&
          !sceneBatchBindGroupOrder_.empty()) {
     sceneBatchBindGroups_.erase(sceneBatchBindGroupOrder_.front());

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -7,12 +7,14 @@
 #define WEBGPU_CPP_IMPLEMENTATION
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <iterator>
 #include <map>
 #include <mutex>
 #include <string_view>
@@ -940,10 +942,22 @@ void GeodeDevice::initSharedPipelines() {
   impl_->filterEngine = std::make_unique<GeodeFilterEngine>(*this, /*verbose=*/false);
 }
 
-wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(
-    const SceneBatchBindGroupKey& key) const {
+wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) {
   const auto it = sceneBatchBindGroups_.find(key);
-  return it != sceneBatchBindGroups_.end() ? it->second.get() : wgpu::BindGroup{};
+  if (it == sceneBatchBindGroups_.end()) {
+    return wgpu::BindGroup{};
+  }
+  // Refresh recency: move the key to the back of the eviction order so the
+  // cap evicts least-recently-USED. One linear scan of at most
+  // kSceneBatchBindGroupCacheCap small keys, only on a hit.
+  const auto orderIt =
+      std::find(sceneBatchBindGroupOrder_.begin(), sceneBatchBindGroupOrder_.end(), key);
+  if (orderIt != sceneBatchBindGroupOrder_.end() &&
+      std::next(orderIt) != sceneBatchBindGroupOrder_.end()) {
+    sceneBatchBindGroupOrder_.erase(orderIt);
+    sceneBatchBindGroupOrder_.push_back(key);
+  }
+  return it->second.get();
 }
 
 void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstddef>
+#include <deque>
 #include <map>
 #include <memory>
 #include <tuple>
@@ -383,9 +384,14 @@ public:
   [[nodiscard]] wgpu::BindGroup findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) const;
 
   /// Store a scene-batch bind group under `key`, taking ownership of the
-  /// +1 handle. Clears the whole cache first when it reaches the cap
-  /// (recorded command buffers keep their own references, so dropping the
-  /// cache's handles mid-frame is safe).
+  /// +1 handle. At the cap, the OLDEST entries are evicted one at a time
+  /// rather than the whole cache being dropped: the cache is device-wide and
+  /// a key belongs to one document's buffers, so wholesale clearing punished
+  /// the live document for documents that had already been torn down, and a
+  /// steady frame then rebuilt every batch group it had just been using.
+  /// Insertion order puts those dead entries first. Recorded command buffers
+  /// keep their own references, so dropping the cache's handle mid-frame is
+  /// safe either way.
   void storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key, wgpu::BindGroup group);
 
   /**
@@ -602,6 +608,13 @@ public:
   /// followed by zeroes. The `.z` components carry the translation (0 for
   /// identity).
   const wgpu::Buffer& identityInstanceRecordBuffer() const;
+
+  /// Zero-filled gradient paint block, one full block long. Bound at binding
+  /// 11 of the Slug fill bind-group layout by draws that have no residence
+  /// slot to bind: those draws are solid or pattern painted and never read
+  /// the array, but the binding must still resolve to a range holding at
+  /// least one whole element of the shader's array stride.
+  const wgpu::Buffer& dummyPaintDataBuffer() const;
   /// @}
 
   /// @name Shared render / compute pipelines (issue #575 fix)
@@ -748,9 +761,12 @@ private:
   std::vector<ScopedWgpuHandle<wgpu::Texture>> pendingTextures_;
 
   // Scene-batch bind groups cached across frames (see
-  // SceneBatchBindGroupKey). Bounded by kSceneBatchBindGroupCacheCap.
+  // SceneBatchBindGroupKey). Bounded by kSceneBatchBindGroupCacheCap, with
+  // `sceneBatchBindGroupOrder_` recording insertion order so the eviction at
+  // the cap drops the oldest entries instead of everything.
   static constexpr std::size_t kSceneBatchBindGroupCacheCap = 256;
   std::map<SceneBatchBindGroupKey, ScopedWgpuHandle<wgpu::BindGroup>> sceneBatchBindGroups_;
+  std::deque<SceneBatchBindGroupKey> sceneBatchBindGroupOrder_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -516,6 +516,22 @@ public:
     return oldest;
   }
 
+  /**
+   * True when a resource stamped with `stamp` (a generation minted by
+   * `beginFrameGeneration`) may still be read by a frame that has not
+   * submitted: some open frame is at or before the stamp, so a recorded draw
+   * in that frame can reference the stamped bytes, and every queue write in a
+   * frame lands before every draw in its submit.
+   *
+   * The never-drawn sentinel `~0` used by the resident-slot stamps is
+   * explicitly NOT claimed - a naive `>=` would read a never-drawn slot as
+   * claimed forever, since `oldestOpenFrameGeneration()` is also `~0` when no
+   * frame is open.
+   */
+  [[nodiscard]] bool frameStampClaimed(uint64_t stamp) const {
+    return stamp != ~uint64_t{0} && stamp >= oldestOpenFrameGeneration();
+  }
+
   /// Record one glyph occurrence served from an already-resident outline.
   void countGlyphResidencyHit() const {
     if (counters_) ++counters_->glyphResidencyHits;

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -354,6 +354,9 @@ public:
     uint64_t recordOffset = 0;
     uint64_t recordBytes = 0;
 
+    friend bool operator==(const SceneBatchBindGroupKey& a,
+                           const SceneBatchBindGroupKey& b) = default;
+
     friend bool operator<(const SceneBatchBindGroupKey& a, const SceneBatchBindGroupKey& b) {
       return std::tie(a.uniformBufferId, a.uniformOffset, a.uniformSize, a.chunkBufferId,
                       a.chunkBytes, a.recordBufferId, a.recordOffset, a.recordBytes) <
@@ -380,8 +383,12 @@ public:
   [[nodiscard]] static uint64_t AllocateBufferId();
 
   /// Look up a cached scene-batch bind group. Returns a borrowed handle
-  /// (valid while the cache entry lives), or an empty handle on miss.
-  [[nodiscard]] wgpu::BindGroup findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) const;
+  /// (valid while the cache entry lives), or an empty handle on miss. A hit
+  /// refreshes the entry to most-recently-used, so eviction at the cap drops
+  /// the coldest entry rather than the oldest-inserted one - with more than
+  /// the cap of live groups, pure insertion order would evict the hottest
+  /// steady-state entry every frame.
+  [[nodiscard]] wgpu::BindGroup findSceneBatchBindGroup(const SceneBatchBindGroupKey& key);
 
   /// Store a scene-batch bind group under `key`, taking ownership of the
   /// +1 handle. At the cap, the OLDEST entries are evicted one at a time

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -19,7 +19,7 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   // bind group layout is stable across draw calls. Every draw binds at
   // least one record; instanced and batched draws bind a contiguous
   // record span indexed by instance_index.
-  wgpu::BindGroupLayoutEntry entries[11] = {};
+  wgpu::BindGroupLayoutEntry entries[12] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -82,16 +82,24 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   // Analytic dual-ray fill: the four dense grid arrays
   // (hBandGrid, vBandGrid, hCurveIndices, vCurveIndices) share ONE
   // combined u32 storage binding; instance records carry the element
-  // bases. This keeps the fragment stage at six storage bindings, under
+  // bases. This keeps the fragment stage at seven storage bindings, under
   // the baseline WebGPU limit of eight per stage.
   entries[10].binding = 10;
   entries[10].visibility = wgpu::ShaderStage::Fragment;
   entries[10].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
   entries[10].buffer.minBindingSize = 0;
 
+  // Gradient paint blocks, addressed by each record's element base, so a run
+  // of differently painted gradient fills shares one draw instead of rebinding
+  // a per-draw gradient uniform.
+  entries[11].binding = 11;
+  entries[11].visibility = wgpu::ShaderStage::Fragment;
+  entries[11].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+  entries[11].buffer.minBindingSize = 0;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = wgpuLabel("GeodeSlugFillBGL");
-  bglDesc.entryCount = 11;
+  bglDesc.entryCount = 12;
   bglDesc.entries = entries;
   bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -695,7 +695,7 @@ struct GeodeResidentSlot {
   /// Bytes last written to the uniform region. A draw whose recomputed
   /// uniform matches this skips the `writeBuffer` entirely (steady-state
   /// static frame => zero buffer writes); a camera/color change rewrites
-  /// only this 368-byte region and keeps the cached bind group.
+  /// only this 416-byte region and keeps the cached bind group.
   std::vector<uint8_t> lastUniform;
 
   GeodeResidentSlot() = default;

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -586,7 +586,7 @@ struct GeodeResidentSlot {
   uint64_t allocationOffset = 0;
   uint64_t allocationSize = 0;
 
-  /// Cached fill bind group. All eleven bindings reference stable
+  /// Cached fill bind group. All twelve bindings reference stable
   /// objects (this slot's `buffer` sub-ranges + device-owned dummy
   /// texture/sampler/identity-instance handles), so it survives frames
   /// and encoders. Rebuilt only when the geometry buffer is

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -69,11 +69,30 @@ struct alignas(16) InstanceRecord {
   uint32_t vGridBase;          // 196 .. 200
   uint32_t hRefsBase;          // 200 .. 204
   uint32_t vRefsBase;          // 204 .. 208
+  // Axis-aligned device-pixel clip rectangle as a half-open range
+  // `[minX, maxX) x [minY, maxY)` over integer pixel indices, matching what
+  // a rasterizer scissor of the same rectangle keeps. Carrying it here
+  // instead of leaving it in raster-stage pass state is what lets a
+  // rect-clipped fill stay inside a deferred batch: the batch's single draw
+  // is recorded after the clip may already have moved on, so pass state at
+  // record time is the wrong clip, while the per-instance value is the clip
+  // that was live when the instance was appended.
+  float clipRect[4];        // 208 .. 224
+  uint32_t clipRectActive;  // 224 .. 228 - 0 = unclipped, 1 = test clipRect
+  // Element index of this instance's gradient paint block inside the bound
+  // paint array. The block holds the gradient transform, the two-circle or
+  // two-point geometry, and the stop ramp; keeping it out of the record and
+  // reachable by index is what lets differently painted gradient fills share
+  // one draw with each other and with the solid fills between them. Only read
+  // when `paintMode` selects a gradient.
+  uint32_t paintBase;           // 228 .. 232
+  uint32_t gradientSpread;      // 232 .. 236 - 0 pad, 1 reflect, 2 repeat
+  uint32_t gradientStopCount;   // 236 .. 240
   // Tail padding to 256 bytes so record-slab slot offsets satisfy the
   // baseline min_storage_buffer_offset_alignment (256) while the WGSL
   // array stride stays a multiple of it. Zero-initialized by the
   // `= {}` population.
-  float _padTail[12];  // 208 .. 256
+  float _padTail[4];  // 240 .. 256
 };
 static_assert(sizeof(InstanceRecord) == 256, "InstanceRecord struct layout mismatch");
 
@@ -595,6 +614,12 @@ struct GeodeResidentSlot {
   Region vRefs;    ///< Vertical curve-reference SSBO (binding 10).
   Region hGrid;    ///< Horizontal band grid (binding 10).
   Region vGrid;    ///< Vertical band grid (binding 10).
+  /// Gradient paint block: transform rows, gradient geometry, and the stop
+  /// ramp, as `vec4` rows addressed by the record's `paintBase` (binding 11).
+  /// Always reserved, so a fill that changes from solid to gradient paint
+  /// rewrites this region rather than re-laying-out the slot; a solid fill
+  /// leaves it zero-filled and its record never reads it.
+  Region paint;
   Region uniform;  ///< Batch-level uniform block (binding 0, 256-aligned).
 
   /// Document-scoped record slab slot for this entity's instance record
@@ -654,6 +679,19 @@ struct GeodeResidentSlot {
   /// (steady-state frames write zero record bytes).
   std::vector<uint8_t> lastRecord;
 
+  /// Bytes last written to the gradient paint region, with the same
+  /// skip-when-unchanged contract as the record and the uniform.
+  std::vector<uint8_t> lastPaint;
+
+  /// Paint published by the last paint write: the record's `paintMode` and
+  /// the two gradient scalars that go with it. They live on the slot rather
+  /// than travelling with each draw because a batch re-derives an instance's
+  /// record at flush time, after the caller's resolved gradient is gone, and
+  /// must reproduce byte-identical bytes.
+  uint32_t paintMode = 0;
+  uint32_t gradientSpread = 0;
+  uint32_t gradientStopCount = 0;
+
   /// Bytes last written to the uniform region. A draw whose recomputed
   /// uniform matches this skips the `writeBuffer` entirely (steady-state
   /// static frame => zero buffer writes); a camera/color change rewrites
@@ -702,6 +740,7 @@ struct GeodeResidentSlot {
       vRefs = other.vRefs;
       hGrid = other.hGrid;
       vGrid = other.vGrid;
+      paint = other.paint;
       uniform = other.uniform;
       vertexCount = other.vertexCount;
       lastResidentFrame = other.lastResidentFrame;
@@ -710,6 +749,11 @@ struct GeodeResidentSlot {
       encodedFingerprint = other.encodedFingerprint;
       owningDeviceId = other.owningDeviceId;
       lastUniform = std::move(other.lastUniform);
+      lastRecord = std::move(other.lastRecord);
+      lastPaint = std::move(other.lastPaint);
+      paintMode = other.paintMode;
+      gradientSpread = other.gradientSpread;
+      gradientStopCount = other.gradientStopCount;
       other.resident = false;
       other.encodedKey = nullptr;
       other.owningDeviceId = 0;
@@ -750,6 +794,10 @@ struct GeodeResidentSlot {
     owningDeviceId = 0;
     lastUniform.clear();
     lastRecord.clear();
+    lastPaint.clear();
+    paintMode = 0;
+    gradientSpread = 0;
+    gradientStopCount = 0;
   }
 };
 

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -85,9 +85,9 @@ struct alignas(16) InstanceRecord {
   // reachable by index is what lets differently painted gradient fills share
   // one draw with each other and with the solid fills between them. Only read
   // when `paintMode` selects a gradient.
-  uint32_t paintBase;           // 228 .. 232
-  uint32_t gradientSpread;      // 232 .. 236 - 0 pad, 1 reflect, 2 repeat
-  uint32_t gradientStopCount;   // 236 .. 240
+  uint32_t paintBase;          // 228 .. 232
+  uint32_t gradientSpread;     // 232 .. 236 - 0 pad, 1 reflect, 2 repeat
+  uint32_t gradientStopCount;  // 236 .. 240
   // Tail padding to 256 bytes so record-slab slot offsets satisfy the
   // baseline min_storage_buffer_offset_alignment (256) while the WGSL
   // array stride stays a multiple of it. Zero-initialized by the

--- a/donner/svg/renderer/geode/GeodeWgpuUtil.h
+++ b/donner/svg/renderer/geode/GeodeWgpuUtil.h
@@ -35,7 +35,6 @@ namespace donner::geode {
 /// binding and the encoder's region reservation cannot drift apart.
 constexpr uint32_t kGradientPaintBlockRows = 25u;
 
-
 /// Wrap a NUL-terminated C string literal in a `wgpu::StringView`
 /// suitable for direct assignment to a descriptor's `label` field.
 /// `std::string_view{}` handles the `strlen()` at compile time when the

--- a/donner/svg/renderer/geode/GeodeWgpuUtil.h
+++ b/donner/svg/renderer/geode/GeodeWgpuUtil.h
@@ -18,6 +18,7 @@
 /// owning smart handles.
 
 #include <atomic>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <string_view>
@@ -26,6 +27,14 @@
 #include <webgpu/webgpu.hpp>
 
 namespace donner::geode {
+
+/// Rows of one gradient paint block, in `vec4` units. The block holds the
+/// gradient transform, its two-point or two-circle geometry, and a full stop
+/// ramp; `paintData` in `shaders/slug_fill.wgsl` documents the row layout and
+/// `GeoEncoder` writes it. Shared here so the device's zero-filled dummy
+/// binding and the encoder's region reservation cannot drift apart.
+constexpr uint32_t kGradientPaintBlockRows = 25u;
+
 
 /// Wrap a NUL-terminated C string literal in a `wgpu::StringView`
 /// suitable for direct assignment to a descriptor's `label` field.

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -76,6 +76,13 @@ struct Uniforms {
   hRefsBase: u32,
   vRefsBase: u32,
   boundingVertices: array<vec4f, 4>,
+  // Draw-level copy of the per-instance clip rectangle, mirrored from the
+  // record the same draw would have written.
+  clipRect: vec4f,
+  clipRectActive: u32,
+  paintBase: u32,
+  gradientSpread: u32,
+  gradientStopCount: u32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -155,9 +162,22 @@ struct InstanceRecord {
   vGridBase: u32,
   hRefsBase: u32,
   vRefsBase: u32,
+  // Axis-aligned device-pixel clip rectangle, half-open over integer pixel
+  // indices: a fragment survives when `floor(pixel_center)` lies in
+  // `[clipRect.xy, clipRect.zw)`. That is exactly the set a rasterizer
+  // scissor of the same rectangle keeps. Carrying the rectangle per instance
+  // is what lets a rect-clipped fill stay inside a deferred batch, whose one
+  // draw is recorded after the clip may already have moved on.
+  clipRect: vec4f,
+  clipRectActive: u32,
+  // Element index of this instance's gradient paint block in `paintData`.
+  // Meaningless (and never read) unless paintMode selects a gradient.
+  paintBase: u32,
+  gradientSpread: u32,
+  gradientStopCount: u32,
   // Tail padding to 256 bytes so record-slab slot offsets satisfy the
   // baseline min_storage_buffer_offset_alignment (256).
-  _padTail: array<vec4f, 3>,
+  _padTail: vec4f,
 };
 @group(0) @binding(7) var<storage, read> instances: array<InstanceRecord>;
 
@@ -176,6 +196,33 @@ struct InstanceRecord {
 // `vBands`; `gridData[hRefsBase + ...]` / `gridData[vRefsBase + ...]`
 // index curves within a band.
 @group(0) @binding(10) var<storage, read> gridData: array<u32>;
+
+// Gradient paint parameters and stop ramp, as vec4 rows. Every instance
+// record carries the element index of its own block, so a run of differently
+// painted gradient fills needs no per-draw uniform rebinding and can share one
+// draw with the solid fills around it. Block layout, relative to `paintBase`:
+//
+//   +0  gradientFromPath row0 (a, c, e, 0)
+//   +1  gradientFromPath row1 (b, d, f, 0)
+//   +2  (startGrad.xy, endGrad.xy)                      linear
+//   +3  (center.xy, focalCenter.xy)                     radial
+//   +4  (radius, focalRadius, 0, 0)                     radial
+//   +5  .. +20  stop colours, straight alpha
+//   +21 .. +24  stop offsets, four per row
+//
+// A solid or pattern instance points at a zero-filled block and never reads
+// it, so the whole array can be one binding over the geometry chunk.
+@group(0) @binding(11) var<storage, read> paintData: array<vec4f>;
+
+const kPaintSolid: u32 = 0u;
+const kPaintPattern: u32 = 1u;
+const kPaintLinearGradient: u32 = 2u;
+const kPaintRadialGradient: u32 = 3u;
+
+const kMaxStops: u32 = 16u;
+const kPaintStopColorRow: u32 = 5u;
+const kPaintStopOffsetRow: u32 = 21u;
+const kInvalidGradientT: f32 = -1e30;
 
 // Sentinel for an empty grid cell (must match EncodedPath::kNoBand).
 const kNoBand: u32 = 0xFFFFFFFFu;
@@ -460,7 +507,145 @@ struct PaintParams {
   vGridBase: u32,
   hRefsBase: u32,
   vRefsBase: u32,
+  clipRect: vec4f,
+  clipRectActive: u32,
+  paintBase: u32,
+  gradientSpread: u32,
+  gradientStopCount: u32,
 };
+
+// ----------------------------------------------------------------------------
+// Gradient paint. The parameter math matches the dedicated gradient pipeline
+// exactly, statement for statement, so a fill that moves between the two
+// produces the same pixels; only where the parameters are read from differs.
+// ----------------------------------------------------------------------------
+
+fn gradient_space(paint: PaintParams, path_pos: vec2f) -> vec2f {
+  let row0 = paintData[paint.paintBase + 0u];
+  let row1 = paintData[paint.paintBase + 1u];
+  let gx = row0.x * path_pos.x + row0.y * path_pos.y + row0.z;
+  let gy = row1.x * path_pos.x + row1.y * path_pos.y + row1.z;
+  return vec2f(gx, gy);
+}
+
+fn linear_gradient_t(paint: PaintParams, gpos: vec2f) -> f32 {
+  let ends = paintData[paint.paintBase + 2u];
+  let start = ends.xy;
+  let axis = ends.zw - start;
+  let axisLenSq = max(dot(axis, axis), 1e-12);
+  return dot(gpos - start, axis) / axisLenSq;
+}
+
+fn radial_gradient_t(paint: PaintParams, gpos: vec2f) -> f32 {
+  let centers = paintData[paint.paintBase + 3u];
+  let radii = paintData[paint.paintBase + 4u];
+  let center = centers.xy;
+  let focal = centers.zw;
+  let outerRadius = radii.x;
+  let focalRadius = radii.y;
+
+  let e = gpos - focal;
+  let d = center - focal;
+  let dr = outerRadius - focalRadius;
+  let a = dot(d, d) - dr * dr;
+  let b = dot(e, d) + focalRadius * dr;
+  let c = dot(e, e) - focalRadius * focalRadius;
+
+  if (abs(a) < 1e-8) {
+    if (abs(b) < 1e-8) {
+      return 1.0;
+    }
+    let linear_t = c / (2.0 * b);
+    if (focalRadius + linear_t * dr < 0.0) {
+      return kInvalidGradientT;
+    }
+    return linear_t;
+  }
+
+  let disc = b * b - a * c;
+  if (disc < 0.0) {
+    return kInvalidGradientT;
+  }
+
+  let sqrtDisc = sqrt(disc);
+  let invA = 1.0 / a;
+  let t0 = (b - sqrtDisc) * invA;
+  let t1 = (b + sqrtDisc) * invA;
+
+  let r1 = focalRadius + t1 * dr;
+  if (r1 >= 0.0) {
+    return t1;
+  }
+  let r0 = focalRadius + t0 * dr;
+  if (r0 >= 0.0) {
+    return t0;
+  }
+  return kInvalidGradientT;
+}
+
+fn gradient_t(paint: PaintParams, path_pos: vec2f) -> f32 {
+  let gpos = gradient_space(paint, path_pos);
+  if (paint.paintMode == kPaintRadialGradient) {
+    return radial_gradient_t(paint, gpos);
+  }
+  return linear_gradient_t(paint, gpos);
+}
+
+fn apply_spread(t: f32, mode: u32) -> f32 {
+  if (mode == 1u) {
+    var r = t - 2.0 * floor(t * 0.5);
+    if (r > 1.0) {
+      r = 2.0 - r;
+    }
+    return r;
+  }
+  if (mode == 2u) {
+    return t - floor(t);
+  }
+  return clamp(t, 0.0, 1.0);
+}
+
+fn load_stop_offset(paint: PaintParams, index: u32) -> f32 {
+  let row = paintData[paint.paintBase + kPaintStopOffsetRow + index / 4u];
+  let lane = index % 4u;
+  if (lane == 0u) {
+    return row.x;
+  }
+  if (lane == 1u) {
+    return row.y;
+  }
+  if (lane == 2u) {
+    return row.z;
+  }
+  return row.w;
+}
+
+fn sample_stops(paint: PaintParams, t: f32) -> vec4f {
+  let count = min(paint.gradientStopCount, kMaxStops);
+  if (count == 0u) {
+    return vec4f(0.0, 0.0, 0.0, 0.0);
+  }
+  let firstOffset = load_stop_offset(paint, 0u);
+  if (t <= firstOffset) {
+    return paintData[paint.paintBase + kPaintStopColorRow];
+  }
+  let lastOffset = load_stop_offset(paint, count - 1u);
+  if (t >= lastOffset) {
+    return paintData[paint.paintBase + kPaintStopColorRow + count - 1u];
+  }
+  for (var i: u32 = 1u; i < count; i = i + 1u) {
+    let o0 = load_stop_offset(paint, i - 1u);
+    let o1 = load_stop_offset(paint, i);
+    if (t <= o1) {
+      let span = max(o1 - o0, 1e-6);
+      let f = (t - o0) / span;
+      let c0 = paintData[paint.paintBase + kPaintStopColorRow + i - 1u];
+      let c1 = paintData[paint.paintBase + kPaintStopColorRow + i];
+      return mix(c0, c1, f);
+    }
+  }
+  return paintData[paint.paintBase + kPaintStopColorRow + count - 1u];
+}
 
 fn load_h_curve(paint: PaintParams, index: u32) -> Quadratic {
   let base = paint.curveBase + index * 6u;
@@ -655,6 +840,20 @@ fn calc_coverage(h: RayCoverage, v: RayCoverage) -> f32 {
 // Fragment stage
 // ============================================================================
 
+// Half-open integer-pixel rectangle test. `pixel_pos` is
+// `@builtin(position).xy`, whose fractional part is always 0.5 at 1
+// sample/pixel, so flooring recovers the exact integer pixel index and the
+// comparison keeps precisely the pixels a rasterizer scissor of the same
+// rectangle would keep.
+fn sample_in_clip_rect(paint: PaintParams, pixel_pos: vec2f) -> bool {
+  if (paint.clipRectActive == 0u) {
+    return true;
+  }
+  let pixel = floor(pixel_pos);
+  return pixel.x >= paint.clipRect.x && pixel.x < paint.clipRect.z &&
+         pixel.y >= paint.clipRect.y && pixel.y < paint.clipRect.w;
+}
+
 fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
   if (uniforms.hasClipPolygon == 0u) {
     return true;
@@ -672,7 +871,10 @@ struct FragOutput {
   @location(0) color: vec4f,
 };
 
-fn shade(paint: PaintParams, in: VertexOutput) -> FragOutput {
+/// Analytic coverage of this fragment, folded through the fill rule and every
+/// clip. Returns zero when nothing of this path covers the pixel; the caller
+/// discards rather than blending a fully transparent fragment.
+fn shade_coverage(paint: PaintParams, in: VertexOutput) -> f32 {
   let pixel_center = in.clip_pos.xy;
 
   // Path-units per pixel, per axis. `sample_pos` is a linear function of the
@@ -725,26 +927,20 @@ fn shade(paint: PaintParams, in: VertexOutput) -> FragOutput {
     coverage = 0.0;
   }
 
+  // Axis-aligned rect clip, in the same viewport-pixel space.
+  if (!sample_in_clip_rect(paint, pixel_center)) {
+    coverage = 0.0;
+  }
+
   // Path-clip mask coverage (multiplicative).
   var clipCoverage: f32 = 1.0;
   if (uniforms.hasClipMask != 0u) {
     clipCoverage = clip_mask_coverage(pixel_center);
   }
-  coverage = coverage * clipCoverage;
+  return coverage * clipCoverage;
+}
 
-  if (coverage <= 0.0) {
-    discard;
-  }
-
-  var out: FragOutput;
-
-  if (paint.paintMode == 0u) {
-    // `paint.color` is premultiplied; scale all channels by coverage.
-    out.color = paint.color * coverage;
-    return out;
-  }
-
-  // Pattern mode.
+fn shade_pattern(paint: PaintParams, in: VertexOutput, coverage: f32) -> vec4f {
   let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
   let wrapped = vec2f(
     fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
@@ -752,20 +948,35 @@ fn shade(paint: PaintParams, in: VertexOutput) -> FragOutput {
   );
   let uv = wrapped / uniforms.tileSize;
   // textureSampleLevel, not textureSample: the batched entry point reads
-  // paintMode per instance, so the solid-color early return above is
+  // paintMode per instance, so the solid-color early return in its caller is
   // non-uniform control flow and WGSL forbids implicit-derivative sampling
   // past it (browser compilers reject the module; native validation does
   // not). Pattern textures are created with a single mip level, so sampling
   // level 0 explicitly is an exact behavioral match.
-  var sampled = textureSampleLevel(patternTexture, patternSampler, uv, 0.0);
-  sampled = sampled * paint.patternOpacity * coverage;
-  out.color = sampled;
-  return out;
+  return textureSampleLevel(patternTexture, patternSampler, uv, 0.0) *
+         paint.patternOpacity * coverage;
+}
+
+fn shade_gradient(paint: PaintParams, in: VertexOutput, coverage: f32) -> vec4f {
+  let raw_t = gradient_t(paint, in.sample_pos);
+  if (raw_t < -1e20) {
+    discard;
+  }
+  let t = apply_spread(raw_t, paint.gradientSpread);
+  // Stops interpolate in straight alpha and premultiply at output, which is
+  // what the CPU renderer does and what the stop-opacity conformance cases
+  // expect.
+  let straight = sample_stops(paint, t);
+  return vec4f(straight.rgb * straight.a, straight.a) * coverage;
 }
 
 /// Shared-paint entry point: every instance of this draw carries the same
 /// paint and the same encoded path, so the parameters come from the uniform
-/// and the fragment stage never touches binding 7.
+/// and the fragment stage never touches binding 7. Gradient paint never
+/// reaches here - a gradient draw either joins an ordered batch, which uses
+/// the batched entry point below, or goes to the dedicated gradient pipeline -
+/// so this entry point does not compile the gradient shading in, and the
+/// fragment cost of a plain solid fill is unchanged by its existence.
 @fragment
 fn fs_main(in: VertexOutput) -> FragOutput {
   var paint: PaintParams;
@@ -787,7 +998,24 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   paint.vGridBase = uniforms.vGridBase;
   paint.hRefsBase = uniforms.hRefsBase;
   paint.vRefsBase = uniforms.vRefsBase;
-  return shade(paint, in);
+  paint.clipRect = uniforms.clipRect;
+  paint.clipRectActive = uniforms.clipRectActive;
+  paint.paintBase = uniforms.paintBase;
+  paint.gradientSpread = uniforms.gradientSpread;
+  paint.gradientStopCount = uniforms.gradientStopCount;
+
+  let coverage = shade_coverage(paint, in);
+  if (coverage <= 0.0) {
+    discard;
+  }
+  var out: FragOutput;
+  if (paint.paintMode == kPaintSolid) {
+    // `paint.color` is premultiplied; scale all channels by coverage.
+    out.color = paint.color * coverage;
+    return out;
+  }
+  out.color = shade_pattern(paint, in, coverage);
+  return out;
 }
 
 /// Cross-entity batch entry point: each instance carries its own paint and
@@ -815,5 +1043,25 @@ fn fs_main_batched(in: VertexOutput) -> FragOutput {
   paint.vGridBase = rec.vGridBase;
   paint.hRefsBase = rec.hRefsBase;
   paint.vRefsBase = rec.vRefsBase;
-  return shade(paint, in);
+  paint.clipRect = rec.clipRect;
+  paint.clipRectActive = rec.clipRectActive;
+  paint.paintBase = rec.paintBase;
+  paint.gradientSpread = rec.gradientSpread;
+  paint.gradientStopCount = rec.gradientStopCount;
+
+  let coverage = shade_coverage(paint, in);
+  if (coverage <= 0.0) {
+    discard;
+  }
+  var out: FragOutput;
+  if (paint.paintMode == kPaintSolid) {
+    out.color = paint.color * coverage;
+    return out;
+  }
+  if (paint.paintMode >= kPaintLinearGradient) {
+    out.color = shade_gradient(paint, in, coverage);
+    return out;
+  }
+  out.color = shade_pattern(paint, in, coverage);
+  return out;
 }

--- a/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
@@ -169,7 +169,38 @@ struct KnownViolation {
   std::string_view reason;
   /// What has to change for this entry to be deleted.
   std::string_view tracking;
+  /// Counters whose measured value differs with cross-entity ordered batching
+  /// compiled in, and the value they take there. A ceiling is the EXACT
+  /// measurement of one build, so a scene that measures differently in the two
+  /// builds needs both numbers rather than the looser of them: recording only
+  /// the maximum would hand the other build slack it has not earned. Only the
+  /// counters named in `sceneBatchingDiffers` are taken from
+  /// `sceneBatchingCeiling`; the rest keep the value above.
+  uint32_t sceneBatchingDiffers = 0;
+  Observed sceneBatchingCeiling = {};
 };
+
+/// Resolve `entry`'s ceiling for the build under test, taking each counter
+/// from whichever measurement applies.
+constexpr Observed effectiveCeiling(const KnownViolation& entry, bool sceneBatching) {
+  Observed out = entry.ceiling;
+  if (!sceneBatching || entry.sceneBatchingDiffers == 0) {
+    return out;
+  }
+  if ((entry.sceneBatchingDiffers & kPathEncodes) != 0) {
+    out.pathEncodes = entry.sceneBatchingCeiling.pathEncodes;
+  }
+  if ((entry.sceneBatchingDiffers & kTextureCreates) != 0) {
+    out.textureCreates = entry.sceneBatchingCeiling.textureCreates;
+  }
+  if ((entry.sceneBatchingDiffers & kBufferWrites) != 0) {
+    out.bufferWrites = entry.sceneBatchingCeiling.bufferWrites;
+  }
+  if ((entry.sceneBatchingDiffers & kBindgroupCreates) != 0) {
+    out.bindgroupCreates = entry.sceneBatchingCeiling.bindgroupCreates;
+  }
+  return out;
+}
 
 constexpr std::array<KnownViolation, 29> kKnownViolations = {{
     {
@@ -301,7 +332,7 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
     {
         /*scene=*/"geode_text_decoration_underline",
         /*violated=*/kPathEncodes | kBufferWrites,
-        /*ceiling=*/{5, 0, 45, 5},
+        /*ceiling=*/{1, 0, 9, 1},
         /*reason=*/
         "glyph and decoration outlines are re-encoded and re-uploaded every frame; placed "
         "text has no path cache or residency",
@@ -417,13 +448,15 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
     {
         /*scene=*/"nested_svg_aspectratio",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{208, 0, 2582, 290},
+        /*ceiling=*/{4, 0, 2357, 265},
         /*reason=*/
         "nested viewports carrying text and use instances re-encode and re-upload the whole "
         "subtree every frame",
         /*tracking=*/
         "clears when nested-viewport subtrees, placed text, and use instances all keep their "
         "cached geometry",
+        /*sceneBatchingDiffers=*/kBufferWrites | kBindgroupCreates,
+        /*sceneBatchingCeiling=*/{4, 0, 746, 84},
     },
     {
         /*scene=*/"poker_chips",
@@ -431,10 +464,13 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
         /*ceiling=*/{12, 0, 96, 20},
         /*reason=*/
         "use instances share one source path with differing stroke styles, so the per-entity "
-        "stroke cache thrashes and re-encodes every instance",
+        "stroke cache thrashes and re-encodes every instance; with ordered batching that same "
+        "thrash costs one more buffer write and saves one bind group",
         /*tracking=*/
         "clears when the stroke cache keys on the resolved stroke style rather than one slot "
         "per source entity",
+        /*sceneBatchingDiffers=*/kBufferWrites | kBindgroupCreates,
+        /*sceneBatchingCeiling=*/{12, 0, 97, 19},
     },
     {
         /*scene=*/"stroking_complex",
@@ -818,6 +854,9 @@ TEST_P(GeodeCounterCorpusTest, SecondFrameIsSteadyState) {
   }
 
   const KnownViolation* known = findKnownViolation(name);
+  const Observed ceilings =
+      known != nullptr ? effectiveCeiling(*known, RendererGeode::sceneBatchingEnabledForTesting())
+                       : Observed{};
   for (const CounterField& field : kCounterFields) {
     const uint64_t value = sample.gated.*field.member;
     const uint64_t target = kSteadyState.*field.member;
@@ -832,7 +871,7 @@ TEST_P(GeodeCounterCorpusTest, SecondFrameIsSteadyState) {
       continue;
     }
 
-    const uint64_t ceiling = known->ceiling.*field.member;
+    const uint64_t ceiling = ceilings.*field.member;
     EXPECT_GT(value, target)
         << name << " now holds the steady-state invariant on " << field.name
         << ", but kKnownViolations still lists it as violating. Delete that counter from the "
@@ -915,8 +954,15 @@ TEST(GeodeCounterCorpusGate, KnownViolationsAreWellFormed) {
     EXPECT_FALSE(entry.tracking.empty())
         << "kKnownViolations entry '" << entry.scene << "' needs a tracking note.";
 
+    EXPECT_EQ(entry.sceneBatchingDiffers & ~entry.violated, 0u)
+        << "kKnownViolations entry '" << entry.scene
+        << "' records a scene-batching ceiling for a counter it does not mark violated, so that "
+        << "number gates nothing. Add the counter to the mask or drop it from the override.";
+
+    const Observed entryCeilings =
+        effectiveCeiling(entry, RendererGeode::sceneBatchingEnabledForTesting());
     for (const CounterField& field : kCounterFields) {
-      const uint64_t ceiling = entry.ceiling.*field.member;
+      const uint64_t ceiling = entryCeilings.*field.member;
       const uint64_t target = kSteadyState.*field.member;
       if ((entry.violated & field.bit) != 0) {
         EXPECT_GT(ceiling, target)

--- a/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
@@ -99,6 +99,11 @@ struct FrameSample {
   }
 };
 
+/// Sentinel for `KnownViolation::sceneBatchingViolated`: no override, the
+/// batching build breaks exactly what `violated` names. A plain `0` cannot
+/// serve, because "breaks nothing" is a meaningful value here.
+constexpr uint32_t kViolatedSameAsBase = ~uint32_t{0};
+
 /// Bit per gated counter, used by `KnownViolation::violated` to say which
 /// invariants a scene is currently allowed (and required) to break.
 enum CounterBit : uint32_t {
@@ -169,6 +174,14 @@ struct KnownViolation {
   std::string_view reason;
   /// What has to change for this entry to be deleted.
   std::string_view tracking;
+  /// Counters this scene still breaks in a build with cross-entity ordered
+  /// batching compiled in. Batching can fix a violation OUTRIGHT rather than
+  /// only moving its number, and an entry that went on listing a counter the
+  /// shipped build already holds would hide the next regression behind a
+  /// stale ceiling - the still-violating assertion is what catches that.
+  /// `kViolatedSameAsBase` keeps `violated`; `0` means the batching build
+  /// breaks nothing here and the scene is held to the shared target.
+  uint32_t sceneBatchingViolated = kViolatedSameAsBase;
   /// Counters whose measured value differs with cross-entity ordered batching
   /// compiled in, and the value they take there. A ceiling is the EXACT
   /// measurement of one build, so a scene that measures differently in the two
@@ -179,6 +192,14 @@ struct KnownViolation {
   uint32_t sceneBatchingDiffers = 0;
   Observed sceneBatchingCeiling = {};
 };
+
+/// Resolve `entry`'s violated mask for the build under test.
+constexpr uint32_t effectiveViolated(const KnownViolation& entry, bool sceneBatching) {
+  if (!sceneBatching || entry.sceneBatchingViolated == kViolatedSameAsBase) {
+    return entry.violated;
+  }
+  return entry.sceneBatchingViolated;
+}
 
 /// Resolve `entry`'s ceiling for the build under test, taking each counter
 /// from whichever measurement applies.
@@ -202,7 +223,7 @@ constexpr Observed effectiveCeiling(const KnownViolation& entry, bool sceneBatch
   return out;
 }
 
-constexpr std::array<KnownViolation, 29> kKnownViolations = {{
+constexpr std::array<KnownViolation, 28> kKnownViolations = {{
     {
         /*scene=*/"donner_icon",
         /*violated=*/kTextureCreates | kBufferWrites | kBindgroupCreates,
@@ -455,6 +476,7 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
         /*tracking=*/
         "clears when nested-viewport subtrees, placed text, and use instances all keep their "
         "cached geometry",
+        /*sceneBatchingViolated=*/kViolatedSameAsBase,
         /*sceneBatchingDiffers=*/kBufferWrites | kBindgroupCreates,
         /*sceneBatchingCeiling=*/{4, 0, 746, 84},
     },
@@ -469,6 +491,7 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
         /*tracking=*/
         "clears when the stroke cache keys on the resolved stroke style rather than one slot "
         "per source entity",
+        /*sceneBatchingViolated=*/kViolatedSameAsBase,
         /*sceneBatchingDiffers=*/kBufferWrites | kBindgroupCreates,
         /*sceneBatchingCeiling=*/{12, 0, 97, 19},
     },
@@ -490,10 +513,14 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
         /*ceiling=*/{0, 0, 9, 1},
         /*reason=*/
         "the stroke outline of a styled use instance draws through the per-frame arena "
-        "instead of a resident buffer",
+        "instead of a resident buffer; ordered batching draws it from the instance record "
+        "instead, which is why the batching build breaks nothing here",
         /*tracking=*/
         "clears when use-instance stroke outlines gain the residency their fills already "
         "have",
+        /*sceneBatchingViolated=*/0,
+        /*sceneBatchingDiffers=*/kBufferWrites,
+        /*sceneBatchingCeiling=*/{0, 0, 0, 1},
     },
     {
         /*scene=*/"svg2_e_use_004",
@@ -501,22 +528,14 @@ constexpr std::array<KnownViolation, 29> kKnownViolations = {{
         /*ceiling=*/{0, 0, 9, 1},
         /*reason=*/
         "the stroke outline of a styled use instance draws through the per-frame arena "
-        "instead of a resident buffer",
+        "instead of a resident buffer; ordered batching draws it from the instance record "
+        "instead, which is why the batching build breaks nothing here",
         /*tracking=*/
         "clears when use-instance stroke outlines gain the residency their fills already "
         "have",
-    },
-    {
-        /*scene=*/"z0rly_test6",
-        /*violated=*/kBindgroupCreates,
-        /*ceiling=*/{0, 0, 0, 22},
-        /*reason=*/
-        "residency removed this scene's outline re-encodes and uniform re-uploads, but its "
-        "music-notation glyphs are drawn from many separate text elements that ordered batching "
-        "does not merge, so each draw still builds its own bind group",
-        /*tracking=*/
-        "clears when bind groups are cached across draws that share a pipeline, or when batching "
-        "merges runs from separate text elements",
+        /*sceneBatchingViolated=*/0,
+        /*sceneBatchingDiffers=*/kBufferWrites,
+        /*sceneBatchingCeiling=*/{0, 0, 0, 1},
     },
 }};
 
@@ -860,7 +879,10 @@ TEST_P(GeodeCounterCorpusTest, SecondFrameIsSteadyState) {
   for (const CounterField& field : kCounterFields) {
     const uint64_t value = sample.gated.*field.member;
     const uint64_t target = kSteadyState.*field.member;
-    const bool expectedToViolate = known != nullptr && (known->violated & field.bit) != 0;
+    const bool expectedToViolate =
+        known != nullptr &&
+        (effectiveViolated(*known, RendererGeode::sceneBatchingEnabledForTesting()) & field.bit) !=
+            0;
 
     if (!expectedToViolate) {
       EXPECT_LE(value, target)
@@ -954,6 +976,14 @@ TEST(GeodeCounterCorpusGate, KnownViolationsAreWellFormed) {
     EXPECT_FALSE(entry.tracking.empty())
         << "kKnownViolations entry '" << entry.scene << "' needs a tracking note.";
 
+    EXPECT_EQ(entry.sceneBatchingViolated == kViolatedSameAsBase
+                  ? 0u
+                  : (entry.sceneBatchingViolated & ~entry.violated),
+              0u)
+        << "kKnownViolations entry '" << entry.scene
+        << "' marks a counter violated in the batching build that the base build does not "
+        << "list, so the base build would fail the shared assertion on it. Widen `violated`.";
+
     EXPECT_EQ(entry.sceneBatchingDiffers & ~entry.violated, 0u)
         << "kKnownViolations entry '" << entry.scene
         << "' records a scene-batching ceiling for a counter it does not mark violated, so that "
@@ -961,10 +991,12 @@ TEST(GeodeCounterCorpusGate, KnownViolationsAreWellFormed) {
 
     const Observed entryCeilings =
         effectiveCeiling(entry, RendererGeode::sceneBatchingEnabledForTesting());
+    const uint32_t entryViolated =
+        effectiveViolated(entry, RendererGeode::sceneBatchingEnabledForTesting());
     for (const CounterField& field : kCounterFields) {
       const uint64_t ceiling = entryCeilings.*field.member;
       const uint64_t target = kSteadyState.*field.member;
-      if ((entry.violated & field.bit) != 0) {
+      if ((entryViolated & field.bit) != 0) {
         EXPECT_GT(ceiling, target)
             << "kKnownViolations entry '" << entry.scene << "' marks " << field.name
             << " as violated but records a ceiling at or below the shared target, so the "

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -210,16 +210,23 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   // arenas (vBands/vCurves/hBandGrid/vBandGrid) on top of bands/curves/vertex/
   // uniform, so first-frame arena growth costs a few more buffer creates.
   EXPECT_LE(c.bufferCreates, 12u);
-  // One group for the batch, one for the snapshot readback.
-  EXPECT_LE(c.bindgroupCreates, 2u);
   EXPECT_LE(c.textureCreates, 3u);  // Target on frame 1; 0 on repeat.
   EXPECT_LE(c.submits, 3u);         // Target = 1.
-  // Three unclipped solid fills of distinct entities in painter order form
-  // one ordered cross-entity batch, so the whole fixture is a single
-  // instanced draw. Each instance's record carries its own color and fill
-  // rule, so the fixture's differing paints (red / blue / green) do not
-  // split the batch.
-  EXPECT_LE(c.drawCalls, 1u);
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    // Three unclipped solid fills of distinct entities in painter order form
+    // one ordered cross-entity batch, so the whole fixture is a single
+    // instanced draw. Each instance's record carries its own color and fill
+    // rule, so the fixture's differing paints (red / blue / green) do not
+    // split the batch. One group for the batch, one for the readback.
+    EXPECT_LE(c.drawCalls, 1u);
+    EXPECT_LE(c.bindgroupCreates, 2u);
+  } else {
+    // Without ordered batching each fill is its own resident draw, reusing
+    // its slot's cached group; the creates are the three slots' groups plus
+    // the readback's.
+    EXPECT_LE(c.drawCalls, 3u);
+    EXPECT_LE(c.bindgroupCreates, 4u);
+  }
   EXPECT_LE(c.pipelineSwitches, 2u);  // Solid pipeline bound once.
 }
 
@@ -420,15 +427,22 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   // set by the slab chunk size, not by the 132 paths. Steady-state frames
   // then re-upload zero geometry (`Lion_NoDirtyPath_ZeroEncodes`).
   EXPECT_LE(c.bufferCreates, 8u);
-  // Ordered cross-entity batching collapsed this from one bind group per
-  // draw (133) to the batch's own group plus the readback's.
-  EXPECT_LE(c.bindgroupCreates, 2u);
   EXPECT_LE(c.textureCreates, 3u);  // Target on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);         // Target = 1.
-  // All 132 paths are unclipped solid fills in painter order sharing one slab
-  // chunk, so they merge into a single instanced draw. Lion has no `<use>`,
-  // so this is entirely the cross-entity path, not same-entity instancing.
-  EXPECT_LE(c.drawCalls, 1u);
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    // All 132 paths are unclipped solid fills in painter order sharing one
+    // slab chunk, so they merge into a single instanced draw. Lion has no
+    // `<use>`, so this is entirely the cross-entity path, not same-entity
+    // instancing. That also collapsed the bind groups from one per draw
+    // (133) to the batch's own plus the readback's.
+    EXPECT_LE(c.drawCalls, 1u);
+    EXPECT_LE(c.bindgroupCreates, 2u);
+  } else {
+    // Without ordered batching every path draws alone from its own resident
+    // slot, each with its own cached bind group.
+    EXPECT_LE(c.drawCalls, 132u);
+    EXPECT_LE(c.bindgroupCreates, 133u);
+  }
   EXPECT_LE(c.pipelineSwitches, 2u);     // All-solid fixture: tracker binds solid once.
   EXPECT_EQ(c.sameSourceDrawPairs, 0u);  // No `<use>` in Lion - every draw has a unique source.
 }
@@ -1208,6 +1222,249 @@ TEST_F(GeodePerfTest, NonAdjacentReuse_EarlierDrawKeepsItsTransform) {
   expectPixel(bmp, 180, 30, green, "converting rect");
   // Background stays empty - nothing rendered where nothing was drawn.
   expectPixel(bmp, 260, 80, clear, "background");
+}
+
+/// Second-frame snapshot plus that frame's counters.
+struct SteadyStateFrame {
+  RendererBitmap bitmap;
+  geode::GeodeCounters counters;
+};
+
+/// Render `svgSource` twice on a fresh renderer and return the second frame's
+/// snapshot and counters. Two frames put every draw in the steady state where
+/// residence and record slots already exist, which is where the batching
+/// hazards live. The counters are sampled before the snapshot so the
+/// readback's own submit and bind group stay out of them.
+SteadyStateFrame renderSteadyState(std::string_view svgSource,
+                                   const std::shared_ptr<geode::GeodeDevice>& device) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(svgSource, sink);
+  if (parsed.hasError()) {
+    ADD_FAILURE() << "ParseSVG failed: " << parsed.error().reason;
+    return {};
+  }
+  SVGDocument document = std::move(parsed.result());
+
+  RendererGeode renderer(device);
+  renderer.draw(document);
+  renderer.draw(document);
+  SteadyStateFrame frame;
+  frame.counters = renderer.lastFrameTimings().counters;
+  frame.bitmap = renderer.takeSnapshot();
+  return frame;
+}
+
+// ---------------------------------------------------------------------------
+// One entity painted twice with different paint.
+//
+// `#r` carries no fill of its own, so the direct draw paints it black and the
+// `<use>` paints it green at a different position. Both draws come from the
+// same entity and therefore from the same residence slot, but their paint
+// differs, so the instanced same-entity path - which expresses one shape at
+// many transforms - does not absorb the second one.
+//
+// The hazard: the second draw resolves the slot's primary record and the
+// conversion of the first draw's pending singleton resolves it again, because
+// neither resolution has marked the slot yet. Both instances then read one
+// record, the later write wins (every buffer write in a submit executes ahead
+// of every draw), and the black rectangle is repainted green at the green
+// rectangle's position, disappearing entirely.
+// ---------------------------------------------------------------------------
+constexpr std::string_view kEntityRepaintedSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 200 100">
+  <rect id="r" x="10" y="10" width="60" height="60"/>
+  <use xlink:href="#r" x="100" y="0" fill="#00cc00"/>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, EntityRepaintedWithDifferentPaint_KeepsBothDraws) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap bmp = renderSteadyState(kEntityRepaintedSvg, device).bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  const std::array<uint8_t, 4> black = {0, 0, 0, 255};
+  const std::array<uint8_t, 4> green = {0, 204, 0, 255};
+  const std::array<uint8_t, 4> clear = {0, 0, 0, 0};
+
+  // The direct draw keeps its own paint and position. Before the aliasing
+  // guard this pixel was empty: the shared record had been overwritten by the
+  // `<use>`, which moved the first draw on top of the second.
+  expectPixel(bmp, 40, 40, black, "direct draw of #r");
+  expectPixel(bmp, 140, 40, green, "<use> of #r");
+  expectPixel(bmp, 90, 90, clear, "background");
+}
+
+// ---------------------------------------------------------------------------
+// Rect clips carried per instance.
+//
+// Two nested viewports clip their contents to different rectangles, and each
+// holds two oversized fills so there is a run of rect-clipped draws to batch.
+// The clip changes between the viewports, which is exactly what a deferred
+// batch cannot take from raster-stage pass state: by the time the first
+// viewport's batch draw is recorded the encoder may already carry the second
+// viewport's clip.
+// ---------------------------------------------------------------------------
+constexpr std::string_view kNestedViewportClipSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100" width="200" height="100">
+  <svg x="0" y="0" width="50" height="100" overflow="hidden">
+    <rect x="0" y="0" width="200" height="40" fill="#ff0000"/>
+    <rect x="0" y="60" width="200" height="40" fill="#0000ff"/>
+  </svg>
+  <svg x="120" y="0" width="50" height="100" overflow="hidden">
+    <rect x="0" y="0" width="200" height="40" fill="#00cc00"/>
+    <rect x="0" y="60" width="200" height="40" fill="#cccc00"/>
+  </svg>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, RectClippedFills_StayInsideTheirOwnViewport) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const SteadyStateFrame frame = renderSteadyState(kNestedViewportClipSvg, device);
+  const RendererBitmap& bmp = frame.bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+  ASSERT_EQ(bmp.dimensions.x, 200);
+  ASSERT_EQ(bmp.dimensions.y, 100);
+
+  const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+  const std::array<uint8_t, 4> blue = {0, 0, 255, 255};
+  const std::array<uint8_t, 4> green = {0, 204, 0, 255};
+  const std::array<uint8_t, 4> yellow = {204, 204, 0, 255};
+  const std::array<uint8_t, 4> clear = {0, 0, 0, 0};
+
+  // Inside the first viewport both fills survive.
+  expectPixel(bmp, 25, 20, red, "first viewport upper fill");
+  expectPixel(bmp, 25, 80, blue, "first viewport lower fill");
+  // Past its right edge nothing from it may appear. A batch that took the
+  // wrong clip, or no clip at all, paints here.
+  expectPixel(bmp, 80, 20, clear, "right of the first viewport");
+  expectPixel(bmp, 80, 80, clear, "right of the first viewport, lower");
+  // Inside the second viewport both fills survive.
+  expectPixel(bmp, 145, 20, green, "second viewport upper fill");
+  expectPixel(bmp, 145, 80, yellow, "second viewport lower fill");
+  // Between and beyond the viewports stays empty.
+  expectPixel(bmp, 100, 20, clear, "between the viewports");
+  expectPixel(bmp, 190, 80, clear, "right of the second viewport");
+
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    // Each viewport's pair of fills collapses into one draw. A rect-clipped
+    // fill can only do that once the clip travels in the record instead of in
+    // raster-stage pass state; while it did not, all four fills drew alone.
+    EXPECT_EQ(frame.counters.drawCalls, 2u)
+        << "the two rect-clipped fills of each viewport should collapse into one draw each";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A stroked outline batches as the instance right after its own element fill,
+// so the two must still composite in that order.
+// ---------------------------------------------------------------------------
+constexpr std::string_view kFillAndStrokeRunSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <rect x="20" y="20" width="60" height="60" fill="#ff0000" stroke="#0000ff" stroke-width="10"/>
+  <rect x="120" y="20" width="60" height="60" fill="#00cc00" stroke="#cccc00" stroke-width="10"/>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, StrokeBatchedWithFill_PaintsOverIt) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const SteadyStateFrame frame = renderSteadyState(kFillAndStrokeRunSvg, device);
+  const RendererBitmap& bmp = frame.bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+  const std::array<uint8_t, 4> blue = {0, 0, 255, 255};
+  const std::array<uint8_t, 4> green = {0, 204, 0, 255};
+  const std::array<uint8_t, 4> yellow = {204, 204, 0, 255};
+
+  // Rect centres keep their fill.
+  expectPixel(bmp, 50, 50, red, "first fill");
+  expectPixel(bmp, 150, 50, green, "second fill");
+  // The stroke straddles the edge - width 10 centred on x=20 covers 15..25 -
+  // so a point two pixels inside the edge is stroke, not fill. It reads as
+  // fill if the outline was dropped or ordered underneath.
+  expectPixel(bmp, 22, 50, blue, "first stroke over its fill");
+  expectPixel(bmp, 122, 50, yellow, "second stroke over its fill");
+
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    // Two fills and two outlines, one draw. While a stroked element ended the
+    // run, this document could not batch at all and drew four times.
+    EXPECT_EQ(frame.counters.drawCalls, 1u)
+        << "a fill/stroke/fill/stroke run should collapse into a single ordered batch";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Solo and batched draws must produce identical pixels.
+//
+// Both documents draw the same shapes at the same positions. The second wraps
+// them in a clip path whose rectangle covers the whole viewport: that clips
+// nothing away, but an active clip mask forces every draw onto the solo path,
+// which reads its paint and geometry parameters from the draw-level uniform
+// instead of from the instance record. Any drift between the two parameter
+// sources - a field mirrored into one and not the other, or mirrored with a
+// different value - surfaces here as a pixel difference.
+// ---------------------------------------------------------------------------
+constexpr std::string_view kTwoConventionBatchedSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <rect x="10" y="10" width="70" height="55" fill="#3366cc"/>
+  <circle cx="140" cy="45" r="33" fill="#cc3366"/>
+  <path d="M 20 95 C 60 60, 120 60, 180 95 Z" fill="#66cc33" fill-rule="evenodd"/>
+</svg>
+)SVG";
+
+constexpr std::string_view kTwoConventionSoloSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <defs>
+    <clipPath id="everything" clipPathUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="200" height="100"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#everything)">
+    <rect x="10" y="10" width="70" height="55" fill="#3366cc"/>
+    <circle cx="140" cy="45" r="33" fill="#cc3366"/>
+    <path d="M 20 95 C 60 60, 120 60, 180 95 Z" fill="#66cc33" fill-rule="evenodd"/>
+  </g>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, RecordSourcedAndUniformSourcedDrawsAgree) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap batched = renderSteadyState(kTwoConventionBatchedSvg, device).bitmap;
+  const RendererBitmap solo = renderSteadyState(kTwoConventionSoloSvg, device).bitmap;
+  ASSERT_FALSE(batched.empty());
+  ASSERT_FALSE(solo.empty());
+  ASSERT_EQ(batched.dimensions.x, solo.dimensions.x);
+  ASSERT_EQ(batched.dimensions.y, solo.dimensions.y);
+
+  size_t differingPixels = 0;
+  int firstX = -1;
+  int firstY = -1;
+  for (int y = 0; y < batched.dimensions.y; ++y) {
+    const uint8_t* a = batched.pixels.data() + static_cast<size_t>(y) * batched.rowBytes;
+    const uint8_t* b = solo.pixels.data() + static_cast<size_t>(y) * solo.rowBytes;
+    const size_t rowBytes = static_cast<size_t>(batched.dimensions.x) * 4u;
+    for (size_t i = 0; i < rowBytes; i += 4u) {
+      if (std::memcmp(a + i, b + i, 4u) != 0) {
+        ++differingPixels;
+        if (firstX < 0) {
+          firstX = static_cast<int>(i / 4u);
+          firstY = y;
+        }
+      }
+    }
+  }
+  EXPECT_EQ(differingPixels, 0u)
+      << "record-sourced and uniform-sourced draws of the same content diverged; first at ("
+      << firstX << ", " << firstY << ")";
 }
 
 }  // namespace

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -1298,6 +1298,154 @@ TEST_F(GeodePerfTest, EntityRepaintedWithDifferentPaint_KeepsBothDraws) {
 }
 
 // ---------------------------------------------------------------------------
+// One entity painted solid once and by a gradient once.
+//
+// Both draws come from the same entity, so they share a residence slot, and the
+// gradient's parameters are published onto that slot. The gradient draw cannot
+// convert the pending singleton (same slot), so it drains the batch and opens
+// its own - and that drain emits the solid draw, which republishes the slot's
+// paint as solid on its way out.
+//
+// The hazard: the batch re-derives its instance's record when it flushes. If
+// that re-derivation re-read the slot, it would read the paint the solid draw
+// left behind, rewrite the record as a solid fill, and paint it in the colour
+// the gradient instance never set - opaque black. Carrying the paint scalars on
+// the instance, and claiming the slot before the drain so the solid draw takes
+// the arena fallback, both keep the gradient a gradient.
+// ---------------------------------------------------------------------------
+constexpr std::string_view kSolidThenGradientSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff0000"/>
+      <stop offset="1" stop-color="#ff0000"/>
+    </linearGradient>
+    <rect id="r" x="10" y="10" width="60" height="60"/>
+  </defs>
+  <g fill="#00cc00"><use xlink:href="#r"/></g>
+  <g fill="url(#g)"><use xlink:href="#r" x="100" y="0"/></g>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, SolidThenGradientOfOneEntity_KeepsBothPaints) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap bmp = renderSteadyState(kSolidThenGradientSvg, device).bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  const std::array<uint8_t, 4> green = {0, 204, 0, 255};
+  const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+
+  expectPixel(bmp, 40, 40, green, "solid draw of #r");
+  // The gradient's stops are both pure red, so every pixel inside it is red
+  // whatever the ramp does. Before the fix this read opaque black: the record
+  // had been rewritten as a solid fill in a colour nothing ever set.
+  expectPixel(bmp, 140, 40, red, "gradient <use> of #r");
+}
+
+// The reverse order, and the same-paint-twice orderings, guard the same
+// machinery from the other side: whichever draw publishes last, each instance
+// must still render the paint it was appended with.
+constexpr std::string_view kGradientThenSolidSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff0000"/>
+      <stop offset="1" stop-color="#ff0000"/>
+    </linearGradient>
+    <rect id="r" x="10" y="10" width="60" height="60"/>
+  </defs>
+  <g fill="url(#g)"><use xlink:href="#r"/></g>
+  <g fill="#00cc00"><use xlink:href="#r" x="100" y="0"/></g>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, GradientThenSolidOfOneEntity_KeepsBothPaints) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap bmp = renderSteadyState(kGradientThenSolidSvg, device).bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  expectPixel(bmp, 40, 40, {255, 0, 0, 255}, "gradient draw of #r");
+  expectPixel(bmp, 140, 40, {0, 204, 0, 255}, "solid <use> of #r");
+}
+
+constexpr std::string_view kGradientTwiceSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff0000"/>
+      <stop offset="1" stop-color="#ff0000"/>
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0000ff"/>
+      <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+    <rect id="r" x="10" y="10" width="60" height="60"/>
+  </defs>
+  <g fill="url(#a)"><use xlink:href="#r"/></g>
+  <g fill="url(#b)"><use xlink:href="#r" x="100" y="0"/></g>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, GradientTwiceOfOneEntity_KeepsBothRamps) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap bmp = renderSteadyState(kGradientTwiceSvg, device).bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  // One slot holds one paint block, so the second ramp overwrites the first
+  // unless the two draws are kept apart. Each must still show its own colour.
+  expectPixel(bmp, 40, 40, {255, 0, 0, 255}, "first gradient draw of #r");
+  expectPixel(bmp, 140, 40, {0, 0, 255, 255}, "second gradient draw of #r");
+}
+
+constexpr std::string_view kCrossEntityGradientRunSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff0000"/>
+      <stop offset="1" stop-color="#ff0000"/>
+    </linearGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0000ff"/>
+      <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="20" width="60" height="60" fill="url(#a)"/>
+  <rect x="110" y="20" width="60" height="60" fill="#00cc00"/>
+  <rect x="210" y="20" width="60" height="60" fill="url(#b)"/>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, GradientAndSolidRunOfDistinctEntities_KeepsPainterOrder) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const SteadyStateFrame frame = renderSteadyState(kCrossEntityGradientRunSvg, device);
+  const RendererBitmap& bmp = frame.bitmap;
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+
+  expectPixel(bmp, 40, 50, {255, 0, 0, 255}, "first gradient fill");
+  expectPixel(bmp, 140, 50, {0, 204, 0, 255}, "solid fill between the gradients");
+  expectPixel(bmp, 240, 50, {0, 0, 255, 255}, "second gradient fill");
+
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    // Distinct entities, so each carries its own record: the interleaved
+    // gradient and solid paints collapse into one draw instead of three plus
+    // the pipeline switches between them.
+    EXPECT_EQ(frame.counters.drawCalls, 1u)
+        << "a gradient/solid/gradient run of distinct entities should form one ordered batch";
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Rect clips carried per instance.
 //
 // Two nested viewports clip their contents to different rectangles, and each

--- a/donner/svg/renderer/geode/tests/GeodeSharedDeviceFrame_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSharedDeviceFrame_tests.cc
@@ -1,0 +1,237 @@
+/// @file
+/// Cross-renderer frame-generation claims on one shared `GeodeDevice`.
+///
+/// Two renderers routinely share a device: an offscreen instance renders an
+/// feImage fragment or a layer thumbnail of the SAME document while the outer
+/// renderer's frame is still open and has already recorded draws. Frame
+/// generations are device-scoped and monotonic, so the inner frame's index
+/// never equals the outer's; any "was this touched in the current frame?"
+/// equality gate therefore reads the outer frame's resident slots as free.
+/// Rewriting a slot's instance record or gradient paint block then corrupts
+/// the outer frame retroactively, because every queue write in a frame lands
+/// before every draw in that frame's submit.
+///
+/// Contract under test:
+///  1. `GeodeDevice::frameStampClaimed` claims exactly the stamps at or after
+///     the oldest still-open generation, and never the never-drawn sentinel.
+///  2. End to end: a mid-frame offscreen render of the same document must not
+///     repaint pixels an outer frame has already recorded (the outer frame
+///     keeps the gradient bytes that were live when its batch was appended).
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGElement.h"
+#include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/shape/ComputedPathComponent.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+
+namespace donner::svg {
+namespace {
+
+/// A flat "gradient" (both stops the same blue) so a paint-block rewrite is a
+/// whole-pixel color change rather than a subtle ramp shift. Gradient fill is
+/// required: solid fills read their color from the slot uniform, while a
+/// gradient reads the slot's paint block, which is exactly the storage an
+/// equality-gated inner pass would rewrite.
+constexpr std::string_view kGradientRectSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="100" y2="0">
+      <stop id="s0" offset="0" stop-color="#0000ff"/>
+      <stop id="s1" offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+  </defs>
+  <rect id="target" x="10" y="10" width="60" height="60" fill="url(#g)"/>
+</svg>
+)SVG";
+
+SVGDocument parseDocument(std::string_view svgSource) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(svgSource, sink);
+  EXPECT_FALSE(parsed.hasError()) << (parsed.hasError() ? parsed.error().reason : "");
+  return std::move(parsed.result());
+}
+
+std::array<uint8_t, 4> pixelAt(const RendererBitmap& bitmap, int x, int y) {
+  const uint8_t* pixel =
+      bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes + static_cast<size_t>(x) * 4;
+  return {pixel[0], pixel[1], pixel[2], pixel[3]};
+}
+
+bool isBlue(const std::array<uint8_t, 4>& px) {
+  return px[2] > 200 && px[0] < 60 && px[1] < 60 && px[3] > 200;
+}
+
+class GeodeSharedDeviceFrameTest : public ::testing::Test {
+protected:
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// frameStampClaimed unit contract
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodeSharedDeviceFrameTest, FrameStampClaimedTracksOpenGenerations) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  constexpr uint64_t kNeverDrawn = ~uint64_t{0};
+
+  // No open frame: nothing is claimed, including the never-drawn sentinel,
+  // which a naive `>=` against `oldestOpenFrameGeneration()`'s `~0` idle
+  // value would misread as permanently claimed.
+  EXPECT_FALSE(device->frameStampClaimed(kNeverDrawn));
+  EXPECT_FALSE(device->frameStampClaimed(0));
+
+  const uint64_t outer = device->beginFrameGeneration();
+  // A stamp from the open frame is claimed; earlier (submitted) stamps and
+  // the sentinel are not.
+  EXPECT_TRUE(device->frameStampClaimed(outer));
+  EXPECT_FALSE(device->frameStampClaimed(outer - 1));
+  EXPECT_FALSE(device->frameStampClaimed(kNeverDrawn));
+
+  // A nested (offscreen) generation: stamps from EITHER open frame are
+  // claimed. This is the cross-renderer case an equality gate gets wrong -
+  // `inner != outer` reads "free" while the outer frame's recorded draws
+  // still depend on the stamped bytes.
+  const uint64_t inner = device->beginFrameGeneration();
+  EXPECT_TRUE(device->frameStampClaimed(outer));
+  EXPECT_TRUE(device->frameStampClaimed(inner));
+
+  device->endFrameGeneration(inner);
+  // The inner frame submitted, the outer is still open: the outer stamp
+  // stays claimed, and so does the inner one (it is newer than the oldest
+  // open generation, so an open frame could still have recorded against
+  // buffers it touched).
+  EXPECT_TRUE(device->frameStampClaimed(outer));
+  EXPECT_TRUE(device->frameStampClaimed(inner));
+
+  device->endFrameGeneration(outer);
+  EXPECT_FALSE(device->frameStampClaimed(outer));
+  EXPECT_FALSE(device->frameStampClaimed(inner));
+  EXPECT_FALSE(device->frameStampClaimed(kNeverDrawn));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: mid-frame offscreen render of the same document
+// ---------------------------------------------------------------------------
+
+/// Drives the outer renderer through the public `RendererInterface` surface
+/// exactly as `RendererDriver::traverseRange` does (setPaint from the
+/// instance's resolved fill, setTransform from the instance transform,
+/// drawPath with the entity-bound `PathShape`), because `draw()` records and
+/// submits atomically and the corruption window is BETWEEN those: the outer
+/// frame records its gradient batch, an offscreen renderer of the same
+/// document then draws mid-frame, and only afterwards does the outer frame
+/// submit.
+TEST_F(GeodeSharedDeviceFrameTest, MidFrameOffscreenRenderKeepsRecordedGradientPaint) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  SVGDocument document = parseDocument(kGradientRectSvg);
+  Registry& registry = document.registry();
+  RendererGeode outer(device);
+
+  // Frame 1: a normal draw establishes residence, the entity's record slot,
+  // and the gradient paint block, and proves the baseline pixels are blue.
+  outer.draw(document);
+  {
+    const RendererBitmap baseline = outer.takeSnapshot();
+    ASSERT_FALSE(baseline.empty());
+    const auto px = pixelAt(baseline, 40, 40);
+    ASSERT_TRUE(isBlue(px)) << "Baseline gradient rect must render blue, got rgba(" << int(px[0])
+                            << "," << int(px[1]) << "," << int(px[2]) << "," << int(px[3]) << ")";
+  }
+
+  auto rectElement = document.querySelector("#target");
+  ASSERT_TRUE(rectElement.has_value());
+  const Entity rectEntity = rectElement->entityHandle().entity();
+  const auto& instance = registry.get<components::RenderingInstanceComponent>(rectEntity);
+  const auto& computedPath = registry.get<components::ComputedPathComponent>(rectEntity);
+
+  // Frame 2, hand-driven: record the gradient rect the way the driver does.
+  RenderViewport viewport;
+  viewport.size = Vector2d(100.0, 100.0);
+  viewport.devicePixelRatio = 1.0;
+  outer.beginFrame(viewport);
+
+  PaintParams gradientPaint;
+  gradientPaint.fill = instance.resolvedFill;
+  gradientPaint.fillOpacity = 1.0;
+  gradientPaint.viewBox = Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0);
+  outer.setPaint(gradientPaint);
+  outer.setTransform(instance.worldFromEntityTransform);
+
+  PathShape shape;
+  shape.path = &computedPath.spline;
+  shape.fillRule = FillRule::NonZero;
+  shape.sourceEntity = EntityHandle(registry, rectEntity);
+  outer.drawPath(shape, StrokeParams{});
+
+  // Record the pending gradient batch into the outer frame's command stream
+  // NOW: a solid non-entity draw flushes it (mirroring any later
+  // state-changing draw in a real traversal). From here until `endFrame`,
+  // the recorded batch draw depends on the entity's record slot and paint
+  // block bytes.
+  PaintParams cornerPaint;
+  cornerPaint.fill = PaintServer::Solid(css::Color(css::RGBA(255, 255, 255, 255)));
+  outer.setPaint(cornerPaint);
+  outer.setTransform(Transform2d());
+  outer.drawRect(Box2d::FromXYWH(90.0, 90.0, 8.0, 8.0), StrokeParams{});
+
+  // Mid-frame: animate the gradient to green and render the same document
+  // through an offscreen renderer on the same device (the feImage-fragment /
+  // layer-thumbnail shape). Its fresh generation must see the outer frame's
+  // claims: if it treats the slots as free it publishes green into the paint
+  // block the outer frame's recorded draw reads at submit.
+  {
+    auto stop0 = document.querySelector("#s0");
+    auto stop1 = document.querySelector("#s1");
+    ASSERT_TRUE(stop0.has_value());
+    ASSERT_TRUE(stop1.has_value());
+    stop0->setAttribute("stop-color", "#00ff00");
+    stop1->setAttribute("stop-color", "#00ff00");
+  }
+  std::unique_ptr<RendererInterface> inner = outer.createOffscreenInstance();
+  ASSERT_NE(inner, nullptr);
+  inner->draw(document);
+
+  outer.endFrame();
+
+  const RendererBitmap result = outer.takeSnapshot();
+  ASSERT_FALSE(result.empty());
+  const auto px = pixelAt(result, 40, 40);
+  EXPECT_TRUE(isBlue(px)) << "Outer frame recorded the gradient as blue before the offscreen "
+                             "render; a green pixel means the inner frame rewrote the paint "
+                             "block the recorded draw reads at submit. Got rgba("
+                          << int(px[0]) << "," << int(px[1]) << "," << int(px[2]) << ","
+                          << int(px[3]) << ")";
+
+  // The inner render itself must show the animated green (it drew last with
+  // the updated document), proving the mid-frame render really painted G2 and
+  // the outer's blue is preservation, not a stale inner pass.
+  const RendererBitmap innerResult = static_cast<RendererGeode*>(inner.get())->takeSnapshot();
+  ASSERT_FALSE(innerResult.empty());
+  const auto innerPx = pixelAt(innerResult, 40, 40);
+  EXPECT_TRUE(innerPx[1] > 200 && innerPx[0] < 60 && innerPx[2] < 60)
+      << "Offscreen render must show the animated green gradient, got rgba(" << int(innerPx[0])
+      << "," << int(innerPx[1]) << "," << int(innerPx[2]) << "," << int(innerPx[3]) << ")";
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/tools/gpu_inventory/manifests/shader_features.json
+++ b/tools/gpu_inventory/manifests/shader_features.json
@@ -1391,6 +1391,13 @@
           "group": 0,
           "name": "gridData",
           "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 11,
+          "group": 0,
+          "name": "paintData",
+          "type": "array<vec4f>"
         }
       ],
       "builtins": [
@@ -1425,6 +1432,7 @@
         "continue",
         "discard",
         "dot",
+        "floor",
         "for",
         "fract",
         "fwidth",
@@ -1435,6 +1443,7 @@
         "mat4x4f",
         "max",
         "min",
+        "mix",
         "normalize",
         "return",
         "round",

--- a/tools/gpu_inventory/manifests_integrity_tests.py
+++ b/tools/gpu_inventory/manifests_integrity_tests.py
@@ -72,15 +72,17 @@ class ShaderFeaturesManifestTest(unittest.TestCase):
             ],
         )
         # The instance-record consolidation folded the per-draw uniform
-        # bindings into the record SSBO plus a combined grid binding, so the
-        # solid-fill shader declares 11 bindings.
-        self.assertEqual(len(shader["bindings"]), 11)
+        # bindings into the record SSBO plus a combined grid binding, and
+        # gradient paint blocks add one more storage binding, so the
+        # solid-fill shader declares 12 bindings.
+        self.assertEqual(len(shader["bindings"]), 12)
         bindings = {entry["binding"]: entry["name"] for entry in shader["bindings"]}
         # Curve references and both band grids live in the combined grid
-        # storage at binding 10; the per-instance records ride binding 7.
+        # storage at binding 10, the per-instance records ride binding 7, and
+        # the gradient paint blocks ride binding 11.
         self.assertEqual(
-            {binding: bindings[binding] for binding in (7, 10)},
-            {7: "instances", 10: "gridData"},
+            {binding: bindings[binding] for binding in (7, 10, 11)},
+            {7: "instances", 10: "gridData", 11: "paintData"},
         )
 
     def test_every_shader_has_an_entry_point(self):


### PR DESCRIPTION
Stacked on the font-identity PR; review that one first. This PR's own diff is
the nine pathID commits.

## Summary

Three changes let ordered batching hold runs it previously had to break:

1. **Clip rect as record data.** The scissor is opened per batched draw from a
   per-instance rect, so a clip no longer forces a solo draw.
2. **Strokes join the batch.** Stroke draws append when their encode compares
   equal, instead of always starting a new run.
3. **Gradient fills resolve by record index.** A 25-row paint block lives in the
   residence slot at binding 11, and the batched shader entry point reads the
   gradient through the record rather than a per-draw uniform.

## Correctness work, which is most of the diff

Batching a gradient made a latent record-lifetime hazard reachable, and the
fixes are worth reviewing more closely than the feature itself.

**Paint replay from the append, not the slot.** A batched instance captures its
paint and clip state by value when it is appended. Previously the flush re-read
those scalars from the residence slot, so a solo draw of the same entity landing
between append and flush could republish the slot and make an already-appended
gradient render as opaque black.

**Resident slots are claimed across every open frame generation.** The slot
reuse gates compared the stamp for equality against the current frame. Frame
generations are per device, so an offscreen renderer created from the same
device mid-frame (an filter fragment, a layer thumbnail) gets a new generation,
reads "slot free", and can rewrite a gradient paint block or record that the
outer frame's already-recorded draws still reference; the queued write lands
before the outer submit. The gates now ask whether the stamp falls within any
open generation, with the never-drawn sentinel handled explicitly. Five gates
were converted, including the two resident gradient paths.

**Stable buffer ids through every batch opener.** The glyph and gradient batch
openers left the bind-group cache keys unstamped, which silently disabled
caching for those batches rather than failing.

## Tests

- A shared-device frame test covering the stamp predicate directly, plus an
  end-to-end case that records a gradient batch, mutates the gradient, renders
  an offscreen pass from the same device mid-frame, and asserts the outer frame
  keeps its original pixels. It fails without the guard.
- Gradient ordering cases for solid-then-gradient, gradient-then-solid,
  gradient-twice, and mixed runs of distinct entities on one slot.
- Counter ratchets pinned per configuration.

## Counter results, verified at this head

Draw and buffer-write counts are deterministic and pinned by the corpus tests,
so these are current rather than historical:

- `z0rly_test6` previously needed a bind-group-create ceiling of 22 and now
  reaches the shared target outright, so its entry is deleted. Its own tracking
  note predicted exactly this once bind groups were cached across draws sharing
  a pipeline.
- Two `use`-instance scenes reach zero buffer writes with batching while still
  needing their ceiling without it.

To express that honestly the ratchet gained a build-aware violated mask
alongside the existing ceiling, because batching can clear a violation outright
rather than only lower its number, and an entry still naming a counter the
shipped build already holds would hide the next regression behind a stale
ceiling.

Wall-clock figures measured earlier on this branch are deliberately not quoted
here: the correctness fixes above landed after that run, and a re-measurement at
this exact head is in progress. I will post it as a comment rather than claim a
number this head has not produced.

## Verification

Both compile-time batching states pass on discrete-GPU hardware: 81 pass, 3
config-gated skips. The gradient perf cases and both shared-device frame cases
are green by name.

Known, inherited from the font/text PRs below this one and not introduced here:
with batching compiled off, the counter corpus is red on three text scenes,
because the ratchet rework in that PR made the entries describe the shipped
build only. Verified by running that branch alone with the flag off and getting
the identical three failures. The compile-time constant means CI never exercises
that configuration; it affects only manual bisection builds.
