### PR TITLE
ci: Retry apt installs inside the shell instead of under a kill-based wrapper

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,92 @@
+name: Install apt packages
+description: >-
+  Install Debian packages with retries that run inside the shell, so a slow
+  mirror costs time instead of failing the job.
+
+# Why this exists rather than a retry wrapper action:
+#
+# These installs used to run under a third-party retry action with a five
+# minute per-attempt timeout. When that timeout fired, the action tried to
+# kill the running command, but the command is `sudo apt-get`, whose process
+# the runner user is not permitted to signal. The kill failed with EPERM and
+# the action reported that error as the step result, so an apt run that was
+# merely slow became a hard job failure. It hit the sanitizer, linker canary,
+# and CodeQL lanes repeatedly, each time costing a rerun on a job that had
+# nothing wrong with it.
+#
+# Retrying inside the shell removes that failure mode: nothing external needs
+# to signal the process, so there is no kill to be denied. A hung apt is still
+# bounded, but by `timeout` sending signals to a process tree the shell owns,
+# and by the job's own `timeout-minutes`.
+inputs:
+  packages:
+    description: >-
+      Packages to install. Whitespace or newline separated; a trailing
+      backslash is not needed.
+    required: true
+  attempts:
+    description: How many times to try the update/install pair.
+    required: false
+    default: "3"
+  attempt-timeout:
+    description: >-
+      Per-attempt wall clock limit, as a `timeout(1)` duration. Generous on
+      purpose: exceeding it means apt is stuck, not merely slow.
+    required: false
+    default: "15m"
+  retry-wait-seconds:
+    description: Seconds to wait between attempts.
+    required: false
+    default: "15"
+
+runs:
+  using: composite
+  steps:
+    - name: Install packages
+      shell: bash
+      env:
+        APT_PACKAGES: ${{ inputs.packages }}
+        APT_ATTEMPTS: ${{ inputs.attempts }}
+        APT_ATTEMPT_TIMEOUT: ${{ inputs.attempt-timeout }}
+        APT_RETRY_WAIT: ${{ inputs.retry-wait-seconds }}
+      run: |
+        set -euo pipefail
+
+        # Collapse the input to one line so the caller can format the list
+        # readably in YAML without worrying about continuations.
+        read -r -a packages <<< "$(printf '%s' "$APT_PACKAGES" | tr '\n' ' ')"
+        if [ "${#packages[@]}" -eq 0 ]; then
+          echo "apt-install: no packages requested" >&2
+          exit 1
+        fi
+
+        export DEBIAN_FRONTEND=noninteractive
+
+        attempt=1
+        while true; do
+          echo "::group::apt attempt ${attempt} of ${APT_ATTEMPTS}"
+          status=0
+          # `timeout` signals the process group it started, which this shell
+          # owns, so a stuck mirror is bounded without any cross-user kill.
+          timeout --signal=TERM --kill-after=30s "$APT_ATTEMPT_TIMEOUT" \
+            sudo -E apt-get update || status=$?
+          if [ "$status" -eq 0 ]; then
+            timeout --signal=TERM --kill-after=30s "$APT_ATTEMPT_TIMEOUT" \
+              sudo -E apt-get install -y --no-install-recommends "${packages[@]}" || status=$?
+          fi
+          echo "::endgroup::"
+
+          if [ "$status" -eq 0 ]; then
+            sudo apt-get clean || true
+            exit 0
+          fi
+
+          if [ "$attempt" -ge "$APT_ATTEMPTS" ]; then
+            echo "apt-install: failed after ${APT_ATTEMPTS} attempts (last status ${status})" >&2
+            exit "$status"
+          fi
+
+          echo "apt-install: attempt ${attempt} failed with status ${status}; retrying in ${APT_RETRY_WAIT}s" >&2
+          sleep "$APT_RETRY_WAIT"
+          attempt=$((attempt + 1))
+        done

--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -52,6 +52,10 @@ runs:
       run: |
         set -euo pipefail
 
+        # `Acquire::Retries` retries an individual fetch inside one apt run, which
+        # is a different layer from retrying the whole install below: it covers a
+        # single flaky mirror response without paying for a full re-run.
+
         # Collapse the input to one line so the caller can format the list
         # readably in YAML without worrying about continuations.
         read -r -a packages <<< "$(printf '%s' "$APT_PACKAGES" | tr '\n' ' ')"
@@ -69,10 +73,11 @@ runs:
           # `timeout` signals the process group it started, which this shell
           # owns, so a stuck mirror is bounded without any cross-user kill.
           timeout --signal=TERM --kill-after=30s "$APT_ATTEMPT_TIMEOUT" \
-            sudo -E apt-get update || status=$?
+            sudo -E apt-get -o Acquire::Retries=3 update || status=$?
           if [ "$status" -eq 0 ]; then
             timeout --signal=TERM --kill-after=30s "$APT_ATTEMPT_TIMEOUT" \
-              sudo -E apt-get install -y --no-install-recommends "${packages[@]}" || status=$?
+              sudo -E apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+                "${packages[@]}" || status=$?
           fi
           echo "::endgroup::"
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -131,6 +131,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     needs: [gatekeeper, validate-generator]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:
@@ -143,10 +144,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ccache ninja-build
-          sudo apt-get clean
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ccache ninja-build
 
       # Cache key includes both gen_cmakelists.py AND MODULE.bazel because the
       # generated CMakeLists.txt embeds FetchContent versions extracted from
@@ -187,6 +187,7 @@ jobs:
 
   macos:
     runs-on: macos-26
+    timeout-minutes: 60
     needs: [gatekeeper, validate-generator]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,20 +55,12 @@ jobs:
 
       - name: Install system dependencies
         if: matrix.build-mode == 'manual'
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6
-            sudo apt-get clean
-
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev libosmesa6
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,17 +43,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/github_hosted_nightly.yml
+++ b/.github/workflows/github_hosted_nightly.yml
@@ -77,17 +77,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev libosmesa6
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -495,19 +495,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6 clang-tidy-19
-            sudo apt-get clean
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev libosmesa6 clang-tidy-19
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -580,16 +580,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        timeout-minutes: 15
-        shell: bash
-        run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-            pkg-config libfontconfig1-dev libfreetype6-dev \
-            mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+        uses: ./.github/actions/apt-install
+        with:
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
             libgl1-mesa-dev libosmesa6
-          sudo apt-get clean
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -34,19 +34,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev clang-tidy-19
-            sudo apt-get clean
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev clang-tidy-19
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -64,17 +64,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6 clang-tidy-19
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev libosmesa6 clang-tidy-19
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -132,17 +127,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
+        uses: ./.github/actions/apt-install
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6 clang-tidy-19
+          packages: >-
+            pkg-config libfontconfig1-dev libfreetype6-dev mesa-vulkan-drivers libvulkan1
+            libvulkan-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libgl1-mesa-dev libosmesa6 clang-tidy-19
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,7 @@ exports_files(
         "donner_splash.svg",
         "BUILD.bazel",
         "MODULE.bazel",
+        ".github/actions/apt-install/action.yml",
         ".github/actions/re-turnstile/action.yml",
         ".github/actions/re-turnstile/admission.py",
         ".github/workflows/cmake.yml",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -126,6 +126,7 @@ py_test(
     srcs = ["ci_runtime_workflow_tests.py"],
     data = [
         "//:.bazelrc",
+        "//:.github/actions/apt-install/action.yml",
         "//:.github/workflows/cmake.yml",
         "//:.github/workflows/coverage.yml",
         "//:.github/workflows/editor_wasm.yml",

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -192,8 +192,11 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         self.assertEqual(2, self.apt_install.count("Acquire::Retries=3"))
         self.assertIn("attempt=$((attempt + 1))", self.apt_install)
 
-        # Every apt-installing lane routes through the action.
-        self.assertNotIn("nick-fields/retry", self.main.split("brew install")[0])
+        # No surviving wrapper wraps an apt install. A wrapper around brew is
+        # fine and still present: brew does not run under sudo, so the kill
+        # that fails here would succeed there.
+        for block in self.main.split("uses: nick-fields/retry")[1:]:
+            self.assertNotIn("apt-get", block.split("- name:", 1)[0])
 
     def test_cmake_generator_validation_retries_only_after_failure(self):
         """Transient Bazel query failures get one retry without masking a persistent failure."""

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -29,6 +29,7 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         cls.editor_wasm = _workflow_text(".github/workflows/editor_wasm.yml")
         cls.lint = _workflow_text(".github/workflows/lint.yml")
         cls.coverage_script = _workflow_text("tools/coverage.sh")
+        cls.apt_install = _workflow_text(".github/actions/apt-install/action.yml")
 
     def _job_body(self, job):
         marker = "\n  %s:\n" % job
@@ -164,16 +165,35 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 self.assertNotIn("tools/ci_bazel_test.sh", step)
 
     def test_linker_canary_uses_bounded_native_apt_retries(self):
-        """The hosted canary must not ask an unprivileged action to kill apt."""
+        """The hosted canary must not ask an unprivileged action to kill apt.
+
+        The bound now lives in the shared action rather than the step: retrying
+        inside the shell means nothing external has to signal a sudo-owned
+        process, which is the failure this contract exists to prevent.
+        """
         job = self._job_body("linker-canary")
         install = job.split("- name: Install system dependencies", 1)[1].split(
             "- name: Setup Bazel", 1
         )[0]
 
         self.assertNotIn("nick-fields/retry", install)
-        self.assertIn("timeout-minutes: 15", install)
-        self.assertEqual(2, install.count("Acquire::Retries=3"))
+        self.assertIn("uses: ./.github/actions/apt-install", install)
         self.assertNotIn("clang-tidy", install)
+
+    def test_shared_apt_action_bounds_and_retries_without_external_kill(self):
+        """Every apt install inherits the bound, so no lane can regress alone."""
+        # No wrapper that would have to kill a sudo-owned process.
+        self.assertNotIn("nick-fields/retry", self.apt_install)
+        # A stuck apt is bounded by a timeout the shell itself owns.
+        self.assertIn("timeout --signal=TERM", self.apt_install)
+        self.assertIn('attempt-timeout', self.apt_install)
+        # Transport-level retries cover a single flaky fetch; the surrounding
+        # loop covers apt failing or hanging outright.
+        self.assertEqual(2, self.apt_install.count("Acquire::Retries=3"))
+        self.assertIn("attempt=$((attempt + 1))", self.apt_install)
+
+        # Every apt-installing lane routes through the action.
+        self.assertNotIn("nick-fields/retry", self.main.split("brew install")[0])
 
     def test_cmake_generator_validation_retries_only_after_failure(self):
         """Transient Bazel query failures get one retry without masking a persistent failure."""


### PR DESCRIPTION
## Problem

Package installs in CI ran under a retry action with a five minute per-attempt
timeout. When that timeout fired, the action tried to kill the running command,
but the command is `sudo apt-get`, whose process the runner user is not
permitted to signal. The kill failed with `EPERM` and the action reported that
error as the step result, so an apt run that was merely slow became a hard job
failure.

Observed shape, from one of the failures:

```
2026-08-19T07:10:00Z  Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
2026-08-19T07:15:01Z  Error: kill EPERM
```

Exactly five minutes, then the wrapper's own error rather than apt's. The build
never started. This recurred on the sanitizer, linker canary, and CodeQL lanes,
each occurrence costing a rerun on a job that had nothing wrong with it.

All seven wrapped installs used the same five minute limit, which is why the
failure moved between lanes rather than staying in one.

## Change

Retry inside the shell, behind one composite action:

- Nothing external needs to signal the process, so there is no kill to be
  denied. The `EPERM` failure mode is removed rather than made rarer.
- A genuinely stuck apt is still bounded, by `timeout(1)` signalling a process
  tree the shell owns. The per-attempt limit is 15 minutes, generous on purpose:
  exceeding it means apt is stuck, not slow.
- The repeated update / install / clean boilerplate collapses into a package
  list input at each call site.

The CMake lane is included for a related reason: it installed packages with no
retry **and** no job timeout, so a stuck install there burned the six hour
default before failing. Runs wedged that way have been observed on several
branches at once, and one from a week earlier was still wedged. It now shares
the action, and both of its jobs are bounded at 60 minutes.

The one remaining wrapped install is a `brew` step on macOS, which does not run
under `sudo` and so cannot hit this failure; it is left alone.

## Verification

All 19 workflow and tooling test batteries pass, including the ones that assert
on workflow structure and runner routing. The composite action's shell is
syntax-checked, and the package lists were transcribed mechanically and diffed
against the originals rather than retyped.
