### PR TITLE
ci: Do not fail the coverage lane when every target was skipped

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -77,6 +77,15 @@ py_test(
 )
 
 py_test(
+    name = "coverage_bep_status_tests",
+    size = "small",
+    srcs = [
+        "coverage_bep_status.py",
+        "coverage_bep_status_tests.py",
+    ],
+)
+
+py_test(
     name = "coverage_instrumentable_targets_tests",
     size = "small",
     srcs = [

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -365,9 +365,16 @@ fi
     mkdir -p "$DONNER_CI_DIAGNOSTICS_DIR/coverage"
     DIAG_FLAGS=(
       --profile="$DONNER_CI_DIAGNOSTICS_DIR/coverage/profile.gz"
-      --build_event_json_file="$DONNER_CI_DIAGNOSTICS_DIR/coverage/bep.json"
     )
+    COVERAGE_BEP="$DONNER_CI_DIAGNOSTICS_DIR/coverage/bep.json"
+  else
+    COVERAGE_BEP="$COVERAGE_HTML_DIR/bep.json"
   fi
+  # The build event stream is written unconditionally, not only under CI
+  # diagnostics: the missing-report guard below reads it to tell "every target
+  # was skipped as incompatible with this platform" apart from a real failure,
+  # and that distinction has to work wherever this script runs.
+  DIAG_FLAGS+=(--build_event_json_file="$COVERAGE_BEP")
   phase_mark() {
     if [ -n "${DONNER_CI_DIAGNOSTICS_DIR:-}" ]; then
       echo "$1=$(date +%s)" >> "$DONNER_CI_DIAGNOSTICS_DIR/coverage/timing.txt"
@@ -404,6 +411,25 @@ fi
   phase_mark bazel_coverage_done
 
   if [ ! -f "$COVERAGE_REPORT" ]; then
+    # Fail closed by default: an absent report must never read as success,
+    # because a silently empty report would claim full coverage of nothing.
+    #
+    # The one benign cause is that every selected target is restricted to a
+    # platform this lane does not run on, so Bazel skipped them all and there
+    # was nothing to measure. A change touching only such a target would
+    # otherwise be unable to pass this lane on any run. Consult the build event
+    # stream, which names skipped targets explicitly, and exit cleanly only
+    # when it positively shows skipping accounted for every target.
+    BEP_STATUS="unknown"
+    if [ -f "$COVERAGE_BEP" ]; then
+      BEP_STATUS="$(python3 tools/coverage_bep_status.py "$COVERAGE_BEP" |
+        python3 -c 'import json, sys; print(json.load(sys.stdin)["status"])')"
+    fi
+    if [ "$BEP_STATUS" = "all_skipped" ]; then
+      echo "No coverage report: every selected target was skipped as incompatible with this platform."
+      echo "Nothing to measure here; treating the lane as satisfied."
+      exit 0
+    fi
     echo "ERROR: Coverage report was not generated"
     exit 1
   fi

--- a/tools/coverage_bep_status.py
+++ b/tools/coverage_bep_status.py
@@ -1,0 +1,114 @@
+"""Classify why a `bazel coverage` run produced no coverage report.
+
+`tools/coverage.sh` fails closed when the report is missing, because a silently
+empty report would report full coverage of nothing. That guard is right for the
+usual causes (a build error, a crashed test, a cancelled run), but it also fires
+on a legitimate case: every selected target is `target_compatible_with` a
+platform this lane does not run on, so Bazel skips them all and there is nothing
+to measure. A pull request that only touches such a target hits this on every
+run and can never go green.
+
+This module reads the build event protocol stream and separates those cases, so
+the shell script keeps failing closed except when the stream positively shows
+that skipping accounted for every target.
+
+Reads a BEP JSON-lines file; writes one JSON document to stdout:
+
+    {"status": "all_skipped", "skipped": ["//pkg:target"], "produced": []}
+
+`status` is one of:
+
+  all_skipped  At least one target was skipped for incompatibility and NO
+               target produced a result. Nothing was measurable here.
+  has_results  At least one target produced a result, so a missing report is a
+               real failure.
+  unknown      The stream is absent, empty, or unparseable. Callers must treat
+               this as a failure: absence of evidence is not evidence that
+               skipping happened.
+"""
+
+import json
+import sys
+
+ALL_SKIPPED = "all_skipped"
+HAS_RESULTS = "has_results"
+UNKNOWN = "unknown"
+
+
+def classify(lines):
+    """Classify an iterable of BEP JSON-lines strings.
+
+    A target that Bazel skips for incompatibility appears as an `aborted` event
+    with reason SKIPPED. A target that actually ran appears as a `completed`
+    event carrying a success field, or as a test result. Malformed lines are
+    ignored rather than fatal: the stream is written incrementally and a run
+    killed mid-write can leave a partial final line.
+    """
+    skipped = []
+    produced = []
+    saw_any = False
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        saw_any = True
+
+        label = _label(event.get("id"))
+
+        aborted = event.get("aborted")
+        if isinstance(aborted, dict) and aborted.get("reason") == "SKIPPED":
+            if label:
+                skipped.append(label)
+            continue
+
+        completed = event.get("completed")
+        if isinstance(completed, dict) and completed.get("success") and label:
+            produced.append(label)
+            continue
+
+        if "testResult" in event and label:
+            produced.append(label)
+
+    if not saw_any:
+        return {"status": UNKNOWN, "skipped": [], "produced": []}
+    if produced:
+        return {"status": HAS_RESULTS, "skipped": skipped, "produced": produced}
+    if skipped:
+        return {"status": ALL_SKIPPED, "skipped": skipped, "produced": []}
+    return {"status": UNKNOWN, "skipped": [], "produced": []}
+
+
+def _label(event_id):
+    """Pull a target label out of a BEP event id, whichever shape it uses."""
+    if not isinstance(event_id, dict):
+        return None
+    for key in ("targetCompleted", "targetConfigured", "testResult", "testSummary"):
+        holder = event_id.get(key)
+        if isinstance(holder, dict) and holder.get("label"):
+            return holder["label"]
+    return None
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.stderr.write("usage: coverage_bep_status.py <bep.json>\n")
+        return 2
+    try:
+        with open(argv[1], "r", encoding="utf-8", errors="replace") as stream:
+            result = classify(stream)
+    except OSError:
+        result = {"status": UNKNOWN, "skipped": [], "produced": []}
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/coverage_bep_status_tests.py
+++ b/tools/coverage_bep_status_tests.py
@@ -1,0 +1,96 @@
+"""Tests for the coverage BEP classifier.
+
+The classifier decides whether a missing coverage report is benign, so the
+interesting cases are the ones where it must REFUSE to say "benign": a real
+build failure, a partial stream, and a run that mixed a skip with a result.
+"""
+
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import coverage_bep_status as status
+
+
+def skipped_event(label):
+    return json.dumps(
+        {
+            "id": {"targetCompleted": {"label": label}},
+            "aborted": {
+                "reason": "SKIPPED",
+                "description": "Target %s build was skipped." % label,
+            },
+        }
+    )
+
+
+def completed_event(label, success=True):
+    return json.dumps(
+        {"id": {"targetCompleted": {"label": label}}, "completed": {"success": success}}
+    )
+
+
+def test_result_event(label):
+    return json.dumps(
+        {"id": {"testResult": {"label": label}}, "testResult": {"status": "PASSED"}}
+    )
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_single_incompatible_target_is_all_skipped(self):
+        # The real shape this was written for: a pull request whose only
+        # affected target is restricted to another platform.
+        result = status.classify([skipped_event("//donner/editor/wasm/tests:smoke")])
+        self.assertEqual(result["status"], status.ALL_SKIPPED)
+        self.assertEqual(result["skipped"], ["//donner/editor/wasm/tests:smoke"])
+
+    def test_every_target_skipped_is_all_skipped(self):
+        result = status.classify(
+            [skipped_event("//a:one"), skipped_event("//b:two")]
+        )
+        self.assertEqual(result["status"], status.ALL_SKIPPED)
+        self.assertEqual(result["skipped"], ["//a:one", "//b:two"])
+
+    def test_one_result_alongside_a_skip_is_not_benign(self):
+        # A target really ran, so a missing report means something went wrong
+        # with the report, not that there was nothing to measure.
+        result = status.classify([skipped_event("//a:one"), completed_event("//b:two")])
+        self.assertEqual(result["status"], status.HAS_RESULTS)
+        self.assertEqual(result["produced"], ["//b:two"])
+
+    def test_test_result_counts_as_a_result(self):
+        result = status.classify([test_result_event("//a:one")])
+        self.assertEqual(result["status"], status.HAS_RESULTS)
+
+    def test_failed_completion_is_not_a_result_but_is_not_benign_either(self):
+        # An unsuccessful completion with no skip is the ordinary build-failure
+        # case; it must stay unknown so the caller keeps failing closed.
+        result = status.classify([completed_event("//a:one", success=False)])
+        self.assertEqual(result["status"], status.UNKNOWN)
+
+    def test_empty_stream_is_unknown(self):
+        self.assertEqual(status.classify([])["status"], status.UNKNOWN)
+        self.assertEqual(status.classify(["", "  "])["status"], status.UNKNOWN)
+
+    def test_unparseable_stream_is_unknown(self):
+        self.assertEqual(status.classify(["not json"])["status"], status.UNKNOWN)
+
+    def test_partial_trailing_line_does_not_hide_a_skip(self):
+        # A run killed mid-write leaves a truncated final line; the completed
+        # events before it still classify.
+        result = status.classify([skipped_event("//a:one"), '{"id": {"targetCom'])
+        self.assertEqual(result["status"], status.ALL_SKIPPED)
+
+    def test_non_object_json_lines_are_ignored(self):
+        self.assertEqual(status.classify(["[1,2,3]", "null"])["status"], status.UNKNOWN)
+
+    def test_missing_file_is_unknown(self):
+        self.assertEqual(status.main(["prog", "/nonexistent/bep.json"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The coverage lane fails closed when `bazel coverage` produces no report:

```
ERROR: Coverage report was not generated
```

That guard is right for the usual causes, and should stay: a build error, a
crashed test, or a cancelled run must not pass, because a silently empty report
would claim full coverage of nothing.

It also fires on a case that is not a failure. When every target selected for a
change is restricted, via `target_compatible_with`, to a platform this lane does
not run on, Bazel skips them all, nothing is measured, and no report is
produced. A change touching only such a target then cannot pass the lane on any
run, no matter how many reruns.

This is not hypothetical. A recent change restricting a browser test to macOS
selected exactly one target, and its coverage run reduced to:

```
Analyzing: target //donner/editor/wasm/tests:chromium_remote_smoke
INFO:
```

with the build event stream recording the target as aborted, reason `SKIPPED`.

## Change

Consult the build event stream before failing. Exit cleanly only when it
positively shows that skipping accounted for every target and none produced a
result. Everything else keeps failing exactly as before, including an absent,
empty, or unparseable stream: absence of evidence that skipping happened is not
evidence for it.

The stream is now written unconditionally rather than only under CI diagnostics,
since the guard has to work wherever the script runs.

The classifier is a separate pure module rather than inline shell, because its
job is to decide when *not* to fail, which is the logic most likely to rot
unnoticed. It has unit tests covering the cases where it must refuse to call a
missing report benign: a real result alongside a skip, a failed completion, an
empty stream, unparseable input, and a stream truncated mid-write by a killed
run.

## Verification

Checked against real artifacts from two production runs, not only synthetic
fixtures:

- the skipped-only run above classifies `all_skipped`, so the lane would now
  pass rather than fail;
- a coverage run that had genuine test failures classifies `has_results`, so it
  still fails closed.

All 19 tooling batteries pass, including the new one.
