### PR TITLE
fix: Keep hidden replay windows at their requested size

### DIFF
--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -1039,6 +1039,20 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
 #endif
 #endif
 
+#ifndef __EMSCRIPTEN__
+  // A hidden window never shows chrome, and dropping it is what makes the
+  // requested size reachable: AppKit constrains a *titled* window's frame to
+  // the display it lands on, so a hidden 1600x900 replay window on a small
+  // headless display (a GitHub-hosted macOS runner is 1024x768) silently
+  // becomes 1024x645. That reshapes the editor's dock layout and invalidates
+  // every device-pixel coordinate a capture test asserts on, while the replay
+  // still reports success. Borderless windows are exempt from that constraint,
+  // so hidden windows get the framebuffer they asked for on any display.
+  if (!options_.visible) {
+    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+  }
+#endif
+
   const int initialWidth =
 #ifdef __EMSCRIPTEN__
       CanvasPixelWidth();

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -1040,17 +1040,26 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
 #endif
 
 #ifndef __EMSCRIPTEN__
-  // A hidden window never shows chrome, and dropping it is what makes the
-  // requested size reachable: AppKit constrains a *titled* window's frame to
-  // the display it lands on, so a hidden 1600x900 replay window on a small
-  // headless display (a GitHub-hosted macOS runner is 1024x768) silently
-  // becomes 1024x645. That reshapes the editor's dock layout and invalidates
-  // every device-pixel coordinate a capture test asserts on, while the replay
-  // still reports success. Borderless windows are exempt from that constraint,
-  // so hidden windows get the framebuffer they asked for on any display.
-  if (!options_.visible) {
-    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
-  }
+  // Hidden windows are undecorated so the window server cannot quietly rewrite
+  // the size they asked for. AppKit constrains a *titled* window's frame to the
+  // display it lands on, and where it lands matters: the first window in a
+  // process is centered and usually escapes, while a later cascaded one is
+  // pushed toward the screen edge and shrunk to fit. A replay window that comes
+  // back smaller reshapes the editor's dock layout, which invalidates every
+  // device-pixel crop and canvas-relative pointer coordinate a capture test
+  // asserts on, while the replay still reports success. Borderless windows are
+  // exempt from that constraint, so hidden windows keep the geometry they
+  // requested on any display.
+  //
+  // Hints are sticky for the lifetime of the GLFW library, so set both arms
+  // rather than only the false one: a hidden window must not leave later
+  // windows in the same process undecorated.
+  //
+  // A visible replay (the interactive debugging path) stays decorated and so
+  // keeps the constraint. It can still reflow on a display smaller than the
+  // recording, which is worth knowing when using it to chase a hidden-replay
+  // failure.
+  glfwWindowHint(GLFW_DECORATED, options_.visible ? GLFW_TRUE : GLFW_FALSE);
 #endif
 
   const int initialWidth =

--- a/donner/editor/gui/EditorWindow.h
+++ b/donner/editor/gui/EditorWindow.h
@@ -164,6 +164,9 @@ struct EditorWindowOptions {
   int initialHeight = 720;
   /// Whether the native desktop window should be shown. Hidden windows still
   /// create a real OpenGL context and are useful for framebuffer replay tests.
+  /// They are additionally created undecorated: a titled window's frame is
+  /// constrained to the display it lands on, and a silently shrunk replay
+  /// window changes the editor's layout. See the constructor for details.
   bool visible = true;
   /// Request an offscreen framebuffer-readback replay surface. Linux uses GLFW's
   /// windowless "null" platform (OSMesa software GL), even when a display is

--- a/donner/editor/tests/EditorWindowOffscreenTarget_tests.cc
+++ b/donner/editor/tests/EditorWindowOffscreenTarget_tests.cc
@@ -53,6 +53,49 @@ TEST(EditorWindowOffscreenTargetTest, ForceOffscreenRenderTargetDefaultsOff) {
   EXPECT_FALSE(EditorWindowOptions{}.forceOffscreenRenderTarget);
 }
 
+// A hidden replay window must get the framebuffer it asked for, whatever the
+// host display can show. macOS constrains a titled window's frame to its
+// screen, so a 1600x900 replay on a 1024x768 headless runner quietly rendered
+// at 1024x645: the dock layout reflowed, the render pane moved, and every
+// capture test that crops device pixels or injects a canvas-relative click
+// compared the wrong region while the replay still reported success.
+//
+// A developer display is large enough that one oversized window can escape the
+// constraint, so this opens a window first and then asks for an oversized one -
+// the position AppKit picks for the second window is what makes the clamp
+// reachable here. Both windows must come back at their requested size.
+TEST(EditorWindowOffscreenTargetTest, HiddenWindowsKeepTheirRequestedSize) {
+  constexpr Vector2i kFirstRequested(1600, 900);
+  constexpr Vector2i kOversizedRequested(4000, 2400);
+
+  const auto openHidden = [](Vector2i requested) {
+    return EditorWindow(EditorWindowOptions{
+        .title = "Hidden Window Size Test",
+        .initialWidth = requested.x,
+        .initialHeight = requested.y,
+        .visible = false,
+        .offscreen = true,
+    });
+  };
+
+  {
+    EditorWindow first = openHidden(kFirstRequested);
+#if defined(__linux__)
+    ASSERT_TRUE(first.valid());
+#else
+    if (!first.valid()) {
+      GTEST_SKIP() << "editor window is unavailable on this host";
+    }
+#endif
+    EXPECT_EQ(first.framebufferSize(), kFirstRequested);
+  }
+
+  EditorWindow oversized = openHidden(kOversizedRequested);
+  ASSERT_TRUE(oversized.valid());
+  EXPECT_EQ(oversized.framebufferSize(), kOversizedRequested)
+      << "the host clamped the hidden replay window to its display";
+}
+
 #if defined(DONNER_EDITOR_WGPU)
 
 TEST(EditorWindowOffscreenTargetTest, ForcedOffscreenTargetRendersAndReadsBackOnEveryPlatform) {

--- a/donner/editor/tests/EditorWindowOffscreenTarget_tests.cc
+++ b/donner/editor/tests/EditorWindowOffscreenTarget_tests.cc
@@ -53,21 +53,28 @@ TEST(EditorWindowOffscreenTargetTest, ForceOffscreenRenderTargetDefaultsOff) {
   EXPECT_FALSE(EditorWindowOptions{}.forceOffscreenRenderTarget);
 }
 
-// A hidden replay window must get the framebuffer it asked for, whatever the
-// host display can show. macOS constrains a titled window's frame to its
-// screen, so a 1600x900 replay on a 1024x768 headless runner quietly rendered
-// at 1024x645: the dock layout reflowed, the render pane moved, and every
-// capture test that crops device pixels or injects a canvas-relative click
-// compared the wrong region while the replay still reported success.
+// A hidden replay window must keep the size it asked for, whatever the host
+// display can show. macOS constrains a titled window's frame to the display it
+// lands on, so a replay window recorded at 1600x900 came back at 1024x645 on a
+// runner with a small virtual display: the dock layout reflowed, the render
+// pane moved, and every capture test that crops device pixels or injects a
+// canvas-relative click compared the wrong region while the replay still
+// reported success.
 //
-// A developer display is large enough that one oversized window can escape the
-// constraint, so this opens a window first and then asks for an oversized one -
-// the position AppKit picks for the second window is what makes the clamp
-// reachable here. Both windows must come back at their requested size.
+// The constraint depends on where the window lands, not on size alone. The
+// first window in a process is centered and escapes it on a large display, so
+// reaching the clamp here takes a second, cascaded window that is larger than
+// the screen. That is also why only part of the replay suite failed in CI.
+//
+// Assert on the logical window size rather than the framebuffer: points are
+// what AppKit constrains, and the comparison then holds at any backing scale
+// instead of assuming the host is 1x.
 TEST(EditorWindowOffscreenTargetTest, HiddenWindowsKeepTheirRequestedSize) {
   constexpr Vector2i kFirstRequested(1600, 900);
   constexpr Vector2i kOversizedRequested(4000, 2400);
 
+  // Returned by value: C++17 guaranteed copy elision constructs into the
+  // caller's storage, so EditorWindow needs neither a copy nor a move ctor.
   const auto openHidden = [](Vector2i requested) {
     return EditorWindow(EditorWindowOptions{
         .title = "Hidden Window Size Test",
@@ -87,13 +94,13 @@ TEST(EditorWindowOffscreenTargetTest, HiddenWindowsKeepTheirRequestedSize) {
       GTEST_SKIP() << "editor window is unavailable on this host";
     }
 #endif
-    EXPECT_EQ(first.framebufferSize(), kFirstRequested);
+    EXPECT_EQ(first.windowSize(), kFirstRequested);
   }
 
   EditorWindow oversized = openHidden(kOversizedRequested);
   ASSERT_TRUE(oversized.valid());
-  EXPECT_EQ(oversized.framebufferSize(), kOversizedRequested)
-      << "the host clamped the hidden replay window to its display";
+  EXPECT_EQ(oversized.windowSize(), kOversizedRequested)
+      << "the host constrained the hidden replay window to its display";
 }
 
 #if defined(DONNER_EDITOR_WGPU)


### PR DESCRIPTION
Three `gl_rnr_replay` tests fail on the GitHub-hosted macOS lane while passing on every lane with a larger display. The cause is not the test logic: the replay window silently comes back smaller than the recording asked for.

macOS AppKit constrains a *titled* window's frame to the display it lands on. The GL replay creates a hidden but titled Cocoa window, because GLFW's windowless null platform is used only on Linux. On a runner whose virtual display is 1024x768, a recorded 1600x900 window becomes 1024x645. Nothing detects the shrink: the editor simply lays out for the smaller window and the replay reports success, so tests that crop absolute device pixels or inject canvas-relative pointer coordinates compare a region that no longer corresponds to the recording. The captures uploaded by the failing run are 1024x645 and show the reflowed dock directly.

That explains each failure:

- `HighZoomRapidPanKeepsPaneCoveredByContent` crops the render pane at device x 576..1164, past the right edge of a 1024-wide frame, so the crop lands on the inspector panel. Coverage measures 0.06 against a floor of 0.90.
- `TextToolLivePointerClickOpensSessionAndTypes` clicks logical (800, 300), documented as inside the render pane of a 1400x600 window. On the clamped window that point is in the side panel, so no editing session opens.
- `FilteredElementOThenRDragDoesNotPopOBackOnRClick` crops for a glyph centroid that is no longer at those coordinates, so `YellowCentroidY` returns `nullopt`.

## Fix

Hidden windows never show chrome, so hint `GLFW_DECORATED = false` for them. Borderless windows are exempt from the frame constraint and come back at the size they requested on any display. This makes the hosted lane produce the same 1600x900 window the larger-display lanes already produce, which is the configuration these tests are green under.

## Verification

Reaching the clamp on a development machine takes a window larger than the display, which is what the new regression test asks for. On a macOS host whose screen `visibleFrame` is 2946x1662:

- without the hint, a hidden window requesting 4000x2400 comes back at (2946, 1630), the visible frame less the title bar
- with the hint, it comes back at (4000, 2400)

The test asserts the logical window size rather than the framebuffer. Points are what AppKit constrains, so the comparison holds at any backing scale and on any display: a smaller host clamps to a different number, but never to the requested one.

Test runs on macOS, Apple Silicon:

- `bazel test --config=geode` over the five Geode editor lane targets plus `editor_window_offscreen_target_tests`: green, including `gl_rnr_replay_tests`
- `bazel test //donner/editor/...`: 86 of 86 pass

## Lane coverage caveat

`gatekeeper` routes trusted-operator pushes and pull requests to the self-hosted macOS runner and skips the GitHub-hosted `macos` job, so this pull request does not itself exercise the lane it repairs. That routing is also why the breakage survived more than one commit before surfacing on an unrelated dependency bump, which misattributed it to that bump's diff.

## Unrelated flake seen once while verifying

One run aborted in `GlRnrReplayTest.DocumentSpaceInputDrivesCanvasSelectionThroughEditorShell` on a ConcurrentDom access guard, reached through `EditorShell::layerInspectorStatusForReadback`. It did not reproduce in 84 further full-shard runs, including 60 at four-way test parallelism.

It is independent of this change: `EditorShell.cc` is untouched here, and the abort is in the selected-element `withReadAccess` block rather than anywhere this diff reaches. The precise mechanism is still being investigated separately, so this note deliberately does not claim one. Flagging it so anyone who hits it while reviewing knows it is not this diff.
