### PR TITLE
Editor UI polish: compositor panel dock, New document, sample catalog, About build info

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -23,8 +23,9 @@ the version number.
 - [ ] **Showcase demo generates and renders** — The v0.8 showcase must generate on demand from
       `donner_splash.svg`, parse, and render in Donner. This is gated by
       `//donner/editor/tests:showcase_asset_tests`, which exercises the generator and validates the
-      derived SVG, plus `//donner/editor/tests:editor_sample_catalog_tests`, which verifies that the
-      editor's built-in Donner Showcase entry uses generated output, and
+      derived SVG, plus `//donner/editor/tests:editor_sample_catalog_tests`, which verifies the
+      sample catalog (the showcase is intentionally no longer a built-in picker sample; it is
+      generated on demand via `//donner/editor/tools:generate_showcase_asset`), and
       `//donner/editor/tools:generate_showcase_asset_cli_tests`, which protects the canonical input
       against same-path, symlink, and hard-link output aliases. No checked-in variant is required.
       (Applies from the v0.8 "Donner SVG Editor & Engine" release onward.)

--- a/docs/release_checklists/v0_8_showcase_checklist.md
+++ b/docs/release_checklists/v0_8_showcase_checklist.md
@@ -21,9 +21,10 @@ automated sample.
 - [ ] Run `bazel test //donner/editor/tests:showcase_asset_tests`. The test
       generates the derived SVG in memory and verifies parsing, text-to-outline
       conversion, overlay serialization, and rendering.
-- [ ] Open the editor's sample picker and select **Donner Showcase**. Confirm it
-      contains the generated outlined `SVG` badge and selection overlay. Treat
-      this as a starting sample, not a prescribed final composition.
+- [ ] Open the editor's sample picker and select **Donner Splash**. The
+      showcase itself is no longer a picker sample: it is generated on demand
+      (see the tool step above) and verified by `showcase_asset_tests`. Treat
+      the splash as a starting sample, not a prescribed final composition.
 - [ ] Open `/tmp/donner-showcase.svg` in Donner and a browser. Confirm the
       crop, overlay, transparency, and outlined `SVG` lettering are correct.
 - [ ] Confirm the canonical input is unchanged and no generated

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -1288,6 +1288,29 @@ embed_resources(
     },
 )
 
+# Bakes "<version>\n<commit>\n" into the editor binary for the About dialog.
+# The version is read from MODULE.bazel (the repo's version source of truth);
+# the commit falls back to "unknown" when git is unavailable.
+genrule(
+    name = "editor_build_info_txt",
+    srcs = [
+        "//:MODULE.bazel",
+        "write_build_info.sh",
+    ],
+    outs = ["editor_build_info.txt"],
+    cmd = "bash $(location write_build_info.sh) $(execpath //:MODULE.bazel) $@",
+    # Runs on the local machine so `git` can reach the real checkout.
+    local = True,
+)
+
+embed_resources(
+    name = "editor_build_info",
+    header_output = "donner/editor/EditorBuildInfo.h",
+    resources = {
+        "kEditorBuildInfo": ":editor_build_info_txt",
+    },
+)
+
 embed_resources(
     name = "editor_splash",
     header_output = "donner/editor/EditorSplash.h",
@@ -1303,7 +1326,6 @@ donner_cc_library(
     deps = [
         ":editor_splash",
         "//donner/base",
-        "//donner/editor/tools:showcase_asset_generator",
     ],
 )
 
@@ -1345,6 +1367,7 @@ donner_cc_binary(
     }),
     visibility = ["//visibility:private"],
     deps = [
+        ":editor_build_info",
         ":editor_shell",
         ":editor_splash",
         ":notice",

--- a/donner/editor/DialogPresenter.cc
+++ b/donner/editor/DialogPresenter.cc
@@ -10,8 +10,26 @@
 
 namespace donner::editor {
 
-DialogPresenter::DialogPresenter(std::string editorNoticeText)
-    : editorNoticeText_(std::move(editorNoticeText)) {}
+DialogPresenter::DialogPresenter(std::string editorNoticeText, std::string editorBuildInfo)
+    : editorNoticeText_(std::move(editorNoticeText)), editorBuildInfo_(std::move(editorBuildInfo)) {
+  // The embedded build info is "<version>\n<commit>\n". Split the first two
+  // lines so the About dialog can render them independently; anything missing
+  // or malformed is left empty rather than shown verbatim.
+  std::size_t start = 0;
+  for (std::string* out : {&editorVersion_, &editorCommit_}) {
+    const std::size_t end = editorBuildInfo_.find('\n', start);
+    *out =
+        editorBuildInfo_.substr(start, end == std::string::npos ? std::string::npos : end - start);
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  if (editorBuildInfo_.empty()) {
+    editorVersion_.clear();
+    editorCommit_.clear();
+  }
+}
 
 void DialogPresenter::requestOpenFile(const std::optional<std::string>& currentFilePath) {
   std::fill(openFilePathBuffer_.begin(), openFilePathBuffer_.end(), '\0');
@@ -125,6 +143,12 @@ void DialogPresenter::render(
                                ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::TextUnformatted("About Donner SVG Editor");
       ImGui::Separator();
+      if (!editorVersion_.empty()) {
+        ImGui::Text("Version: %s", editorVersion_.c_str());
+      }
+      if (!editorCommit_.empty()) {
+        ImGui::Text("Commit: %s", editorCommit_.c_str());
+      }
       ImGui::TextUnformatted("(c) 2024-2026 Jeff McGlynn");
       ImGui::Spacing();
       ImGui::TextWrapped(

--- a/donner/editor/DialogPresenter.h
+++ b/donner/editor/DialogPresenter.h
@@ -11,7 +11,8 @@ namespace donner::editor {
 /// Owns the editor's popup/modal state and renders the corresponding ImGui dialogs.
 class DialogPresenter {
 public:
-  explicit DialogPresenter(std::string editorNoticeText);
+  explicit DialogPresenter(std::string editorNoticeText,
+                           std::string editorBuildInfo = std::string());
 
   void requestOpenFile(const std::optional<std::string>& currentFilePath);
   void requestSaveFile(const std::optional<std::string>& currentFilePath,
@@ -58,6 +59,12 @@ private:
   std::string openFileError_;
   std::string saveFileError_;
   std::string editorNoticeText_;
+  /// Embedded "<version>\n<commit>\n" build metadata, or empty when unset.
+  std::string editorBuildInfo_;
+  /// Version line parsed from \ref editorBuildInfo_, or empty when unset.
+  std::string editorVersion_;
+  /// Commit line parsed from \ref editorBuildInfo_, or empty when unset.
+  std::string editorCommit_;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/EditorDockLayout.cc
+++ b/donner/editor/EditorDockLayout.cc
@@ -55,6 +55,10 @@ EditorDockNodes BuildDefaultDockLayout(ImGuiID dockspaceId, const EditorDockLayo
                               &rightLowerId);
   nodes.rightTop = layersId;
 
+  // The right column below Layers hosts the Inspector, with the Compositor
+  // Debug Info panel docked at the bottom when it is enabled. Splitting the
+  // inspector area this way keeps the compositor diagnostics reachable in the
+  // side column while leaving its pane resizable via the splitter.
   if (params.includeCompositorDebug) {
     ImGuiID compositorId = 0;
     ImGuiID inspectorId = 0;
@@ -80,10 +84,11 @@ ImGuiDockNodeFlags EditorDockSpaceFlags(bool locked) {
   // The canvas central node always stays clear of docked panels.
   ImGuiDockNodeFlags flags = ImGuiDockNodeFlags_NoDockingOverCentralNode;
   if (locked) {
-    // Disable the splitter/resizer, prevent new splits, and block undocking
-    // (tear-off) so the locked layout cannot be accidentally rearranged.
-    flags |= ImGuiDockNodeFlags_NoResize | ImGuiDockNodeFlags_NoDockingSplit |
-             ImGuiDockNodeFlags_NoUndocking;
+    // Fix the layout structure: block new splits and undocking (tear-off) so
+    // panels cannot be accidentally rearranged. The existing splitters stay
+    // resizable so the right column width and panel heights (e.g. the
+    // Layers/Inspector pane) can be adjusted.
+    flags |= ImGuiDockNodeFlags_NoDockingSplit | ImGuiDockNodeFlags_NoUndocking;
   }
   return flags;
 }

--- a/donner/editor/EditorDockLayout.h
+++ b/donner/editor/EditorDockLayout.h
@@ -11,7 +11,7 @@ namespace donner::editor {
 inline constexpr const char* kRenderPaneWindowName = "Render";
 inline constexpr const char* kLayersWindowName = "Layers";
 inline constexpr const char* kInspectorWindowName = "Inspector";
-inline constexpr const char* kCompositorDebugWindowName = "Compositor Debug";
+inline constexpr const char* kCompositorDebugWindowName = "Compositor Debug Info";
 
 /// Stable string hashed into the editor's root DockSpace id.
 inline constexpr const char* kEditorDockSpaceName = "EditorDockSpace";
@@ -28,7 +28,7 @@ inline constexpr const char* kEditorCompactDockSpaceName = "EditorCompactDockSpa
 
 /// Node ids produced by \ref BuildDefaultDockLayout. Ids of zero mean the node
 /// was not created (e.g. \ref EditorDockNodes::rightBottom when the compositor
-/// debug panel is excluded from the layout).
+/// debug info panel is not enabled).
 struct EditorDockNodes {
   /// Root DockSpace node id (equal to the id passed to \ref BuildDefaultDockLayout).
   ImGuiID root = 0;
@@ -38,7 +38,8 @@ struct EditorDockNodes {
   ImGuiID rightTop = 0;
   /// Middle-right node hosting the Inspector panel.
   ImGuiID rightMid = 0;
-  /// Bottom-right node hosting the Compositor Debug panel (zero when excluded).
+  /// Bottom-right node hosting the Compositor Debug Info panel (zero when the
+  /// panel is not enabled).
   ImGuiID rightBottom = 0;
 };
 
@@ -51,9 +52,11 @@ struct EditorDockLayoutParams {
   /// Fraction of the right column height assigned to the Layers panel (top).
   float layersRatio = 0.34f;
   /// Fraction of the remaining right column height assigned to the Compositor
-  /// Debug panel (bottom). Ignored when \ref includeCompositorDebug is false.
+  /// Debug Info panel (bottom). Ignored when \ref includeCompositorDebug is
+  /// false.
   float compositorRatio = 0.34f;
-  /// Whether the Compositor Debug panel gets a reserved node in the layout.
+  /// Whether the Compositor Debug Info panel gets a reserved node in the
+  /// inspector area (the bottom of the right column).
   bool includeCompositorDebug = false;
   /// Whether persistent Layers and Inspector nodes are included. Compact touch
   /// mode omits them and presents one panel at a time as an overlay sheet.
@@ -63,9 +66,10 @@ struct EditorDockLayoutParams {
 /**
  * Build the editor's default panel layout under `dockspaceId`, discarding any
  * previously built nodes. The central node hosts the canvas; the right column
- * stacks Layers over Inspector (and Compositor Debug at the bottom when
- * requested). The canvas node is flagged as the central node with no tab bar so
- * it reads as a plain viewport rather than a docked tab.
+ * stacks Layers over Inspector, and the Compositor Debug Info panel at the
+ * bottom of the inspector area when requested. The canvas node is flagged as
+ * the central node with no tab bar so it reads as a plain viewport rather than
+ * a docked tab.
  *
  * Requires a live ImGui context. The bound windows do not need to have been
  * submitted yet; DockBuilder records the binding for their next `Begin()`.
@@ -78,10 +82,11 @@ EditorDockNodes BuildDefaultDockLayout(ImGuiID dockspaceId, const EditorDockLayo
 
 /**
  * Shared dock-node flags to pass to `ImGui::DockSpace()` for the given lock
- * state. When locked, splitters, resizing, and undocking (tear-off) are all
- * disabled so the layout cannot be accidentally torn apart; when unlocked the
- * layout is freely rearrangeable within the main viewport (multi-viewport
- * tear-off to OS windows stays disabled at the config-flag level).
+ * state. When locked, the layout structure is fixed: no new splits and no
+ * undocking (tear-off), but the existing splitters stay resizable so the right
+ * column width and panel heights can be adjusted. When unlocked the layout is
+ * freely rearrangeable within the main viewport (multi-viewport tear-off to OS
+ * windows stays disabled at the config-flag level).
  *
  * @param locked Whether the layout is locked.
  */

--- a/donner/editor/EditorSampleCatalog.cc
+++ b/donner/editor/EditorSampleCatalog.cc
@@ -3,11 +3,9 @@
 #include <array>
 #include <span>
 #include <string>
-#include <utility>
+#include <string_view>
 
-#include "donner/base/Utils.h"
 #include "donner/editor/EditorSplash.h"
-#include "donner/editor/tools/GenerateShowcaseAsset.h"
 
 namespace donner::editor {
 namespace {
@@ -70,25 +68,15 @@ std::string_view SourceFromEmbedded(std::span<const unsigned char> bytes) noexce
   return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
 }
 
-std::string GenerateShowcaseSource() {
-  const std::string_view canonicalSplash = SourceFromEmbedded(embedded::kEditorSplashSvg);
-  auto generated = GenerateShowcaseAsset(canonicalSplash);
-  UTILS_RELEASE_ASSERT_MSG(generated.ok(), generated.error.c_str());
-  return std::move(generated.value);
-}
-
 struct EditorSampleCatalogStorage {
   EditorSampleCatalogStorage()
-      : showcaseSource(GenerateShowcaseSource()),
-        samples(
+      : samples(
             {{{"donner-splash", "Donner Splash", SourceFromEmbedded(embedded::kEditorSplashSvg)},
               {"basic-shapes", "Basic Shapes", kBasicShapesSvg},
               {"text-style", "Text and Style", kTextStyleSvg},
-              {"gradients-clip", "Gradients and Clip", kGradientsClipSvg},
-              {"donner-showcase", "Donner Showcase", showcaseSource}}}) {}
+              {"gradients-clip", "Gradients and Clip", kGradientsClipSvg}}}) {}
 
-  std::string showcaseSource;
-  std::array<EditorSample, 5> samples;
+  std::array<EditorSample, 4> samples;
 };
 
 const EditorSampleCatalogStorage& CatalogStorage() {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -113,14 +113,14 @@ void PublishSampleThumbnailStats(int requested, int started, int completed, int 
       {
         const frame = Number(window['__donnerMainLoopRenderedFrames'] || 0) + 1;
         const previous = window['__donnerSampleThumbnailStats'] || ({
-          'carouselFrame' : frame,
-          'firstRequestFrame' : 0,
-          'ready' : 0,
-          'publicationFrames' : ([]),
-        });
-        const publicationFrames =
-            Array.isArray(previous['publicationFrames']) ? previous['publicationFrames'].slice()
-                                                         : ([]);
+                           'carouselFrame' : frame,
+                           'firstRequestFrame' : 0,
+                           'ready' : 0,
+                           'publicationFrames' : ([]),
+                         });
+        const publicationFrames = Array.isArray(previous['publicationFrames'])
+                                      ? previous['publicationFrames'].slice()
+                                      : ([]);
         for (let published = Number(previous['ready'] || 0); published < $4; ++published) {
           publicationFrames.push(frame);
         }
@@ -342,6 +342,9 @@ constexpr float kSourcePaneCollapseThreshold = kMinSourcePaneWidth;
 constexpr float kKeyboardZoomStep = 1.5f;
 constexpr float kMinRightPaneWidth = 220.0f;
 constexpr float kMaxRightPaneWidth = 900.0f;
+/// Blank document created by File > New and the sample picker's "New SVG".
+constexpr std::string_view kNewDocumentSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400"/>)";
 #ifdef __EMSCRIPTEN__
 // emscripten-glfw normalizes every DOM_DELTA_PIXEL wheel at 100 px per scroll
 // unit, where desktop GLFW scales precise trackpad deltas at 10 px per unit.
@@ -642,8 +645,8 @@ bool SidebarSnapshotRefreshPendingAfterPass(std::size_t deferredThumbnailCount) 
   return deferredThumbnailCount > 0u;
 }
 
-bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile) noexcept {
-  return dismiss || openFile;
+bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile, bool newDocument) noexcept {
+  return dismiss || openFile || newDocument;
 }
 
 DeferredRenderAction DeferredRenderActionForState(bool hasDocument, bool penDragFlushed,
@@ -1147,12 +1150,11 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       interactionController_(),
       inputBridge_(window_, kWheelZoomStep),
       compositorDebugPanel_(window.geodeDevice()),
-      dialogPresenter_(options_.editorNoticeText) {
+      dialogPresenter_(options_.editorNoticeText, options_.editorBuildInfo) {
   // One presenter owns where document pixels land for the whole session.
-  documentPresenter_ =
-      MakeDocumentPresenter([this](std::optional<FramebufferUnderlayPlan> plan) {
-        installFramebufferUnderlayPlan(std::move(plan));
-      });
+  documentPresenter_ = MakeDocumentPresenter([this](std::optional<FramebufferUnderlayPlan> plan) {
+    installFramebufferUnderlayPlan(std::move(plan));
+  });
   renderCoordinator_.asyncRenderer().setCompositorDiagnosticsEnabled(false);
   // Install the embedded + system font catalog as the process-wide default provider, so every
   // document FontManager created by the render paths resolves font-family names against embedded
@@ -1831,6 +1833,7 @@ bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::stri
   const std::string canonicalSource = textEditor_.getText();
   if (path.has_value()) {
     app_.setCurrentFilePath(std::move(*path));
+    activeSampleId_.clear();
   } else {
     app_.clearCurrentFilePath();
   }
@@ -1840,8 +1843,21 @@ bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::stri
   return true;
 }
 
+void EditorShell::requestNewDocument() {
+  pendingNewDocument_ = true;
+  pendingSampleLoadNeedsConfirmation_ = false;
+  pendingSampleLoadDiscardConfirmed_ = false;
+  pendingSampleLoadId_.clear();
+  // The blank document supersedes the current document frame. Start cancellation in the click
+  // frame so the next UI frame can claim the DOM as soon as SVG traversal reaches a safe point.
+  cancelSampleThumbnailGeneration();
+  renderCoordinator_.asyncRenderer().cancelInFlight();
+  window_.wakeEventLoop();
+}
+
 void EditorShell::queuePendingSampleLoad(std::string sampleId) {
   pendingSampleLoadId_ = std::move(sampleId);
+  pendingNewDocument_ = false;
   pendingSampleLoadNeedsConfirmation_ = false;
   pendingSampleLoadDiscardConfirmed_ = false;
   // The selected sample supersedes the current document frame. Start cancellation in the click
@@ -1852,12 +1868,13 @@ void EditorShell::queuePendingSampleLoad(std::string sampleId) {
 
 void EditorShell::cancelPendingSampleLoad() {
   pendingSampleLoadId_.clear();
+  pendingNewDocument_ = false;
   pendingSampleLoadNeedsConfirmation_ = false;
   pendingSampleLoadDiscardConfirmed_ = false;
 }
 
 void EditorShell::confirmPendingSampleLoadDiscard() {
-  if (pendingSampleLoadId_.empty()) {
+  if (pendingSampleLoadId_.empty() && !pendingNewDocument_) {
     return;
   }
   pendingSampleLoadNeedsConfirmation_ = false;
@@ -1866,22 +1883,50 @@ void EditorShell::confirmPendingSampleLoadDiscard() {
 }
 
 void EditorShell::processPendingSampleLoad() {
-  if (pendingSampleLoadId_.empty()) {
+  if (pendingSampleLoadId_.empty() && !pendingNewDocument_) {
     return;
   }
   const bool hasDocument = app_.hasDocument();
   std::optional<svg::DocumentWriteAccess> documentAccess =
       hasDocument ? app_.document().document().tryWriteAccess() : std::nullopt;
   const bool documentWriteAvailable = !hasDocument || documentAccess.has_value();
-  if (!internal::PendingDocumentReplacementCanProcess(!pendingSampleLoadId_.empty(),
-                                                      documentWriteAvailable,
-                                                      app_.document().hasPendingMutations())) {
+  if (!internal::PendingDocumentReplacementCanProcess(
+          !pendingSampleLoadId_.empty() || pendingNewDocument_, documentWriteAvailable,
+          app_.document().hasPendingMutations())) {
     return;
   }
 
   if (!pendingSampleLoadDiscardConfirmed_ && (app_.isDirty() || textEditor_.isTextChanged())) {
     pendingSampleLoadNeedsConfirmation_ = true;
     showSamplePicker_ = true;
+    return;
+  }
+
+  if (pendingNewDocument_) {
+    pendingNewDocument_ = false;
+    pendingSampleLoadNeedsConfirmation_ = false;
+    pendingSampleLoadDiscardConfirmed_ = false;
+#ifdef DONNER_EDITOR_WGPU
+    // The previous frame's direct callback has run, but remains installed until the next
+    // render-pane submission. Detach it before releasing presentation resources for the old
+    // document.
+    window_.setWgpuDirectRenderCallback({});
+#endif
+    // If the previous render is packaging a result after releasing the DOM, ensure that result is
+    // dropped instead of landing over the replacement document.
+    renderCoordinator_.asyncRenderer().cancelInFlight();
+    std::string error;
+    if (tryLoadSource(kNewDocumentSvg, std::nullopt, &error)) {
+      activeSampleId_.clear();
+#ifdef __EMSCRIPTEN__
+      PublishActiveSampleId("");
+#endif
+      welcomePlaceholderActive_ = false;
+      showSamplePicker_ = false;
+      requestRenderAtEndOfFrame_ = true;
+    } else {
+      std::fprintf(stderr, "[editor] failed to create new document: %s\n", error.c_str());
+    }
     return;
   }
 
@@ -2016,6 +2061,9 @@ bool EditorShell::trySavePath(std::string_view path, std::string* error) {
   }
 
   app_.setCurrentFilePath(std::string(path));
+  // The document now has a real backing path; drop any sample identity so the
+  // picker highlight and published active-sample id do not go stale.
+  activeSampleId_.clear();
   app_.setCleanSourceText(textEditor_.getText());
   documentSyncController_.resetForLoadedDocument(textEditor_.getText());
   dialogPresenter_.clearSaveFileError();
@@ -2173,7 +2221,15 @@ void EditorShell::serviceNativeDialogs() {
 }
 
 void EditorShell::updateWindowTitle() {
-  const WindowChromeState chromeState{.filePath = app_.currentFilePath(), .edited = app_.isDirty()};
+  std::optional<std::string> documentName;
+  if (!app_.currentFilePath().has_value() && !activeSampleId_.empty()) {
+    if (const EditorSample* sample = FindEditorSample(activeSampleId_)) {
+      documentName = std::string(sample->title) + " Sample";
+    }
+  }
+  const WindowChromeState chromeState{.filePath = app_.currentFilePath(),
+                                      .documentName = std::move(documentName),
+                                      .edited = app_.isDirty()};
 
   // On platforms with native title-bar chrome (macOS) the edited "dot" and
   // proxy icon are shown by the OS, so keep them out of the title text.
@@ -2222,6 +2278,11 @@ void EditorShell::applyPendingHistoryActions() {
 void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   if (menuActions.openAbout) {
     dialogPresenter_.requestAbout();
+  }
+  if (menuActions.newFile) {
+    cancelSampleThumbnailGeneration();
+    cancelPendingSampleLoad();
+    requestNewDocument();
   }
   if (menuActions.openFile) {
     cancelSampleThumbnailGeneration();
@@ -2412,6 +2473,12 @@ void EditorShell::handleGlobalShortcuts() {
       !sourcePaneFocused && !ImGui::GetIO().WantTextInput) {
     handleTextEditingKeyboard();
     return;
+  }
+
+  if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_N, /*repeat=*/false)) {
+    cancelSampleThumbnailGeneration();
+    cancelPendingSampleLoad();
+    requestNewDocument();
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false)) {
@@ -4498,14 +4565,15 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
       ImGui::OpenPopup("Discard changes?");
     }
     if (ImGui::BeginPopupModal("Discard changes?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-      ImGui::TextUnformatted("Loading a sample replaces the current document.");
+      ImGui::TextUnformatted("This replaces the current document.");
       ImGui::Spacing();
       if (ImGui::Button("Cancel", ImVec2(112.0f, 40.0f))) {
         cancelPendingSampleLoad();
         ImGui::CloseCurrentPopup();
       }
       ImGui::SameLine();
-      if (ImGui::Button("Discard & Load", ImVec2(148.0f, 40.0f))) {
+      const char* confirmLabel = pendingNewDocument_ ? "Discard & New" : "Discard & Load";
+      if (ImGui::Button(confirmLabel, ImVec2(148.0f, 40.0f))) {
         confirmPendingSampleLoadDiscard();
         ImGui::CloseCurrentPopup();
       }
@@ -4533,7 +4601,13 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
     }
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
-  if (internal::SamplePickerActionsNeedFollowupFrame(actions.dismiss, actions.openFile)) {
+  if (actions.newDocument) {
+    cancelSampleThumbnailGeneration();
+    cancelPendingSampleLoad();
+    requestNewDocument();
+  }
+  if (internal::SamplePickerActionsNeedFollowupFrame(actions.dismiss, actions.openFile,
+                                                     actions.newDocument)) {
     // These actions mutate state after the picker has already drawn this frame.
     // Explicitly present the replacement document/modal even if no further DOM
     // input arrives to wake the event-driven browser loop.
@@ -4548,8 +4622,14 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
         window.location.assign(url);
       }
     });
+#elif defined(__APPLE__)
+    const std::string openCommand =
+        std::string("open \"") + std::string(kSamplePickerGitHubUrl) + "\"";
+    std::system(openCommand.c_str());
 #else
-    ImGui::SetClipboardText(kSamplePickerGitHubUrl.data());
+    const std::string openCommand =
+        std::string("xdg-open \"") + std::string(kSamplePickerGitHubUrl) + "\"";
+    std::system(openCommand.c_str());
 #endif
   }
   if (actions.loadSample) {
@@ -5142,10 +5222,10 @@ void EditorShell::renderSidebars() {
   }
   thumbnailTextures_.retainThumbnailsOnly(liveThumbnailKeys);
 
-  // The Compositor Debug panel is a developer diagnostics view, hidden unless
-  // toggled on from the View menu. It is now an ordinary dockable window in the
-  // same DockSpace (its content is unchanged); the homegrown detach/float host
-  // is gone - unlock the layout to tear it off into a floating imgui window.
+  // The Compositor Debug Info panel is a developer diagnostics view, hidden
+  // unless toggled on from the View menu. It is docked in the inspector area
+  // (the bottom of the right column) by default; the dock splitters stay
+  // resizable so the pane can be made taller and the right column wider.
   if (!showCompositorDebugPanel_) {
     return;
   }
@@ -6768,12 +6848,11 @@ void EditorShell::recordFrameTelemetry(
     const ViewportState& viewport = interactionController_.viewport();
     const Box2d documentRect = viewport.imageScreenRect();
     const Vector2d documentSize = documentRect.size();
-    PublishViewportStats(
-        viewport.paneOrigin.x, viewport.paneOrigin.y, viewport.paneSize.x, viewport.paneSize.y,
-        documentRect.topLeft.x, documentRect.topLeft.y, documentSize.x, documentSize.y,
-        viewport.zoom,
-        static_cast<double>(renderCoordinator_.documentCanvasCommitTotal()),
-        static_cast<double>(renderCoordinator_.overviewInfillRenderTotal()));
+    PublishViewportStats(viewport.paneOrigin.x, viewport.paneOrigin.y, viewport.paneSize.x,
+                         viewport.paneSize.y, documentRect.topLeft.x, documentRect.topLeft.y,
+                         documentSize.x, documentSize.y, viewport.zoom,
+                         static_cast<double>(renderCoordinator_.documentCanvasCommitTotal()),
+                         static_cast<double>(renderCoordinator_.overviewInfillRenderTotal()));
     PublishOverlayStats(
         compositorTileOverlay_ ? 1 : 0, geometryDebugOverlay_ ? 1 : 0,
         renderCoordinator_.immediateOverlaySnapshot().has_value() ? 1 : 0,

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -81,6 +81,9 @@ struct EditorShellOptions {
   /// Show the in-workspace welcome and sample picker on the first frame.
   bool showWelcome = false;
   std::string editorNoticeText;
+  /// Embedded "<version>\n<commit>\n" build metadata displayed in the About
+  /// dialog. May be empty when the build did not embed it.
+  std::string editorBuildInfo;
   /// Optional destination path for a `.donner-repro` recording of the
   /// user's UI interactions. When set, the shell constructs a
   /// `ReproRecorder` and snapshots ImGui input state at the start of
@@ -315,6 +318,9 @@ private:
 
   bool tryOpenPath(std::string_view path, std::string* error);
   bool tryLoadSource(std::string_view source, std::optional<std::string> path, std::string* error);
+  /// Start creating a blank document, deferring the replacement to a safe
+  /// frame (mirrors \ref queuePendingSampleLoad).
+  void requestNewDocument();
   void queuePendingSampleLoad(std::string sampleId);
   void cancelPendingSampleLoad();
   void confirmPendingSampleLoadDiscard();
@@ -684,8 +690,9 @@ private:
   /// DockSpace owns panel sizing.
   float rightPaneWidth_ = 420.0f;
   /// Whether the DockSpace panel layout is locked (default). While locked the
-  /// splitters, resizing, and tear-off are all disabled; an unlock toggle lives
-  /// in the View menu.
+  /// layout structure is fixed: no new splits and no tear-off, but the existing
+  /// splitters stay resizable so the right column width and panel heights can
+  /// be adjusted; an unlock toggle lives in the View menu.
   bool dockLayoutLocked_ = true;
   /// Set for one frame by the View menu's "Reset Layout" item to rebuild the
   /// default layout, discarding any persisted/rearranged state.
@@ -698,9 +705,9 @@ private:
   /// Whether the active DockSpace includes persistent sidebars. Used to rebind
   /// the canvas between separate desktop and compact roots on profile changes.
   bool dockSidebarsIncludedInLayout_ = true;
-  /// Whether the currently built layout reserves a node for the Compositor Debug
-  /// panel. Tracks \ref showCompositorDebugPanel_ so toggling the panel rebuilds
-  /// the layout to add or reclaim its slot.
+  /// Whether the currently built layout reserves a node for the Compositor
+  /// Debug Info panel in the inspector area. Tracks \ref showCompositorDebugPanel_
+  /// so toggling the panel rebuilds the layout to add or reclaim its slot.
   bool dockCompositorIncludedInLayout_ = false;
   std::vector<svg::SVGElement> lastHighlightedSelection_;
   std::optional<svg::SVGElement> lastTreeSelection_;
@@ -767,6 +774,7 @@ private:
   bool samplePresentationPending_ = false;
   std::string activeSampleId_;
   std::string pendingSampleLoadId_;
+  bool pendingNewDocument_ = false;
   bool pendingSampleLoadNeedsConfirmation_ = false;
   bool pendingSampleLoadDiscardConfirmed_ = false;
   /// Current compact sheet state. Desktop keeps the source/sidebar preferences
@@ -774,7 +782,7 @@ private:
   bool compactPanelVisible_ = false;
   bool compactInspectorSheet_ = false;
   EditorAdaptiveUiLayout adaptiveUiLayout_;
-  /// Whether the Compositor Debug panel window renders. Off by default: it is a
+  /// Whether the Compositor Debug Info panel window renders. Off by default: it is a
   /// developer-facing composite-tile diagnostics view, toggled on via the View
   /// menu. The user-facing Layers panel is unrelated and always visible.
   bool showCompositorDebugPanel_ = false;

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -125,7 +125,8 @@ template <typename Resolver>
   return static_cast<bool>(std::forward<Resolver>(resolveWhenIdle)());
 }
 
-[[nodiscard]] bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile) noexcept;
+[[nodiscard]] bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile,
+                                                        bool newDocument) noexcept;
 [[nodiscard]] DeferredRenderAction DeferredRenderActionForState(bool hasDocument,
                                                                 bool penDragFlushed,
                                                                 bool rendererBusy) noexcept;

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -15,6 +15,7 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 
   switch (command) {
     case MenuBarCommand::OpenAbout: actions->openAbout = true; return;
+    case MenuBarCommand::NewFile: actions->newFile = true; return;
     case MenuBarCommand::OpenFile: actions->openFile = true; return;
     case MenuBarCommand::OpenSamples: actions->openSamples = true; return;
     case MenuBarCommand::SaveFile: actions->saveFile = true; return;
@@ -148,6 +149,7 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
   ImGui::SameLine(0.0f, theme.space4);
 
   if (ImGui::BeginMenu("File")) {
+    ApplyMenuBarCommand(ImGui::MenuItem("New", "Cmd+N"), MenuBarCommand::NewFile, state, &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Open...", "Cmd+O"), MenuBarCommand::OpenFile, state,
                         &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Open Sample..."), MenuBarCommand::OpenSamples, state,
@@ -224,7 +226,7 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
                         &actions);
     ImGui::Separator();
     ApplyMenuBarCommand(
-        ImGui::MenuItem("Compositor Debug", nullptr, state.showCompositorDebugPanel),
+        ImGui::MenuItem("Compositor Debug Info", nullptr, state.showCompositorDebugPanel),
         MenuBarCommand::ToggleCompositorDebugPanel, state, &actions);
     ApplyMenuBarCommand(
         ImGui::MenuItem("Compositor Tile Overlay", nullptr, state.compositorTileOverlay),

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -41,7 +41,7 @@ struct MenuBarState {
   /// True when the document has at least one selectable element. Enables the canvas "Select All"
   /// when the source pane is not focused.
   bool hasSelectableElements = false;
-  /// Current visibility of the Compositor Debug panel (drives the View-menu
+  /// Current visibility of the Compositor Debug Info panel (drives the View-menu
   /// checkmark). Off by default.
   bool showCompositorDebugPanel = false;
   /// Whether compositor tile boundaries and identities are drawn directly over the canvas.
@@ -63,6 +63,7 @@ struct MenuBarState {
 
 struct MenuBarActions {
   bool openAbout = false;
+  bool newFile = false;
   bool openFile = false;
   bool openSamples = false;
   bool saveFile = false;
@@ -94,7 +95,7 @@ struct MenuBarActions {
   bool zoomOut = false;
   bool actualSize = false;
   bool toggleSourceFocusMode = false;
-  /// Set when the user toggles the Compositor Debug panel via the View menu.
+  /// Set when the user toggles the Compositor Debug Info panel via the View menu.
   bool toggleCompositorDebugPanel = false;
   /// Set when the user toggles compositor tile boundaries over the canvas.
   bool toggleCompositorTileOverlay = false;
@@ -120,6 +121,7 @@ struct MenuBarActions {
 /// Semantic command emitted by a top-level menu item.
 enum class MenuBarCommand {
   OpenAbout,
+  NewFile,
   OpenFile,
   OpenSamples,
   SaveFile,
@@ -168,7 +170,7 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 /// Apply View-menu visibility toggle actions to persistent UI state.
 ///
 /// @param actions Edge-triggered menu actions from \ref MenuBarPresenter::render.
-/// @param showCompositorDebugPanel Current Compositor Debug panel visibility.
+/// @param showCompositorDebugPanel Current Compositor Debug Info panel visibility.
 /// @param perfOverlayMode Current performance overlay mode.
 /// @param geometryDebugOverlay Current Geode geometry debug overlay state.
 ///   Optional (may be null) so callers without a document renderer skip it.

--- a/donner/editor/NativeWindowChrome.cc
+++ b/donner/editor/NativeWindowChrome.cc
@@ -11,6 +11,8 @@ std::string ComposeWindowTitle(const WindowChromeState& state, bool showEditedDo
   }
   if (state.filePath.has_value() && !state.filePath->empty()) {
     title += std::filesystem::path(*state.filePath).filename().string();
+  } else if (state.documentName.has_value() && !state.documentName->empty()) {
+    title += *state.documentName;
   } else {
     title += "untitled";
   }

--- a/donner/editor/NativeWindowChrome.h
+++ b/donner/editor/NativeWindowChrome.h
@@ -22,6 +22,9 @@ namespace donner::editor {
 struct WindowChromeState {
   /// Path of the open document, or `std::nullopt` for an untitled buffer.
   std::optional<std::string> filePath;
+  /// Display name used for the title when no file path is set (e.g. the name
+  /// of the built-in sample currently open). Ignored when \ref filePath is set.
+  std::optional<std::string> documentName;
   /// Whether the document has unsaved changes.
   bool edited = false;
 };
@@ -33,9 +36,10 @@ struct WindowChromeState {
 ///   with a bullet ("● ") in the text itself. Callers pass false on
 ///   platforms that show the edited state natively (macOS), where the dot
 ///   is rendered by the OS via `setDocumentEdited:` instead.
-/// @return Title such as "diagram.svg - Donner SVG Editor" or, for an
-///   unsaved untitled buffer with `showEditedDotInText`, "● untitled -
-///   Donner SVG Editor".
+/// @return Title such as "diagram.svg - Donner SVG Editor", "Donner Splash
+///   Sample - Donner SVG Editor" for a built-in sample without a file path, or
+///   "● untitled - Donner SVG Editor" for an unsaved untitled buffer with
+///   `showEditedDotInText`.
 [[nodiscard]] std::string ComposeWindowTitle(const WindowChromeState& state,
                                              bool showEditedDotInText);
 

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -16,11 +16,6 @@ constexpr float kCardHeight = 96.0f;
 constexpr float kThumbnailWidth = 104.0f;
 constexpr float kThumbnailHeight = 64.0f;
 constexpr float kHeadingSpacing = 8.0f;
-#ifdef __EMSCRIPTEN__
-constexpr std::string_view kGitHubActionLabel = "View on GitHub";
-#else
-constexpr std::string_view kGitHubActionLabel = "Copy GitHub Link";
-#endif
 
 std::size_t BoundedSampleCount(std::size_t sampleCount) noexcept {
   return std::min(sampleCount, kSamplePickerMaxVisibleSamples);
@@ -118,9 +113,6 @@ std::string_view SamplePickerDescription(std::string_view sampleId) noexcept {
   if (sampleId == "donner-splash") {
     return "A quick look at Donner";
   }
-  if (sampleId == "donner-showcase") {
-    return "Generated in Donner";
-  }
   if (sampleId == "basic-shapes") {
     return "Shapes, fills, and strokes";
   }
@@ -142,6 +134,7 @@ void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
   switch (command) {
     case SamplePickerCommand::Dismiss: actions->dismiss = true; return;
     case SamplePickerCommand::OpenFile: actions->openFile = true; return;
+    case SamplePickerCommand::NewDocument: actions->newDocument = true; return;
     case SamplePickerCommand::LoadSample:
       if (FindEditorSample(sampleId) != nullptr) {
         actions->loadSample = true;
@@ -177,15 +170,26 @@ SamplePickerActions SamplePickerPresenter::render(
   ImGui::TextWrapped("Edit SVG graphics and source together.");
   ImGui::Dummy(ImVec2(0.0f, kHeadingSpacing));
 
+  const float newWidth = std::max(96.0f, ImGui::CalcTextSize("New SVG").x + 2.0f * theme.space4);
+  if (ImGui::Button("New SVG", ImVec2(newWidth, kSamplePickerMinTouchTarget))) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::NewDocument, {}, &actions);
+  }
+  ImGui::SameLine(0.0f, theme.space2);
   const float openWidth = std::max(112.0f, ImGui::CalcTextSize("Open SVG").x + 2.0f * theme.space4);
   if (ImGui::Button("Open SVG", ImVec2(openWidth, kSamplePickerMinTouchTarget))) {
     ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
   }
   ImGui::SameLine(0.0f, theme.space2);
-  const float githubWidth =
-      std::max(128.0f, ImGui::CalcTextSize(kGitHubActionLabel.data()).x + 2.0f * theme.space4);
-  if (ImGui::Button(kGitHubActionLabel.data(), ImVec2(githubWidth, kSamplePickerMinTouchTarget))) {
+  // The GitHub action reads as a hyperlink (underlined, link-colored, hand
+  // cursor) and reports the same edge-triggered action the old button did.
+  const float linkY =
+      ImGui::GetCursorPosY() + (kSamplePickerMinTouchTarget - ImGui::GetTextLineHeight()) * 0.5f;
+  ImGui::SetCursorPosY(linkY);
+  if (ImGui::TextLink(kSamplePickerGitHubUrl.data())) {
     ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, &actions);
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Open on GitHub");
   }
   ImGui::Dummy(ImVec2(0.0f, theme.space3));
 

--- a/donner/editor/SamplePickerPresenter.h
+++ b/donner/editor/SamplePickerPresenter.h
@@ -58,6 +58,7 @@ struct SamplePickerState {
 struct SamplePickerActions {
   bool dismiss = false;
   bool openFile = false;
+  bool newDocument = false;
   bool loadSample = false;
   std::string sampleId;
   bool openGitHub = false;
@@ -77,6 +78,7 @@ using SamplePickerThumbnailProvider =
 enum class SamplePickerCommand {
   Dismiss,
   OpenFile,
+  NewDocument,
   LoadSample,
   OpenGitHub,
 };

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -771,9 +771,14 @@ void PublishWgpuReadbackStatsForSmokeTests(const WgpuReadbackView& view, int req
         rowCenter - kThumbnailHeight * 0.5 + kProbeInset, kThumbnailWidth - kProbeInset * 2.0,
         kThumbnailHeight - kProbeInset * 2.0);
   };
-  const std::array<WgpuReadbackStats, 5> carouselStats = {
-      thumbnailStats(0, 282.0), thumbnailStats(1, 282.0), thumbnailStats(2, 282.0),
-      thumbnailStats(0, 390.0), thumbnailStats(1, 390.0),
+  // One probe per sample card, laid out three across then wrapping. This must
+  // track the sample catalog: a probe past the last card reads an empty slot and
+  // reports a thumbnail that never rendered.
+  const std::array<WgpuReadbackStats, 4> carouselStats = {
+      thumbnailStats(0, 282.0),
+      thumbnailStats(1, 282.0),
+      thumbnailStats(2, 282.0),
+      thumbnailStats(0, 390.0),
   };
   constexpr int kPublishedStatStride = 7;
   std::array<int, carouselStats.size() * kPublishedStatStride> packedCarouselStats{};

--- a/donner/editor/main.cc
+++ b/donner/editor/main.cc
@@ -158,6 +158,7 @@ EM_JS(void, PublishWasmPinchZoomPolicy, (double wheelDeltaPerLnScale),
 #include "donner/base/FailureSignalHandler.h"
 #endif
 
+#include "donner/editor/EditorBuildInfo.h"
 #include "donner/editor/EditorShell.h"
 #include "donner/editor/Notice.h"
 #include "donner/editor/PinchZoomPolicy.h"
@@ -292,8 +293,8 @@ void RunWasmEditorFrame(void* userdata) {
   // and a press taken the same way left the click buffered and the shape
   // unselected. Consuming the request first keeps the request-clearing
   // unconditional.
-  const bool browserRequested = ConsumeBrowserEditorFrameRequest()
-                                || state->window->hasQueuedInputEvents();
+  const bool browserRequested =
+      ConsumeBrowserEditorFrameRequest() || state->window->hasQueuedInputEvents();
   const bool timerDue = state->nextIdleWakeAtMs.has_value() && nowMs >= *state->nextIdleWakeAtMs;
   if (!editorRequested && !browserRequested && !timerDue) {
     // The GPU device lives on this thread, so its callbacks (the raster
@@ -303,8 +304,7 @@ void RunWasmEditorFrame(void* userdata) {
     // 1.9 second first-sample present, the idle-timer period, with the
     // raster thread burning 265 poll round trips. A non-blocking poll on
     // every skipped tick is nanoseconds when nothing is pending.
-    if (const std::shared_ptr<donner::geode::GeodeDevice> device =
-            state->window->geodeDevice()) {
+    if (const std::shared_ptr<donner::geode::GeodeDevice> device = state->window->geodeDevice()) {
       device->pollSuspending(false);
     }
     return;
@@ -417,6 +417,7 @@ int main(int argc, char** argv) {
                    .initialPath = initialPath,
                    .showWelcome = showWelcome,
                    .editorNoticeText = EmbeddedBytesToString(donner::embedded::kEditorNoticeText),
+                   .editorBuildInfo = EmbeddedBytesToString(donner::embedded::kEditorBuildInfo),
                    .reproOutputPath = reproOutputPath});
   if (!shell->valid()) {
     if (svgPath.has_value()) {

--- a/donner/editor/tests/EditorDockLayout_tests.cc
+++ b/donner/editor/tests/EditorDockLayout_tests.cc
@@ -98,6 +98,7 @@ TEST_F(EditorDockLayoutTest, BuildsCanvasCentralNodeWithStackedRightColumn) {
   EXPECT_NE(nodes.central, 0u);
   EXPECT_NE(nodes.rightTop, 0u);
   EXPECT_NE(nodes.rightMid, 0u);
+  // The Compositor Debug Info panel is docked in the inspector area.
   EXPECT_NE(nodes.rightBottom, 0u);
   // Every panel lands in a distinct node.
   EXPECT_NE(nodes.central, nodes.rightTop);
@@ -157,11 +158,9 @@ TEST_F(EditorDockLayoutTest, CompactLayoutReservesEntireDockspaceForCanvas) {
   EditorDockLayoutParams params = DefaultParams(/*includeCompositorDebug=*/false);
   params.includeSidebars = false;
 
-  const EditorDockNodes nodes =
-      RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false,
-                      /*build=*/true, params);
-  RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false,
-                  /*build=*/false);
+  const EditorDockNodes nodes = RenderDockFrame(
+      dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false, /*build=*/true, params);
+  RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false, /*build=*/false);
 
   EXPECT_EQ(nodes.central, dockspaceId);
   EXPECT_EQ(nodes.rightTop, 0u);
@@ -197,9 +196,12 @@ TEST_F(EditorDockLayoutTest, ResetRestoresDefaultLayoutAfterRearrange) {
   EXPECT_NE(DockNodeIdForWindow(kInspectorWindowName), original.central);
 }
 
-TEST_F(EditorDockLayoutTest, LockGatesResizeSplitAndUndock) {
+TEST_F(EditorDockLayoutTest, LockGatesSplitAndUndockButKeepsResizing) {
   const ImGuiDockNodeFlags locked = EditorDockSpaceFlags(true);
-  EXPECT_TRUE(locked & ImGuiDockNodeFlags_NoResize);
+  // Locking fixes the layout structure: no new splits and no undocking
+  // (tear-off), but the existing splitters stay resizable so the right column
+  // width and panel heights can be adjusted.
+  EXPECT_FALSE(locked & ImGuiDockNodeFlags_NoResize);
   EXPECT_TRUE(locked & ImGuiDockNodeFlags_NoDockingSplit);
   EXPECT_TRUE(locked & ImGuiDockNodeFlags_NoUndocking);
 
@@ -221,13 +223,16 @@ TEST_F(EditorDockLayoutTest, LockFlagsPropagateToLiveDockNodes) {
   RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/true, /*build=*/false);
   ImGuiDockNode* rootLocked = ImGui::DockBuilderGetNode(dockspaceId);
   ASSERT_NE(rootLocked, nullptr);
-  EXPECT_TRUE(rootLocked->MergedFlags & ImGuiDockNodeFlags_NoResize);
+  // Locked nodes keep splitters resizable but block undocking.
+  EXPECT_FALSE(rootLocked->MergedFlags & ImGuiDockNodeFlags_NoResize);
+  EXPECT_TRUE(rootLocked->MergedFlags & ImGuiDockNodeFlags_NoUndocking);
 
   RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/false);
   RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/false);
   ImGuiDockNode* rootUnlocked = ImGui::DockBuilderGetNode(dockspaceId);
   ASSERT_NE(rootUnlocked, nullptr);
   EXPECT_FALSE(rootUnlocked->MergedFlags & ImGuiDockNodeFlags_NoResize);
+  EXPECT_FALSE(rootUnlocked->MergedFlags & ImGuiDockNodeFlags_NoUndocking);
 }
 
 }  // namespace

--- a/donner/editor/tests/EditorSampleCatalog_tests.cc
+++ b/donner/editor/tests/EditorSampleCatalog_tests.cc
@@ -12,21 +12,17 @@
 #include "donner/svg/SVGSVGElement.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace donner::editor {
 namespace {
 
-using ::testing::HasSubstr;
-using ::testing::Not;
-
 TEST(EditorSampleCatalog, HasStableUniqueAsciiIdsInDisplayOrder) {
   const std::span<const EditorSample> samples = GetEditorSampleCatalog();
-  ASSERT_EQ(samples.size(), 5u);
+  ASSERT_EQ(samples.size(), 4u);
 
-  constexpr std::array<std::string_view, 5> kExpectedIds = {
-      "donner-splash", "basic-shapes", "text-style", "gradients-clip", "donner-showcase"};
+  constexpr std::array<std::string_view, 4> kExpectedIds = {"donner-splash", "basic-shapes",
+                                                            "text-style", "gradients-clip"};
   std::unordered_set<std::string_view> ids;
   for (std::size_t i = 0; i < samples.size(); ++i) {
     EXPECT_EQ(samples[i].id, kExpectedIds[i]);
@@ -49,14 +45,9 @@ TEST(EditorSampleCatalog, EntriesHaveTitlesAndSources) {
   EXPECT_EQ(FindEditorSample("missing-sample"), nullptr);
 }
 
-TEST(EditorSampleCatalog, GeneratesShowcaseFromCanonicalSplashOnDemand) {
+TEST(EditorSampleCatalog, ShowcaseSampleRemovedFromCatalog) {
   const EditorSample* showcase = FindEditorSample("donner-showcase");
-  ASSERT_NE(showcase, nullptr);
-  EXPECT_EQ(showcase->title, "Donner Showcase");
-  EXPECT_THAT(showcase->source, HasSubstr("id=\"showcase_svg_label_outlines\""));
-  EXPECT_THAT(showcase->source, HasSubstr("data-donner-converted-from=\"text\""));
-  EXPECT_THAT(showcase->source, HasSubstr("id=\"donner-editor-overlay\""));
-  EXPECT_THAT(showcase->source, Not(HasSubstr("<text")));
+  EXPECT_EQ(showcase, nullptr);
 }
 
 TEST(EditorSampleCatalog, SourcesParseWithUsableRootDimensions) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -458,11 +458,17 @@ TEST(EditorShellInternalTest, BusyFrameReplaysDocumentUiBooleansWithoutEvaluatin
 
 TEST(EditorShellInternalTest, LateSamplePickerActionsRequestAHostFollowupFrame) {
   EXPECT_FALSE(internal::SamplePickerActionsNeedFollowupFrame(/*dismiss=*/false,
-                                                              /*openFile=*/false));
+                                                              /*openFile=*/false,
+                                                              /*newDocument=*/false));
   EXPECT_TRUE(internal::SamplePickerActionsNeedFollowupFrame(/*dismiss=*/true,
-                                                             /*openFile=*/false));
+                                                             /*openFile=*/false,
+                                                             /*newDocument=*/false));
   EXPECT_TRUE(internal::SamplePickerActionsNeedFollowupFrame(/*dismiss=*/false,
-                                                             /*openFile=*/true));
+                                                             /*openFile=*/true,
+                                                             /*newDocument=*/false));
+  EXPECT_TRUE(internal::SamplePickerActionsNeedFollowupFrame(/*dismiss=*/false,
+                                                             /*openFile=*/false,
+                                                             /*newDocument=*/true));
 }
 
 TEST(EditorShellInternalTest, BusyDeferredRenderWaitsForWorkerCompletionInsteadOfSpinning) {

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -54,6 +54,7 @@ TEST_F(MenuBarPresenterTest, RendersDisabledMenusWithoutActions) {
   const MenuBarActions actions = RenderFrame(state);
 
   EXPECT_FALSE(actions.openAbout);
+  EXPECT_FALSE(actions.newFile);
   EXPECT_FALSE(actions.openFile);
   EXPECT_FALSE(actions.saveFile);
   EXPECT_FALSE(actions.saveFileAs);
@@ -84,6 +85,7 @@ TEST_F(MenuBarPresenterTest, RendersEnabledStateWithBoldMenuFont) {
   const MenuBarActions actions = RenderFrame(state, font);
 
   EXPECT_FALSE(actions.openAbout);
+  EXPECT_FALSE(actions.newFile);
   EXPECT_FALSE(actions.openFile);
   EXPECT_FALSE(actions.saveFile);
   EXPECT_FALSE(actions.saveFileAs);
@@ -120,6 +122,7 @@ TEST_F(MenuBarPresenterTest, RendersEachOpenMenuWithoutImplicitActions) {
     PrimeMainMenuPopup(menuLabel);
     const MenuBarActions actions = RenderFrame(state);
     EXPECT_FALSE(actions.openAbout) << menuLabel;
+    EXPECT_FALSE(actions.newFile) << menuLabel;
     EXPECT_FALSE(actions.openFile) << menuLabel;
     EXPECT_FALSE(actions.openSamples) << menuLabel;
     EXPECT_FALSE(actions.saveFile) << menuLabel;
@@ -213,6 +216,10 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   MenuBarActions actions;
   ApplyMenuBarCommand(true, MenuBarCommand::OpenAbout, state, &actions);
   EXPECT_TRUE(actions.openAbout);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::NewFile, state, &actions);
+  EXPECT_TRUE(actions.newFile);
 
   actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::OpenFile, state, &actions);

--- a/donner/editor/tests/NativeWindowChrome_tests.cc
+++ b/donner/editor/tests/NativeWindowChrome_tests.cc
@@ -30,28 +30,60 @@ TEST(ComposeWindowTitle, UntitledEditedNativeIndicatorOmitsDot) {
 }
 
 TEST(ComposeWindowTitle, NamedFileUsesBasename) {
-  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
-                                .edited = false};
+  const WindowChromeState state{
+      .filePath = std::optional<std::string>("/home/user/art/diagram.svg"), .edited = false};
   EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
             "diagram.svg - Donner SVG Editor");
 }
 
 TEST(ComposeWindowTitle, NamedFileEditedShowsDotInText) {
-  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
-                                .edited = true};
+  const WindowChromeState state{
+      .filePath = std::optional<std::string>("/home/user/art/diagram.svg"), .edited = true};
   EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
             std::string(kDotPrefix) + "diagram.svg - Donner SVG Editor");
 }
 
 TEST(ComposeWindowTitle, NamedFileEditedNativeIndicatorOmitsDot) {
-  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
-                                .edited = true};
+  const WindowChromeState state{
+      .filePath = std::optional<std::string>("/home/user/art/diagram.svg"), .edited = true};
   EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/false),
             "diagram.svg - Donner SVG Editor");
 }
 
 TEST(ComposeWindowTitle, EmptyPathTreatedAsUntitled) {
   const WindowChromeState state{.filePath = std::optional<std::string>(""), .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "untitled - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, SampleDocumentNameUsedWithoutFilePath) {
+  const WindowChromeState state{.filePath = std::nullopt,
+                                .documentName = std::optional<std::string>("Donner Splash Sample"),
+                                .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "Donner Splash Sample - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, SampleDocumentNameEditedShowsDotInText) {
+  const WindowChromeState state{.filePath = std::nullopt,
+                                .documentName = std::optional<std::string>("Donner Splash Sample"),
+                                .edited = true};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            std::string(kDotPrefix) + "Donner Splash Sample - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, FilePathTakesPrecedenceOverDocumentName) {
+  const WindowChromeState state{
+      .filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
+      .documentName = std::optional<std::string>("Donner Splash Sample"),
+      .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "diagram.svg - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, EmptyDocumentNameTreatedAsUntitled) {
+  const WindowChromeState state{
+      .filePath = std::nullopt, .documentName = std::optional<std::string>(""), .edited = false};
   EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
             "untitled - Donner SVG Editor");
 }

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -67,8 +67,8 @@ TEST(SamplePickerPresenter, EmptyCatalogLayoutHasNoRowsOrColumns) {
 }
 
 TEST(SamplePickerPresenter, DescriptionsCoverCatalogAndFallback) {
-  constexpr std::array<std::string_view, 5> kSampleIds = {
-      "donner-splash", "basic-shapes", "text-style", "gradients-clip", "donner-showcase"};
+  constexpr std::array<std::string_view, 4> kSampleIds = {"donner-splash", "basic-shapes",
+                                                          "text-style", "gradients-clip"};
   for (const std::string_view id : kSampleIds) {
     EXPECT_FALSE(SamplePickerDescription(id).empty());
   }
@@ -84,6 +84,11 @@ TEST(SamplePickerPresenter, CommandsProduceSemanticActions) {
   actions = SamplePickerActions{};
   ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
   EXPECT_TRUE(actions.openFile);
+
+  actions = SamplePickerActions{};
+  ApplySamplePickerCommand(true, SamplePickerCommand::NewDocument, {}, &actions);
+  EXPECT_TRUE(actions.newDocument);
+  EXPECT_FALSE(actions.openFile);
 
   actions = SamplePickerActions{};
 
@@ -122,14 +127,15 @@ TEST(SamplePickerPresenter, CommandsIgnoreEmptySampleAndNullAccumulator) {
 
 /// True when no action flag is set on @p actions.
 bool NoActions(const SamplePickerActions& actions) {
-  return !actions.dismiss && !actions.openFile && !actions.loadSample && !actions.openGitHub &&
-         actions.sampleId.empty();
+  return !actions.dismiss && !actions.openFile && !actions.newDocument && !actions.loadSample &&
+         !actions.openGitHub && actions.sampleId.empty();
 }
 
 /// Accumulate every edge-triggered flag from @p frame into @p merged.
 void MergeActions(SamplePickerActions& merged, const SamplePickerActions& frame) {
   merged.dismiss = merged.dismiss || frame.dismiss;
   merged.openFile = merged.openFile || frame.openFile;
+  merged.newDocument = merged.newDocument || frame.newDocument;
   merged.loadSample = merged.loadSample || frame.loadSample;
   merged.openGitHub = merged.openGitHub || frame.openGitHub;
   if (!frame.sampleId.empty()) {
@@ -268,39 +274,31 @@ TEST_F(SamplePickerPresenterImGuiTest, ClickingDismissButtonEmitsDismiss) {
   EXPECT_TRUE(dismissed.dismiss) << "Dismiss button not found along the top-right edge";
 }
 
-TEST_F(SamplePickerPresenterImGuiTest, ClickingActionButtonsEmitsOpenFileAndOpenGitHub) {
+TEST_F(SamplePickerPresenterImGuiTest, ClickingActionButtonsEmitsNewDocumentOpenFileAndOpenGitHub) {
   const SamplePickerState state;
   constexpr float kHostWidth = 1024.0f;
 
   Frame(state, {}, kHostWidth);
 
-  // The "Open SVG" button hugs the left content edge below the heading text;
-  // its vertical position depends on font metrics, so probe downward.
-  float openRowY = -1.0f;
-  for (float y = 56.0f; y <= 400.0f; y += 6.0f) {
-    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(60.0f, y));
-    EXPECT_FALSE(actions.dismiss);
-    EXPECT_FALSE(actions.loadSample);
-    if (actions.openFile) {
-      openRowY = y;
-      break;
+  // Scan the action-button band for the three primary actions. The "New SVG"
+  // and "Open SVG" buttons are 44px touch targets while the GitHub hyperlink
+  // is a thin centered text link, so probe a grid across the whole band.
+  bool foundNew = false;
+  bool foundOpen = false;
+  bool foundGit = false;
+  for (float y = 40.0f; y <= 200.0f && !(foundNew && foundOpen && foundGit); y += 4.0f) {
+    for (float x = 0.0f; x <= 800.0f && !(foundNew && foundOpen && foundGit); x += 8.0f) {
+      const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, y));
+      EXPECT_FALSE(actions.dismiss);
+      EXPECT_FALSE(actions.loadSample);
+      foundNew = foundNew || actions.newDocument;
+      foundOpen = foundOpen || actions.openFile;
+      foundGit = foundGit || actions.openGitHub;
     }
   }
-  ASSERT_GT(openRowY, 0.0f) << "Open SVG button not found along the left edge";
-
-  // The GitHub action sits on the same row, right of the 112px-wide Open SVG
-  // button (8px gap).
-  bool openedGitHub = false;
-  for (float x = 132.0f; x <= 300.0f; x += 12.0f) {
-    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, openRowY));
-    EXPECT_FALSE(actions.dismiss);
-    EXPECT_FALSE(actions.loadSample);
-    if (actions.openGitHub) {
-      openedGitHub = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(openedGitHub) << "GitHub action button not found on the Open SVG row";
+  EXPECT_TRUE(foundNew) << "New SVG button not found";
+  EXPECT_TRUE(foundOpen) << "Open SVG button not found";
+  EXPECT_TRUE(foundGit) << "GitHub hyperlink not found on the action band";
 }
 
 TEST_F(SamplePickerPresenterImGuiTest, ClickingFirstSampleCardLoadsThatSample) {

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -199,7 +199,10 @@ cc_binary(
         ":wasm_enabled": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    deps = _EDITOR_WASM_BINARY_DEPS + ["//donner/editor:notice"],
+    deps = _EDITOR_WASM_BINARY_DEPS + [
+        "//donner/editor:editor_build_info",
+        "//donner/editor:notice",
+    ],
 )
 
 wasm_cc_binary(

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -713,7 +713,7 @@ test("WGPU diagnostics do not block the first carousel interaction", async ({ pa
     .toEqual({
       active: false,
       pending: false,
-      ready: 5,
+      ready: 4,
       resultReady: false,
     });
   await expect

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -501,11 +501,11 @@ test("welcome picker paints before asynchronously rendering real SVG thumbnails"
 
   await expect
     .poll(async () => page.evaluate(() => window.__donnerSampleThumbnailStats?.ready || 0), {
-      message: "expected all five catalog SVGs to publish real Donner-rendered thumbnails",
+      message: "expected all four catalog SVGs to publish real Donner-rendered thumbnails",
       timeout: 15000,
       intervals: [0, 25, 50, 100],
     })
-    .toBe(5);
+    .toBe(4);
 
   let geodeThumbnailStats: WgpuCarouselThumbnailStats[] | undefined;
   if (kBackend === "geode") {
@@ -534,16 +534,16 @@ test("welcome picker paints before asynchronously rendering real SVG thumbnails"
     settled.thumbnails?.carouselFrame || 0,
   );
   expect(settled.thumbnails).toMatchObject({
-    requested: 5,
-    started: 5,
-    completed: 5,
-    rendered: 5,
-    ready: 5,
+    requested: 4,
+    started: 4,
+    completed: 4,
+    rendered: 4,
+    ready: 4,
     pending: false,
     active: false,
     resultReady: false,
   });
-  expect(settled.thumbnails?.publicationFrames).toHaveLength(5);
+  expect(settled.thumbnails?.publicationFrames).toHaveLength(4);
   const publicationFrames = settled.thumbnails?.publicationFrames || [];
   for (let index = 1; index < publicationFrames.length; ++index) {
     expect(publicationFrames[index]).toBeGreaterThan(publicationFrames[index - 1]);
@@ -555,7 +555,6 @@ test("welcome picker paints before asynchronously rendering real SVG thumbnails"
     { id: "basic-shapes", column: 1, row: 0 },
     { id: "text-style", column: 2, row: 0 },
     { id: "gradients-clip", column: 0, row: 1 },
-    { id: "donner-showcase", column: 1, row: 1 },
   ] as const;
   if (kBackend === "geode") {
     expect(geodeThumbnailStats).toHaveLength(thumbnailSamples.length);
@@ -575,7 +574,7 @@ test("welcome picker paints before asynchronously rendering real SVG thumbnails"
         .toBeLessThan(stats.samples - 32);
       fingerprints.add(stats.fingerprint);
     }
-    expect(fingerprints.size, "all five card interiors should contain distinct source art").toBe(5);
+    expect(fingerprints.size, "all four card interiors should contain distinct source art").toBe(4);
     expect(geodeThumbnailStats?.[2].backgroundPixels).toBeGreaterThan(1000);
     expect(geodeThumbnailStats?.[2].glyphPixels).toBeGreaterThan(20);
   } else {
@@ -850,7 +849,6 @@ for (
     { id: "basic-shapes", name: "Basic Shapes", xFraction: 0.5, y: 282 },
     { id: "text-style", name: "Text and Style", xFraction: 0.76, y: 282 },
     { id: "gradients-clip", name: "Gradients and Clip", xFraction: 0.24, y: 390 },
-    { id: "donner-showcase", name: "Donner Showcase", xFraction: 0.5, y: 390 },
   ] as const
 ) {
   test(`carousel loads ${sample.name} on the first interactive frame`, async ({ page }) => {

--- a/donner/editor/write_build_info.sh
+++ b/donner/editor/write_build_info.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Writes "<version>\n<commit>\n" to the output file.
+#
+# The version string is read from MODULE.bazel, the repo's single source of
+# truth for the Donner version. The commit is the current git HEAD, falling
+# back to "unknown" when git is unavailable (e.g. a sandboxed or bare build).
+#
+# Usage: write_build_info.sh <path/to/MODULE.bazel> <output>
+set -euo pipefail
+
+MODULE="$1"
+OUT="$2"
+
+# Resolve the MODULE.bazel symlink in the Bazel execroot to the real source
+# tree so `git` can find the checkout's `.git`.
+if command -v realpath >/dev/null 2>&1; then
+  MODULE_REAL="$(realpath "$MODULE")"
+elif [ -L "$MODULE" ]; then
+  TARGET="$(readlink "$MODULE")"
+  case "$TARGET" in
+    /*) MODULE_REAL="$TARGET" ;;
+    *) MODULE_REAL="$(cd "$(dirname "$MODULE")" && pwd -P)/$TARGET" ;;
+  esac
+else
+  MODULE_REAL="$(cd "$(dirname "$MODULE")" && pwd -P)/$(basename "$MODULE")"
+fi
+WS="$(dirname "$MODULE_REAL")"
+
+VERSION="$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$MODULE" | head -n1)"
+if [ -z "$VERSION" ]; then
+  VERSION="unknown"
+fi
+COMMIT="$(git -C "$WS" rev-parse HEAD 2>/dev/null || echo unknown)"
+
+printf '%s\n%s\n' "$VERSION" "$COMMIT" > "$OUT"

--- a/donner_splash.svg
+++ b/donner_splash.svg
@@ -784,7 +784,7 @@
       xlink:href="#radial-gradient-63" />
   </defs>
   <g class="cls-94">
-    <g id="Background">
+    <g id="Background" data-donner-locked="true">
       <rect class="cls-89" width="892" height="512" />
     </g>
     <g id="Sunburst">

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -507,6 +507,17 @@ TEST(EditorControlSessionTest, DraggingSplashBackgroundDropsGhostPixelsFromPrese
                                                                 {"render_after_load", true}});
   ASSERT_TRUE(load.body.value("ok", false)) << load.body.dump(2);
 
+  // The splash Background is locked by default (data-donner-locked), so unlock
+  // it through the same Layers-panel handler the UI uses before dragging it.
+  ToolCallResult unlock =
+      session.handleToolCall("click_layer_button", json{{"selector", "#Background"},
+                                                       {"button", "lock"},
+                                                       {"include_display_before_render", false},
+                                                       {"include_final_frame", false},
+                                                       {"include_display_frame", false}});
+  ASSERT_TRUE(unlock.body.value("ok", false)) << unlock.body.dump(2);
+  ASSERT_EQ(unlock.body["after"].value("locked", true), false) << unlock.body.dump(2);
+
   ToolCallResult drag =
       session.handleToolCall("drag_selector", json{{"selector", "#Background"},
                                                    {"delta_x", 96.0},


### PR DESCRIPTION
Editor UI polish batch:

- Rename Compositor Debug to Compositor Debug Info and dock it at the bottom of the inspector area by default when toggled on.
- Keep the locked panel layout structurally fixed (no tear-off, no new splits) while leaving the existing splitters resizable, so the right column width and panel heights can be adjusted.
- Remove the Donner Showcase entry from the sample catalog (now 4 samples) and update the wasm smoke expectations and release checklists accordingly.
- Title the window with the open sample name (e.g. Donner Splash Sample) when no file path is set.
- Add a New SVG button to the sample picker and File > New (Cmd+N) that create a blank document through the deferred document-replacement flow.
- Turn the sample-picker GitHub action into a clickable hyperlink showing the real URL; it opens in the browser on native and a new tab on wasm.
- Lock the splash Background group by default via data-donner-locked, and adapt the editor-control drag test to unlock it before dragging.
- Show the version (read from MODULE.bazel) and git commit hash in the About dialog, embedded into the binary at build time.

Validation: full `bazel test //...` is green (447 pass, 20 skipped); clang-format, buildifier, and the banned-patterns lint pass.
