### PR TITLE
Restore editor UX and animate source navigation

### DIFF
--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -1,7 +1,7 @@
 # Design: Editor Fluid Canvas Rendering
 
 **Status:** Implementation in progress
-**Author:** Codex
+**Author:** Unknown (model-authored; exact identifier not recorded)
 **Created:** 2026-05-27
 
 ## Summary
@@ -422,6 +422,19 @@ thing now and cull it" instead of "allocate a texture and upload it forever."
 
 Selection chrome is UI, not document content. It should not use a full-document raster target.
 
+Cached document tiles have one backend-specific presentation boundary. Geode/WGPU builds sample
+them directly into the window framebuffer. The non-WGPU GL path samples the same tile textures,
+with their full affine placement and paint order, into one pane-sized explicit intermediate and
+presents that texture with one axis-aligned ImGui image. The intermediate reuses unchanged
+compositions, retains no CPU copy of tile pixels, and reports both RGBA8 textures in presentation
+resource diagnostics. `//donner/editor/tests:render_pane_presenter_visual_repro_tests` pins affine
+placement and cache reuse, while `//donner/editor/tests:gl_texture_cache_tests` pins resource
+accounting. The WGPU presenter retains a compatibility-only per-tile fallback for a frame whose
+payload cannot enter the direct Geode underlay.
+`//donner/editor/tests:render_pane_presenter_visual_repro_tests` under `--config=geode` covers that
+fallback, while `//donner/editor/tests:gl_rnr_replay_tests` covers direct Geode and native GL
+presentation.
+
 Replace the current full-canvas overlay texture with:
 
 - immediate Geode drawing for handles, AABBs, marquee, and path outlines directly into the
@@ -432,8 +445,7 @@ Replace the current full-canvas overlay texture with:
 - culling against the visible document rect before path transformation/draw.
 
 In Geode editor builds, the immediate chrome path must use Donner renderer calls, not ImGui path
-commands. The render-pane presenter still uses ImGui to present cached canvas tiles, then
-`EditorWindow` invokes a post-ImGui direct-render callback before surface presentation/readback.
+commands. `EditorWindow` invokes a direct-render callback before surface presentation/readback.
 That callback points `RendererGeode` at the current swapchain texture, preserves existing
 framebuffer contents, pushes a framebuffer-space clip rect for the artboard, and calls
 `OverlayRenderer::drawChromeFromSnapshot`.
@@ -467,6 +479,10 @@ The retained snapshot above does not weaken that rule, because the rule is about
 chrome is re-pointed at the presented transform at draw time, so it never puts a newer transform
 over older pixels. Only geometry, which no reprojection can reconcile, is allowed to lead, and only
 by the single render it takes the gate to release.
+
+During an active move, resize, or rotate gesture, the immediate chrome uses gesture-owned oriented
+bounds and handles only. It does not traverse selected geometry or text layout on each pointer
+frame. Detailed path outlines and text baselines return after the interaction settles.
 
 Large selections use LOD:
 

--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -90,9 +90,8 @@ This design proposes a second responsiveness pass:
   - [x] Add large-selection LOD: combined bounds first, visible path outlines during idle.
 - [x] **M3: Clip and cull source-pane ropes.**
   - [x] Push a source-pane clip rect around `renderFocusReferenceLinks`.
-  - [x] Skip rope simulation/draw only when the complete connector/route AABB is outside the
-        visible text region. Endpoint visibility alone cannot cull a rope whose middle crosses the
-        viewport.
+  - [x] Accept animated-rope visibility only after computing the complete connector/route AABB.
+        Endpoint visibility alone cannot cull a rope whose middle crosses the viewport.
   - [x] Cap animated rope count and fall back to static straight connectors for overflow.
 - [x] **M4: Immediate-mode cheap compositor spans.**
   - [x] Add a `StaticSpanPlan` for each paint-order gap: `CachedTile` or `Immediate`.
@@ -507,9 +506,10 @@ presented transform every time it is drawn.
 clip and cull:
 
 - push a clip rect for the source text content area before rope drawing;
-- compute a cheap route AABB from source endpoint, target endpoint, and slack bounds, even when
-  both endpoints are outside opposite edges of the visible region;
-- skip simulation and draw when the route AABB is outside the visible text region;
+- compute the actual bounded catenary route before accepting an animated candidate as visible, even
+  when both endpoints are outside the same or opposite edges of the visible region;
+- skip drawing and discard retained simulation state when the complete route AABB is outside the
+  visible text region; overflow static connectors use their exact chord and decoration bounds;
 - cap active simulated ropes, e.g. 64 visible ropes, and draw overflow as static straight lines or a
   chip count;
 - sleep ropes immediately when the source pane is not hovered, not scrolling, and no rope is near

--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -90,8 +90,9 @@ This design proposes a second responsiveness pass:
   - [x] Add large-selection LOD: combined bounds first, visible path outlines during idle.
 - [x] **M3: Clip and cull source-pane ropes.**
   - [x] Push a source-pane clip rect around `renderFocusReferenceLinks`.
-  - [x] Skip rope simulation/draw for links whose source/target/route AABB is outside the visible
-        text region.
+  - [x] Skip rope simulation/draw only when the complete connector/route AABB is outside the
+        visible text region. Endpoint visibility alone cannot cull a rope whose middle crosses the
+        viewport.
   - [x] Cap animated rope count and fall back to static straight connectors for overflow.
 - [x] **M4: Immediate-mode cheap compositor spans.**
   - [x] Add a `StaticSpanPlan` for each paint-order gap: `CachedTile` or `Immediate`.
@@ -506,7 +507,8 @@ presented transform every time it is drawn.
 clip and cull:
 
 - push a clip rect for the source text content area before rope drawing;
-- compute a cheap route AABB from source endpoint, target endpoint, and slack bounds;
+- compute a cheap route AABB from source endpoint, target endpoint, and slack bounds, even when
+  both endpoints are outside opposite edges of the visible region;
 - skip simulation and draw when the route AABB is outside the visible text region;
 - cap active simulated ropes, e.g. 64 visible ropes, and draw overflow as static straight lines or a
   chip count;
@@ -629,7 +631,8 @@ Per design-doc invariant policy:
 - "Large selection first feedback is combined bounds only" must be enforced by
   `overlay_renderer_tests`.
 - "Immediate spans preserve paint order" must be enforced by compositor golden tests.
-- "Ropes cannot draw outside the source pane" must be enforced by a text-editor visual/unit test.
+- "Ropes cannot draw outside the source pane, and a crossing visible segment is not culled with its
+  endpoints" is enforced by `//donner/editor/tests:text_editor_tests`.
 
 ## Security / Privacy
 

--- a/docs/design_docs/0054-editor_design_language.md
+++ b/docs/design_docs/0054-editor_design_language.md
@@ -14,8 +14,9 @@ tokens and color intent.
 
 The visual MVP includes the application bar, dock tabs, source palette, canvas toolbar,
 Fill/Stroke chrome, canvas zoom control, and structured Inspector property lists for XML and
-computed CSS. The source pane starts collapsed behind a persistent reveal rail, and Transform uses
-aligned paired fields, direct click-to-type behavior, and a concurrent-DOM-safe edit lifecycle.
+computed CSS. The source pane starts collapsed behind a persistent reveal rail and slides in or out
+without resizing its contents, and Transform uses aligned paired fields, direct click-to-type
+behavior, and a concurrent-DOM-safe edit lifecycle.
 Toolbar and cursor artwork use one two-tone contrast system. It does not include workspace modes or
 runtime SVG interaction. The implemented interaction contract also keeps text entry, outlined-shape
 dragging, and source reveal within the UI frame budget by coalescing document work and validating
@@ -51,6 +52,8 @@ asynchronous source analysis by document revision.
 - Present XML and computed CSS as compact property lists with CSS-shaped values, separate cascade
   provenance, typed color swatches, and full-value hover disclosure.
 - Start with a canvas-first workspace while retaining an obvious, full-height source reveal rail.
+  Slide the fixed-width source surface behind that rail so opening and closing preserve readable
+  text geometry throughout the transition.
 - Present Position, Size, and Rotation as stable responsive rows, with the raw matrix behind a
   disclosure.
 - Give Transform axis labels dedicated fixed columns so field rectangles align independent of label
@@ -95,6 +98,7 @@ asynchronous source analysis by document revision.
 - [x] Remove viewport implementation telemetry from the Inspector.
 - [x] Polish XML attributes and computed CSS into compact, provenance-aware property lists.
 - [x] Collapse source by default behind a persistent reveal rail.
+- [x] Slide the source pane in and out without compressing its text layout.
 - [x] Rework Transform into responsive Position, Size, Rotation, and matrix rows.
 - [x] Align Transform fields on fixed axis/value columns and enable simple click-to-type input.
 - [x] Fix Transform activation's concurrent-DOM lock-upgrade deadlock.
@@ -130,6 +134,10 @@ The following targets enforce the design-language contracts:
 - `//donner/editor/tests:editor_shell_tests`
 - `//donner/editor/tests:text_editor_tests`
 - `//donner/editor/tests:inspector_ui_fuzzer`
+
+`//donner/editor/tests:editor_shell_layout_tests` pins intermediate source-pane slide geometry and
+its bounded frame-to-frame progress. `//donner/editor/tests:editor_shell_tests` owns the real ImGui
+pane and replay integration.
 
 The full editor frame is verified through
 `//donner/editor/tests:editor_rnr_gl_replay` with `zoom-out-drag-jump.rnr`, full-frame capture, and

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -283,9 +283,10 @@ struct RenderResult {
   };
 
   /// One composite tile from the worker's `CompositorController::
-  /// snapshotCompositorTiles()` snapshot. The editor uploads one GL texture
-  /// per tile (keyed on `id`) and
-  /// blits each tile at its canvas offset. Immediate tiles intentionally use
+  /// snapshotCompositorTiles()` snapshot. The editor uploads one GL texture per tile (keyed on
+  /// `id`). The GL presenter composes those cached textures into one pane-sized presentation
+  /// texture; the WebGPU presenter composites them directly into the framebuffer. Immediate tiles
+  /// intentionally use
   /// transient ids and always carry a fresh payload. Geometry fields are
   /// doc-unit quantities so the editor can scale them by the current
   /// `pixelsPerDocUnit` during canvas-resize debouncing.
@@ -340,10 +341,9 @@ struct RenderResult {
   };
 
   struct CompositedPreview {
-    /// Paint-order tile list. Blit in `tiles` order: each tile gets
-    /// one `AddImage` call at `(canvasOffsetDoc + dragTranslationDoc)
-    /// * pixelsPerDocUnit` with size `bitmapDimsDoc *
-    /// pixelsPerDocUnit`.
+    /// Paint-order tile list. Presentation samples the tiles in this order at
+    /// `(canvasOffsetDoc + dragTranslationDoc) * pixelsPerDocUnit`, with size
+    /// `bitmapDimsDoc * pixelsPerDocUnit`.
     std::vector<CompositedTile> tiles;
     /// Primary editor-promoted entity represented by a movable layer tile. Null when Off or when
     /// the requested selection must remain inside its owning compositor tiles.
@@ -758,8 +758,8 @@ public:
     return lastSegmentInspectorRows_;
   }
 
-  /// Unified in-paint-order snapshot of every tile the compositor
-  /// blits to produce the final composite.
+  /// Unified in-paint-order snapshot of every tile the compositor samples to produce the final
+  /// composite.
   /// The editor's layer-inspector panel renders this list with
   /// thumbnails for every tile so the operator can see the
   /// comprehensive composite at a glance.

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -859,10 +859,20 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "document_composite_texture",
+    hdrs = ["DocumentCompositeTexture.h"],
+    deps = [
+        ":imgui_headers",
+        "//donner/base",
+    ],
+)
+
+donner_cc_library(
     name = "render_pane_presenter",
     srcs = ["RenderPanePresenter.cc"],
     hdrs = ["RenderPanePresenter.h"],
     deps = [
+        ":document_composite_texture",
         ":gl_texture_cache",
         ":imgui_headers",
         ":menu_bar_presenter",
@@ -897,6 +907,65 @@ donner_cc_library(
         ":whole_app_worker_config",
         "//donner/base",
     ],
+)
+
+donner_cc_library(
+    name = "editor_shell_presentation",
+    srcs = ["EditorShellPresentation.cc"],
+    hdrs = ["EditorShellPresentation.h"],
+    defines = select({
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
+        "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":frame_cost_breakdown",
+        ":gl_texture_cache",
+        ":overlay_renderer",
+        ":presented_frame_composer",
+        ":render_pane_presenter",
+        ":select_tool",
+        ":tracy_wrapper",
+        ":viewport_state",
+        "//donner/base",
+        "//donner/editor/gui:editor_window",
+        "//donner/svg/renderer:renderer_interface",
+    ] + select({
+        ":wasm_geode_enabled": [
+            "//donner/svg/renderer:renderer_geode",
+        ],
+        "//donner/svg/renderer:renderer_backend_geode": [
+            "//donner/svg/renderer:renderer_geode",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+donner_cc_library(
+    name = "document_presentation_compositor",
+    srcs = ["DocumentPresentationCompositor.cc"],
+    hdrs = ["DocumentPresentationCompositor.h"],
+    defines = select({
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
+        "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":document_composite_texture",
+        ":editor_shell_presentation",
+        ":gl_texture_cache",
+        ":presented_frame_composer",
+        ":render_pane_presenter",
+        ":select_tool",
+        ":viewport_state",
+        "//donner/base",
+    ] + select({
+        ":wasm_geode_enabled": [],
+        "//donner/svg/renderer:renderer_backend_geode": [],
+        "//conditions:default": [
+            "//third_party/glad",
+        ],
+    }),
 )
 
 donner_cc_library(
@@ -954,8 +1023,6 @@ donner_cc_library(
     name = "editor_shell",
     srcs = [
         "EditorShell.cc",
-        "EditorShellPresentation.cc",
-        "EditorShellPresentation.h",
         "FillStrokeWidget.cc",
     ],
     hdrs = [
@@ -975,6 +1042,7 @@ donner_cc_library(
         ":compositor_debug_panel",
         ":dialog_presenter",
         ":disclosure_chevron",
+        ":document_presentation_compositor",
         ":document_presenter",
         ":document_save",
         ":document_sync_controller",
@@ -984,6 +1052,7 @@ donner_cc_library(
         ":editor_input_bridge",
         ":editor_sample_catalog",
         ":editor_shell_layout",
+        ":editor_shell_presentation",
         ":editor_symbol_glyphs",
         ":editor_theme",
         ":embedded_svg_icon",

--- a/donner/editor/DocumentCompositeTexture.h
+++ b/donner/editor/DocumentCompositeTexture.h
@@ -1,0 +1,17 @@
+#pragma once
+/// @file
+
+#include "donner/base/Box.h"
+#include "donner/base/Vector2.h"
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor {
+
+/// One axis-aligned document composite suitable for a single ImGui image draw.
+struct DocumentCompositeTextureView {
+  ImTextureID texture = 0;
+  Vector2i dimensions = Vector2i::Zero();
+  Box2d screenRect;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/DocumentPresentationCompositor.cc
+++ b/donner/editor/DocumentPresentationCompositor.cc
@@ -1,0 +1,656 @@
+#include "donner/editor/DocumentPresentationCompositor.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "donner/editor/EditorShellPresentation.h"
+#include "donner/editor/PresentedFrameComposer.h"
+#include "donner/editor/RenderPanePresenter.h"
+
+namespace donner::editor {
+
+#ifndef DONNER_EDITOR_WGPU
+namespace {
+
+struct TileKey {
+  ImTextureID texture = 0;
+  std::string id;
+  Entity layerEntity = entt::null;
+  std::uint64_t generation = 0;
+  Vector2i bitmapDimsPx = Vector2i::Zero();
+  Vector2d canvasOffsetDoc = Vector2d::Zero();
+  Vector2d bitmapDimsDoc = Vector2d::Zero();
+  Vector2d dragTranslationDoc = Vector2d::Zero();
+  Vector2d uvBottomRight = Vector2d(1.0, 1.0);
+  Transform2d documentFromCachedDocument = Transform2d();
+  bool metadataOnly = false;
+  bool isDragTarget = false;
+};
+
+TileKey MakeTileKey(const GlTextureCache::TileView& tile) {
+  return TileKey{
+      .texture = tile.texture,
+      .id = tile.id,
+      .layerEntity = tile.layerEntity,
+      .generation = tile.generation,
+      .bitmapDimsPx = tile.bitmapDimsPx,
+      .canvasOffsetDoc = tile.canvasOffsetDoc,
+      .bitmapDimsDoc = tile.bitmapDimsDoc,
+      .dragTranslationDoc = tile.dragTranslationDoc,
+      .uvBottomRight = tile.uvBottomRight,
+      .documentFromCachedDocument = tile.documentFromCachedDocument,
+      .metadataOnly = tile.metadataOnly,
+      .isDragTarget = tile.isDragTarget,
+  };
+}
+
+bool EqualTransform(const Transform2d& lhs, const Transform2d& rhs) {
+  return std::equal(std::begin(lhs.data), std::end(lhs.data), std::begin(rhs.data));
+}
+
+bool EqualTileKey(const TileKey& lhs, const TileKey& rhs) {
+  return lhs.texture == rhs.texture && lhs.id == rhs.id && lhs.layerEntity == rhs.layerEntity &&
+         lhs.generation == rhs.generation && lhs.bitmapDimsPx == rhs.bitmapDimsPx &&
+         lhs.canvasOffsetDoc == rhs.canvasOffsetDoc && lhs.bitmapDimsDoc == rhs.bitmapDimsDoc &&
+         lhs.dragTranslationDoc == rhs.dragTranslationDoc &&
+         lhs.uvBottomRight == rhs.uvBottomRight &&
+         EqualTransform(lhs.documentFromCachedDocument, rhs.documentFromCachedDocument) &&
+         lhs.metadataOnly == rhs.metadataOnly && lhs.isDragTarget == rhs.isDragTarget;
+}
+
+struct DragKey {
+  Entity entity = entt::null;
+  std::vector<Entity> extraEntities;
+  Vector2d translation = Vector2d::Zero();
+  Transform2d documentFromCachedDocument = Transform2d();
+  std::uint64_t dragGeneration = 0;
+};
+
+std::optional<DragKey> MakeDragKey(const std::optional<SelectTool::ActiveDragPreview>& preview) {
+  if (!preview.has_value()) {
+    return std::nullopt;
+  }
+  return DragKey{
+      .entity = preview->entity,
+      .extraEntities = preview->extraEntities,
+      .translation = preview->translation,
+      .documentFromCachedDocument = preview->documentFromCachedDocument,
+      .dragGeneration = preview->dragGeneration,
+  };
+}
+
+bool EqualDragKey(const std::optional<DragKey>& lhs, const std::optional<DragKey>& rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+  if (!lhs.has_value()) {
+    return true;
+  }
+  return lhs->entity == rhs->entity && lhs->extraEntities == rhs->extraEntities &&
+         lhs->translation == rhs->translation &&
+         EqualTransform(lhs->documentFromCachedDocument, rhs->documentFromCachedDocument) &&
+         lhs->dragGeneration == rhs->dragGeneration;
+}
+
+struct RequestKey {
+  ViewportState viewport;
+  Box2d imageClipRect;
+  std::vector<TileKey> overviewTiles;
+  std::vector<TileKey> tiles;
+  std::optional<DragKey> activeDrag;
+  std::optional<DragKey> displayedDrag;
+  Entity suppressedLayerEntity = entt::null;
+  bool suppressDragTargetTiles = false;
+};
+
+bool EqualViewport(const ViewportState& lhs, const ViewportState& rhs) {
+  return lhs.paneOrigin == rhs.paneOrigin && lhs.paneSize == rhs.paneSize &&
+         lhs.documentViewBox == rhs.documentViewBox &&
+         lhs.devicePixelRatio == rhs.devicePixelRatio && lhs.zoom == rhs.zoom &&
+         lhs.panDocPoint == rhs.panDocPoint && lhs.panScreenPoint == rhs.panScreenPoint;
+}
+
+bool EqualTileKeys(const std::vector<TileKey>& lhs, const std::vector<TileKey>& rhs) {
+  return lhs.size() == rhs.size() &&
+         std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), EqualTileKey);
+}
+
+bool EqualRequest(const RequestKey& lhs, const RequestKey& rhs) {
+  return EqualViewport(lhs.viewport, rhs.viewport) && lhs.imageClipRect == rhs.imageClipRect &&
+         EqualTileKeys(lhs.overviewTiles, rhs.overviewTiles) &&
+         EqualTileKeys(lhs.tiles, rhs.tiles) && EqualDragKey(lhs.activeDrag, rhs.activeDrag) &&
+         EqualDragKey(lhs.displayedDrag, rhs.displayedDrag) &&
+         lhs.suppressedLayerEntity == rhs.suppressedLayerEntity &&
+         lhs.suppressDragTargetTiles == rhs.suppressDragTargetTiles;
+}
+
+RequestKey MakeRequestKey(const ViewportState& viewport, const Box2d& imageClipRect,
+                          std::span<const GlTextureCache::TileView> overviewTiles,
+                          std::span<const GlTextureCache::TileView> tiles,
+                          const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+                          const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+                          Entity suppressedLayerEntity, bool suppressDragTargetTiles) {
+  RequestKey key{
+      .viewport = viewport,
+      .imageClipRect = imageClipRect,
+      .activeDrag = MakeDragKey(activeDragPreview),
+      .displayedDrag = MakeDragKey(displayedDragPreview),
+      .suppressedLayerEntity = suppressedLayerEntity,
+      .suppressDragTargetTiles = suppressDragTargetTiles,
+  };
+  key.overviewTiles.reserve(overviewTiles.size());
+  for (const GlTextureCache::TileView& tile : overviewTiles) {
+    key.overviewTiles.push_back(MakeTileKey(tile));
+  }
+  key.tiles.reserve(tiles.size());
+  for (const GlTextureCache::TileView& tile : tiles) {
+    key.tiles.push_back(MakeTileKey(tile));
+  }
+  return key;
+}
+
+GLuint CompileShader(GLenum type, const char* source) {
+  const GLuint shader = glCreateShader(type);
+  if (shader == 0) {
+    return 0;
+  }
+  glShaderSource(shader, 1, &source, nullptr);
+  glCompileShader(shader);
+  GLint compiled = GL_FALSE;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+  if (compiled == GL_TRUE) {
+    return shader;
+  }
+  std::array<char, 1024> log{};
+  GLsizei length = 0;
+  glGetShaderInfoLog(shader, static_cast<GLsizei>(log.size()), &length, log.data());
+  std::fprintf(stderr, "DocumentPresentationCompositor shader compile failed: %.*s\n",
+               static_cast<int>(length), log.data());
+  glDeleteShader(shader);
+  return 0;
+}
+
+GLuint LinkProgram(const char* vertexSource, const char* fragmentSource) {
+  const GLuint vertex = CompileShader(GL_VERTEX_SHADER, vertexSource);
+  const GLuint fragment = CompileShader(GL_FRAGMENT_SHADER, fragmentSource);
+  if (vertex == 0 || fragment == 0) {
+    if (vertex != 0) {
+      glDeleteShader(vertex);
+    }
+    if (fragment != 0) {
+      glDeleteShader(fragment);
+    }
+    return 0;
+  }
+  const GLuint program = glCreateProgram();
+  glAttachShader(program, vertex);
+  glAttachShader(program, fragment);
+  glLinkProgram(program);
+  glDeleteShader(vertex);
+  glDeleteShader(fragment);
+  GLint linked = GL_FALSE;
+  glGetProgramiv(program, GL_LINK_STATUS, &linked);
+  if (linked == GL_TRUE) {
+    return program;
+  }
+  std::array<char, 1024> log{};
+  GLsizei length = 0;
+  glGetProgramInfoLog(program, static_cast<GLsizei>(log.size()), &length, log.data());
+  std::fprintf(stderr, "DocumentPresentationCompositor program link failed: %.*s\n",
+               static_cast<int>(length), log.data());
+  glDeleteProgram(program);
+  return 0;
+}
+
+struct SavedGlState {
+  GLint framebuffer = 0;
+  GLint program = 0;
+  GLint activeTexture = 0;
+  GLint texture0 = 0;
+  GLint arrayBuffer = 0;
+  GLint vertexArray = 0;
+  std::array<GLint, 4> viewport{};
+  std::array<GLint, 4> scissorBox{};
+  std::array<GLfloat, 4> clearColor{};
+  GLint blendSrcRgb = 0;
+  GLint blendDstRgb = 0;
+  GLint blendSrcAlpha = 0;
+  GLint blendDstAlpha = 0;
+  GLint blendEquationRgb = 0;
+  GLint blendEquationAlpha = 0;
+  GLboolean blend = GL_FALSE;
+  GLboolean scissor = GL_FALSE;
+  GLboolean depth = GL_FALSE;
+  GLboolean cull = GL_FALSE;
+  GLboolean stencil = GL_FALSE;
+
+  SavedGlState() {
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+    glGetIntegerv(GL_CURRENT_PROGRAM, &program);
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture);
+    glActiveTexture(GL_TEXTURE0);
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture0);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer);
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertexArray);
+    glGetIntegerv(GL_VIEWPORT, viewport.data());
+    glGetIntegerv(GL_SCISSOR_BOX, scissorBox.data());
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor.data());
+    glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrcRgb);
+    glGetIntegerv(GL_BLEND_DST_RGB, &blendDstRgb);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcAlpha);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDstAlpha);
+    glGetIntegerv(GL_BLEND_EQUATION_RGB, &blendEquationRgb);
+    glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &blendEquationAlpha);
+    blend = glIsEnabled(GL_BLEND);
+    scissor = glIsEnabled(GL_SCISSOR_TEST);
+    depth = glIsEnabled(GL_DEPTH_TEST);
+    cull = glIsEnabled(GL_CULL_FACE);
+    stencil = glIsEnabled(GL_STENCIL_TEST);
+  }
+
+  ~SavedGlState() {
+    glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(framebuffer));
+    glUseProgram(static_cast<GLuint>(program));
+    glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer));
+    glBindVertexArray(static_cast<GLuint>(vertexArray));
+    glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+    glScissor(scissorBox[0], scissorBox[1], scissorBox[2], scissorBox[3]);
+    glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
+    glBlendFuncSeparate(static_cast<GLenum>(blendSrcRgb), static_cast<GLenum>(blendDstRgb),
+                        static_cast<GLenum>(blendSrcAlpha), static_cast<GLenum>(blendDstAlpha));
+    glBlendEquationSeparate(static_cast<GLenum>(blendEquationRgb),
+                            static_cast<GLenum>(blendEquationAlpha));
+    const auto restoreEnable = [](GLenum capability, GLboolean enabled) {
+      if (enabled == GL_TRUE) {
+        glEnable(capability);
+      } else {
+        glDisable(capability);
+      }
+    };
+    restoreEnable(GL_BLEND, blend);
+    restoreEnable(GL_SCISSOR_TEST, scissor);
+    restoreEnable(GL_DEPTH_TEST, depth);
+    restoreEnable(GL_CULL_FACE, cull);
+    restoreEnable(GL_STENCIL_TEST, stencil);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture0));
+    glActiveTexture(static_cast<GLenum>(activeTexture));
+  }
+};
+
+struct Vertex {
+  float x = 0.0f;
+  float y = 0.0f;
+  float u = 0.0f;
+  float v = 0.0f;
+};
+
+Box2d QuadBounds(const PresentedTileQuad& quad) {
+  Box2d bounds = Box2d::CreateEmpty(quad.topLeft);
+  bounds.addPoint(quad.topRight);
+  bounds.addPoint(quad.bottomRight);
+  bounds.addPoint(quad.bottomLeft);
+  return bounds;
+}
+
+bool IsValidSize(const Vector2i& size) {
+  return size.x > 0 && size.y > 0 && size.x <= ViewportState::kMaxCanvasDim &&
+         size.y <= ViewportState::kMaxCanvasDim;
+}
+
+}  // namespace
+#endif
+
+struct DocumentPresentationCompositor::Impl {
+#ifndef DONNER_EDITOR_WGPU
+  GLuint framebuffer = 0;
+  GLuint premultipliedTexture = 0;
+  GLuint resolvedTexture = 0;
+  GLuint vertexArray = 0;
+  GLuint vertexBuffer = 0;
+  GLuint tileProgram = 0;
+  GLuint resolveProgram = 0;
+  Vector2i allocationSize = Vector2i::Zero();
+  std::optional<RequestKey> lastRequest;
+  DocumentCompositeTextureView view;
+  std::uint64_t compositionCount = 0;
+
+  ~Impl() {
+    if (tileProgram != 0) {
+      glDeleteProgram(tileProgram);
+    }
+    if (resolveProgram != 0) {
+      glDeleteProgram(resolveProgram);
+    }
+    if (vertexBuffer != 0) {
+      glDeleteBuffers(1, &vertexBuffer);
+    }
+    if (vertexArray != 0) {
+      glDeleteVertexArrays(1, &vertexArray);
+    }
+    if (premultipliedTexture != 0) {
+      glDeleteTextures(1, &premultipliedTexture);
+    }
+    if (resolvedTexture != 0) {
+      glDeleteTextures(1, &resolvedTexture);
+    }
+    if (framebuffer != 0) {
+      glDeleteFramebuffers(1, &framebuffer);
+    }
+  }
+
+  bool ensurePrograms() {
+    if (tileProgram != 0 && resolveProgram != 0 && vertexArray != 0 && vertexBuffer != 0) {
+      return true;
+    }
+    constexpr const char* kVersion = "#version 330 core\n";
+    const std::string vertexSource = std::string(kVersion) +
+                                     R"glsl(layout(location = 0) in vec2 positionPx;
+layout(location = 1) in vec2 textureUv;
+uniform vec2 outputSizePx;
+out vec2 uv;
+void main() {
+  vec2 ndc = positionPx / outputSizePx * 2.0 - 1.0;
+  gl_Position = vec4(ndc, 0.0, 1.0);
+  uv = textureUv;
+}
+)glsl";
+    const std::string tileFragmentSource = std::string(kVersion) +
+                                           R"glsl(in vec2 uv;
+uniform sampler2D sourceTexture;
+out vec4 outputColor;
+void main() {
+  vec4 color = texture(sourceTexture, uv);
+  outputColor = vec4(color.rgb * color.a, color.a);
+}
+)glsl";
+    const std::string resolveFragmentSource = std::string(kVersion) +
+                                              R"glsl(in vec2 uv;
+uniform sampler2D sourceTexture;
+out vec4 outputColor;
+void main() {
+  vec4 color = texture(sourceTexture, uv);
+  outputColor = color.a > 0.0 ? vec4(color.rgb / color.a, color.a) : vec4(0.0);
+}
+)glsl";
+    tileProgram = LinkProgram(vertexSource.c_str(), tileFragmentSource.c_str());
+    resolveProgram = LinkProgram(vertexSource.c_str(), resolveFragmentSource.c_str());
+    if (tileProgram == 0 || resolveProgram == 0) {
+      return false;
+    }
+    glGenVertexArrays(1, &vertexArray);
+    glGenBuffers(1, &vertexBuffer);
+    if (vertexArray == 0 || vertexBuffer == 0) {
+      return false;
+    }
+    glBindVertexArray(vertexArray);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(Vertex) * 6u), nullptr,
+                 GL_STREAM_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          reinterpret_cast<void*>(offsetof(Vertex, x)));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          reinterpret_cast<void*>(offsetof(Vertex, u)));
+    return true;
+  }
+
+  bool ensureTextures(const Vector2i& size) {
+    if (!IsValidSize(size)) {
+      return false;
+    }
+    if (framebuffer == 0) {
+      glGenFramebuffers(1, &framebuffer);
+    }
+    if (premultipliedTexture == 0) {
+      glGenTextures(1, &premultipliedTexture);
+    }
+    if (resolvedTexture == 0) {
+      glGenTextures(1, &resolvedTexture);
+    }
+    if (framebuffer == 0 || premultipliedTexture == 0 || resolvedTexture == 0) {
+      return false;
+    }
+    if (allocationSize == size) {
+      return true;
+    }
+    const auto allocate = [&](GLuint texture) {
+      glBindTexture(GL_TEXTURE_2D, texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, size.x, size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                   nullptr);
+    };
+    allocate(premultipliedTexture);
+    allocate(resolvedTexture);
+    allocationSize = size;
+    lastRequest.reset();
+    return true;
+  }
+
+  bool attach(GLuint texture) const {
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    return glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+  }
+
+  void setClip(const Box2d& clip, const Vector2i& size) const {
+    const int left = std::clamp(static_cast<int>(std::floor(clip.topLeft.x)), 0, size.x);
+    const int top = std::clamp(static_cast<int>(std::floor(clip.topLeft.y)), 0, size.y);
+    const int right = std::clamp(static_cast<int>(std::ceil(clip.bottomRight.x)), 0, size.x);
+    const int bottom = std::clamp(static_cast<int>(std::ceil(clip.bottomRight.y)), 0, size.y);
+    glScissor(left, top, std::max(0, right - left), std::max(0, bottom - top));
+  }
+
+  void drawQuad(GLuint texture, const PresentedTileQuad& quad, const Vector2d& uvBottomRight,
+                GLuint program, const Vector2i& outputSize) const {
+    const float u = static_cast<float>(uvBottomRight.x);
+    const float v = static_cast<float>(uvBottomRight.y);
+    const std::array<Vertex, 6> vertices = {
+        Vertex{static_cast<float>(quad.topLeft.x), static_cast<float>(quad.topLeft.y), 0.0f, 0.0f},
+        Vertex{static_cast<float>(quad.topRight.x), static_cast<float>(quad.topRight.y), u, 0.0f},
+        Vertex{static_cast<float>(quad.bottomRight.x), static_cast<float>(quad.bottomRight.y), u,
+               v},
+        Vertex{static_cast<float>(quad.topLeft.x), static_cast<float>(quad.topLeft.y), 0.0f, 0.0f},
+        Vertex{static_cast<float>(quad.bottomRight.x), static_cast<float>(quad.bottomRight.y), u,
+               v},
+        Vertex{static_cast<float>(quad.bottomLeft.x), static_cast<float>(quad.bottomLeft.y), 0.0f,
+               v},
+    };
+    glUseProgram(program);
+    glUniform2f(glGetUniformLocation(program, "outputSizePx"), static_cast<float>(outputSize.x),
+                static_cast<float>(outputSize.y));
+    glUniform1i(glGetUniformLocation(program, "sourceTexture"), 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glBindVertexArray(vertexArray);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, static_cast<GLsizeiptr>(sizeof(vertices)), vertices.data());
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+  }
+#endif
+};
+
+DocumentPresentationCompositor::DocumentPresentationCompositor()
+    : impl_(std::make_unique<Impl>()) {}
+
+DocumentPresentationCompositor::~DocumentPresentationCompositor() = default;
+
+DocumentCompositeTextureView DocumentPresentationCompositor::compose(
+    const ViewportState& viewport, const Box2d& imageClipRect,
+    std::span<const GlTextureCache::TileView> overviewTiles,
+    std::span<const GlTextureCache::TileView> tiles,
+    const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+    const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+    Entity suppressedLayerEntity, bool suppressDragTargetTiles) {
+#ifdef DONNER_EDITOR_WGPU
+  (void)viewport;
+  (void)imageClipRect;
+  (void)overviewTiles;
+  (void)tiles;
+  (void)activeDragPreview;
+  (void)displayedDragPreview;
+  (void)suppressedLayerEntity;
+  (void)suppressDragTargetTiles;
+  return {};
+#else
+  const double dpr = viewport.devicePixelRatio;
+  if (!std::isfinite(dpr) || dpr <= 0.0) {
+    reset();
+    return {};
+  }
+  const Vector2i outputSize(std::max(1, static_cast<int>(std::ceil(viewport.paneSize.x * dpr))),
+                            std::max(1, static_cast<int>(std::ceil(viewport.paneSize.y * dpr))));
+  RequestKey request =
+      MakeRequestKey(viewport, imageClipRect, overviewTiles, tiles, activeDragPreview,
+                     displayedDragPreview, suppressedLayerEntity, suppressDragTargetTiles);
+  if (impl_->lastRequest.has_value() && EqualRequest(*impl_->lastRequest, request) &&
+      impl_->view.texture != 0) {
+    return impl_->view;
+  }
+
+  SavedGlState savedState;
+  if (!impl_->ensurePrograms() || !impl_->ensureTextures(outputSize) ||
+      !impl_->attach(impl_->premultipliedTexture)) {
+    std::fprintf(stderr, "DocumentPresentationCompositor failed to initialize GL resources\n");
+    reset();
+    return {};
+  }
+
+  glViewport(0, 0, outputSize.x, outputSize.y);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
+  glDisable(GL_STENCIL_TEST);
+  glDisable(GL_SCISSOR_TEST);
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glEnable(GL_BLEND);
+  glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+  glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+  const Vector2d paneOriginPx = viewport.paneOrigin * dpr;
+  Transform2d outputFromCanvas(Transform2d::uninitialized);
+  const double devicePixelsPerDocUnit = viewport.devicePixelsPerDocUnit();
+  outputFromCanvas.data[0] = devicePixelsPerDocUnit;
+  outputFromCanvas.data[1] = 0.0;
+  outputFromCanvas.data[2] = 0.0;
+  outputFromCanvas.data[3] = devicePixelsPerDocUnit;
+  outputFromCanvas.data[4] = viewport.panScreenPoint.x * dpr -
+                             viewport.panDocPoint.x * devicePixelsPerDocUnit - paneOriginPx.x;
+  outputFromCanvas.data[5] = viewport.panScreenPoint.y * dpr -
+                             viewport.panDocPoint.y * devicePixelsPerDocUnit - paneOriginPx.y;
+  const Box2d outputClipRect(imageClipRect.topLeft * dpr - paneOriginPx,
+                             imageClipRect.bottomRight * dpr - paneOriginPx);
+  const std::optional<PresentedDragBaseline> dragBaseline =
+      PresentedBaselineFromDragPreviews(activeDragPreview, displayedDragPreview);
+
+  const auto computeTileQuad = [&](const GlTextureCache::TileView& tile) {
+    if (!ShouldPresentCompositedTile(tile, suppressedLayerEntity, suppressDragTargetTiles) ||
+        (suppressDragTargetTiles && TileMatchesActiveDragPreview(tile, activeDragPreview))) {
+      return std::optional<PresentedTileQuad>();
+    }
+    return ComputePresentedTileQuad(PresentedGeometryFromTileView(tile, activeDragPreview),
+                                    outputFromCanvas, dragBaseline);
+  };
+  const auto drawTile = [&](const GlTextureCache::TileView& tile) {
+    const std::optional<PresentedTileQuad> quad = computeTileQuad(tile);
+    if (!quad.has_value()) {
+      return;
+    }
+    impl_->drawQuad(static_cast<GLuint>(tile.texture), *quad, tile.uvBottomRight,
+                    impl_->tileProgram, outputSize);
+  };
+
+  glEnable(GL_SCISSOR_TEST);
+  if (!overviewTiles.empty()) {
+    std::vector<Box2d> activeTileBounds;
+    activeTileBounds.reserve(tiles.size() * 2u);
+    for (const GlTextureCache::TileView& tile : tiles) {
+      if (const std::optional<PresentedTileQuad> quad = computeTileQuad(tile)) {
+        activeTileBounds.push_back(QuadBounds(*quad));
+      }
+      if (TileMatchesActiveDragPreview(tile, activeDragPreview)) {
+        const std::optional<PresentedTileQuad> cachedQuad = ComputePresentedTileQuad(
+            PresentedGeometryFromTileView(tile, std::nullopt), outputFromCanvas, std::nullopt);
+        if (cachedQuad.has_value()) {
+          activeTileBounds.push_back(QuadBounds(*cachedQuad));
+        }
+      }
+    }
+    for (const Box2d& overviewClipRect :
+         SubtractPresentedTileBoundsFromClip(outputClipRect, activeTileBounds)) {
+      impl_->setClip(overviewClipRect, outputSize);
+      for (const GlTextureCache::TileView& tile : overviewTiles) {
+        drawTile(tile);
+      }
+    }
+  }
+  impl_->setClip(outputClipRect, outputSize);
+  for (const GlTextureCache::TileView& tile : tiles) {
+    drawTile(tile);
+  }
+
+  if (!impl_->attach(impl_->resolvedTexture)) {
+    std::fprintf(stderr, "DocumentPresentationCompositor resolve framebuffer is incomplete\n");
+    reset();
+    return {};
+  }
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_BLEND);
+  glClear(GL_COLOR_BUFFER_BIT);
+  const PresentedTileQuad fullQuad{
+      .topLeft = Vector2d::Zero(),
+      .topRight = Vector2d(outputSize.x, 0.0),
+      .bottomRight = Vector2d(outputSize.x, outputSize.y),
+      .bottomLeft = Vector2d(0.0, outputSize.y),
+  };
+  impl_->drawQuad(impl_->premultipliedTexture, fullQuad, Vector2d(1.0, 1.0), impl_->resolveProgram,
+                  outputSize);
+
+  impl_->lastRequest = std::move(request);
+  ++impl_->compositionCount;
+  impl_->view = DocumentCompositeTextureView{
+      .texture = static_cast<ImTextureID>(impl_->resolvedTexture),
+      .dimensions = outputSize,
+      .screenRect = Box2d(viewport.paneOrigin, viewport.paneOrigin + viewport.paneSize),
+  };
+  return impl_->view;
+#endif
+}
+
+void DocumentPresentationCompositor::reset() {
+#ifndef DONNER_EDITOR_WGPU
+  impl_->lastRequest.reset();
+  impl_->view = {};
+#endif
+}
+
+std::uint64_t DocumentPresentationCompositor::retainedBytes() const {
+#ifdef DONNER_EDITOR_WGPU
+  return 0;
+#else
+  if (impl_->allocationSize.x <= 0 || impl_->allocationSize.y <= 0) {
+    return 0;
+  }
+  return static_cast<std::uint64_t>(impl_->allocationSize.x) *
+         static_cast<std::uint64_t>(impl_->allocationSize.y) * 4u * 2u;
+#endif
+}
+
+std::uint64_t DocumentPresentationCompositor::compositionCountForTesting() const {
+#ifdef DONNER_EDITOR_WGPU
+  return 0;
+#else
+  return impl_->compositionCount;
+#endif
+}
+
+}  // namespace donner::editor

--- a/donner/editor/DocumentPresentationCompositor.h
+++ b/donner/editor/DocumentPresentationCompositor.h
@@ -1,0 +1,69 @@
+#pragma once
+/// @file
+/// Explicit intermediate-texture composition for non-WGPU document tiles.
+
+#include <memory>
+#include <optional>
+#include <span>
+
+#include "donner/base/Box.h"
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/Vector2.h"
+#include "donner/editor/DocumentCompositeTexture.h"
+#include "donner/editor/GlTextureCache.h"
+#include "donner/editor/SelectTool.h"
+#include "donner/editor/ViewportState.h"
+
+namespace donner::editor {
+
+/**
+ * Composes cached non-WGPU document tiles into one transparent GL texture.
+ *
+ * The compositor preserves each tile's full affine presentation quad, including live drag and
+ * transform previews. It performs the tile blend in premultiplied form, resolves back to straight
+ * alpha for ImGui, and caches the result while all presentation inputs remain unchanged.
+ */
+class DocumentPresentationCompositor {
+public:
+  DocumentPresentationCompositor();
+  ~DocumentPresentationCompositor();
+
+  DocumentPresentationCompositor(const DocumentPresentationCompositor&) = delete;
+  DocumentPresentationCompositor& operator=(const DocumentPresentationCompositor&) = delete;
+
+  /**
+   * Compose the current document presentation into one pane-sized texture.
+   *
+   * @param viewport Presented document-to-screen mapping.
+   * @param imageClipRect Visible document region clipped to the render pane.
+   * @param overviewTiles Low-resolution infill tiles drawn below active coverage.
+   * @param tiles Active paint-order tile views.
+   * @param activeDragPreview Live drag transform to advance eligible tiles.
+   * @param displayedDragPreview Drag transform already represented by cached tiles.
+   * @param suppressedLayerEntity Layer omitted from this presentation frame.
+   * @param suppressDragTargetTiles Whether active drag-target tiles are omitted.
+   * @return Cached or newly composed texture view, or an empty view when composition is invalid.
+   */
+  [[nodiscard]] DocumentCompositeTextureView compose(
+      const ViewportState& viewport, const Box2d& imageClipRect,
+      std::span<const GlTextureCache::TileView> overviewTiles,
+      std::span<const GlTextureCache::TileView> tiles,
+      const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+      const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+      Entity suppressedLayerEntity, bool suppressDragTargetTiles);
+
+  /// Invalidate the cached request and clear its presented view while retaining allocations.
+  void reset();
+
+  /// Bytes retained by the two RGBA8 intermediate textures.
+  [[nodiscard]] std::uint64_t retainedBytes() const;
+
+  /// Number of cache-miss compositions, exposed for deterministic performance tests.
+  [[nodiscard]] std::uint64_t compositionCountForTesting() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1326,6 +1326,10 @@ std::optional<float> EditorShell::nextIdleWakeSeconds() const {
   includeWake(documentSyncController_.nextTextSyncWakeSeconds());
   includeWake(textEditor_.nextFlashWakeSeconds());
   includeWake(textEditor_.nextRopeAnimationWakeSeconds());
+  const bool sourcePaneTargetVisible = !adaptiveUiLayout_.compactTouch() && sourcePaneVisible_;
+  if (sourcePaneRevealProgress_ != (sourcePaneTargetVisible ? 1.0f : 0.0f)) {
+    includeWake(1.0f / 60.0f);
+  }
   // Caret blink: wake at the next visibility flip while a text session is
   // editing. The flip only re-pushes the caret chrome and recaptures the
   // overlay snapshot; it never schedules a content render.
@@ -2942,11 +2946,11 @@ void EditorShell::convertSelectedTextToOutlines() {
   app_.setSelection(std::move(newSelection));
 }
 
-void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float paneWidth,
-                                   ImFont* codeFont) {
+void EditorShell::renderSourcePane(float paneOriginX, float paneOriginY, float paneHeight,
+                                   float paneWidth, ImFont* codeFont) {
   constexpr ImGuiWindowFlags kPaneFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
                                           ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar;
-  ImGui::SetNextWindowPos(ImVec2(0.0f, paneOriginY), ImGuiCond_Always);
+  ImGui::SetNextWindowPos(ImVec2(paneOriginX, paneOriginY), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(paneWidth, paneHeight), ImGuiCond_Always);
   ImGui::Begin("Source", nullptr, kPaneFlags);
   // TextEditor owns the canonical, edit-remapped diagnostic ranges used for both inline
@@ -5307,7 +5311,7 @@ void EditorShell::renderLayerPanelContents() {
 }
 
 void EditorShell::renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
-                                           float sourcePaneWidth) {
+                                           float sourcePaneEdgeX) {
   const EditorTheme& theme = EditorTheme::Active();
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
   ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
@@ -5315,17 +5319,18 @@ void EditorShell::renderSourcePaneSplitter(float windowWidth, float paneOriginY,
       ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |
       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar |
       ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoBackground;
-  const bool renderedVisibleSplitter = sourcePaneVisible_ && sourcePaneWidth > 0.0f;
+  const bool renderedVisibleSplitter = sourcePaneRevealProgress_ > 0.0f && sourcePaneEdgeX > 0.0f;
+  const bool sourcePaneSettledOpen = sourcePaneVisible_ && sourcePaneRevealProgress_ >= 1.0f;
 
   if (renderedVisibleSplitter) {
-    const float splitterLeft = sourcePaneWidth - kSourcePaneSplitterThickness * 0.5f;
+    const float splitterLeft = sourcePaneEdgeX - kSourcePaneSplitterThickness * 0.5f;
     ImGui::SetNextWindowPos(ImVec2(splitterLeft, paneOriginY), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(kSourcePaneSplitterThickness, paneHeight), ImGuiCond_Always);
     ImGui::Begin("##source_pane_splitter", nullptr, kSplitterFlags);
     ImGui::InvisibleButton("##source_pane_splitter_handle",
                            ImVec2(kSourcePaneSplitterThickness, paneHeight));
-    if (ImGui::IsItemActive()) {
-      const float nextWidth = sourcePaneWidth + ImGui::GetIO().MouseDelta.x;
+    if (sourcePaneSettledOpen && ImGui::IsItemActive()) {
+      const float nextWidth = sourcePaneWidth_ + ImGui::GetIO().MouseDelta.x;
       if (nextWidth < kSourcePaneCollapseThreshold) {
         setSourcePaneVisible(false);
       } else {
@@ -5351,7 +5356,7 @@ void EditorShell::renderSourcePaneSplitter(float windowWidth, float paneOriginY,
     }
   }
 
-  if (renderedVisibleSplitter && (ImGui::IsItemHovered() || ImGui::IsItemActive())) {
+  if (sourcePaneSettledOpen && (ImGui::IsItemHovered() || ImGui::IsItemActive())) {
     ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
   } else if (!renderedVisibleSplitter && ImGui::IsItemHovered()) {
     ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
@@ -7068,6 +7073,8 @@ void EditorShell::runFrame() {
       .preferTouch = kPreferTouchInput,
   });
   const bool compactUi = adaptiveUiLayout_.compactTouch();
+  sourcePaneRevealProgress_ = AdvanceSourcePaneRevealProgress(
+      sourcePaneRevealProgress_, !compactUi && sourcePaneVisible_, ImGui::GetIO().DeltaTime);
   const float menuBarHeight = compactUi ? adaptiveUiLayout_.topBarHeight : ImGui::GetFrameHeight();
   const float paneOriginY = menuBarHeight;
   const float paneHeight = std::max(0.0f, static_cast<float>(windowSize.y) - paneOriginY);
@@ -7075,9 +7082,10 @@ void EditorShell::runFrame() {
       .windowWidth = static_cast<float>(windowSize.x),
       .sourcePaneVisible = !compactUi && sourcePaneVisible_,
       .sourcePaneWidth = sourcePaneWidth_,
+      .sourcePaneRevealProgress = compactUi ? 0.0f : sourcePaneRevealProgress_,
       .minSourcePaneWidth = kMinSourcePaneWidth,
       .maxSourcePaneWidth = kMaxSourcePaneWidth,
-      .sourcePaneRailWidth = kSourcePaneRevealHandleWidth,
+      .sourcePaneRailWidth = compactUi ? 0.0f : kSourcePaneRevealHandleWidth,
       .rightPaneWidth = rightPaneWidth_,
       .rightPaneVisible = !compactUi,
       .minRightPaneWidth = kMinRightPaneWidth,
@@ -7125,8 +7133,9 @@ void EditorShell::runFrame() {
   markPhase(mainFrameCost.menusDialogsMs);
 
   std::ignore = highlightSelectionSourceIfNeeded();
-  if (!compactUi && sourcePaneVisible_) {
-    renderSourcePane(paneOriginY, paneHeight, mainPaneLayout.sourcePaneWidth, codeFont_);
+  if (!compactUi && mainPaneLayout.sourcePaneWidth > 0.0f) {
+    renderSourcePane(mainPaneLayout.sourcePaneX, paneOriginY, paneHeight,
+                     mainPaneLayout.sourcePaneWidth, codeFont_);
   }
   markPhase(mainFrameCost.sourcePaneMs);
   // The canvas pane must never window-scroll: an ImGui scrollbar here would
@@ -7146,7 +7155,7 @@ void EditorShell::runFrame() {
   // Debug float are now owned by the DockSpace submitted above.
   if (!compactUi) {
     renderSourcePaneSplitter(static_cast<float>(windowSize.x), paneOriginY, paneHeight,
-                             mainPaneLayout.sourcePaneWidth);
+                             mainPaneLayout.renderPaneX);
   }
   if (!contentOnlyCaptureThisFrame_ && showSamplePicker_) {
     renderSamplePicker(ImVec2(0.0f, paneOriginY),

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -35,6 +35,7 @@
 #include "donner/css/parser/ColorParser.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/DisclosureChevron.h"
+#include "donner/editor/DocumentPresentationCompositor.h"
 #include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/EditorDockLayout.h"
@@ -304,30 +305,31 @@ void AccumulateFrameLoopPhaseCost(double layoutMs, double menusDialogsMs, double
 }
 
 void PublishPresentationResourceStats(double totalTrackedBytes, double peakTrackedBytes,
-                                      double pendingRetiredBytes, double agedRetiredBytes,
-                                      double activeTileTextures, double overviewTileTextures,
-                                      double pendingRetiredTextures, double agedRetiredTextures,
-                                      double retiredFrameCount, double lifetimeTextureCreates,
-                                      double lifetimeBufferCreates) {
+                                      double documentCompositeBytes, double pendingRetiredBytes,
+                                      double agedRetiredBytes, double activeTileTextures,
+                                      double overviewTileTextures, double pendingRetiredTextures,
+                                      double agedRetiredTextures, double retiredFrameCount,
+                                      double lifetimeTextureCreates, double lifetimeBufferCreates) {
   MAIN_THREAD_ASYNC_EM_ASM(
       {
         window['__donnerPresentationResourceStats'] = ({
           'totalTrackedBytes' : $0,
           'peakTrackedBytes' : $1,
-          'pendingRetiredBytes' : $2,
-          'agedRetiredBytes' : $3,
-          'activeTileTextures' : $4,
-          'overviewTileTextures' : $5,
-          'pendingRetiredTextures' : $6,
-          'agedRetiredTextures' : $7,
-          'retiredFrameCount' : $8,
-          'lifetimeTextureCreates' : $9,
-          'lifetimeBufferCreates' : $10,
+          'documentCompositeBytes' : $2,
+          'pendingRetiredBytes' : $3,
+          'agedRetiredBytes' : $4,
+          'activeTileTextures' : $5,
+          'overviewTileTextures' : $6,
+          'pendingRetiredTextures' : $7,
+          'agedRetiredTextures' : $8,
+          'retiredFrameCount' : $9,
+          'lifetimeTextureCreates' : $10,
+          'lifetimeBufferCreates' : $11,
         });
       },
-      totalTrackedBytes, peakTrackedBytes, pendingRetiredBytes, agedRetiredBytes,
-      activeTileTextures, overviewTileTextures, pendingRetiredTextures, agedRetiredTextures,
-      retiredFrameCount, lifetimeTextureCreates, lifetimeBufferCreates);
+      totalTrackedBytes, peakTrackedBytes, documentCompositeBytes, pendingRetiredBytes,
+      agedRetiredBytes, activeTileTextures, overviewTileTextures, pendingRetiredTextures,
+      agedRetiredTextures, retiredFrameCount, lifetimeTextureCreates, lifetimeBufferCreates);
 }
 
 #endif
@@ -1266,6 +1268,8 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
     // unique_ptr is released.
     ConfigureEmbeddedSvgIconRenderer(*directOverlayRenderer_);
   }
+#else
+  documentPresentationCompositor_ = std::make_unique<DocumentPresentationCompositor>();
 #endif
   PrewarmEditorIcons();
   if (!rotateCursorSet_.initialize(window_.rawHandle(), window_.geodeDevice())) {
@@ -1753,6 +1757,7 @@ void EditorShell::maybeLogResourceDiagnostics(const FrameCostBreakdown& frameCos
   std::cerr << "[DonnerResource] frame=" << resourceDiagnosticsFrame_
             << " tracked_mib=" << MegabytesRoundedUp(resources.totalTrackedBytes)
             << " peak_mib=" << MegabytesRoundedUp(resources.peakTrackedBytes)
+            << " document_composite_mib=" << MegabytesRoundedUp(resources.documentCompositeBytes)
             << " active_tile_mib=" << MegabytesRoundedUp(resources.activeTileBytes)
             << " overview_tile_mib=" << MegabytesRoundedUp(resources.overviewTileBytes)
             << " retired_mib="
@@ -4200,8 +4205,6 @@ void EditorShell::renderRenderPanePresentation(
   }
   const Entity presentSuppressedLayerEntity =
       penPreviewSuppressedEntity != entt::null ? penPreviewSuppressedEntity : suppressedLayerEntity;
-  interactionController_.frameHistory().setLatestMemorySample(
-      MemorySampleFromPresentationResources(textures_.presentationResourceStats()));
   // Document tiles use the direct framebuffer path where possible. The
   // framebuffer pass also owns the transparency checkerboard unconditionally:
   // there is no draw-list checkerboard to fall back to, because every pixel the
@@ -4235,12 +4238,9 @@ void EditorShell::renderRenderPanePresentation(
   };
   const bool drawOverviewTiles =
       ShouldPresentOverviewTiles(textures_.activeTilesViewportBounded(), textures_.overviewTiles());
-  if (!contentOnlyCaptureThisFrame_ && directDocumentRenderer_ != nullptr &&
-      directDocumentClipRect.has_value()) {
+  if (directDocumentRenderer_ != nullptr && directDocumentClipRect.has_value()) {
     // Tiles ride the framebuffer pass only when every one of them is a Geode
-    // texture. The remaining case is the browser bitmap bridge, whose CPU tiles
-    // are still blitted as images by the render pane - an image blit, never
-    // path geometry.
+    // texture. A non-Geode compatibility payload falls back through the render pane.
     underlayPresentsTiles =
         ((drawOverviewTiles && hasDirectlyPresentableTile(textures_.overviewTiles())) ||
          hasDirectlyPresentableTile(textures_.tiles())) &&
@@ -4294,6 +4294,32 @@ void EditorShell::renderRenderPanePresentation(
     };
   }
   installImmediateChromePlan(std::move(chromePlan));
+#ifndef DONNER_EDITOR_WGPU
+  const std::optional<Box2d> intermediateDocumentClipRect =
+      PresentedImageClipRect(paneRect, presentedDocumentViewport.imageScreenRect());
+  DocumentCompositeTextureView documentComposite;
+  if (documentPresentationCompositor_ != nullptr && intermediateDocumentClipRect.has_value() &&
+      (!textures_.tiles().empty() || !textures_.overviewTiles().empty())) {
+    const bool drawOverviewTiles = ShouldPresentOverviewTiles(
+        textures_.activeTilesViewportBounded(), textures_.overviewTiles());
+    const std::vector<GlTextureCache::TileView> noOverviewTiles;
+    documentComposite = documentPresentationCompositor_->compose(
+        presentedDocumentViewport, *intermediateDocumentClipRect,
+        drawOverviewTiles ? textures_.overviewTiles() : noOverviewTiles, textures_.tiles(),
+        activeDragPreview, displayedDragPreview, presentSuppressedLayerEntity,
+        suppressDragTargetTiles);
+  } else if (documentPresentationCompositor_ != nullptr) {
+    documentPresentationCompositor_->reset();
+  }
+  textures_.setDocumentCompositeBytes(documentPresentationCompositor_ != nullptr
+                                          ? documentPresentationCompositor_->retainedBytes()
+                                          : 0u);
+#else
+  const DocumentCompositeTextureView documentComposite;
+  textures_.setDocumentCompositeBytes(0u);
+#endif
+  interactionController_.frameHistory().setLatestMemorySample(
+      MemorySampleFromPresentationResources(textures_.presentationResourceStats()));
   RenderPanePresenterState paneState{
       .viewport = interactionController_.viewport(),
       .presentedDocumentViewport = &presentedDocumentViewport,
@@ -4306,6 +4332,7 @@ void EditorShell::renderRenderPanePresentation(
       .suppressedLayerEntity = presentSuppressedLayerEntity,
       .suppressDragTargetTiles = suppressDragTargetTiles,
       .documentPresentedDirectly = documentPresentedDirectly,
+      .documentComposite = documentComposite,
       .compositorTileOverlay = !contentOnlyCaptureThisFrame_ && compositorTileOverlay_,
       .perfOverlayMode = contentOnlyCaptureThisFrame_ ? PerfOverlayMode::Off : perfOverlayMode_,
   };
@@ -6772,7 +6799,9 @@ void EditorShell::recordFrameTelemetry(
   // `donner/base/MemoryAttribution.h`); the render thread publishes the
   // compositor's half from `AsyncRenderer::workerLoop`. The frame publisher
   // reads both and is the only writer of the page-visible stats object.
-  SetRetainedBytes(MemoryCategory::PresentationTiles, presentationResources.activeTileBytes);
+  SetRetainedBytes(
+      MemoryCategory::PresentationTiles,
+      presentationResources.activeTileBytes + presentationResources.documentCompositeBytes);
   SetEntryCount(MemoryCategory::PresentationTiles,
                 static_cast<std::uint64_t>(presentationResources.activeTileTextures));
   SetRetainedBytes(MemoryCategory::PresentationOverviewTiles,
@@ -6824,6 +6853,7 @@ void EditorShell::recordFrameTelemetry(
   PublishPresentationResourceStats(
       static_cast<double>(presentationResources.totalTrackedBytes),
       static_cast<double>(presentationResources.peakTrackedBytes),
+      static_cast<double>(presentationResources.documentCompositeBytes),
       static_cast<double>(presentationResources.pendingRetiredBytes),
       static_cast<double>(presentationResources.agedRetiredBytes),
       static_cast<double>(presentationResources.activeTileTextures),

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3054,7 +3054,23 @@ Box2d EditorShell::canvasZoomControlScreenRect() const {
 
 void EditorShell::renderFillStrokeToolbarWidget() {
   const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
-  const bool canEditPaint = app_.hasDocument() && !rendererBusy;
+  const bool canvasInteractionActive = selectTool_.isDragging() || selectTool_.isMarqueeing() ||
+                                       penTool_.isDraggingAnchor() || textTool_.isDraggingBox() ||
+                                       textTool_.isAdjustingFrame();
+  svg::SVGDocumentHandle currentPaintDocument;
+  std::optional<Entity> currentPaintSelection;
+  if (app_.hasDocument()) {
+    currentPaintDocument = app_.document().document().handle();
+    if (!app_.selectedElements().empty()) {
+      currentPaintSelection = app_.selectedElements().front().unsafeEntityHandle().entity();
+    }
+  }
+  const bool paintSnapshotMatchesSelection =
+      toolbarPaintSnapshot_ != nullptr && toolbarPaintSnapshotDocument_ == currentPaintDocument &&
+      toolbarPaintSnapshotSelection_ == currentPaintSelection;
+  const FillStrokeWidgetInteractionState interactionState = ResolveFillStrokeWidgetInteractionState(
+      app_.hasDocument(), rendererBusy, canvasInteractionActive, paintSnapshotMatchesSelection);
+  const bool canEditPaint = interactionState.canEdit;
   std::string editorSource;
   std::string documentSource;
   std::optional<std::string_view> sourceForRanges;
@@ -3065,14 +3081,17 @@ void EditorShell::renderFillStrokeToolbarWidget() {
       sourceForRanges = std::string_view(editorSource);
     }
   }
-  // The worker owns the selected element while busy. Preserve the last idle
-  // presentation instead of replacing the selected paint with the unrelated
-  // authoring default for every render update.
+  // The worker owns the selected element while busy, and drag-frame handoffs
+  // alternate between busy and idle as previews land. Preserve one paint and
+  // enabled-state presentation for the entire canvas interaction instead of
+  // letting the swap arrow and selected swatches oscillate with worker state.
   ToolbarPaintState paintState;
-  if (!rendererBusy) {
+  if (interactionState.refreshPaintSnapshot) {
     paintState = ToolbarPaintStateForApp(app_, sourceForRanges);
     toolbarPaintSnapshot_ = std::make_unique<ToolbarPaintState>(paintState);
-  } else if (toolbarPaintSnapshot_ != nullptr) {
+    toolbarPaintSnapshotDocument_ = std::move(currentPaintDocument);
+    toolbarPaintSnapshotSelection_ = currentPaintSelection;
+  } else if (paintSnapshotMatchesSelection) {
     paintState = *toolbarPaintSnapshot_;
   } else {
     paintState = ToolbarPaintStateForActivePaint(app_.activePaintStyle());

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -396,7 +396,8 @@ private:
   /// Selects every selectable element on the canvas via the shared `setSelection()` path, so the
   /// canvas highlight, source-pane sync, and overlay all update together. No-op without a document.
   void selectAllCanvasElements();
-  void renderSourcePane(float paneOriginY, float paneHeight, float paneWidth, ImFont* codeFont);
+  void renderSourcePane(float paneOriginX, float paneOriginY, float paneHeight, float paneWidth,
+                        ImFont* codeFont);
   void renderRenderPane(ImGuiWindowFlags paneFlags);
   // Frame stages split out of `runFrame` and `renderRenderPane`, deliberately kept out of line.
   //
@@ -460,7 +461,7 @@ private:
   [[nodiscard]] FormatBarFontPreview fontPreviewForFamily(std::string_view family);
   void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
-                                float sourcePaneWidth);
+                                float sourcePaneEdgeX);
   /// Submit the host window and DockSpace that own the canvas (central node) and
   /// the right-column dockable panels, (re)building the default locked layout on
   /// first frame, after a reset, or when the docked-panel set changes.
@@ -778,6 +779,8 @@ private:
   bool sourceFocusMode_ = true;
   /// Preferred width for the source pane when it is visible.
   float sourcePaneWidth_ = 560.0f;
+  /// Linear progress for the source-pane slide animation.
+  float sourcePaneRevealProgress_ = 0.0f;
   bool sourcePaneVisible_ = false;
   bool showSamplePicker_ = false;
   bool welcomePlaceholderActive_ = false;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -289,6 +289,10 @@ public:
   ///
   /// @param action Tool or paint action decoded from a replay frame.
   void applyReplayActionForTesting(const repro::ReproAction& action);
+  /// Set the source-pane target visibility before deterministic replay frames.
+  ///
+  /// @param visible True to open the source pane.
+  void setSourcePaneVisibleForReplay(bool visible) { setSourcePaneVisible(visible); }
   /// Current selection label for replay/readback harnesses.
   [[nodiscard]] std::optional<std::string> selectedElementLabelForReadback() const;
 

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -66,6 +66,8 @@ struct ReproAction;
 
 namespace donner::editor {
 
+class DocumentPresentationCompositor;
+
 namespace internal {
 struct ToolbarPaintState;
 }
@@ -665,6 +667,8 @@ private:
   std::unique_ptr<FramebufferCheckerboardRenderer> directCheckerboardRenderer_;
   std::unique_ptr<svg::RendererGeode> directDocumentRenderer_;
   std::unique_ptr<svg::RendererGeode> directOverlayRenderer_;
+#else
+  std::unique_ptr<DocumentPresentationCompositor> documentPresentationCompositor_;
 #endif
 
   std::string lastWindowTitle_;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -642,8 +642,12 @@ private:
   bool sidebarSnapshotRefreshPending_ = false;
   /// Last paint presentation read while the document was idle. The renderer
   /// owns the document registry while busy, so worker frames replay this
-  /// value instead of substituting the unrelated authoring paint.
+  /// value instead of substituting the unrelated authoring paint. The owner
+  /// fields prevent a drag that changes selection from replaying the previous
+  /// element's paint.
   std::unique_ptr<internal::ToolbarPaintState> toolbarPaintSnapshot_;
+  svg::SVGDocumentHandle toolbarPaintSnapshotDocument_;
+  std::optional<Entity> toolbarPaintSnapshotSelection_;
   /// Document-derived menu/shortcut state from the last idle UI epoch. Busy frames must replay
   /// these values instead of traversing the live registry behind the worker's write guard.
   bool cachedCanvasHasSelectableElements_ = false;

--- a/donner/editor/EditorShellLayout.cc
+++ b/donner/editor/EditorShellLayout.cc
@@ -16,6 +16,12 @@ constexpr float kCompactPanelMinWidth = 280.0f;
 constexpr float kCompactPanelMaxWidth = 380.0f;
 constexpr float kCompactPanelMinHeight = 220.0f;
 constexpr float kCompactPanelMaxHeight = 360.0f;
+constexpr float kSourcePaneRevealDurationSeconds = 0.20f;
+
+float EaseSourcePaneRevealProgress(float progress) {
+  const float clamped = std::clamp(progress, 0.0f, 1.0f);
+  return clamped * clamped * (3.0f - 2.0f * clamped);
+}
 
 }  // namespace
 
@@ -69,23 +75,27 @@ EditorMainPaneLayout ComputeEditorMainPaneLayout(const EditorMainPaneLayoutInput
   const float minRenderPaneWidth = std::max(0.0f, input.minRenderPaneWidth);
   const float maxRightPaneWidth =
       input.rightPaneVisible ? std::max(minRightPaneWidth, input.maxRightPaneWidth) : 0.0f;
-  const float sourcePaneRailWidth =
-      input.sourcePaneVisible ? 0.0f : std::clamp(input.sourcePaneRailWidth, 0.0f, windowWidth);
+  const float hiddenSourcePaneRailWidth = std::clamp(input.sourcePaneRailWidth, 0.0f, windowWidth);
   const float sourcePaneUpperBound = std::max(
       0.0f, std::min(maxSourcePaneWidth, windowWidth - minRightPaneWidth - minRenderPaneWidth));
   const float sourcePaneLowerBound = std::min(minSourcePaneWidth, sourcePaneUpperBound);
-  const float sourcePaneWidth =
-      input.sourcePaneVisible
-          ? std::clamp(input.sourcePaneWidth, sourcePaneLowerBound, sourcePaneUpperBound)
-          : 0.0f;
-  const float leftChromeWidth = sourcePaneWidth + sourcePaneRailWidth;
+  const float fullSourcePaneWidth =
+      std::clamp(input.sourcePaneWidth, sourcePaneLowerBound, sourcePaneUpperBound);
+  const float linearRevealProgress = std::clamp(
+      input.sourcePaneRevealProgress.value_or(input.sourcePaneVisible ? 1.0f : 0.0f), 0.0f, 1.0f);
+  const float revealProgress = EaseSourcePaneRevealProgress(linearRevealProgress);
+  const bool sourcePaneParticipates = input.sourcePaneVisible || linearRevealProgress > 0.0f;
+  const float sourcePaneWidth = sourcePaneParticipates ? fullSourcePaneWidth : 0.0f;
+  const float leftChromeWidth =
+      std::lerp(hiddenSourcePaneRailWidth, fullSourcePaneWidth, revealProgress);
   const float rightPaneUpperBound =
       std::max(minRightPaneWidth,
                std::min(maxRightPaneWidth, windowWidth - leftChromeWidth - minRenderPaneWidth));
 
   EditorMainPaneLayout layout;
+  layout.sourcePaneX = sourcePaneParticipates ? leftChromeWidth - fullSourcePaneWidth : 0.0f;
   layout.sourcePaneWidth = sourcePaneWidth;
-  layout.sourcePaneRailWidth = sourcePaneRailWidth;
+  layout.sourcePaneRailWidth = sourcePaneParticipates ? 0.0f : hiddenSourcePaneRailWidth;
   layout.rightPaneWidth =
       input.rightPaneVisible
           ? std::clamp(input.rightPaneWidth, minRightPaneWidth, rightPaneUpperBound)
@@ -94,6 +104,22 @@ EditorMainPaneLayout ComputeEditorMainPaneLayout(const EditorMainPaneLayoutInput
   layout.renderPaneWidth = std::max(0.0f, windowWidth - leftChromeWidth - layout.rightPaneWidth);
   layout.rightPaneX = windowWidth - layout.rightPaneWidth;
   return layout;
+}
+
+float AdvanceSourcePaneRevealProgress(float currentProgress, bool targetVisible,
+                                      float deltaSeconds) {
+  const float target = targetVisible ? 1.0f : 0.0f;
+  if (!std::isfinite(currentProgress)) {
+    return target;
+  }
+
+  const float current = std::clamp(currentProgress, 0.0f, 1.0f);
+  if (!std::isfinite(deltaSeconds) || deltaSeconds <= 0.0f || current == target) {
+    return current;
+  }
+
+  const float step = deltaSeconds / kSourcePaneRevealDurationSeconds;
+  return targetVisible ? std::min(1.0f, current + step) : std::max(0.0f, current - step);
 }
 
 RightSidebarLayout ComputeRightSidebarLayout(const RightSidebarLayoutInput& input) {
@@ -202,10 +228,9 @@ bool RenderPaneViewportLatchReady(const RenderPaneLatchInput& input) {
     return false;
   }
 
-  const bool dockGeometrySettled = input.dockCentralNode.width > 0.0f &&
-                                   input.dockCentralNode.height > 0.0f &&
-                                   SameRect(input.paneWindow, input.dockCentralNode) &&
-                                   CentralNodeMatchesDockHost(input);
+  const bool dockGeometrySettled =
+      input.dockCentralNode.width > 0.0f && input.dockCentralNode.height > 0.0f &&
+      SameRect(input.paneWindow, input.dockCentralNode) && CentralNodeMatchesDockHost(input);
   if (dockGeometrySettled) {
     return true;
   }

--- a/donner/editor/EditorShellLayout.h
+++ b/donner/editor/EditorShellLayout.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <optional>
+
 namespace donner::editor {
 
 /// Editor chrome profile selected from viewport constraints and input type.
@@ -71,6 +73,8 @@ struct EditorMainPaneLayoutInput {
   bool sourcePaneVisible = true;
   /// Preferred source pane width when visible.
   float sourcePaneWidth = 0.0f;
+  /// Optional linear reveal progress. Absent snaps to the target visibility.
+  std::optional<float> sourcePaneRevealProgress;
   /// Minimum source pane width while visible.
   float minSourcePaneWidth = 0.0f;
   /// Maximum source pane width while visible.
@@ -91,6 +95,8 @@ struct EditorMainPaneLayoutInput {
 
 /// Computed geometry for the editor's horizontal source/render/sidebar layout.
 struct EditorMainPaneLayout {
+  /// Left edge of the full-width source pane. Negative while it slides in or out.
+  float sourcePaneX = 0.0f;
   /// Effective source pane width. Zero when the source pane is hidden.
   float sourcePaneWidth = 0.0f;
   /// Effective source reveal-rail width. Zero while the source pane is visible.
@@ -113,6 +119,17 @@ struct EditorMainPaneLayout {
  */
 [[nodiscard]] EditorMainPaneLayout ComputeEditorMainPaneLayout(
     const EditorMainPaneLayoutInput& input);
+
+/**
+ * Advance the source-pane reveal toward its target at the fixed UI animation rate.
+ *
+ * @param currentProgress Current linear progress in [0, 1].
+ * @param targetVisible True to advance toward fully visible.
+ * @param deltaSeconds Elapsed frame time in seconds.
+ * @return Updated linear progress in [0, 1].
+ */
+[[nodiscard]] float AdvanceSourcePaneRevealProgress(float currentProgress, bool targetVisible,
+                                                    float deltaSeconds);
 
 /// Inputs used to compute the editor's right sidebar pane layout.
 struct RightSidebarLayoutInput {

--- a/donner/editor/EditorShellPresentation.cc
+++ b/donner/editor/EditorShellPresentation.cc
@@ -102,24 +102,6 @@ Box2d FramebufferBoxFromScreenBox(const Box2d& screenBox, double devicePixelRati
   return Box2d(screenBox.topLeft * devicePixelRatio, screenBox.bottomRight * devicePixelRatio);
 }
 
-std::optional<Transform2d> FramebufferFromTextureTransform(const PresentedTileQuad& tileQuad,
-                                                           const Vector2i& textureSizePx) {
-  if (textureSizePx.x <= 0 || textureSizePx.y <= 0) {
-    return std::nullopt;
-  }
-
-  const Vector2d sourceSize(static_cast<double>(textureSizePx.x),
-                            static_cast<double>(textureSizePx.y));
-  Transform2d framebufferFromTexture(Transform2d::uninitialized);
-  framebufferFromTexture.data[0] = (tileQuad.topRight.x - tileQuad.topLeft.x) / sourceSize.x;
-  framebufferFromTexture.data[1] = (tileQuad.topRight.y - tileQuad.topLeft.y) / sourceSize.x;
-  framebufferFromTexture.data[2] = (tileQuad.bottomLeft.x - tileQuad.topLeft.x) / sourceSize.y;
-  framebufferFromTexture.data[3] = (tileQuad.bottomLeft.y - tileQuad.topLeft.y) / sourceSize.y;
-  framebufferFromTexture.data[4] = tileQuad.topLeft.x;
-  framebufferFromTexture.data[5] = tileQuad.topLeft.y;
-  return framebufferFromTexture;
-}
-
 }  // namespace
 
 FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
@@ -188,7 +170,7 @@ FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
 
     const Vector2i textureSizePx = tile.textureSnapshot->dimensions();
     const std::optional<Transform2d> framebufferFromTexture =
-        FramebufferFromTextureTransform(*tileQuad, textureSizePx);
+        ComputePresentedOutputFromTextureTransform(*tileQuad, textureSizePx);
     if (!framebufferFromTexture.has_value()) {
       return false;
     }

--- a/donner/editor/EditorShellPresentation.cc
+++ b/donner/editor/EditorShellPresentation.cc
@@ -19,25 +19,29 @@
 
 namespace donner::editor {
 
-Transform2d PresentedFramebufferFromDocumentTransform(const ViewportState& viewport) {
-  const double devicePixelsPerDocUnit = viewport.devicePixelsPerDocUnit();
+Transform2d PresentedFramebufferFromDocumentTransform(const ViewportState& viewport,
+                                                      const Vector2d& framebufferFromLogicalScale) {
+  const Vector2d framebufferPixelsPerDocUnit =
+      framebufferFromLogicalScale * viewport.pixelsPerDocUnit();
   const Vector2d framebufferOriginFromDocumentOrigin =
-      viewport.panScreenPoint * viewport.devicePixelRatio -
-      viewport.panDocPoint * devicePixelsPerDocUnit;
+      viewport.panScreenPoint * framebufferFromLogicalScale -
+      viewport.panDocPoint * framebufferPixelsPerDocUnit;
 
   Transform2d framebufferFromDocument(Transform2d::uninitialized);
-  framebufferFromDocument.data[0] = devicePixelsPerDocUnit;
+  framebufferFromDocument.data[0] = framebufferPixelsPerDocUnit.x;
   framebufferFromDocument.data[1] = 0.0;
   framebufferFromDocument.data[2] = 0.0;
-  framebufferFromDocument.data[3] = devicePixelsPerDocUnit;
+  framebufferFromDocument.data[3] = framebufferPixelsPerDocUnit.y;
   framebufferFromDocument.data[4] = framebufferOriginFromDocumentOrigin.x;
   framebufferFromDocument.data[5] = framebufferOriginFromDocumentOrigin.y;
   return framebufferFromDocument;
 }
 
 SelectionChromeSnapshot ChromePlacedOnPresentedDocument(const ViewportState& presentedViewport,
+                                                        const Vector2d& framebufferFromLogicalScale,
                                                         SelectionChromeSnapshot snapshot) {
-  snapshot.canvasFromDoc = PresentedFramebufferFromDocumentTransform(presentedViewport);
+  snapshot.canvasFromDoc =
+      PresentedFramebufferFromDocumentTransform(presentedViewport, framebufferFromLogicalScale);
   return snapshot;
 }
 
@@ -98,8 +102,10 @@ Box2d PresentedTileQuadBounds(const PresentedTileQuad& tileQuad) {
   return bounds;
 }
 
-Box2d FramebufferBoxFromScreenBox(const Box2d& screenBox, double devicePixelRatio) {
-  return Box2d(screenBox.topLeft * devicePixelRatio, screenBox.bottomRight * devicePixelRatio);
+Box2d FramebufferBoxFromScreenBox(const Box2d& screenBox,
+                                  const Vector2d& framebufferFromLogicalScale) {
+  return Box2d(screenBox.topLeft * framebufferFromLogicalScale,
+               screenBox.bottomRight * framebufferFromLogicalScale);
 }
 
 }  // namespace
@@ -125,7 +131,7 @@ FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
 
   const auto checkerboardStart = std::chrono::steady_clock::now();
   cost.checkerboardDrawCount =
-      checkerboardRenderer.draw(target, imageClipRect, viewport.devicePixelRatio);
+      checkerboardRenderer.draw(target, imageClipRect, target.framebufferFromLogicalScale);
   cost.checkerboardMs = ElapsedMs(checkerboardStart);
 
   renderer.setTargetTexture(target.texture);
@@ -133,16 +139,16 @@ FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
   renderer.beginFrame(renderViewport);
 
   svg::ResolvedClip clip;
-  clip.clipRect = FramebufferBoxFromScreenBox(imageClipRect, viewport.devicePixelRatio);
+  clip.clipRect = FramebufferBoxFromScreenBox(imageClipRect, target.framebufferFromLogicalScale);
   renderer.pushClip(clip);
   renderer.setTransform(Transform2d());
 
   const Transform2d framebufferFromCanvasTransform =
-      PresentedFramebufferFromDocumentTransform(viewport);
+      PresentedFramebufferFromDocumentTransform(viewport, target.framebufferFromLogicalScale);
   const std::optional<PresentedDragBaseline> dragBaseline =
       PresentedBaselineFromDragPreviews(activeDragPreview, displayedDragPreview);
   const Box2d framebufferClipRect =
-      FramebufferBoxFromScreenBox(imageClipRect, viewport.devicePixelRatio);
+      FramebufferBoxFromScreenBox(imageClipRect, target.framebufferFromLogicalScale);
 
   const auto computeTileQuad = [&](const GlTextureCache::TileView& tile) {
     if (tile.textureSnapshot == nullptr ||
@@ -261,15 +267,16 @@ double DrawImmediateChromeToFramebuffer(svg::RendererGeode& renderer,
   renderer.beginFrame(renderViewport);
 
   svg::ResolvedClip clip;
-  clip.clipRect = FramebufferBoxFromScreenBox(paneClipRect, viewport.devicePixelRatio);
+  clip.clipRect = FramebufferBoxFromScreenBox(paneClipRect, target.framebufferFromLogicalScale);
   renderer.setTransform(Transform2d());
   renderer.pushClip(clip);
 
   // What makes chrome/content desync impossible: chrome is placed with the
   // transform the tiles were placed with this frame, from the same viewport and
   // the same function, not the one capture happened to sample.
-  OverlayRenderer::drawChromeFromSnapshot(renderer,
-                                          ChromePlacedOnPresentedDocument(viewport, snapshot));
+  OverlayRenderer::drawChromeFromSnapshot(
+      renderer,
+      ChromePlacedOnPresentedDocument(viewport, target.framebufferFromLogicalScale, snapshot));
 
   renderer.popClip();
   renderer.endFrame();
@@ -282,20 +289,24 @@ FramebufferCheckerboardRenderer::FramebufferCheckerboardRenderer(
     : device_(std::move(device)) {}
 
 std::optional<geode::CheckerboardScissorPx>
-FramebufferCheckerboardRenderer::ScissorRectFromScreenBox(const Box2d& screenBox,
-                                                          double devicePixelRatio,
-                                                          const Vector2i& framebufferSizePx) {
-  if (devicePixelRatio <= 0.0 || framebufferSizePx.x <= 0 || framebufferSizePx.y <= 0) {
+FramebufferCheckerboardRenderer::ScissorRectFromScreenBox(
+    const Box2d& screenBox, const Vector2d& framebufferFromLogicalScale,
+    const Vector2i& framebufferSizePx) {
+  if (framebufferFromLogicalScale.x <= 0.0 || framebufferFromLogicalScale.y <= 0.0 ||
+      framebufferSizePx.x <= 0 || framebufferSizePx.y <= 0) {
     return std::nullopt;
   }
 
   const double maxX = static_cast<double>(framebufferSizePx.x);
   const double maxY = static_cast<double>(framebufferSizePx.y);
-  const double left = std::clamp(std::floor(screenBox.topLeft.x * devicePixelRatio), 0.0, maxX);
-  const double top = std::clamp(std::floor(screenBox.topLeft.y * devicePixelRatio), 0.0, maxY);
-  const double right = std::clamp(std::ceil(screenBox.bottomRight.x * devicePixelRatio), 0.0, maxX);
+  const double left =
+      std::clamp(std::floor(screenBox.topLeft.x * framebufferFromLogicalScale.x), 0.0, maxX);
+  const double top =
+      std::clamp(std::floor(screenBox.topLeft.y * framebufferFromLogicalScale.y), 0.0, maxY);
+  const double right =
+      std::clamp(std::ceil(screenBox.bottomRight.x * framebufferFromLogicalScale.x), 0.0, maxX);
   const double bottom =
-      std::clamp(std::ceil(screenBox.bottomRight.y * devicePixelRatio), 0.0, maxY);
+      std::clamp(std::ceil(screenBox.bottomRight.y * framebufferFromLogicalScale.y), 0.0, maxY);
   if (left >= right || top >= bottom) {
     return std::nullopt;
   }
@@ -309,13 +320,14 @@ FramebufferCheckerboardRenderer::ScissorRectFromScreenBox(const Box2d& screenBox
 }
 
 int FramebufferCheckerboardRenderer::draw(const gui::EditorWindowWgpuRenderTarget& target,
-                                          const Box2d& imageClipRect, double devicePixelRatio) {
+                                          const Box2d& imageClipRect,
+                                          const Vector2d& framebufferFromLogicalScale) {
   if (device_ == nullptr || !target.texture) {
     return 0;
   }
 
-  const std::optional<geode::CheckerboardScissorPx> scissor =
-      ScissorRectFromScreenBox(imageClipRect, devicePixelRatio, target.framebufferSizePx);
+  const std::optional<geode::CheckerboardScissorPx> scissor = ScissorRectFromScreenBox(
+      imageClipRect, framebufferFromLogicalScale, target.framebufferSizePx);
   if (!scissor.has_value()) {
     return 0;
   }
@@ -325,7 +337,7 @@ int FramebufferCheckerboardRenderer::draw(const gui::EditorWindowWgpuRenderTarge
   // cells for the same document.
   static_assert(kFramebufferCheckerboardSize == geode::kTransparencyCheckerboardCellLogicalPx);
   geode::CheckerboardUnderlayParams params;
-  params.devicePixelRatio = devicePixelRatio;
+  params.devicePixelRatio = framebufferFromLogicalScale.x;
   params.cellSizeLogicalPx = kFramebufferCheckerboardSize;
   // The window framebuffer *is* the anchor: the pattern is fixed to the window
   // and the document slides over it, so the target's own origin is the anchor.

--- a/donner/editor/EditorShellPresentation.h
+++ b/donner/editor/EditorShellPresentation.h
@@ -52,8 +52,10 @@ std::optional<PresentedDragBaseline> PresentedBaselineFromDragPreviews(
  * can disagree and the chrome annotates pixels that moved.
  *
  * @param viewport Viewport this frame's document pixels are placed with.
+ * @param framebufferFromLogicalScale Physical framebuffer pixels per ImGui logical pixel.
  */
-[[nodiscard]] Transform2d PresentedFramebufferFromDocumentTransform(const ViewportState& viewport);
+[[nodiscard]] Transform2d PresentedFramebufferFromDocumentTransform(
+    const ViewportState& viewport, const Vector2d& framebufferFromLogicalScale);
 
 /**
  * Return @p snapshot re-pointed at the transform @p presentedViewport places
@@ -65,10 +67,12 @@ std::optional<PresentedDragBaseline> PresentedBaselineFromDragPreviews(
  * other than the presented one.
  *
  * @param presentedViewport Viewport this frame's document pixels landed in.
+ * @param framebufferFromLogicalScale Physical framebuffer pixels per ImGui logical pixel.
  * @param snapshot Captured chrome geometry.
  */
 [[nodiscard]] SelectionChromeSnapshot ChromePlacedOnPresentedDocument(
-    const ViewportState& presentedViewport, SelectionChromeSnapshot snapshot);
+    const ViewportState& presentedViewport, const Vector2d& framebufferFromLogicalScale,
+    SelectionChromeSnapshot snapshot);
 
 /// Everything the immediate chrome pass needs to draw one frame of editor
 /// chrome. Captured by value because the direct-render callback runs later in
@@ -98,17 +102,18 @@ public:
    *
    * @param target Window framebuffer for this frame.
    * @param imageClipRect Render-pane rect in screen pixels; the checkerboard is clipped to it.
-   * @param devicePixelRatio Device pixels per logical pixel.
+   * @param framebufferFromLogicalScale Physical framebuffer pixels per ImGui logical pixel.
    * @return Number of draws submitted, for the frame cost breakdown.
    */
   [[nodiscard]] int draw(const gui::EditorWindowWgpuRenderTarget& target,
-                         const Box2d& imageClipRect, double devicePixelRatio);
+                         const Box2d& imageClipRect, const Vector2d& framebufferFromLogicalScale);
 
 private:
   /// The device-pixel scissor covering @p screenBox, or nullopt when the box is
   /// degenerate or entirely outside the framebuffer.
   [[nodiscard]] static std::optional<geode::CheckerboardScissorPx> ScissorRectFromScreenBox(
-      const Box2d& screenBox, double devicePixelRatio, const Vector2i& framebufferSizePx);
+      const Box2d& screenBox, const Vector2d& framebufferFromLogicalScale,
+      const Vector2i& framebufferSizePx);
 
   std::shared_ptr<geode::GeodeDevice> device_;
   geode::GeodeCheckerboardPass checkerboardPass_;

--- a/donner/editor/FillStrokeWidget.cc
+++ b/donner/editor/FillStrokeWidget.cc
@@ -48,6 +48,16 @@ constexpr float kFillChipBottom = 29.0f;
 
 }  // namespace
 
+FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive,
+    bool paintSnapshotMatchesSelection) {
+  return FillStrokeWidgetInteractionState{
+      .canEdit = hasDocument && !rendererBusy && !canvasInteractionActive,
+      .refreshPaintSnapshot =
+          !rendererBusy && (!canvasInteractionActive || !paintSnapshotMatchesSelection),
+  };
+}
+
 FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
                                                      const ImVec2& widgetMax) {
   const float x = widgetMin.x;

--- a/donner/editor/FillStrokeWidget.h
+++ b/donner/editor/FillStrokeWidget.h
@@ -17,8 +17,8 @@ namespace donner::editor::internal {
 
 /// Interactive regions of the Fill/Stroke widget, in hit-test priority order.
 enum class FillStrokeWidgetRegion {
-  None,         ///< No interactive region under the point.
-  FillSwatch,   ///< Front (fill) swatch: opens the fill color picker.
+  None,          ///< No interactive region under the point.
+  FillSwatch,    ///< Front (fill) swatch: opens the fill color picker.
   StrokeSwatch,  ///< Back (stroke) swatch: opens the stroke color picker.
   Swap,          ///< Double-arrow affordance: swaps fill and stroke paints.
   FillNone,      ///< Fill "set none" affordance.
@@ -30,13 +30,37 @@ enum class FillStrokeWidgetRegion {
 /// Screen-space rectangles for every drawable/interactive part of the widget.
 struct FillStrokeWidgetLayout {
   ImVec2 fillMin, fillMax;              ///< Front (fill) swatch.
-  ImVec2 strokeMin, strokeMax;         ///< Back (stroke) swatch.
-  ImVec2 swapMin, swapMax;             ///< Swap double-arrow affordance.
-  ImVec2 fillNoneMin, fillNoneMax;     ///< Fill "set none" affordance.
+  ImVec2 strokeMin, strokeMax;          ///< Back (stroke) swatch.
+  ImVec2 swapMin, swapMax;              ///< Swap double-arrow affordance.
+  ImVec2 fillNoneMin, fillNoneMax;      ///< Fill "set none" affordance.
   ImVec2 strokeNoneMin, strokeNoneMax;  ///< Stroke "set none" affordance.
-  ImVec2 fillChipMin, fillChipMax;     ///< Fill custom-paint label chip.
+  ImVec2 fillChipMin, fillChipMax;      ///< Fill custom-paint label chip.
   ImVec2 strokeChipMin, strokeChipMax;  ///< Stroke custom-paint label chip.
 };
+
+/// Stable interaction policy for one fill/stroke toolbar frame.
+struct FillStrokeWidgetInteractionState {
+  /// Whether widget actions may mutate the active paint.
+  bool canEdit = false;
+  /// Whether the shell should replace its cached paint snapshot this frame.
+  bool refreshPaintSnapshot = false;
+};
+
+/**
+ * Resolve editability and snapshot refresh without keying drag chrome to a renderer busy bit.
+ *
+ * The caller reports whether its snapshot belongs to the current document and first selected
+ * element, not merely whether any snapshot exists.
+ *
+ * @param hasDocument Whether the editor currently owns a document.
+ * @param rendererBusy Whether the async renderer currently owns document access.
+ * @param canvasInteractionActive Whether a canvas gesture is in progress.
+ * @param paintSnapshotMatchesSelection Whether the cached paint belongs to the current selection.
+ * @return Editability and snapshot-refresh policy for the current toolbar frame.
+ */
+[[nodiscard]] FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive,
+    bool paintSnapshotMatchesSelection);
 
 /// Compute widget sub-rectangles from the widget's outer bounds.
 [[nodiscard]] FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
@@ -67,7 +91,7 @@ void DrawSwapAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& m
 /// Draw a "set none" affordance. @p fillVariant selects the solid (fill) motif
 /// versus the hollow (stroke) motif; @p active brightens it when the slot is
 /// already none.
-void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool fillVariant,
-                        bool active);
+void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                        bool fillVariant, bool active);
 
 }  // namespace donner::editor::internal

--- a/donner/editor/GlTextureCache.cc
+++ b/donner/editor/GlTextureCache.cc
@@ -889,6 +889,7 @@ PresentationResourceStats GlTextureCache::presentationResourceStats() const {
     return allocationBytes(Vector2i(entry.width, entry.height));
   };
 
+  stats.documentCompositeBytes = documentCompositeBytes_;
   stats.activeTileTextures = static_cast<int>(tileTextures_.size());
   for (const auto& [_, entry] : tileTextures_) {
     if (entry.texture != 0) {
@@ -937,8 +938,9 @@ PresentationResourceStats GlTextureCache::presentationResourceStats() const {
   }
 #endif
 
-  stats.totalTrackedBytes = stats.activeTileBytes + stats.overviewTileBytes +
-                            stats.pendingRetiredBytes + stats.agedRetiredBytes;
+  stats.totalTrackedBytes = stats.documentCompositeBytes + stats.activeTileBytes +
+                            stats.overviewTileBytes + stats.pendingRetiredBytes +
+                            stats.agedRetiredBytes;
   peakTrackedResourceBytes_ = std::max(peakTrackedResourceBytes_, stats.totalTrackedBytes);
   stats.peakTrackedBytes = peakTrackedResourceBytes_;
   return stats;

--- a/donner/editor/GlTextureCache.h
+++ b/donner/editor/GlTextureCache.h
@@ -48,6 +48,8 @@ struct CompositedTileTextureIdentity {
 
 /// Approximate resource footprint retained by the editor presentation texture cache.
 struct PresentationResourceStats {
+  /// Bytes retained by an external explicit document-composite target.
+  std::uint64_t documentCompositeBytes = 0;
   /// Bytes retained by active composited tile textures.
   std::uint64_t activeTileBytes = 0;
   /// Bytes retained by the zoom-out overview tile textures.
@@ -157,9 +159,9 @@ struct PresentationCoverageDiagnostics {
  *
  * Composited preview rendering is per-tile: instead of three named bg/promoted/fg
  * textures, the cache owns one GL texture per `CompositedTile` (keyed on the tile id), allocated
- * lazily on first upload and freed when the tile leaves the snapshot. The editor's
- * `RenderPanePresenter` iterates `tiles()` in paint order and blits each tile at its
- * `(canvasOffsetDoc + dragTranslationDoc) * pixelsPerDocUnit` origin.
+ * lazily on first upload and freed when the tile leaves the snapshot. The GL presentation
+ * compositor samples `tiles()` in paint order into one pane-sized texture. WebGPU builds retain
+ * the direct-framebuffer presentation path.
  */
 class GlTextureCache {
 public:
@@ -210,6 +212,8 @@ public:
   ThumbnailTextureView retainThumbnailTextureSnapshot(
       std::uint64_t key, std::shared_ptr<const svg::RendererTextureSnapshot> textureSnapshot);
 
+  /// Report bytes retained by the non-WGPU explicit document compositor.
+  void setDocumentCompositeBytes(std::uint64_t bytes) { documentCompositeBytes_ = bytes; }
   /// Evict every cached thumbnail texture whose key is not in @p liveKeys,
   /// freeing the backing GL/WGPU texture. Called after each Layers-panel render
   /// so thumbnails for removed rows do not leak across refreshes.
@@ -220,9 +224,8 @@ public:
   /// Number of thumbnail textures currently retained (testing/diagnostics).
   [[nodiscard]] std::size_t thumbnailTextureCount() const { return thumbnailTextures_.size(); }
 
-  /// One composite-tile entry as the presenter sees it: the GL
-  /// texture handle (resolved from the upload cache) plus the
-  /// geometry fields the presenter needs to blit in paint order.
+  /// One composite-tile entry as presentation sees it: the GL texture handle
+  /// (resolved from the upload cache) plus its paint-order geometry.
   struct TileView {
     ImTextureID texture = 0;
     std::string id;
@@ -353,6 +356,7 @@ private:
   int metadataOnlyMissCount_ = 0;
   int duplicateLiveTextureCount_ = 0;
   FrameCostBreakdown::CompositedUpload lastCompositedUploadCost_;
+  std::uint64_t documentCompositeBytes_ = 0;
   mutable std::uint64_t peakTrackedResourceBytes_ = 0;
 
 #ifdef DONNER_EDITOR_WGPU

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -801,23 +801,11 @@ SelectionChromeSnapshot OverlayRenderer::captureChromeSnapshot(
   const bool includePathPointChrome = pathOutlinesOnly;
 
   // A live select gesture carries immutable start bounds and the exact current
-  // document transform. Keep its path outline sampled from the live DOM so it
-  // scales and rotates with the presented object, while retaining the
-  // lightweight oriented-bounds path for handles and omitting per-element
-  // AABBs and path-point chrome.
+  // document transform. Build its lightweight bounds chrome directly from
+  // that state instead of traversing selected geometry while the async
+  // renderer may hold the document. Detailed path and text-baseline chrome
+  // refine after the interaction settles.
   if (combinedBoundsOnly && activeBoundsPreview.has_value()) {
-    AppendChromeItems(
-        selection, cullRectDoc, &snapshot.paths, &snapshot.aabbsDoc,
-        /*outPathAnchorPoints=*/nullptr, /*outPathControlLines=*/nullptr,
-        /*outPathControlPoints=*/nullptr, &snapshot.textBaselinesDoc,
-        AppendChromeItemsOptions{
-            .includePaths = true,
-            .includePerElementAabbs = false,
-            .includePathPointChrome = false,
-            .canvasScale = scale,
-            .devicePixelRatio = devicePixelRatio,
-            .representedDocumentFromLiveDocument = representedDocumentFromLiveDocument,
-        });
     const auto corners = TransformedBoxCorners(activeBoundsPreview->startBoundsDoc,
                                                activeBoundsPreview->documentFromStartDocument);
     std::array<Vector2d, 4> representedCorners;

--- a/donner/editor/OverlayRenderer.h
+++ b/donner/editor/OverlayRenderer.h
@@ -356,10 +356,10 @@ public:
   /// otherwise not mutating these components on the same registry.
   /// When `cullRectDoc` is present, path outlines, AABBs, and handles
   /// fully outside that document-space rect are skipped before draw.
-  /// `CombinedBoundsOnly` normally skips selected path extraction and stores
-  /// one combined bounds box for low-latency large-selection feedback. During
-  /// an active scale/rotate preview it also captures path outlines so they
-  /// remain visible and aligned with the gesture.
+  /// `CombinedBoundsOnly` skips selected path extraction and stores one
+  /// combined bounds box for low-latency interaction feedback. An active
+  /// scale/rotate preview derives oriented bounds and handles directly from
+  /// gesture-owned geometry without traversing the selection.
   /// @param devicePixelRatio Viewport framebuffer scale used to convert
   ///   logical UI stroke widths into device pixels.
   ///

--- a/donner/editor/PresentedFrameComposer.cc
+++ b/donner/editor/PresentedFrameComposer.cc
@@ -150,6 +150,27 @@ std::optional<PresentedTileQuad> ComputePresentedTileQuad(
   return quad;
 }
 
+std::optional<Transform2d> ComputePresentedOutputFromTextureTransform(
+    const PresentedTileQuad& tileQuad, const Vector2i& textureSizePx) {
+  if (!IsValidQuad(tileQuad) || textureSizePx.x <= 0 || textureSizePx.y <= 0) {
+    return std::nullopt;
+  }
+
+  const Vector2d sourceSize(static_cast<double>(textureSizePx.x),
+                            static_cast<double>(textureSizePx.y));
+  Transform2d outputFromTexture(Transform2d::uninitialized);
+  outputFromTexture.data[0] = (tileQuad.topRight.x - tileQuad.topLeft.x) / sourceSize.x;
+  outputFromTexture.data[1] = (tileQuad.topRight.y - tileQuad.topLeft.y) / sourceSize.x;
+  outputFromTexture.data[2] = (tileQuad.bottomLeft.x - tileQuad.topLeft.x) / sourceSize.y;
+  outputFromTexture.data[3] = (tileQuad.bottomLeft.y - tileQuad.topLeft.y) / sourceSize.y;
+  outputFromTexture.data[4] = tileQuad.topLeft.x;
+  outputFromTexture.data[5] = tileQuad.topLeft.y;
+  if (!IsFinite(outputFromTexture)) {
+    return std::nullopt;
+  }
+  return outputFromTexture;
+}
+
 std::optional<PresentedTileRect> ComputePresentedTileRect(
     const PresentedFrameTileGeometry& tile, const Transform2d& outputFromCanvasTransform,
     const std::optional<PresentedDragBaseline>& dragBaseline) {

--- a/donner/editor/PresentedFrameComposer.h
+++ b/donner/editor/PresentedFrameComposer.h
@@ -118,6 +118,17 @@ struct PresentedPixelRect {
     const std::optional<PresentedDragBaseline>& dragBaseline);
 
 /**
+ * Recover the affine transform that maps source texture pixels onto a presented tile quad.
+ *
+ * @param tileQuad Presented output-space tile corners.
+ * @param textureSizePx Source texture dimensions in pixels.
+ * @return Transform from texture pixels to output coordinates, or `std::nullopt` for invalid
+ *   inputs.
+ */
+[[nodiscard]] std::optional<Transform2d> ComputePresentedOutputFromTextureTransform(
+    const PresentedTileQuad& tileQuad, const Vector2i& textureSizePx);
+
+/**
  * Compute the output-space rectangle for a presented tile.
  *
  * @param tile Geometry for the tile being presented.

--- a/donner/editor/README.md
+++ b/donner/editor/README.md
@@ -38,8 +38,8 @@ gesture-owned bounds instead of rewalking selected path geometry, and cached dra
 to live selections by entity identity. Source reveal preserves the canvas center and keeps the
 existing full-document raster when a pane-bounded raster would be larger. Reference ropes are
 clipped by their complete route, so the visible middle remains drawn when both endpoints are above
-and below the fold. CSS source annotations run against an isolated source snapshot and are applied
-only after revision validation.
+and below the fold, while fully offscreen routes retain no simulation state. CSS source annotations
+run against an isolated source snapshot and are applied only after revision validation.
 
 ## Building
 

--- a/donner/editor/README.md
+++ b/donner/editor/README.md
@@ -21,7 +21,8 @@ When extending the UI:
 - update the focused theme or visual replay coverage for changed contracts
 
 The source pane is collapsed on startup behind the left reveal rail. Source-navigation commands
-open it automatically. Transform controls use responsive Position, Size, and Rotation rows; the
+open it automatically through a fixed-width slide, so the source text does not compress during the
+transition. Transform controls use responsive Position, Size, and Rotation rows; the
 advanced matrix remains available through its disclosure. Numeric fields drag to adjust and enter
 text mode on a simple click-release. Tool and cursor SVGs use black cores with white halos so they
 remain legible over light and dark content. The toolbar exposes only ready tools; unfinished path
@@ -35,8 +36,10 @@ DOM rewrap and source writeback once on release; text and select handles share t
 Text input is coalesced into one document synchronization per UI frame. Active move chrome uses
 gesture-owned bounds instead of rewalking selected path geometry, and cached drag pixels are matched
 to live selections by entity identity. Source reveal preserves the canvas center and keeps the
-existing full-document raster when a pane-bounded raster would be larger. CSS source annotations run
-against an isolated source snapshot and are applied only after revision validation.
+existing full-document raster when a pane-bounded raster would be larger. Reference ropes are
+clipped by their complete route, so the visible middle remains drawn when both endpoints are above
+and below the fold. CSS source annotations run against an isolated source snapshot and are applied
+only after revision validation.
 
 ## Building
 

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -1164,8 +1164,14 @@ Entity RenderCoordinator::selectedCompositedEntityForDiagnostics(EditorApp& app)
     return entt::null;
   }
 
-  return app.document().document().withReadAccess(
-      [this, &app](svg::DocumentReadAccess&) { return selectedCompositedEntity(app); });
+  const svg::SVGElement& selected = *app.selectedElement();
+  return selected.withReadAccess(
+      [&selected](svg::DocumentReadAccess&, EntityHandle handle) -> Entity {
+        if (!selected.isa<svg::SVGGraphicsElement>() || IsDisplayNone(selected)) {
+          return entt::null;
+        }
+        return handle.entity();
+      });
 }
 
 std::vector<Entity> RenderCoordinator::selectedCompositedExtraEntities(EditorApp& app,

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -668,6 +668,7 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     }
     return tileQuad;
   };
+#ifdef DONNER_EDITOR_WGPU
   const auto computeTileQuad = [&](const GlTextureCache::TileView& tile) {
     if (!ShouldPresentCompositedTile(tile, state.suppressedLayerEntity,
                                      state.suppressDragTargetTiles)) {
@@ -682,10 +683,8 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     }
     const float uvRight = static_cast<float>(tile.uvBottomRight.x);
     const float uvBottom = static_cast<float>(tile.uvBottomRight.y);
-    // Draw-list fallback for frames with no directly presentable Geode tile and
-    // for non-WGPU builds; the quads carry the affine drag-preview transform
-    // that AddImage cannot express. Retired by the presentation-path
-    // unification.
+    // A non-Geode payload cannot enter the direct framebuffer underlay. Keep the compatibility
+    // fallback so device-loss or bitmap-bridge frames remain visible.
     paneDrawList->AddImageQuad(  // NOLINT(banned_patterns: sanctioned fallback presentation)
         tile.texture, ToImVec2(tileQuad->topLeft), ToImVec2(tileQuad->topRight),
         ToImVec2(tileQuad->bottomRight), ToImVec2(tileQuad->bottomLeft), ImVec2(0.0f, 0.0f),
@@ -698,9 +697,8 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     if (drawOverviewTiles) {
       std::vector<Box2d> activeTileBounds;
       activeTileBounds.reserve(state.textures.tiles().size());
-      for (const auto& tile : state.textures.tiles()) {
-        const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile);
-        if (tileQuad.has_value()) {
+      for (const GlTextureCache::TileView& tile : state.textures.tiles()) {
+        if (const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile)) {
           activeTileBounds.push_back(PresentedTileQuadBounds(*tileQuad));
         }
         if (TileMatchesActiveDragPreview(tile, state.activeDragPreview)) {
@@ -713,23 +711,30 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
         }
       }
 
-      const std::vector<Box2d> overviewClipRects =
-          SubtractPresentedTileBoundsFromClip(*imageClipRect, activeTileBounds);
-      for (const Box2d& overviewClipRect : overviewClipRects) {
+      for (const Box2d& overviewClipRect :
+           SubtractPresentedTileBoundsFromClip(*imageClipRect, activeTileBounds)) {
         paneDrawList->PushClipRect(ToImVec2(overviewClipRect.topLeft),
                                    ToImVec2(overviewClipRect.bottomRight),
                                    /*intersect_with_current_clip_rect=*/true);
-        for (const auto& tile : state.textures.overviewTiles()) {
+        for (const GlTextureCache::TileView& tile : state.textures.overviewTiles()) {
           drawTile(tile);
         }
         paneDrawList->PopClipRect();
       }
     }
-    for (const auto& tile : state.textures.tiles()) {
+    for (const GlTextureCache::TileView& tile : state.textures.tiles()) {
       drawTile(tile);
     }
     paneDrawList->PopClipRect();
   }
+#else
+  const DocumentCompositeTextureView& documentComposite = state.documentComposite;
+  if (documentComposite.texture != 0 && !state.documentPresentedDirectly) {
+    paneDrawList->AddImage(
+        documentComposite.texture, ToImVec2(documentComposite.screenRect.topLeft),
+        ToImVec2(documentComposite.screenRect.bottomRight), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+  }
+#endif
   if (state.compositorTileOverlay && imageClipRect.has_value()) {
     paneDrawList->PushClipRect(ToImVec2(imageClipRect->topLeft),
                                ToImVec2(imageClipRect->bottomRight),

--- a/donner/editor/RenderPanePresenter.h
+++ b/donner/editor/RenderPanePresenter.h
@@ -9,6 +9,7 @@
 #include "donner/base/Box.h"
 #include "donner/base/Path.h"
 #include "donner/base/Vector2.h"
+#include "donner/editor/DocumentCompositeTexture.h"
 #include "donner/editor/GlTextureCache.h"
 #include "donner/editor/MenuBarPresenter.h"
 #include "donner/editor/OverlayRenderer.h"
@@ -46,6 +47,7 @@ struct RenderPanePresenterState {
   Entity suppressedLayerEntity = entt::null;
   bool suppressDragTargetTiles = false;
   bool documentPresentedDirectly = false;
+  DocumentCompositeTextureView documentComposite;
   bool compositorTileOverlay = false;
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
 };

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -2311,8 +2311,6 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
       drawStaticConnector();
       continue;
     }
-    ++animatedLinkCount;
-
     const auto updateStart = std::chrono::steady_clock::now();
     const Vector2d start = ToVector2d(layout->start);
     const Vector2d tip = ToVector2d(layout->tip);
@@ -2351,6 +2349,7 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
       focusReferenceRopes_.erase(link);
       continue;
     }
+    ++animatedLinkCount;
 
     const auto drawStart = std::chrono::steady_clock::now();
     const ImU32 color = ropeState.hovered ? BrightenReferenceColor(layout->color) : layout->color;

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -2282,10 +2282,7 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
       continue;
     }
     ++ropeCost.laidOutCount;
-    if (!BoxesIntersect(layoutBounds(*layout), visibleTextBounds)) {
-      ++ropeCost.culledCount;
-      continue;
-    }
+    const Box2d connectorLayoutBounds = layoutBounds(*layout);
 
     const auto drawStaticConnector = [&] {
       const auto drawStart = std::chrono::steady_clock::now();
@@ -2307,9 +2304,14 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
     };
 
     if (animatedLinkCount >= kMaxAnimatedFocusReferenceRopes) {
+      if (!BoxesIntersect(connectorLayoutBounds, visibleTextBounds)) {
+        ++ropeCost.culledCount;
+        continue;
+      }
       drawStaticConnector();
       continue;
     }
+    ++animatedLinkCount;
 
     const auto updateStart = std::chrono::steady_clock::now();
     const Vector2d start = ToVector2d(layout->start);
@@ -2337,12 +2339,16 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
     ropeState.chordLength = chordLength;
     ropeState.lastFrameSeen = focusReferenceRopeFrame_;
     ropeCost.updateMs += MillisecondsSince(updateStart);
-    ++animatedLinkCount;
 
     const std::optional<Box2d> routeBounds = ropeState.path.bounds();
-    if (routeBounds.has_value() && !BoxesIntersect(*routeBounds, visibleTextBounds)) {
+    Box2d completeRouteBounds = connectorLayoutBounds;
+    if (routeBounds.has_value()) {
+      AddPointToBox(&completeRouteBounds, ToImVec2(routeBounds->topLeft));
+      AddPointToBox(&completeRouteBounds, ToImVec2(routeBounds->bottomRight));
+    }
+    if (!BoxesIntersect(completeRouteBounds, visibleTextBounds)) {
       ++ropeCost.culledCount;
-      ++visibleLinkIndex;
+      focusReferenceRopes_.erase(link);
       continue;
     }
 

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1521,8 +1521,8 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
   const float textStartX =
       lineStart.x + textStart_ + static_cast<float>(visualLine.indentColumns) * charAdvance_.x;
 
-  const auto drawSourceCoordinates = [&](const Coordinates& rangeStart,
-                                         const Coordinates& rangeEnd, ImU32 color) {
+  const auto drawSourceCoordinates = [&](const Coordinates& rangeStart, const Coordinates& rangeEnd,
+                                         ImU32 color) {
     if (rangeEnd.line < visualLine.lineNo || rangeStart.line > visualLine.lineNo) {
       return;
     }
@@ -2272,32 +2272,8 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
     }
     return bounds;
   };
-  const auto sourcePointIntersectsVisibleRows = [&](const SourcePoint& point) {
-    if (isLineHiddenByFocus(point.line)) {
-      return false;
-    }
-
-    int visualIndex = point.line;
-    if ((wordWrapEnabled_ || focusPartitionActive_) && !visualLines_.empty()) {
-      visualIndex = visualLineIndexForCoordinates(Coordinates(point.line, point.column));
-      if (visualIndex < 0 || visualIndex >= static_cast<int>(visualLines_.size()) ||
-          visualLines_[visualIndex].lineNo != point.line) {
-        return false;
-      }
-    }
-
-    const double rowTop = uiCursorPos_.y + static_cast<double>(visualIndex) * charAdvance_.y;
-    const double rowBottom = rowTop + charAdvance_.y;
-    return rowBottom >= visibleTextBounds.topLeft.y && rowTop <= visibleTextBounds.bottomRight.y;
-  };
-
   drawList->PushClipRect(clipMin, clipMax, true);
   for (const FocusReferenceLink& link : focusPartition_.referenceLinks) {
-    if (!sourcePointIntersectsVisibleRows(link.from)) {
-      ++ropeCost.culledCount;
-      continue;
-    }
-
     const auto layoutStart = std::chrono::steady_clock::now();
     std::optional<FocusReferenceConnectorLayout> layout =
         focusReferenceConnectorLayout(link, visibleLinkIndex);

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -1707,6 +1707,12 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
   glfwGetFramebufferSize(window_, &displayW, &displayH);
 #endif
 #ifdef DONNER_EDITOR_WGPU
+  Vector2d framebufferFromLogicalScale(1.0, 1.0);
+  if (const ImDrawData* drawData = ImGui::GetDrawData();
+      drawData != nullptr && drawData->DisplaySize.x > 0.0f && drawData->DisplaySize.y > 0.0f) {
+    framebufferFromLogicalScale = Vector2d(static_cast<double>(displayW) / drawData->DisplaySize.x,
+                                           static_cast<double>(displayH) / drawData->DisplaySize.y);
+  }
   svg::RendererBitmap* targetReadback = readback;
 #if defined(__EMSCRIPTEN__) && defined(DONNER_EDITOR_WGPU)
   const bool publishSmokeReadbackStats = WgpuReadbackStatsEnabled();
@@ -1899,6 +1905,7 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
       EditorWindowWgpuRenderTarget underlayTarget{
           .texture = target,
           .framebufferSizePx = Vector2i(displayW, displayH),
+          .framebufferFromLogicalScale = framebufferFromLogicalScale,
       };
       wgpuUnderlayRenderCallback_(underlayTarget);
       timing.underlayMs = ElapsedMs(underlayStart);
@@ -1913,6 +1920,7 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
     EditorWindowWgpuRenderTarget directTarget{
         .texture = target,
         .framebufferSizePx = Vector2i(displayW, displayH),
+        .framebufferFromLogicalScale = framebufferFromLogicalScale,
     };
     wgpuDirectRenderCallback_(directTarget);
     timing.directMs = ElapsedMs(directStart);

--- a/donner/editor/gui/EditorWindow.h
+++ b/donner/editor/gui/EditorWindow.h
@@ -271,6 +271,8 @@ struct EditorWindowWgpuRenderTarget {
   wgpu::Texture texture;
   /// Framebuffer dimensions in physical pixels.
   Vector2i framebufferSizePx = Vector2i::Zero();
+  /// Physical framebuffer pixels per ImGui logical pixel for this frame.
+  Vector2d framebufferFromLogicalScale = Vector2d(1.0, 1.0);
 };
 
 /// Callback invoked before ImGui renders, after the surface has been cleared.

--- a/donner/editor/repro/GlRnrReplay.cc
+++ b/donner/editor/repro/GlRnrReplay.cc
@@ -281,11 +281,12 @@ void QueueRecordedScrollEvents(EditorShell& shell, const ReproFrame& frame) {
 
 [[nodiscard]] PixelRect LogicalRectToPixelRect(const Box2d& logicalRect,
                                                const svg::RendererBitmap& bitmap,
-                                               double devicePixelRatio, PixelSnapMode snapMode) {
-  const double left = logicalRect.topLeft.x * devicePixelRatio;
-  const double top = logicalRect.topLeft.y * devicePixelRatio;
-  const double right = logicalRect.bottomRight.x * devicePixelRatio;
-  const double bottom = logicalRect.bottomRight.y * devicePixelRatio;
+                                               const Vector2d& framebufferFromLogicalScale,
+                                               PixelSnapMode snapMode) {
+  const double left = logicalRect.topLeft.x * framebufferFromLogicalScale.x;
+  const double top = logicalRect.topLeft.y * framebufferFromLogicalScale.y;
+  const double right = logicalRect.bottomRight.x * framebufferFromLogicalScale.x;
+  const double bottom = logicalRect.bottomRight.y * framebufferFromLogicalScale.y;
 
   const int unclampedX0 = snapMode == PixelSnapMode::Contained ? static_cast<int>(std::ceil(left))
                                                                : static_cast<int>(std::floor(left));
@@ -309,9 +310,9 @@ void QueueRecordedScrollEvents(EditorShell& shell, const ReproFrame& frame) {
   };
 }
 
-[[nodiscard]] std::optional<PixelRect> CropRectForMode(GlRnrReplayCropMode cropMode,
-                                                       const ViewportState& viewport,
-                                                       const svg::RendererBitmap& bitmap) {
+[[nodiscard]] std::optional<PixelRect> CropRectForMode(
+    GlRnrReplayCropMode cropMode, const ViewportState& viewport, const svg::RendererBitmap& bitmap,
+    const Vector2d& framebufferFromLogicalScale) {
   if (cropMode == GlRnrReplayCropMode::Full) {
     return std::nullopt;
   }
@@ -331,7 +332,7 @@ void QueueRecordedScrollEvents(EditorShell& shell, const ReproFrame& frame) {
                                      ? PixelSnapMode::Contained
                                      : PixelSnapMode::Covering;
   PixelRect pixelRect =
-      LogicalRectToPixelRect(logicalRect, bitmap, viewport.devicePixelRatio, snapMode);
+      LogicalRectToPixelRect(logicalRect, bitmap, framebufferFromLogicalScale, snapMode);
   if (pixelRect.width <= 0 || pixelRect.height <= 0) {
     return std::nullopt;
   }
@@ -360,8 +361,10 @@ void QueueRecordedScrollEvents(EditorShell& shell, const ReproFrame& frame) {
 
 [[nodiscard]] svg::RendererBitmap CropForOutput(const svg::RendererBitmap& bitmap,
                                                 GlRnrReplayCropMode cropMode,
-                                                const ViewportState& viewport) {
-  const std::optional<PixelRect> cropRect = CropRectForMode(cropMode, viewport, bitmap);
+                                                const ViewportState& viewport,
+                                                const Vector2d& framebufferFromLogicalScale) {
+  const std::optional<PixelRect> cropRect =
+      CropRectForMode(cropMode, viewport, bitmap, framebufferFromLogicalScale);
   return cropRect.has_value() ? CropBitmap(bitmap, *cropRect) : bitmap;
 }
 
@@ -462,6 +465,18 @@ std::string_view GlRnrReplayCropModeSuffix(GlRnrReplayCropMode cropMode) {
   }
 
   return "";
+}
+
+Vector2d GlRnrReplayFramebufferFromLogicalScale(const Vector2i& framebufferSize,
+                                                const Vector2d& logicalDisplaySize) {
+  if (framebufferSize.x <= 0 || framebufferSize.y <= 0 || !std::isfinite(logicalDisplaySize.x) ||
+      !std::isfinite(logicalDisplaySize.y) || logicalDisplaySize.x <= 0.0 ||
+      logicalDisplaySize.y <= 0.0) {
+    return Vector2d(1.0, 1.0);
+  }
+
+  return Vector2d(static_cast<double>(framebufferSize.x) / logicalDisplaySize.x,
+                  static_cast<double>(framebufferSize.y) / logicalDisplaySize.y);
 }
 
 bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result,
@@ -720,8 +735,12 @@ bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result
 
     if (captureReason.has_value()) {
       const std::filesystem::path path = CapturePath(options, frame, *captureReason);
+      const ImVec2 logicalDisplaySize = ImGui::GetIO().DisplaySize;
+      const svg::RendererBitmap framebuffer = window.endFrameAndReadPixels();
+      const Vector2d framebufferFromLogicalScale = GlRnrReplayFramebufferFromLogicalScale(
+          framebuffer.dimensions, Vector2d(logicalDisplaySize.x, logicalDisplaySize.y));
       const svg::RendererBitmap bitmap = CropForOutput(
-          window.endFrameAndReadPixels(), options.cropMode, shell.viewportForReadback());
+          framebuffer, options.cropMode, shell.viewportForReadback(), framebufferFromLogicalScale);
       if (!WriteCapture(bitmap, path, error)) {
         return false;
       }

--- a/donner/editor/repro/GlRnrReplay.cc
+++ b/donner/editor/repro/GlRnrReplay.cc
@@ -540,6 +540,7 @@ bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result
   if (!shell.valid()) {
     return SetError(error, "failed to initialize editor shell");
   }
+  shell.setSourcePaneVisibleForReplay(options.sourcePaneVisible);
 
   AsyncRenderer& replayRenderer = shell.asyncRendererForReplay();
   replayRenderer.setReplayRenderDelayForTesting(

--- a/donner/editor/repro/GlRnrReplay.h
+++ b/donner/editor/repro/GlRnrReplay.h
@@ -263,6 +263,16 @@ struct GlRnrReplayResult {
 [[nodiscard]] std::string_view GlRnrReplayCropModeSuffix(GlRnrReplayCropMode cropMode);
 
 /**
+ * Return the pixel scale between a captured framebuffer and ImGui's logical display.
+ *
+ * @param framebufferSize Captured framebuffer dimensions in physical pixels.
+ * @param logicalDisplaySize ImGui display dimensions in logical pixels.
+ * @return Per-axis framebuffer pixels per logical pixel, or (1, 1) for invalid dimensions.
+ */
+[[nodiscard]] Vector2d GlRnrReplayFramebufferFromLogicalScale(const Vector2i& framebufferSize,
+                                                              const Vector2d& logicalDisplaySize);
+
+/**
  * Replay an `.rnr` recording through `EditorShell`, capture the OpenGL
  * framebuffer, and write requested frames as PNGs.
  *

--- a/donner/editor/repro/GlRnrReplay.h
+++ b/donner/editor/repro/GlRnrReplay.h
@@ -58,6 +58,8 @@ struct GlRnrReplayOptions {
   int workerRenderDelayMsForTesting = 0;
   /// Drive canvas tool input from recorded document coordinates instead of GUI screen hit-testing.
   bool driveDocumentSpaceInput = false;
+  /// Open the source pane before replaying the first frame.
+  bool sourcePaneVisible = false;
   /// Suppress non-document render-pane chrome when writing captures.
   bool contentOnlyCapture = false;
   /// Read retained GPU textures back to count diagnostic pixels. Expensive and disabled unless a

--- a/donner/editor/repro/GlRnrReplay.h
+++ b/donner/editor/repro/GlRnrReplay.h
@@ -58,7 +58,9 @@ struct GlRnrReplayOptions {
   int workerRenderDelayMsForTesting = 0;
   /// Drive canvas tool input from recorded document coordinates instead of GUI screen hit-testing.
   bool driveDocumentSpaceInput = false;
-  /// Open the source pane before replaying the first frame.
+  /// Set the source pane's animation target visible before the first frame.
+  ///
+  /// Frame zero captures the beginning of the slide-in transition.
   bool sourcePaneVisible = false;
   /// Suppress non-document render-pane chrome when writing captures.
   bool contentOnlyCapture = false;

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -15,7 +15,10 @@ donner_cc_library(
     hdrs = ["BitmapGoldenCompare.h"],
     # //donner/gpu: the Metal vertical slice test (design 0053) uses the one
     # blessed pixelmatch comparator for its frozen-baseline comparison.
-    visibility = ["//donner/gpu/metal/tests:__pkg__"],
+    visibility = [
+        "//donner/gpu/metal/tests:__pkg__",
+        "//tools/mcp-servers/editor-control:__pkg__",
+    ],
     deps = [
         "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/renderer:renderer_interface",

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -368,6 +368,7 @@ donner_cc_test(
     deps = [
         "//donner/base",
         "//donner/base:base_test_utils",
+        "//donner/editor:document_presentation_compositor",
         "//donner/editor:gl_texture_cache",
         "//donner/editor:imgui_headers",
         "//donner/editor:menu_bar_presenter",

--- a/donner/editor/tests/EditorRnrGlReplay.cc
+++ b/donner/editor/tests/EditorRnrGlReplay.cc
@@ -428,7 +428,8 @@ void PrintFrameCost(const FrameCostBreakdown& cost) {
 }
 
 void PrintPresentationResources(const PresentationResourceStats& resources) {
-  std::cout << "{\"active_tile_bytes\":" << resources.activeTileBytes
+  std::cout << "{\"document_composite_bytes\":" << resources.documentCompositeBytes
+            << ",\"active_tile_bytes\":" << resources.activeTileBytes
             << ",\"overview_tile_bytes\":" << resources.overviewTileBytes
             << ",\"pending_retired_bytes\":" << resources.pendingRetiredBytes
             << ",\"aged_retired_bytes\":" << resources.agedRetiredBytes

--- a/donner/editor/tests/EditorRnrGlReplay.cc
+++ b/donner/editor/tests/EditorRnrGlReplay.cc
@@ -66,7 +66,8 @@ void PrintUsage(std::string_view argv0) {
                "       [--worker-delay-ms <n>]\n"
                "       [--worker-scheduling realtime|drain-each-frame|hold-frames-behind]\n"
                "       [--hold-frames-behind <n>]\n"
-               "       [--drive-document-input] [--content-only-capture]\n"
+               "       [--drive-document-input] [--source-pane-visible]\n"
+               "       [--content-only-capture]\n"
                "       [--visible] [--no-pace] [--print-diagnostics]\n"
                "       [--diagnostics-frame <n>]...\n";
 }
@@ -181,6 +182,11 @@ void PrintUsage(std::string_view argv0) {
 
     if (arg == "--drive-document-input") {
       options->driveDocumentSpaceInput = true;
+      continue;
+    }
+
+    if (arg == "--source-pane-visible") {
+      options->sourcePaneVisible = true;
       continue;
     }
 

--- a/donner/editor/tests/EditorShellLayout_tests.cc
+++ b/donner/editor/tests/EditorShellLayout_tests.cc
@@ -134,6 +134,43 @@ TEST(EditorShellLayoutTest, MainLayoutGivesSourceWidthBackToRenderPaneWhenHidden
   EXPECT_FLOAT_EQ(layout.rightPaneWidth, 420.0f);
 }
 
+TEST(EditorShellLayoutTest, SourcePaneRevealAdvancesOverMultipleFrames) {
+  EXPECT_FLOAT_EQ(AdvanceSourcePaneRevealProgress(0.0f, false, 0.05f), 0.0f);
+
+  const float opening = AdvanceSourcePaneRevealProgress(0.0f, true, 0.05f);
+  EXPECT_GT(opening, 0.0f);
+  EXPECT_LT(opening, 1.0f);
+  EXPECT_FLOAT_EQ(AdvanceSourcePaneRevealProgress(opening, true, 1.0f), 1.0f);
+
+  const float closing = AdvanceSourcePaneRevealProgress(1.0f, false, 0.05f);
+  EXPECT_GT(closing, 0.0f);
+  EXPECT_LT(closing, 1.0f);
+  EXPECT_FLOAT_EQ(AdvanceSourcePaneRevealProgress(closing, false, 1.0f), 0.0f);
+}
+
+TEST(EditorShellLayoutTest, MainLayoutSlidesSourceContentAtIntermediateReveal) {
+  const EditorMainPaneLayout layout = ComputeEditorMainPaneLayout({
+      .windowWidth = 1600.0f,
+      .sourcePaneVisible = true,
+      .sourcePaneWidth = 560.0f,
+      .sourcePaneRevealProgress = 0.5f,
+      .minSourcePaneWidth = 240.0f,
+      .maxSourcePaneWidth = 900.0f,
+      .sourcePaneRailWidth = 32.0f,
+      .rightPaneWidth = 420.0f,
+      .minRightPaneWidth = 220.0f,
+      .maxRightPaneWidth = 900.0f,
+      .minRenderPaneWidth = 220.0f,
+  });
+
+  EXPECT_FLOAT_EQ(layout.sourcePaneWidth, 560.0f);
+  EXPECT_LT(layout.sourcePaneX, 0.0f);
+  EXPECT_GT(layout.renderPaneX, 32.0f);
+  EXPECT_LT(layout.renderPaneX, 560.0f);
+  EXPECT_FLOAT_EQ(layout.sourcePaneX + layout.sourcePaneWidth, layout.renderPaneX);
+  EXPECT_FLOAT_EQ(layout.sourcePaneRailWidth, 0.0f);
+}
+
 TEST(EditorShellLayoutTest, MainLayoutGivesFullWidthToCompactCanvas) {
   const EditorMainPaneLayout layout = ComputeEditorMainPaneLayout({
       .windowWidth = 390.0f,
@@ -209,7 +246,6 @@ TEST(EditorShellLayoutTest, DraggingSplitterDownPreservesLayerMinimum) {
 
   EXPECT_FLOAT_EQ(nextFraction, 0.2f);
 }
-
 
 // The render pane geometry of a settled desktop frame: a 1280x699 dock host below the menu bar,
 // split into a 947-wide canvas column and a right sidebar column, with the docked pane window

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -55,6 +55,13 @@ constexpr std::string_view kStyledSvg = R"svg(
 </svg>
 )svg";
 
+constexpr std::string_view kPaintSnapshotSelectionChangeSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect id="first" x="10" y="12" width="40" height="24" fill="#ff0000"/>
+  <rect id="second" x="65" y="12" width="40" height="24" fill="#0000ff"/>
+</svg>
+)svg";
+
 constexpr std::string_view kReferencedSvg = R"svg(
 <svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
   <defs>
@@ -640,6 +647,35 @@ TEST(EditorShellInternalTest, FillStrokeWidgetLayoutAndHitTestClassifyRegions) {
   EXPECT_EQ(hit(fillChip, true, false), internal::FillStrokeWidgetRegion::FillChip);
   const ImVec2 strokeChip = center(layout.strokeChipMin, layout.strokeChipMax);
   EXPECT_EQ(hit(strokeChip, false, true), internal::FillStrokeWidgetRegion::StrokeChip);
+}
+
+TEST(EditorShellInternalTest, FillStrokeWidgetInteractionStateIgnoresBusyHandoffsDuringDrag) {
+  const internal::FillStrokeWidgetInteractionState idleDrag =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
+          /*paintSnapshotMatchesSelection=*/true);
+  const internal::FillStrokeWidgetInteractionState busyDrag =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/true, /*canvasInteractionActive=*/true,
+          /*paintSnapshotMatchesSelection=*/true);
+  EXPECT_EQ(idleDrag.canEdit, busyDrag.canEdit);
+  EXPECT_EQ(idleDrag.refreshPaintSnapshot, busyDrag.refreshPaintSnapshot);
+  EXPECT_FALSE(idleDrag.canEdit);
+  EXPECT_FALSE(idleDrag.refreshPaintSnapshot);
+
+  const internal::FillStrokeWidgetInteractionState firstDragFrame =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
+          /*paintSnapshotMatchesSelection=*/false);
+  EXPECT_FALSE(firstDragFrame.canEdit);
+  EXPECT_TRUE(firstDragFrame.refreshPaintSnapshot);
+
+  const internal::FillStrokeWidgetInteractionState settled =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/false,
+          /*paintSnapshotMatchesSelection=*/true);
+  EXPECT_TRUE(settled.canEdit);
+  EXPECT_TRUE(settled.refreshPaintSnapshot);
 }
 
 TEST(EditorShellInternalTest, SourceHelpersPreferInitialSourceAndCanonicalizeTrailingNewline) {
@@ -1262,6 +1298,13 @@ public:
 
   static bool SelectToolIsMarqueeing(const EditorShell& shell) {
     return shell.selectTool_.isMarqueeing();
+  }
+
+  static bool BeginSelectedShapeDrag(EditorShell& shell, const Vector2d& documentPoint,
+                                     const Box2d& selectionBounds) {
+    const std::array<Box2d, 1> bounds = {selectionBounds};
+    return shell.selectTool_.tryStartRedragOnSelected(shell.app_, documentPoint, MouseModifiers{},
+                                                      bounds);
   }
 
   static void BufferPendingClick(EditorShell& shell, const Vector2d& documentPoint,
@@ -3446,6 +3489,68 @@ TEST(EditorShellTest, FillStrokeToolbarKeepsChosenPaintVisibleWhileRendererIsBus
                                                            std::chrono::seconds(2)));
   std::ignore = renderer.pollResult();
   renderer.setReplayRenderDelayForTesting(std::chrono::milliseconds(0));
+}
+
+TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableDuringShapeDrag) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kStyledSvg, "styled.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  std::optional<svg::SVGElement> target =
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  ASSERT_TRUE(EditorShellTestAccess::BeginSelectedShapeDrag(
+      shell, Vector2d(20.0, 20.0), Box2d::FromXYWH(10.0, 12.0, 40.0, 24.0)));
+
+  constexpr ImVec2 kCursor(20.0f, 40.0f);
+  constexpr ImU32 kEnabledSwap = IM_COL32(215, 222, 232, 255);
+  constexpr ImU32 kDisabledSwap = IM_COL32(120, 126, 134, 255);
+  const auto expectStableDragChrome = [&]() {
+    EXPECT_TRUE(DrawDataContainsColor(kDisabledSwap));
+    EXPECT_FALSE(DrawDataContainsColor(kEnabledSwap));
+    EXPECT_TRUE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255))) << "Fill swatch changed";
+    EXPECT_TRUE(DrawDataContainsColor(IM_COL32(0, 0, 255, 255))) << "Stroke swatch changed";
+  };
+
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  expectStableDragChrome();
+}
+
+TEST(EditorShellTest, FillStrokeToolbarCapturesNewSelectionBeforeFreezingShapeDrag) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window,
+                    OptionsWithSource(kPaintSnapshotSelectionChangeSvg, "paint_selection.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  svg::SVGDocument& document = EditorShellTestAccess::App(shell).document().document();
+  std::optional<svg::SVGElement> first = document.querySelector("#first");
+  std::optional<svg::SVGElement> second = document.querySelector("#second");
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+
+  constexpr ImVec2 kCursor(20.0f, 40.0f);
+  EditorShellTestAccess::App(shell).setSelection(*first);
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  ASSERT_TRUE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255)));
+
+  EditorShellTestAccess::App(shell).setSelection(*second);
+  ASSERT_TRUE(EditorShellTestAccess::BeginSelectedShapeDrag(
+      shell, Vector2d(75.0, 20.0), Box2d::FromXYWH(65.0, 12.0, 40.0, 24.0)));
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+
+  EXPECT_TRUE(DrawDataContainsColor(IM_COL32(0, 0, 255, 255)))
+      << "The drag must freeze the newly selected element's fill";
+  EXPECT_FALSE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255)))
+      << "The drag must not replay the previous selection's fill";
 }
 
 TEST(EditorShellTest, ToolPaletteSelectCommitsOpenPenPath) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -990,6 +990,7 @@ public:
 
   static void SetSourcePaneVisible(EditorShell& shell, bool visible) {
     shell.setSourcePaneVisible(visible);
+    shell.sourcePaneRevealProgress_ = visible ? 1.0f : 0.0f;
   }
 
   static void RevealSourceRange(EditorShell& shell, SourceByteRange byteRange) {
@@ -1174,7 +1175,7 @@ public:
 
   static void RenderSourcePane(EditorShell& shell, float paneOriginY, float paneHeight,
                                float paneWidth, ImFont* codeFont) {
-    shell.renderSourcePane(paneOriginY, paneHeight, paneWidth, codeFont);
+    shell.renderSourcePane(/*paneOriginX=*/0.0f, paneOriginY, paneHeight, paneWidth, codeFont);
   }
 
   static void RenderRenderPane(EditorShell& shell, const Vector2d& renderPaneOrigin,

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -1899,6 +1899,9 @@ TEST(EditorShellTest, LayerInspectorReadbackIncludesSelectedStyleAndPathDiagnost
   EditorShellTestAccess::App(shell).setSelection(*target);
   (void)target->getComputedStyle();
   RunFramesUntilDisplayedSelectionBounds(window, shell);
+  ASSERT_TRUE(shell.asyncRendererForReplay().waitUntilNoRenderInFlightForTesting(
+      std::chrono::steady_clock::now() + std::chrono::seconds(2)));
+  RunShellFrame(window, shell);
 
   const LayerInspectorStatusReadback status = shell.layerInspectorStatusForReadback();
 

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -190,8 +190,11 @@ TEST(EditorShellPresentationTest, ChromeTransformEqualsTileTransformInTheSameFra
   SelectionChromeSnapshot snapshot;
   snapshot.canvasFromDoc = Transform2d::Scale(11.0) * Transform2d::Translate(Vector2d(3.0, 5.0));
 
-  const SelectionChromeSnapshot placed = ChromePlacedOnPresentedDocument(viewport, snapshot);
-  const Transform2d presentedFromDocument = PresentedFramebufferFromDocumentTransform(viewport);
+  const Vector2d framebufferFromLogicalScale(2.0, 2.0);
+  const SelectionChromeSnapshot placed =
+      ChromePlacedOnPresentedDocument(viewport, framebufferFromLogicalScale, snapshot);
+  const Transform2d presentedFromDocument =
+      PresentedFramebufferFromDocumentTransform(viewport, framebufferFromLogicalScale);
   EXPECT_THAT(placed.canvasFromDoc.data, ::testing::ElementsAreArray(presentedFromDocument.data));
 
   // The same transform is what the tile compose places quads with: a tile
@@ -222,9 +225,27 @@ TEST(EditorShellPresentationTest, ChromePlacementIgnoresTheCaptureTimeTransform)
   SelectionChromeSnapshot capturedAtFourX;
   capturedAtFourX.canvasFromDoc = Transform2d::Scale(4.0);
 
-  EXPECT_THAT(ChromePlacedOnPresentedDocument(viewport, capturedAtOneX).canvasFromDoc.data,
-              ::testing::ElementsAreArray(
-                  ChromePlacedOnPresentedDocument(viewport, capturedAtFourX).canvasFromDoc.data));
+  const Vector2d framebufferFromLogicalScale(1.0, 1.0);
+  EXPECT_THAT(
+      ChromePlacedOnPresentedDocument(viewport, framebufferFromLogicalScale, capturedAtOneX)
+          .canvasFromDoc.data,
+      ::testing::ElementsAreArray(
+          ChromePlacedOnPresentedDocument(viewport, framebufferFromLogicalScale, capturedAtFourX)
+              .canvasFromDoc.data));
+}
+
+TEST(EditorShellPresentationTest, PresentationUsesFramebufferScaleInsteadOfRasterDpr) {
+  ViewportState viewport;
+  viewport.devicePixelRatio = 1.0;
+  viewport.zoom = 1.0;
+  viewport.panScreenPoint = Vector2d(320.0, 240.0);
+  viewport.panDocPoint = Vector2d(100.0, 60.0);
+
+  const Transform2d framebufferFromDocument =
+      PresentedFramebufferFromDocumentTransform(viewport, Vector2d(2.0, 2.0));
+  EXPECT_EQ(framebufferFromDocument.transformPosition(Vector2d(0.0, 0.0)), Vector2d(440.0, 360.0));
+  EXPECT_EQ(framebufferFromDocument.transformPosition(Vector2d(200.0, 120.0)),
+            Vector2d(840.0, 600.0));
 }
 
 TEST(EditorShellInternalTest, CursorForTransformHandleIntentMapsResizeAndRotateHandles) {

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <iterator>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -283,6 +284,22 @@ std::optional<std::filesystem::path> WriteStaticContentReplay(
   file.metadata.windowHeight = 480;
   file.metadata.displayScale = 1.0;
 
+  repro::ReproViewport viewport;
+  viewport.paneOriginX = 220.0;
+  viewport.paneOriginY = 180.0;
+  viewport.paneSizeW = 200.0;
+  viewport.paneSizeH = 120.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.zoom = 1.0;
+  viewport.panDocX = 100.0;
+  viewport.panDocY = 60.0;
+  viewport.panScreenX = 320.0;
+  viewport.panScreenY = 240.0;
+  viewport.viewBoxX = 0.0;
+  viewport.viewBoxY = 0.0;
+  viewport.viewBoxW = 200.0;
+  viewport.viewBoxH = 120.0;
+
   for (std::uint64_t frameIndex = 0; frameIndex <= lastFrame; ++frameIndex) {
     repro::ReproFrame frame;
     frame.index = frameIndex;
@@ -290,6 +307,7 @@ std::optional<std::filesystem::path> WriteStaticContentReplay(
     frame.deltaMs = 1000.0 / 60.0;
     frame.mouseX = 320.0;
     frame.mouseY = 240.0;
+    frame.viewport = viewport;
     file.frames.push_back(frame);
   }
 
@@ -2156,6 +2174,7 @@ TEST(GlRnrReplayTest, ContentOnlyDocumentCanvasCaptureMatchesRendererGroundTruth
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
   std::optional<svg::RendererBitmap> actual = LoadCaptureBitmap(result, kFirstPresentedReplayFrame);
   ASSERT_TRUE(actual.has_value());
@@ -2190,6 +2209,7 @@ TEST(GlRnrReplayTest, DirectDocumentCanvasCaptureIsNotDimmedByRenderPaneBackgrou
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
   std::optional<svg::RendererBitmap> actual = LoadCaptureBitmap(result, kFirstPresentedReplayFrame);
   ASSERT_TRUE(actual.has_value());
@@ -3220,21 +3240,21 @@ TEST(GlRnrReplayTest, HoldFramesBehindRecordsWithheldReplayDiagnostics) {
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
-  // The first result is ready on `kFirstPresentedReplayFrame`; `holdFramesBehind = 1` withholds it
-  // for exactly that one poll and releases it on the next frame.
-  const repro::GlRnrReplayFrameDiagnostics* withheld =
-      FindFrameDiagnostics(result, kFirstPresentedReplayFrame);
-  ASSERT_NE(withheld, nullptr);
+  // Viewport initialization decides which replay frame first posts work. Assert the deterministic
+  // hold relative to the completed result instead of pinning that initialization to a frame index.
+  const auto withheld = std::find_if(
+      result.frameDiagnostics.begin(), result.frameDiagnostics.end(),
+      [](const repro::GlRnrReplayFrameDiagnostics& frame) { return frame.replayResultWithheld; });
+  ASSERT_NE(withheld, result.frameDiagnostics.end());
   EXPECT_EQ(withheld->replayWorkerScheduling, repro::GlRnrReplayWorkerScheduling::HoldFramesBehind);
   EXPECT_EQ(withheld->replayWorkerRenderDelayMsForTesting, 1);
   EXPECT_EQ(withheld->replayHoldFramesBehind, 1);
   EXPECT_EQ(withheld->replayResultHoldPollsThisFrame, 1u);
-  EXPECT_TRUE(withheld->replayResultWithheld);
 
-  const repro::GlRnrReplayFrameDiagnostics* released =
-      FindFrameDiagnostics(result, kFirstPresentedReplayFrame + 1);
-  ASSERT_NE(released, nullptr);
+  const auto released = std::next(withheld);
+  ASSERT_NE(released, result.frameDiagnostics.end());
   EXPECT_EQ(released->replayResultHoldPollsThisFrame, 0u);
   EXPECT_FALSE(released->replayResultWithheld);
   EXPECT_NE(FindCapture(result, kFirstPresentedReplayFrame + 1), nullptr);
@@ -3565,13 +3585,10 @@ TEST(GlRnrReplayTest, GeodeDragZoomRebuildsDonnerDGestureBoundsEveryPresentedFra
         << "Selection overlay was not rebuilt for presented zoom frame " << frame;
     EXPECT_TRUE(diagnostics->frameCost.overlay.selectionBoundsOnly)
         << "Active drag should use gesture-owned bounds chrome on presented zoom frame " << frame;
-    // Gesture-owned bounds chrome keeps exactly one selection outline per selected element so the
-    // outline scales and rotates with the presented object; it drops per-element AABBs and
-    // path-point chrome. Pinned by
-    // `OverlayRendererTest.ActiveCombinedBoundsPreviewKeepsScaledSelectionPath`.
-    EXPECT_EQ(diagnostics->frameCost.overlay.pathCount, 1)
-        << "Active drag lost the gesture-scaled selection outline on presented zoom frame "
-        << frame;
+    // Gesture-owned bounds chrome skips live path and text traversal while the worker may hold the
+    // document. The oriented bounds and handles still advance with the presented object.
+    EXPECT_EQ(diagnostics->frameCost.overlay.pathCount, 0)
+        << "Active drag traversed selection paths on presented zoom frame " << frame;
     EXPECT_EQ(diagnostics->frameCost.overlay.handleCount, 4)
         << "Selection transform handles were not rebuilt for presented zoom frame " << frame;
     EXPECT_GT(diagnostics->frameCost.overlay.payloadBytes, 0u)

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -2716,11 +2716,17 @@ TEST(GlRnrReplayTest, HighZoomRapidPanKeepsPaneCoveredByContent) {
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
 
-  // Pane rect in device pixels (logical origin 568,29 size 604x863 at DPR 1).
+  // Full captures are in the host framebuffer's physical pixels. Scale the recorded logical pane
+  // instead of assuming its DPR 1 metadata matches the host (Retina replays are 2x).
   // Inset by 8 logical px so pane-border chrome never counts.
   const auto paneCrop = [&](const svg::RendererBitmap& bitmap) {
-    return CropBitmap(*&bitmap,
-                      PixelCrop{.x = 568 + 8, .y = 29 + 8, .width = 604 - 16, .height = 863 - 16});
+    const double captureScaleX = static_cast<double>(bitmap.dimensions.x) / 1600.0;
+    const double captureScaleY = static_cast<double>(bitmap.dimensions.y) / 900.0;
+    return CropBitmap(
+        bitmap, PixelCrop{.x = static_cast<int>(std::lround((568.0 + 8.0) * captureScaleX)),
+                          .y = static_cast<int>(std::lround((29.0 + 8.0) * captureScaleY)),
+                          .width = static_cast<int>(std::lround((604.0 - 16.0) * captureScaleX)),
+                          .height = static_cast<int>(std::lround((863.0 - 16.0) * captureScaleY))});
   };
   // Ratio of pane pixels showing document content (either stripe color).
   // Non-content pixels are the checkerboard/background plus the in-pane

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -199,6 +199,19 @@ TEST(GlRnrReplayTest, CropModeParsingAcceptsAliasesAndRejectsUnknownValues) {
   EXPECT_EQ(repro::GlRnrReplayCropModeSuffix(repro::GlRnrReplayCropMode::DocumentCanvas), "canvas");
 }
 
+TEST(GlRnrReplayTest, CaptureCropScaleComesFromFramebufferAndLogicalDisplaySizes) {
+  EXPECT_EQ(
+      repro::GlRnrReplayFramebufferFromLogicalScale(Vector2i(1280, 960), Vector2d(640.0, 480.0)),
+      Vector2d(2.0, 2.0));
+  EXPECT_EQ(
+      repro::GlRnrReplayFramebufferFromLogicalScale(Vector2i(900, 800), Vector2d(600.0, 400.0)),
+      Vector2d(1.5, 2.0));
+  EXPECT_EQ(repro::GlRnrReplayFramebufferFromLogicalScale(Vector2i::Zero(), Vector2d(640.0, 480.0)),
+            Vector2d(1.0, 1.0));
+  EXPECT_EQ(repro::GlRnrReplayFramebufferFromLogicalScale(Vector2i(1280, 960), Vector2d::Zero()),
+            Vector2d(1.0, 1.0));
+}
+
 TEST(GlRnrReplayTest, RunGlRnrReplayValidatesOptionsBeforeOpeningWindow) {
   repro::GlRnrReplayOptions options;
   repro::GlRnrReplayResult result;

--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -260,6 +260,16 @@ TEST(GlTextureCacheTest, ResetCompositedClearsMetadataBookkeepingAndCost) {
   EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i::Zero());
 }
 
+TEST(GlTextureCacheTest, DocumentCompositeBytesParticipateInTrackedResourceTotal) {
+  GlTextureCache cache;
+  cache.setDocumentCompositeBytes(8192u);
+
+  const PresentationResourceStats stats = cache.presentationResourceStats();
+  EXPECT_EQ(stats.documentCompositeBytes, 8192u);
+  EXPECT_EQ(stats.totalTrackedBytes, 8192u);
+  EXPECT_EQ(stats.peakTrackedBytes, 8192u);
+}
+
 TEST(GlTextureCacheTest, EmptyThumbnailAndRetainOnEmptyDoNotAllocate) {
   GlTextureCache cache;
   svg::RendererBitmap bitmap;

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -250,7 +250,7 @@ TEST(OverlayRendererTest, EditingChromeOnlySkipsSelectionGeometry) {
   EXPECT_TRUE(snapshot.handleAnchorsDoc.empty());
 }
 
-TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsTextBaseline) {
+TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewSkipsTextBaselineTraversal) {
   constexpr std::string_view kTextSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
            <text id="t" x="50" y="80" font-size="20" font-family="sans-serif">Hello</text>
@@ -273,11 +273,10 @@ TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsTextBaseline) {
       boundsPreview, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  ASSERT_EQ(snapshot.textBaselinesDoc.size(), 1u);
-  EXPECT_NEAR(snapshot.textBaselinesDoc.front().startDoc.y, 96.0, 1.0);
+  EXPECT_TRUE(snapshot.textBaselinesDoc.empty());
 }
 
-TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsScaledSelectionPath) {
+TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewAvoidsSelectionPathCapture) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kTrivialSvg));
   auto rect = app.document().document().querySelector("#r1");
@@ -296,9 +295,7 @@ TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsScaledSelectionPath) {
       boundsPreview, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  EXPECT_EQ(snapshot.paths.front().pathDoc.bounds(),
-            scale.transformBox(boundsPreview.startBoundsDoc));
+  EXPECT_TRUE(snapshot.paths.empty());
   EXPECT_TRUE(snapshot.aabbsDoc.empty());
   ASSERT_TRUE(snapshot.orientedBoundsDoc.has_value());
   EXPECT_EQ(snapshot.orientedBoundsDoc->cornersDoc[0], Vector2d(30.0, 36.0));

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -13,6 +14,7 @@
 
 #include "donner/base/MathUtils.h"
 #include "donner/base/tests/TestTempDir.h"
+#include "donner/editor/DocumentPresentationCompositor.h"
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/MenuBarPresenter.h"
 #include "donner/editor/RenderPanePresenter.h"
@@ -159,6 +161,24 @@ svg::RendererBitmap CapturePresenterFrame(
   // the presenter; the presenter no longer consumes a chrome snapshot.
   const std::optional<SelectionChromeSnapshot> noOverlaySnapshot;
   RenderPanePresenter presenter;
+  DocumentCompositeTextureView documentComposite;
+#ifndef DONNER_EDITOR_WGPU
+  std::unique_ptr<DocumentPresentationCompositor> compositor;
+#endif
+
+#ifndef DONNER_EDITOR_WGPU
+  if (!documentPresentedDirectly) {
+    compositor = std::make_unique<DocumentPresentationCompositor>();
+    const bool drawOverviewTiles = ShouldPresentOverviewTiles(
+        textures->activeTilesViewportBounded(), textures->overviewTiles());
+    const std::vector<GlTextureCache::TileView> noOverviewTiles;
+    documentComposite = compositor->compose(
+        viewport, viewport.imageScreenRect(),
+        drawOverviewTiles ? textures->overviewTiles() : noOverviewTiles, textures->tiles(),
+        activePreview, displayedPreview, suppressedLayerEntity,
+        /*suppressDragTargetTiles=*/false);
+  }
+#endif
 
   window->beginFrame();
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -191,6 +211,7 @@ svg::RendererBitmap CapturePresenterFrame(
       .contentRegion = Vector2d(kLogicalWidth, kLogicalHeight),
       .suppressedLayerEntity = suppressedLayerEntity,
       .documentPresentedDirectly = documentPresentedDirectly,
+      .documentComposite = documentComposite,
       .compositorTileOverlay = compositorTileOverlay,
   });
   ImGui::End();
@@ -284,6 +305,60 @@ TEST(RenderPanePresenterVisualReproTest, WritesDisplayNoneSuppressionScreenshots
          "display:none layer is suppressed.";
 }
 
+TEST(RenderPanePresenterVisualReproTest, IntermediateCompositeReusesUnchangedPresentation) {
+  gui::EditorWindow window(gui::EditorWindowOptions{
+      .title = "Document Composite Cache Repro",
+      .initialWidth = kLogicalWidth,
+      .initialHeight = kLogicalHeight,
+      .visible = false,
+      .offscreen = true,
+      .offscreenContentScale = 1.0,
+      .enableFramebufferReadback = true,
+  });
+  if (!window.valid()) {
+    GTEST_SKIP() << "Hidden editor window is unavailable on this host";
+  }
+
+  GlTextureCache textures(window.geodeDevice());
+  textures.initialize();
+  textures.uploadComposited(MakePreview(/*includeHiddenLayer=*/true));
+
+  ViewportState viewport;
+  viewport.paneSize = Vector2d(kLogicalWidth, kLogicalHeight);
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, static_cast<double>(kLogicalWidth),
+                                             static_cast<double>(kLogicalHeight));
+  viewport.panScreenPoint = Vector2d::Zero();
+  viewport.panDocPoint = Vector2d::Zero();
+
+  DocumentPresentationCompositor compositor;
+  const DocumentCompositeTextureView first =
+      compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                         std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+  const DocumentCompositeTextureView second =
+      compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                         std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+
+#ifdef DONNER_EDITOR_WGPU
+  EXPECT_EQ(first.texture, 0u);
+  EXPECT_EQ(second.texture, 0u);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 0u);
+  EXPECT_EQ(compositor.retainedBytes(), 0u);
+#else
+  ASSERT_NE(first.texture, 0u);
+  EXPECT_EQ(second.texture, first.texture);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 1u)
+      << "An unchanged UI frame must reuse the explicit document composite.";
+  EXPECT_EQ(compositor.retainedBytes(),
+            static_cast<std::uint64_t>(kLogicalWidth) * kLogicalHeight * 4u * 2u);
+
+  viewport.panScreenPoint.x = 1.0;
+  (void)compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                           std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 2u)
+      << "A viewport change must invalidate the document composite.";
+#endif
+}
+
 TEST(RenderPanePresenterVisualReproTest,
      ViewMenuCompositorTileOverlayRendersMetadataOverDirectPresentation) {
   gui::EditorWindow window(gui::EditorWindowOptions{
@@ -374,26 +449,26 @@ TEST(RenderPanePresenterVisualReproTest,
   // 2x. Document-space chrome drawn with the live transform lands at twice the
   // offset and twice the size, floating off the pixels it is annotating.
   constexpr double kLiveZoomAheadOfPresentation = 2.0;
-  const svg::RendererBitmap withoutOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
-      kLiveZoomAheadOfPresentation);
-  const svg::RendererBitmap withOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
-      kLiveZoomAheadOfPresentation);
+  const svg::RendererBitmap withoutOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
+                            kLiveZoomAheadOfPresentation);
+  const svg::RendererBitmap withOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
+                            kLiveZoomAheadOfPresentation);
   // Aligned baseline: the same overlay with the live viewport matching the
   // presented one. Its extent is this host's presented-tile far corner plus
   // whatever label overhang this host's text rendering produces, which makes
   // the divergence assertion below host-independent.
-  const svg::RendererBitmap alignedWithoutOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
-      /*liveZoomAheadOfPresentation=*/1.0);
-  const svg::RendererBitmap alignedWithOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
-      /*liveZoomAheadOfPresentation=*/1.0);
+  const svg::RendererBitmap alignedWithoutOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
+                            /*liveZoomAheadOfPresentation=*/1.0);
+  const svg::RendererBitmap alignedWithOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
+                            /*liveZoomAheadOfPresentation=*/1.0);
   ASSERT_FALSE(alignedWithoutOverlay.empty());
   ASSERT_FALSE(alignedWithOverlay.empty());
   ASSERT_EQ(alignedWithOverlay.pixels.size(), alignedWithoutOverlay.pixels.size());
@@ -457,8 +532,7 @@ TEST(RenderPanePresenterVisualReproTest,
           std::max(alignedMaxLogicalY, static_cast<double>(y) / readbackFromLogicalY);
     }
   }
-  ASSERT_GT(alignedChangedPixels, 0)
-      << "The aligned baseline overlay must draw something at all.";
+  ASSERT_GT(alignedChangedPixels, 0) << "The aligned baseline overlay must draw something at all.";
 
   // The tile covers document (54,44)-(132,122); drawn against the 2x live
   // viewport its annotations would land at roughly twice the offset and size.

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -532,6 +532,9 @@ protected:
   }
 
   [[nodiscard]] float LastScrollY() const { return editor.lastScroll_; }
+  [[nodiscard]] float FocusReferenceClipTop() const {
+    return editor.uiCursorPos_.y + editor.lastScroll_;
+  }
   [[nodiscard]] float LastScrollX() const { return editor.lastScrollX_; }
   [[nodiscard]] float LastScrollViewportHeight() const { return editor.scrollViewportHeight_; }
   [[nodiscard]] float CharacterAdvanceX() const { return editor.charAdvance_.x; }
@@ -684,6 +687,20 @@ protected:
     }
 
     return rope->path.bounds();
+  }
+
+  [[nodiscard]] std::optional<Box2d> FocusReferenceRestCatenaryBounds(
+      const FocusReferenceLink& link, int linkIndex) const {
+    const auto layout = FocusReferenceLayout(link, linkIndex);
+    if (!layout.has_value()) {
+      return std::nullopt;
+    }
+
+    const RopeSimulationOptions options = editor.focusReferenceRopeOptions();
+    RopeSimulation rope;
+    rope.resetCatenary(Vector2d(layout->start.x, layout->start.y),
+                       Vector2d(layout->tip.x, layout->tip.y), options);
+    return rope.toPath(options).bounds();
   }
 
   [[nodiscard]] std::vector<Vector2d> FocusReferenceRopePoints(
@@ -3310,6 +3327,20 @@ std::string LongFocusReferenceSource() {
   return source.str();
 }
 
+std::string SaggingFocusReferenceSource() {
+  std::ostringstream source;
+  for (int line = 0; line < 64; ++line) {
+    if (line == 36) {
+      source << "target\n";
+    } else if (line == 37) {
+      source << std::string(90, ' ') << "fill:url(#target)\n";
+    } else {
+      source << "<!-- filler " << line << " -->\n";
+    }
+  }
+  return source.str();
+}
+
 TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpointsOffscreen) {
   editor.setText(LongFocusReferenceSource());
   editor.resetTextChanged();
@@ -3337,6 +3368,44 @@ TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpoints
   EXPECT_EQ(ropeCost.drawnCount, 1);
   EXPECT_EQ(ropeCost.activeStateCount, 1);
   EXPECT_NE(FocusReferenceRope(crossingLink), nullptr);
+}
+
+TEST_F(TextEditorTests, FocusReferenceRopesRenderWhenSameSideCatenarySagsIntoViewport) {
+  editor.setWordWrapEnabled(false);
+  editor.setText(SaggingFocusReferenceSource());
+  editor.resetTextChanged();
+
+  const FocusReferenceLink saggingLink{
+      .from = SourcePoint{.line = 37, .column = 101},
+      .to = SourcePoint{.line = 36, .column = 0},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 64}},
+      .referenceLinks = {saggingLink},
+  });
+
+  constexpr ImVec2 kEditorSize(520.0f, 120.0f);
+  RenderEditorFrame(kEditorSize);
+  editor.selectAndFocus(Coordinates(55, 0), Coordinates(55, 6));
+  RenderEditorFrame(kEditorSize);
+  RenderEditorFrame(kEditorSize);
+
+  EXPECT_GT(LastScrollY(), 0.0f);
+  const auto layout = FocusReferenceLayout(saggingLink, 0);
+  ASSERT_TRUE(layout.has_value());
+  EXPECT_LT(std::max(layout->start.y, layout->tip.y), FocusReferenceClipTop() - 48.0f)
+      << "startY=" << layout->start.y << " tipY=" << layout->tip.y
+      << " clipTop=" << FocusReferenceClipTop() << " scrollY=" << LastScrollY();
+  const std::optional<Box2d> restCatenaryBounds = FocusReferenceRestCatenaryBounds(saggingLink, 0);
+  ASSERT_TRUE(restCatenaryBounds.has_value());
+  EXPECT_GT(restCatenaryBounds->bottomRight.y, FocusReferenceClipTop());
+  const FrameCostBreakdown::SourceRopes& ropeCost = editor.lastSourceRopeCost();
+  EXPECT_EQ(ropeCost.candidateCount, 1);
+  EXPECT_EQ(ropeCost.laidOutCount, 1);
+  EXPECT_EQ(ropeCost.culledCount, 0);
+  EXPECT_EQ(ropeCost.drawnCount, 1);
+  EXPECT_EQ(ropeCost.activeStateCount, 1);
+  EXPECT_NE(FocusReferenceRope(saggingLink), nullptr);
 }
 
 TEST_F(TextEditorTests, FocusReferenceRopesClipToScrolledSourceViewport) {

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -3297,7 +3297,7 @@ TEST_F(TextEditorTests, FocusReferenceSourceUnderlineHandlesReferenceCharactersA
   EXPECT_LT(bangUnderline->start.x, bangUnderline->end.x);
 }
 
-TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpointsOffscreen) {
+std::string LongFocusReferenceSource() {
   std::ostringstream source;
   source << "  <defs>\n"
          << "    <linearGradient id=\"grad\"/>\n"
@@ -3307,7 +3307,11 @@ TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpoints
     source << "  <!-- filler " << i << " -->\n";
   }
   source << "  <circle stroke=\"url(#grad)\"/>\n";
-  editor.setText(source.str());
+  return source.str();
+}
+
+TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpointsOffscreen) {
+  editor.setText(LongFocusReferenceSource());
   editor.resetTextChanged();
 
   const FocusReferenceLink crossingLink{
@@ -3336,16 +3340,7 @@ TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpoints
 }
 
 TEST_F(TextEditorTests, FocusReferenceRopesClipToScrolledSourceViewport) {
-  std::ostringstream source;
-  source << "  <defs>\n"
-         << "    <linearGradient id=\"grad\"/>\n"
-         << "  </defs>\n"
-         << "  <rect fill=\"url(#grad)\"/>\n";
-  for (int i = 0; i < 80; ++i) {
-    source << "  <!-- filler " << i << " -->\n";
-  }
-  source << "  <circle stroke=\"url(#grad)\"/>\n";
-  editor.setText(source.str());
+  editor.setText(LongFocusReferenceSource());
   editor.resetTextChanged();
 
   const FocusReferenceLink scrolledLink{
@@ -3371,6 +3366,30 @@ TEST_F(TextEditorTests, FocusReferenceRopesClipToScrolledSourceViewport) {
   EXPECT_EQ(ropeCost.drawnCount, 1);
   EXPECT_EQ(ropeCost.activeStateCount, 1);
   EXPECT_NE(FocusReferenceRope(scrolledLink), nullptr);
+}
+
+TEST_F(TextEditorTests, FocusReferenceRopesCullRoutesEntirelyBelowViewport) {
+  editor.setText(LongFocusReferenceSource());
+  editor.resetTextChanged();
+
+  const FocusReferenceLink belowViewport{
+      .from = SourcePoint{.line = 84, .column = 23},
+      .to = SourcePoint{.line = 83, .column = 4},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 1, .endLine = 85}},
+      .referenceLinks = {belowViewport},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 120.0f));
+
+  const FrameCostBreakdown::SourceRopes& ropeCost = editor.lastSourceRopeCost();
+  EXPECT_EQ(ropeCost.candidateCount, 1);
+  EXPECT_EQ(ropeCost.laidOutCount, 1);
+  EXPECT_EQ(ropeCost.culledCount, 1);
+  EXPECT_EQ(ropeCost.drawnCount, 0);
+  EXPECT_EQ(ropeCost.activeStateCount, 0);
+  EXPECT_EQ(FocusReferenceRope(belowViewport), nullptr);
 }
 
 TEST_F(TextEditorTests, FocusReferenceRopesUseStaticConnectorsAfterAnimatedCap) {

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -3408,6 +3408,44 @@ TEST_F(TextEditorTests, FocusReferenceRopesRenderWhenSameSideCatenarySagsIntoVie
   EXPECT_NE(FocusReferenceRope(saggingLink), nullptr);
 }
 
+TEST_F(TextEditorTests, FocusReferenceRopesDoNotCountOffscreenRoutesAgainstAnimatedCap) {
+  editor.setWordWrapEnabled(false);
+  editor.setText(SaggingFocusReferenceSource());
+  editor.resetTextChanged();
+
+  std::vector<FocusReferenceLink> links;
+  links.reserve(65);
+  for (int column = 0; column < 64; ++column) {
+    links.push_back(FocusReferenceLink{
+        .from = SourcePoint{.line = 36, .column = column},
+        .to = SourcePoint{.line = 36, .column = 0},
+    });
+  }
+  const FocusReferenceLink saggingLink{
+      .from = SourcePoint{.line = 37, .column = 101},
+      .to = SourcePoint{.line = 36, .column = 0},
+  };
+  links.push_back(saggingLink);
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 64}},
+      .referenceLinks = std::move(links),
+  });
+
+  constexpr ImVec2 kEditorSize(520.0f, 120.0f);
+  RenderEditorFrame(kEditorSize);
+  editor.selectAndFocus(Coordinates(55, 0), Coordinates(55, 6));
+  RenderEditorFrame(kEditorSize);
+  RenderEditorFrame(kEditorSize);
+
+  const FrameCostBreakdown::SourceRopes& ropeCost = editor.lastSourceRopeCost();
+  EXPECT_EQ(ropeCost.candidateCount, 65);
+  EXPECT_EQ(ropeCost.laidOutCount, 65);
+  EXPECT_EQ(ropeCost.culledCount, 64);
+  EXPECT_EQ(ropeCost.drawnCount, 1);
+  EXPECT_EQ(ropeCost.activeStateCount, 1);
+  EXPECT_NE(FocusReferenceRope(saggingLink), nullptr);
+}
+
 TEST_F(TextEditorTests, FocusReferenceRopesClipToScrolledSourceViewport) {
   editor.setText(LongFocusReferenceSource());
   editor.resetTextChanged();

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -3297,7 +3297,7 @@ TEST_F(TextEditorTests, FocusReferenceSourceUnderlineHandlesReferenceCharactersA
   EXPECT_LT(bangUnderline->start.x, bangUnderline->end.x);
 }
 
-TEST_F(TextEditorTests, FocusReferenceRopesCullOffscreenLinksBeforeSimulation) {
+TEST_F(TextEditorTests, FocusReferenceRopesRenderAcrossViewportWithBothEndpointsOffscreen) {
   std::ostringstream source;
   source << "  <defs>\n"
          << "    <linearGradient id=\"grad\"/>\n"
@@ -3310,29 +3310,29 @@ TEST_F(TextEditorTests, FocusReferenceRopesCullOffscreenLinksBeforeSimulation) {
   editor.setText(source.str());
   editor.resetTextChanged();
 
-  const FocusReferenceLink visibleLink{
-      .from = SourcePoint{.line = 3, .column = 19},
-      .to = SourcePoint{.line = 1, .column = 6},
-  };
-  const FocusReferenceLink offscreenLink{
+  const FocusReferenceLink crossingLink{
       .from = SourcePoint{.line = 84, .column = 23},
       .to = SourcePoint{.line = 1, .column = 6},
   };
   editor.setFocusPartition(FocusPartition{
       .fullColor = {LineRange{.startLine = 1, .endLine = 85}},
-      .referenceLinks = {visibleLink, offscreenLink},
+      .referenceLinks = {crossingLink},
   });
 
-  RenderEditorFrame(ImVec2(520.0f, 120.0f));
+  constexpr ImVec2 kEditorSize(520.0f, 120.0f);
+  RenderEditorFrame(kEditorSize);
+  editor.selectAndFocus(Coordinates(42, 2), Coordinates(42, 10));
+  RenderEditorFrame(kEditorSize);
+  RenderEditorFrame(kEditorSize);
 
+  EXPECT_GT(LastScrollY(), 0.0f);
   const FrameCostBreakdown::SourceRopes& ropeCost = editor.lastSourceRopeCost();
-  EXPECT_EQ(ropeCost.candidateCount, 2);
+  EXPECT_EQ(ropeCost.candidateCount, 1);
   EXPECT_EQ(ropeCost.laidOutCount, 1);
-  EXPECT_EQ(ropeCost.culledCount, 1);
+  EXPECT_EQ(ropeCost.culledCount, 0);
   EXPECT_EQ(ropeCost.drawnCount, 1);
   EXPECT_EQ(ropeCost.activeStateCount, 1);
-  EXPECT_NE(FocusReferenceRope(visibleLink), nullptr);
-  EXPECT_EQ(FocusReferenceRope(offscreenLink), nullptr);
+  EXPECT_NE(FocusReferenceRope(crossingLink), nullptr);
 }
 
 TEST_F(TextEditorTests, FocusReferenceRopesClipToScrolledSourceViewport) {

--- a/tools/gpu_inventory/manifests/editor_integration.json
+++ b/tools/gpu_inventory/manifests/editor_integration.json
@@ -35,6 +35,9 @@
     "donner/editor/CompositorDebugPanel.h": {
       "usesEditorWgpuDefine": true
     },
+    "donner/editor/DocumentPresentationCompositor.cc": {
+      "usesEditorWgpuDefine": true
+    },
     "donner/editor/EditorShell.cc": {
       "usesEditorWgpuDefine": true,
       "wgpuCFunctions": [
@@ -103,6 +106,9 @@
       ]
     },
     "donner/editor/ImGuiBackendIncludes.h": {
+      "usesEditorWgpuDefine": true
+    },
+    "donner/editor/RenderPanePresenter.cc": {
       "usesEditorWgpuDefine": true
     },
     "donner/editor/ViewportInteractionController.h": {
@@ -312,6 +318,9 @@
       ]
     },
     "donner/editor/tests/LayersPanel_tests.cc": {
+      "usesEditorWgpuDefine": true
+    },
+    "donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc": {
       "usesEditorWgpuDefine": true
     },
     "donner/editor/tests/ViewportInteractionController_tests.cc": {

--- a/tools/mcp-servers/editor-control/BUILD.bazel
+++ b/tools/mcp-servers/editor-control/BUILD.bazel
@@ -93,6 +93,8 @@ donner_cc_test(
         ":editor_control_session",
         "//donner/base:base_test_utils",
         "//donner/editor/repro:repro_file",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/svg/renderer",
         "@com_google_gtest//:gtest",
         "@com_google_gtest//:gtest_main",
         "@nlohmann_json//:json",

--- a/tools/mcp-servers/editor-control/EditorControlSession.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession.cc
@@ -470,6 +470,7 @@ json EditorControlSession::toolList() {
                     {"gl_visible", {{"type", "boolean"}, {"default", false}}},
                     {"gl_pace", {{"type", "boolean"}, {"default", true}}},
                     {"gl_drive_document_input", {{"type", "boolean"}, {"default", false}}},
+                    {"gl_source_pane_visible", {{"type", "boolean"}, {"default", false}}},
                     {"gl_timeout_ms", {{"type", "integer"}, {"minimum", 1}, {"default", 120000}}},
                     {"include_gl_images", {{"type", "boolean"}, {"default", true}}},
                     {"include_frame_results", {{"type", "boolean"}, {"default", true}}},

--- a/tools/mcp-servers/editor-control/EditorControlSession.h
+++ b/tools/mcp-servers/editor-control/EditorControlSession.h
@@ -115,6 +115,7 @@ public:
   struct CapturedRenderResult {
     RenderResult renderResult;
     DisplayFrameSnapshot displayFrame;
+    std::optional<svg::RendererBitmap> presentedBitmap;
   };
 
 private:
@@ -145,6 +146,8 @@ private:
   void installFontCatalogOnDocument();
   [[nodiscard]] nlohmann::json sourceStateJson() const;
 
+public:
+  /// CPU mirror of the editor's tile presentation cache, exposed for focused composition tests.
   class HeadlessTextureCache {
   public:
     void reset();
@@ -168,6 +171,7 @@ private:
     std::vector<DisplayTileView> tiles_;
   };
 
+private:
   [[nodiscard]] bool renderCurrentFrame(std::vector<CapturedRenderResult>* results,
                                         std::string* error);
   [[nodiscard]] std::optional<svg::RendererBitmap> composeDisplayFrameBitmap(

--- a/tools/mcp-servers/editor-control/EditorControlSessionGlReadback.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionGlReadback.cc
@@ -455,6 +455,9 @@ std::vector<std::string> BazelGlRnrReplayCommand(const repro::GlRnrReplayOptions
   if (options.driveDocumentSpaceInput) {
     args.push_back("--drive-document-input");
   }
+  if (options.sourcePaneVisible) {
+    args.push_back("--source-pane-visible");
+  }
   if (options.workerRenderDelayMsForTesting > 0) {
     args.push_back("--worker-delay-ms");
     args.push_back(std::to_string(options.workerRenderDelayMsForTesting));

--- a/tools/mcp-servers/editor-control/EditorControlSessionGlReadback.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionGlReadback.cc
@@ -415,7 +415,7 @@ bool ParseBazelGlRnrReplayResult(const json& object, repro::GlRnrReplayResult* r
 
 std::vector<std::string> BazelGlRnrReplayCommand(const repro::GlRnrReplayOptions& options) {
   std::vector<std::string> args{
-      "bazel",
+      "tools/llm-bazel-wrap.sh",
       "run",
       "--noshow_progress",
       "--noshow_loading_progress",

--- a/tools/mcp-servers/editor-control/EditorControlSessionInternal.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionInternal.cc
@@ -128,17 +128,18 @@ std::optional<std::string> EncodeBitmapPngBase64(const svg::RendererBitmap& bitm
   return Base64Encode(png);
 }
 
-json RenderResultJson(const RenderResult& result, ToolCallResult* out,
-                      const EditorControlSession::CaptureOptions& capture,
+json RenderResultJson(const RenderResult& result, const svg::RendererBitmap* presentedBitmap,
+                      ToolCallResult* out, const EditorControlSession::CaptureOptions& capture,
                       std::string_view imagePrefix) {
+  const svg::RendererBitmap& finalBitmap = presentedBitmap ? *presentedBitmap : result.bitmap;
   json resultJson{
       {"version", result.version},
       {"worker_ms", result.workerMs},
-      {"bitmap", BitmapSummary(result.bitmap)},
+      {"bitmap", BitmapSummary(finalBitmap)},
   };
 
   if (capture.includeFinalFrame) {
-    AttachBitmapImage(out, std::string(imagePrefix) + "/final_frame", result.bitmap,
+    AttachBitmapImage(out, std::string(imagePrefix) + "/final_frame", finalBitmap,
                       capture.embedPngBase64, &resultJson["bitmap"]);
   }
 
@@ -187,7 +188,10 @@ json CapturedRenderResultJson(const EditorControlSession::CapturedRenderResult& 
                               ToolCallResult* out,
                               const EditorControlSession::CaptureOptions& capture,
                               std::string_view imagePrefix) {
-  json resultJson = RenderResultJson(captured.renderResult, out, capture, imagePrefix);
+  const svg::RendererBitmap* presentedBitmap =
+      captured.presentedBitmap.has_value() ? &*captured.presentedBitmap : nullptr;
+  json resultJson =
+      RenderResultJson(captured.renderResult, presentedBitmap, out, capture, imagePrefix);
   resultJson["display_preview"] = DisplayFrameJson(captured.displayFrame);
   return resultJson;
 }

--- a/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -99,75 +98,6 @@ json DirtyFlagsToJson(std::uint16_t flags) {
     }
   }
   return out;
-}
-
-std::uint8_t PremultiplyChannel(std::uint8_t channel, std::uint8_t alpha,
-                                svg::AlphaType alphaType) {
-  if (alphaType == svg::AlphaType::Premultiplied) {
-    return channel;
-  }
-  return static_cast<std::uint8_t>((static_cast<int>(channel) * static_cast<int>(alpha) + 127) /
-                                   255);
-}
-
-std::uint8_t BlendChannel(std::uint8_t src, std::uint8_t dst, std::uint8_t srcAlpha) {
-  const int invAlpha = 255 - static_cast<int>(srcAlpha);
-  return static_cast<std::uint8_t>(
-      std::min(255, static_cast<int>(src) + (static_cast<int>(dst) * invAlpha + 127) / 255));
-}
-
-void BlendBitmapOver(svg::RendererBitmap* destination, const svg::RendererBitmap& source,
-                     int targetX, int targetY, int targetWidth, int targetHeight) {
-  if (destination == nullptr || destination->empty() || source.empty() || targetWidth <= 0 ||
-      targetHeight <= 0) {
-    return;
-  }
-
-  const std::size_t sourceRowBytes =
-      source.rowBytes > 0 ? source.rowBytes : static_cast<std::size_t>(source.dimensions.x) * 4;
-  const std::size_t destinationRowBytes = destination->rowBytes;
-  for (int y = 0; y < targetHeight; ++y) {
-    const int dy = targetY + y;
-    if (dy < 0 || dy >= destination->dimensions.y) {
-      continue;
-    }
-    const int sy =
-        std::clamp(static_cast<int>((static_cast<int64_t>(y) * source.dimensions.y) / targetHeight),
-                   0, source.dimensions.y - 1);
-    for (int x = 0; x < targetWidth; ++x) {
-      const int dx = targetX + x;
-      if (dx < 0 || dx >= destination->dimensions.x) {
-        continue;
-      }
-      const int sx = std::clamp(
-          static_cast<int>((static_cast<int64_t>(x) * source.dimensions.x) / targetWidth), 0,
-          source.dimensions.x - 1);
-      const std::size_t sourceIndex =
-          static_cast<std::size_t>(sy) * sourceRowBytes + static_cast<std::size_t>(sx) * 4;
-      const std::size_t destinationIndex =
-          static_cast<std::size_t>(dy) * destinationRowBytes + static_cast<std::size_t>(dx) * 4;
-      if (sourceIndex + 3 >= source.pixels.size() ||
-          destinationIndex + 3 >= destination->pixels.size()) {
-        continue;
-      }
-
-      const std::uint8_t srcAlpha = source.pixels[sourceIndex + 3];
-      const std::uint8_t srcRed =
-          PremultiplyChannel(source.pixels[sourceIndex], srcAlpha, source.alphaType);
-      const std::uint8_t srcGreen =
-          PremultiplyChannel(source.pixels[sourceIndex + 1], srcAlpha, source.alphaType);
-      const std::uint8_t srcBlue =
-          PremultiplyChannel(source.pixels[sourceIndex + 2], srcAlpha, source.alphaType);
-      destination->pixels[destinationIndex] =
-          BlendChannel(srcRed, destination->pixels[destinationIndex], srcAlpha);
-      destination->pixels[destinationIndex + 1] =
-          BlendChannel(srcGreen, destination->pixels[destinationIndex + 1], srcAlpha);
-      destination->pixels[destinationIndex + 2] =
-          BlendChannel(srcBlue, destination->pixels[destinationIndex + 2], srcAlpha);
-      destination->pixels[destinationIndex + 3] =
-          BlendChannel(srcAlpha, destination->pixels[destinationIndex + 3], srcAlpha);
-    }
-  }
 }
 
 std::string CompositeTileKindName(
@@ -306,11 +236,11 @@ std::optional<svg::RendererBitmap> EditorControlSession::HeadlessTextureCache::c
     return std::nullopt;
   }
 
-  svg::RendererBitmap composed;
-  composed.dimensions = canvasSize;
-  composed.rowBytes = static_cast<std::size_t>(canvasSize.x) * 4;
-  composed.alphaType = svg::AlphaType::Premultiplied;
-  composed.pixels.resize(static_cast<std::size_t>(canvasSize.y) * composed.rowBytes, 0);
+  svg::Renderer renderer;
+  renderer.beginFrame(svg::RenderViewport{
+      .size = Vector2d(static_cast<double>(canvasSize.x), static_cast<double>(canvasSize.y)),
+      .devicePixelRatio = 1.0,
+  });
 
   const double pixelsPerDocX = static_cast<double>(canvasSize.x) / viewBox.size().x;
   const double pixelsPerDocY = static_cast<double>(canvasSize.y) / viewBox.size().y;
@@ -325,22 +255,29 @@ std::optional<svg::RendererBitmap> EditorControlSession::HeadlessTextureCache::c
       continue;
     }
 
-    const std::optional<PresentedTileRect> tileRect = ComputePresentedTileRect(
+    const std::optional<PresentedTileQuad> tileQuad = ComputePresentedTileQuad(
         PresentedGeometryFromDisplayTile(tile), canvasPixelsFromCanvasTransform, dragBaseline);
-    if (!tileRect.has_value()) {
+    if (!tileQuad.has_value()) {
       continue;
     }
-    const std::optional<PresentedPixelRect> pixelRect =
-        RoundPresentedTileRectToPixelRect(*tileRect);
-    if (!pixelRect.has_value()) {
+    const svg::RendererBitmap& bitmap = tileIt->second.bitmap;
+    const std::optional<Transform2d> canvasPixelsFromTexture =
+        ComputePresentedOutputFromTextureTransform(*tileQuad, bitmap.dimensions);
+    if (!canvasPixelsFromTexture.has_value()) {
       continue;
     }
 
-    BlendBitmapOver(&composed, tileIt->second.bitmap, pixelRect->x, pixelRect->y, pixelRect->width,
-                    pixelRect->height);
+    renderer.setTransform(*canvasPixelsFromTexture);
+    renderer.drawBitmap(
+        bitmap, svg::ImageParams{
+                    .targetRect =
+                        Box2d(Vector2d::Zero(), Vector2d(static_cast<double>(bitmap.dimensions.x),
+                                                         static_cast<double>(bitmap.dimensions.y))),
+                });
   }
 
-  return composed;
+  renderer.endFrame();
+  return renderer.takeSnapshot();
 }
 
 ToolCallResult EditorControlSession::renderFrameTool(const json& arguments) {
@@ -559,9 +496,11 @@ bool EditorControlSession::renderCurrentFrame(std::vector<CapturedRenderResult>*
   while (std::chrono::steady_clock::now() < deadline) {
     if (auto result = asyncRenderer_.pollResult(); result.has_value()) {
       DisplayFrameSnapshot displayFrame = recordDisplayFrame(*result);
+      std::optional<svg::RendererBitmap> presentedBitmap = composeDisplayFrameBitmap(displayFrame);
       results->push_back(CapturedRenderResult{
           .renderResult = std::move(*result),
           .displayFrame = std::move(displayFrame),
+          .presentedBitmap = std::move(presentedBitmap),
       });
       // A completed render can leave a deferred first-frame cache warmup queued on the
       // worker. That warmup traverses the document from the worker thread, while the next

--- a/tools/mcp-servers/editor-control/EditorControlSessionRnr.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionRnr.cc
@@ -500,6 +500,7 @@ ToolCallResult EditorControlSession::replayRnr(const json& arguments) {
   bool glVisible = false;
   bool glPace = true;
   bool glDriveDocumentInput = false;
+  bool glSourcePaneVisible = false;
   int glCaptureFrame = -1;
   int glCaptureLeftMouseDown = 0;
   int glMaxFrame = -1;
@@ -524,6 +525,7 @@ ToolCallResult EditorControlSession::replayRnr(const json& arguments) {
       !ReadOptionalBool(arguments, "gl_pace", true, &glPace, &error) ||
       !ReadOptionalBool(arguments, "gl_drive_document_input", false, &glDriveDocumentInput,
                         &error) ||
+      !ReadOptionalBool(arguments, "gl_source_pane_visible", false, &glSourcePaneVisible, &error) ||
       !ReadOptionalInt(arguments, "gl_capture_frame", -1, &glCaptureFrame, &error) ||
       !ReadOptionalInt(arguments, "gl_capture_left_mousedown", 0, &glCaptureLeftMouseDown,
                        &error) ||
@@ -585,6 +587,7 @@ ToolCallResult EditorControlSession::replayRnr(const json& arguments) {
     replayOptions.pace = glPace;
     replayOptions.visible = glVisible;
     replayOptions.driveDocumentSpaceInput = glDriveDocumentInput;
+    replayOptions.sourcePaneVisible = glSourcePaneVisible;
 
     GlReadbackRunner glReadbackRunner = GlReadbackRunner::InProcess;
     if (!SelectGlReadbackRunner(&glReadbackRunner, &error)) {
@@ -616,6 +619,7 @@ ToolCallResult EditorControlSession::replayRnr(const json& arguments) {
         {"output_dir", replayOptions.outputDir.string()},
         {"crop", glCrop},
         {"gl_drive_document_input", replayOptions.driveDocumentSpaceInput},
+        {"gl_source_pane_visible", replayOptions.sourcePaneVisible},
         {"capture_count", replayResult.captures.size()},
         {"captures", json::array()},
     };

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -354,6 +354,7 @@ TEST(EditorControlSessionTest, ToolListExposesSelectorDragAndRenderTools) {
   EXPECT_TRUE(hasTool("replay_rnr"));
   ASSERT_NE(replayTool, nullptr);
   EXPECT_TRUE((*replayTool)["inputSchema"]["properties"].contains("gl_drive_document_input"));
+  EXPECT_TRUE((*replayTool)["inputSchema"]["properties"].contains("gl_source_pane_visible"));
 }
 
 TEST(EditorControlSessionTest, CatalogFontFamilyMutationChangesRenderedGlyphs) {

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -1,10 +1,12 @@
 #include "tools/mcp-servers/editor-control/EditorControlSession.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -13,6 +15,8 @@
 
 #include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/repro/ReproFile.h"
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/svg/renderer/Renderer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "nlohmann/json.hpp"
@@ -866,7 +870,7 @@ TEST(EditorControlSessionTest, TransformSelectorRotatesThroughHandleAndExposesAf
                                                         {"delta_y", 48.0},
                                                         {"frames", 2},
                                                         {"release", false},
-                                                        {"include_final_frame", false}});
+                                                        {"include_final_frame", true}});
   ASSERT_TRUE(rotate.body.value("ok", false)) << rotate.body.dump(2);
   EXPECT_EQ(rotate.body.value("gesture_kind", ""), "rotate");
   EXPECT_EQ(rotate.body.value("corner", ""), "top_right");
@@ -887,6 +891,117 @@ TEST(EditorControlSessionTest, TransformSelectorRotatesThroughHandleAndExposesAf
   EXPECT_NEAR(center.y, 30.0, 1e-6);
   EXPECT_NEAR(topRight.x, 40.0, 1e-6);
   EXPECT_NEAR(topRight.y, 40.0, 1e-6);
+
+  ASSERT_TRUE(lastFrame["stages"].is_array()) << lastFrame.dump(2);
+  ASSERT_FALSE(lastFrame["stages"].empty()) << lastFrame.dump(2);
+  const json& finalBitmap = lastFrame["stages"].back()["bitmap"];
+  ASSERT_TRUE(finalBitmap["dimensions"].is_object()) << finalBitmap.dump(2);
+  EXPECT_GT(finalBitmap["dimensions"].value("x", 0), 0) << finalBitmap.dump(2);
+  EXPECT_GT(finalBitmap["dimensions"].value("y", 0), 0) << finalBitmap.dump(2);
+  EXPECT_TRUE(finalBitmap.value("png_attached", false)) << finalBitmap.dump(2);
+}
+
+TEST(EditorControlSessionTest, HeadlessTileCompositionPreservesAffinePlacementAndAlpha) {
+  const auto makeBitmap = [](Vector2i dimensions, std::size_t rowBytes,
+                             std::initializer_list<std::array<std::uint8_t, 4>> pixels) {
+    svg::RendererBitmap bitmap;
+    bitmap.dimensions = dimensions;
+    bitmap.rowBytes = rowBytes;
+    bitmap.alphaType = svg::AlphaType::Unpremultiplied;
+    bitmap.pixels.resize(static_cast<std::size_t>(dimensions.y) * rowBytes, 0xa5u);
+    auto pixel = pixels.begin();
+    for (int y = 0; y < dimensions.y; ++y) {
+      for (int x = 0; x < dimensions.x; ++x, ++pixel) {
+        const std::size_t offset =
+            static_cast<std::size_t>(y) * rowBytes + static_cast<std::size_t>(x) * 4u;
+        std::copy(pixel->begin(), pixel->end(), bitmap.pixels.begin() + offset);
+      }
+    }
+    return bitmap;
+  };
+
+  const svg::RendererBitmap rotatedBitmap =
+      makeBitmap(Vector2i(2, 3), 12u,
+                 {std::array<std::uint8_t, 4>{255u, 0u, 0u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 0u, 255u, 128u},
+                  std::array<std::uint8_t, 4>{255u, 255u, 0u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 255u, 255u, 192u},
+                  std::array<std::uint8_t, 4>{255u, 0u, 255u, 64u},
+                  std::array<std::uint8_t, 4>{0u, 0u, 0u, 255u}});
+  const svg::RendererBitmap overlappingBitmap =
+      makeBitmap(Vector2i(2, 2), 8u,
+                 {std::array<std::uint8_t, 4>{255u, 128u, 0u, 128u},
+                  std::array<std::uint8_t, 4>{64u, 0u, 128u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 255u, 0u, 96u},
+                  std::array<std::uint8_t, 4>{255u, 255u, 255u, 192u}});
+
+  Transform2d documentFromRotatedTexture(Transform2d::uninitialized);
+  documentFromRotatedTexture.data[0] = 0.0;
+  documentFromRotatedTexture.data[1] = 1.0;
+  documentFromRotatedTexture.data[2] = -1.0;
+  documentFromRotatedTexture.data[3] = 0.0;
+  documentFromRotatedTexture.data[4] = 3.0;
+  documentFromRotatedTexture.data[5] = 0.0;
+
+  RenderResult::CompositedPreview preview;
+  preview.tiles = {
+      RenderResult::CompositedTile{
+          .id = "rotated",
+          .generation = 1u,
+          .bitmap = rotatedBitmap,
+          .bitmapDimsPx = rotatedBitmap.dimensions,
+          .rasterCanvasSize = Vector2i(8, 8),
+          .canvasOffsetDoc = Vector2d(1.0, 1.0),
+          .bitmapDimsDoc = Vector2d(2.0, 3.0),
+          .documentFromCachedDocument = documentFromRotatedTexture,
+      },
+      RenderResult::CompositedTile{
+          .id = "overlap",
+          .generation = 1u,
+          .bitmap = overlappingBitmap,
+          .bitmapDimsPx = overlappingBitmap.dimensions,
+          .rasterCanvasSize = Vector2i(8, 8),
+          .canvasOffsetDoc = Vector2d(0.0, 2.0),
+          .bitmapDimsDoc = Vector2d(2.0, 2.0),
+      },
+  };
+
+  EditorControlSession::HeadlessTextureCache cache;
+  cache.uploadComposited(preview);
+  EditorControlSession::DisplayFrameSnapshot display{
+      .path = "tiles",
+      .hasCachedTiles = true,
+      .tiles = cache.tiles(),
+  };
+  const std::optional<svg::RendererBitmap> actual =
+      cache.composeDisplayFrame(display, Box2d::FromXYWH(0.0, 0.0, 8.0, 8.0), Vector2i(8, 8));
+  ASSERT_TRUE(actual.has_value());
+
+  svg::Renderer reference;
+  reference.beginFrame(svg::RenderViewport{
+      .size = Vector2d(8.0, 8.0),
+      .devicePixelRatio = 1.0,
+  });
+  Transform2d outputFromRotatedTexture(Transform2d::uninitialized);
+  outputFromRotatedTexture.data[0] = 0.0;
+  outputFromRotatedTexture.data[1] = 1.0;
+  outputFromRotatedTexture.data[2] = -1.0;
+  outputFromRotatedTexture.data[3] = 0.0;
+  outputFromRotatedTexture.data[4] = 2.0;
+  outputFromRotatedTexture.data[5] = 1.0;
+  reference.setTransform(outputFromRotatedTexture);
+  reference.drawBitmap(rotatedBitmap, svg::ImageParams{
+                                          .targetRect = Box2d::FromXYWH(0.0, 0.0, 2.0, 3.0),
+                                      });
+  reference.setTransform(Transform2d::Translate(0.0, 2.0));
+  reference.drawBitmap(overlappingBitmap, svg::ImageParams{
+                                              .targetRect = Box2d::FromXYWH(0.0, 0.0, 2.0, 2.0),
+                                          });
+  reference.endFrame();
+  const svg::RendererBitmap expected = reference.takeSnapshot();
+
+  tests::CompareBitmapToBitmap(*actual, expected, "headless_affine_tile_composition",
+                               tests::PixelmatchIdentityParams());
 }
 
 TEST(EditorControlSessionTest, SplashOThenRDragKeepsStableSplitLayerPaintOrder) {

--- a/tools/mcp-servers/editor-control/README.md
+++ b/tools/mcp-servers/editor-control/README.md
@@ -66,7 +66,9 @@ build before the first proxied request after startup.
   `gl_capture_left_mousedown` to replay through the real OpenGL editor shell and
   return framebuffer PNGs; `gl_drive_document_input: true` uses recorded
   document-space mouse coordinates for MCP-generated replays,
-  `gl_source_pane_visible: true` opens the source pane before the first replay frame, and
+  `gl_source_pane_visible: true` sets the source pane's animation target to visible before the
+  first replay frame,
+  so frame zero captures the beginning of its slide-in transition, and
   `gl_crop: "document-canvas"` hides source and side panels in the capture. Raw
   `bazel-bin` MCP launches route GL readback through `bazel run //donner/editor/tests:editor_rnr_gl_replay` so macOS Cocoa/GL initialization
   happens in the same environment as the replay helper.

--- a/tools/mcp-servers/editor-control/README.md
+++ b/tools/mcp-servers/editor-control/README.md
@@ -65,10 +65,10 @@ build before the first proxied request after startup.
   metadata. Pass `gl_readback: true` with `gl_capture_frame` or
   `gl_capture_left_mousedown` to replay through the real OpenGL editor shell and
   return framebuffer PNGs; `gl_drive_document_input: true` uses recorded
-  document-space mouse coordinates for MCP-generated replays, and
+  document-space mouse coordinates for MCP-generated replays,
+  `gl_source_pane_visible: true` opens the source pane before the first replay frame, and
   `gl_crop: "document-canvas"` hides source and side panels in the capture. Raw
-  `bazel-bin` MCP launches route GL readback through `bazel run
-  //donner/editor/tests:editor_rnr_gl_replay` so macOS Cocoa/GL initialization
+  `bazel-bin` MCP launches route GL readback through `bazel run //donner/editor/tests:editor_rnr_gl_replay` so macOS Cocoa/GL initialization
   happens in the same environment as the replay helper.
 - `editor_control_wrapper_state`: Inspect the Python wrapper, child process, and
   last build result.


### PR DESCRIPTION
The editor UX improvements now land together on current main, including source navigation that stays spatially continuous across pane and scroll boundaries.

- Restore affine editor-control final-frame capture, native GL document composition, and stable fill/stroke controls.
- Slide the fixed-width source pane behind its reveal rail over 200 ms instead of snapping or compressing its text layout.
- Cull source-reference ropes from their complete routed bounds, retaining a visible middle segment when both endpoints are outside opposite viewport edges.
- Expose source-pane visibility to deterministic GL replay, derive replay crops from the captured framebuffer scale, and use the repository Bazel environment for replay subprocesses.
- Place direct Geode/WGPU tiles, chrome, checkerboard clips, and replay crops from the same host framebuffer scale.

## Diagnosis

The source pane previously switched directly between hidden and full-width geometry. Reference ropes were rejected before their catenary route was known, which discarded routes whose endpoints were offscreen while their middle remained visible. HiDPI replay crops also used the recorded document DPR instead of the actual framebuffer-to-logical display scale. Correcting the crop exposed a second coordinate mismatch: direct WGPU presentation still placed tiles and chrome with the recorded raster DPR. The final repair publishes the host framebuffer's actual per-axis scale to both direct passes, so presentation and capture share one coordinate space. Current main lacked three previously reviewed editor presentation and interaction packets, so this branch restores those changes before adding the source-navigation fixes.

## Verification

- `bazel test //... --test_output=errors` (448 passed, 20 intentional platform skips)
- `bazel test //donner/editor/tests:editor_shell_layout_tests //donner/editor/tests:text_editor_tests //donner/editor/tests:editor_shell_tests //donner/editor/tests:gl_rnr_replay_tests //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- `bazel test //donner/editor/tests:gl_rnr_replay_tests --nocache_test_results --test_output=errors`
- `bazel test --config=ci --config=geode //donner/editor/tests:editor_window_tests //donner/editor/tests:layer_thumbnail_golden_tests //donner/editor/tests:async_renderer_tests //donner/editor/tests:rnr_replay_tests //donner/editor/tests:gl_rnr_replay_tests --test_output=errors`
- `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/lint.sh`
- Exact-head MCP GL captures of the intermediate translated source surface and settled pane
- `git diff --check origin/main..HEAD`