### PR TITLE
Render embedded document fonts safely in the editor

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -186,7 +186,7 @@ build:wasm-size --linkopt=-sFILESYSTEM=0
 common:editor-wasm --config=wasm-geode
 common:editor-wasm --//donner/editor/wasm:enable_wasm=true
 common:editor-wasm --//donner/svg/renderer:text=true
-common:editor-wasm --//donner/svg/renderer:text_full=false
+common:editor-wasm --//donner/svg/renderer:text_full=true
 build:editor-wasm --copt=-pthread
 build:editor-wasm --copt=-Oz
 build:editor-wasm --linkopt=-pthread

--- a/docs/design_docs/0056-geode_only_web_editor_runtime.md
+++ b/docs/design_docs/0056-geode_only_web_editor_runtime.md
@@ -21,7 +21,7 @@ worker.
 - Ship one immutable editor package containing only Geode.
 - Render the canvas, overlays, carousel images, and Layers panel thumbnails through Geode.
 - Fail at Bazel analysis if an enabled editor Wasm target selects another renderer.
-- Preserve editor text and embedded UI fonts.
+- Preserve editor text, document-provided fonts, and embedded UI fonts.
 - Start only when WebGPU, shared memory, and cross-origin isolation are available.
 - Keep browser pixel regressions tied to the renderer users actually run.
 
@@ -59,7 +59,7 @@ presentation versions remain blocked.
 ## Build and Packaging Contract
 
 - `bazel run //donner/editor/wasm:serve_http` applies the editor transition automatically.
-- `--config=editor-wasm` selects Geode, text support, pthreads, and size optimization.
+- `--config=editor-wasm` selects Geode, the full text tier, pthreads, and size optimization.
 - The package size test rejects software-renderer names in shipped JavaScript.
 - The editor workflow builds, tests, stages, and records provenance for one package and one Bazel
   config.
@@ -68,7 +68,9 @@ presentation versions remain blocked.
 ## Testing and Validation
 
 - `//donner/editor/wasm:editor_wasm_transition_tests` proves the default run transition selects the
-  complete Geode configuration and runtime options.
+  complete Geode and full-text configuration plus its runtime options.
+- `//donner/editor/tests:editor_embedded_font_render_tests` proves validated untrusted
+  document-provided fonts render identically to their trusted test-data reference.
 - A negative build with editor Wasm enabled and another renderer selected must fail with the
   Geode-only analysis error.
 - `//donner/editor/wasm:wasm_geode_package_size_tests` proves the package size and forbidden-token
@@ -81,8 +83,9 @@ presentation versions remain blocked.
 
 ## Security and Rollout
 
-SVG, XML, CSS, and font inputs remain untrusted. This change removes one executable renderer and its
-runtime selector from the editor package, reducing the shipped surface. The service worker remains
+SVG, XML, CSS, and font inputs remain untrusted. Document fonts use the full text tier's
+length-aware FreeType decoder rather than entering the compact backend's length-unaware parser.
+The package contains one executable renderer and no runtime selector. The service worker remains
 restricted to the editor origin and only establishes the isolation headers required by pthreads.
 
 CI builds one immutable Geode candidate and records its source revision, package files, hashes,

--- a/docs/editor_architecture.md
+++ b/docs/editor_architecture.md
@@ -7,7 +7,11 @@
 `//donner/editor` is Donner's in-tree SVG editor. The native GLFW host and the
 WebAssembly browser host share one Dear ImGui application that presents a document
 as synchronized interactive canvas and XML source views. Native and Wasm release
-targets use the Geode GPU backend and the basic text tier.
+targets use the Geode GPU backend and the full text tier. The full tier uses the
+length-aware FreeType path for validated document-provided fonts, while HarfBuzz
+provides OpenType shaping. `//donner/editor/tests:editor_embedded_font_render_tests`
+compares an untrusted embedded font against the same trusted reference, and
+`//donner/editor/wasm:editor_wasm_transition_tests` pins the browser product to this tier.
 
 Two properties shape the whole design:
 

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -16,6 +16,7 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//build_defs:embed_resources.bzl", "embed_resources")
 load("//build_defs:package.bzl", "donner_package")
 load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "donner_multi_transitioned_binary")
+load(":editor_product_config.bzl", "EDITOR_RENDERER_BACKEND", "EDITOR_TEXT", "EDITOR_TEXT_FULL")
 
 #Editor libraries are public so the  // examples:svg_viewer target (in the
 #separate examples Bazel module) can depend on `: text_editor`.BCR
@@ -1388,15 +1389,15 @@ donner_cc_binary(
 donner_multi_transitioned_binary(
     name = "editor",
     dep = ":editor_impl",
-    renderer_backend = "geode",
+    renderer_backend = EDITOR_RENDERER_BACKEND,
     tags = ["codeql_default"],
     target_compatible_with = select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    text = "true",
-    text_full = "false",
+    text = EDITOR_TEXT,
+    text_full = EDITOR_TEXT_FULL,
 )
 
 donner_cc_library(

--- a/donner/editor/editor_product_config.bzl
+++ b/donner/editor/editor_product_config.bzl
@@ -2,4 +2,4 @@
 
 EDITOR_RENDERER_BACKEND = "geode"
 EDITOR_TEXT = "true"
-EDITOR_TEXT_FULL = "false"
+EDITOR_TEXT_FULL = "true"

--- a/donner/editor/editor_product_config.bzl
+++ b/donner/editor/editor_product_config.bzl
@@ -1,0 +1,5 @@
+"""Renderer feature settings shared by the native editor and its product-contract tests."""
+
+EDITOR_RENDERER_BACKEND = "geode"
+EDITOR_TEXT = "true"
+EDITOR_TEXT_FULL = "false"

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -5,8 +5,10 @@ load(
     "donner_cc_fuzzer",
     "donner_cc_library",
     "donner_cc_test",
+    "donner_multi_transitioned_test",
     "donner_perf_cc_test",
 )
+load("//donner/editor:editor_product_config.bzl", "EDITOR_TEXT", "EDITOR_TEXT_FULL")
 
 donner_cc_library(
     name = "bitmap_golden_compare",
@@ -70,6 +72,30 @@ donner_cc_test(
         "@com_google_gtest//:gtest_main",
         "@stb//:truetype",
     ],
+)
+
+donner_cc_test(
+    name = "editor_embedded_font_render_test_impl",
+    srcs = ["EditorEmbeddedFontRender_tests.cc"],
+    data = ["//donner/svg/renderer/testdata"],
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":bitmap_golden_compare",
+        "//donner/base:base_test_utils",
+        "//donner/editor:editor_app",
+        "//donner/svg/renderer",
+        "//donner/svg/renderer/tests:image_comparison_test_fixture",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "editor_embedded_font_render_tests",
+    dep = ":editor_embedded_font_render_test_impl",
+    renderer_backend = "tiny_skia",
+    text = EDITOR_TEXT,
+    text_full = EDITOR_TEXT_FULL,
 )
 
 donner_cc_test(

--- a/donner/editor/tests/EditorEmbeddedFontRender_tests.cc
+++ b/donner/editor/tests/EditorEmbeddedFontRender_tests.cc
@@ -1,0 +1,48 @@
+/// @file
+/// Product-contract coverage for fonts embedded in SVG documents opened by the editor.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "donner/base/tests/Runfiles.h"
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
+
+namespace donner::editor {
+namespace {
+
+std::string ReadRunfile(std::string_view path) {
+  std::ifstream input(Runfiles::instance().Rlocation(std::string(path)));
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  return contents.str();
+}
+
+TEST(EditorEmbeddedFontRenderTest, UntrustedDocumentFontMatchesTrustedReference) {
+  const std::string source = ReadRunfile("donner/svg/renderer/testdata/z0rly_test6.svg");
+  ASSERT_FALSE(source.empty());
+
+  EditorApp referenceApp;
+  ASSERT_TRUE(referenceApp.loadFromString(source));
+  svg::TrustDocumentFontFacesForTesting(referenceApp.document().document());
+  svg::Renderer referenceRenderer;
+  referenceRenderer.draw(referenceApp.document().document());
+  const svg::RendererBitmap reference = referenceRenderer.takeSnapshot();
+
+  EditorApp documentApp;
+  ASSERT_TRUE(documentApp.loadFromString(source));
+  svg::Renderer documentRenderer;
+  documentRenderer.draw(documentApp.document().document());
+  const svg::RendererBitmap actual = documentRenderer.takeSnapshot();
+
+  tests::CompareBitmapToBitmap(actual, reference, "z0rly_document_font",
+                               tests::PixelmatchIdentityParams());
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -335,20 +335,26 @@ py_test(
         # renderer code to the editor package. Measured at this layer:
         # wasm 11,243,015 raw and package 11,455,433 raw. Budgets keep about
         # 1 percent headroom over the measured values.
+        #
+        # Full-text editor retune: length-aware document-font decoding adds
+        # FreeType, HarfBuzz, WOFF2, and Brotli to the browser product.
+        # Measured at this layer: wasm 12,780,770 raw / 5,076,932 gzip,
+        # js 174,075 raw / 49,060 gzip, and package 12,996,401 raw. Each
+        # transfer and decode budget keeps about 1 percent headroom.
         "--max-wasm-raw-bytes",
-        "11360000",
+        "12909000",
         "--max-wasm-gzip-bytes",
-        "4535000",
+        "5128000",
         "--max-wasm-function-body-bytes",
         "46000",
         "--max-wasm-data-segments",
         "64",
         "--max-js-raw-bytes",
-        "172500",
+        "175900",
         "--max-js-gzip-bytes",
-        "48800",
+        "49560",
         "--max-total-raw-bytes",
-        "11570000",
+        "13127000",
         "--expected-js-property",
         "__donnerLastScrollEvent",
         # SHIP BLOCKER, tracked with the deferred WebKit decision: the WebGPU diagnostic

--- a/donner/editor/wasm/editor_wasm_transition.bzl
+++ b/donner/editor/wasm/editor_wasm_transition.bzl
@@ -15,7 +15,7 @@ def _editor_wasm_geode_transition_impl(settings, _attr):
         "//donner/svg/renderer/wasm:enable_wasm": True,
         "//donner/svg/renderer:renderer_backend": "geode",
         "//donner/svg/renderer:text": True,
-        "//donner/svg/renderer:text_full": False,
+        "//donner/svg/renderer:text_full": True,
         "//donner/svg/renderer/geode:enable_geode": True,
         "//command_line_option:compilation_mode": "opt",
         "//command_line_option:copt": _append_once(

--- a/donner/editor/wasm/editor_wasm_transition_tests.py
+++ b/donner/editor/wasm/editor_wasm_transition_tests.py
@@ -19,7 +19,7 @@ linkopt_oz=True
 renderer_backend=geode
 renderer_wasm_enabled=True
 text=True
-text_full=False
+text_full=True
 """
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
Embedded document fonts now render through the editor's secure, length-aware text tier instead of falling back to a face that lacks their private-use glyphs.

- Route the native and WebAssembly editor products through the full FreeType and HarfBuzz text tier.
- Keep untrusted font bytes behind the validated, length-aware memory-face path and preserve existing aggregate font-data limits.
- Add a renderer-independent identity regression for embedded document fonts and pin the WebAssembly product transition.
- Retune the existing WebAssembly package limits to the measured full-text product with approximately one percent headroom.

## Diagnosis

The basic editor text tier correctly rejected untrusted CFF bytes before they could reach the length-unaware fallback parser. The editor then substituted its safe embedded Public Sans fallback, which rendered Bravura private-use music glyphs as rectangles. The shipping products need the existing full text tier, where validated byte spans are passed to FreeType with their exact lengths and shaped by HarfBuzz.

## Verification

- `bazel test //... --test_output=errors` (449 passed, 20 intentional platform skips)
- `bazel test //donner/editor/tests:editor_embedded_font_render_tests //donner/editor/wasm:editor_wasm_transition_tests //donner/editor/wasm:wasm_geode_package_size_tests //donner/editor/wasm/tests:chromium_remote_smoke --test_output=errors --remote_download_outputs=all`
- `bazel build //donner/editor:editor`
- `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- MCP GL capture of the affected document at the red checkpoint and exact green head
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/lint.sh`
- `git diff --check origin/main..HEAD`