### PR TITLE
Keep hierarchical drags aligned with transformed parents

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,9 @@ jobs:
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Local complexity lint compares the whole PR diff to its target branch.
+          fetch-depth: 0
 
       - name: Cache Bazel
         uses: actions/cache@v6

--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -17,6 +17,7 @@ py_test(
         "check_banned_patterns.py",
         "check_banned_patterns_tests.py",
     ],
+    data = ["//tools:lint.sh"],
 )
 
 py_test(

--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -18,6 +18,7 @@ Rules enforced:
   - No imgui / GLFW / Tracy headers outside `donner/editor/**` (path-scoped)
   - No ImGui `AddImageQuad`: present document textures through direct framebuffer composition
   - No direct TreeComponent structural mutation outside approved low-level code
+  - No C++ method above the local decision-point complexity limit
 
 Usage:
   python3 build_defs/check_banned_patterns.py            # Check all files
@@ -29,6 +30,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import subprocess
 import sys
 import unicodedata
 from pathlib import Path
@@ -355,6 +357,79 @@ _REF_RETURN_EXEMPT_PATHS = (
     "donner/base/RcStringOrRef.h",
 )
 
+_MAX_METHOD_DECISION_POINTS = 10
+_METHOD_DEFINITION_RE = re.compile(
+    r"""
+    ^[ \t]*
+    (?:[A-Za-z_][A-Za-z0-9_:<>,~*&\[\] ]*[ \t]+)?
+    (?P<name>(?:[A-Za-z_][A-Za-z0-9_]*::)+~?[A-Za-z_][A-Za-z0-9_]*)
+    \s*\([^;{}]*\)
+    \s*(?:const\s*)?(?:noexcept(?:\s*\([^)]*\))?\s*)?(?:override\s*)?(?:final\s*)?
+    \{
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+_METHOD_DECISION_RE = re.compile(
+    r"\b(?:if|for|while|catch)\s*\(|\bcase\b|&&|\|\||(?<!\?)\?(?!\?)"
+)
+
+
+def _method_body_end(stripped: str, opening_brace: int) -> int:
+    """Return the matching closing brace offset, or the end of the source."""
+    depth = 0
+    for offset in range(opening_brace, len(stripped)):
+        if stripped[offset] == "{":
+            depth += 1
+        elif stripped[offset] == "}":
+            depth -= 1
+            if depth == 0:
+                return offset
+    return len(stripped)
+
+
+def _method_complexities(stripped: str) -> Dict[str, int]:
+    """Return the maximum decision-point count for each out-of-line method name."""
+    result: Dict[str, int] = {}
+    for match in _METHOD_DEFINITION_RE.finditer(stripped):
+        opening_brace = stripped.find("{", match.start(), match.end())
+        body_end = _method_body_end(stripped, opening_brace)
+        decision_points = len(_METHOD_DECISION_RE.findall(stripped[opening_brace:body_end]))
+        name = match.group("name")
+        result[name] = max(result.get(name, 0), decision_points)
+    return result
+
+
+def _check_method_complexity(
+    stripped: str, baseline_stripped: str | None = None
+) -> List[Tuple[int, str, str]]:
+    """Flag out-of-line C++ methods with too many local decision points."""
+    baseline = _method_complexities(baseline_stripped) if baseline_stripped is not None else {}
+    errors: List[Tuple[int, str, str]] = []
+    for match in _METHOD_DEFINITION_RE.finditer(stripped):
+        opening_brace = stripped.find("{", match.start(), match.end())
+        body_end = _method_body_end(stripped, opening_brace)
+        decision_points = len(_METHOD_DECISION_RE.findall(stripped[opening_brace:body_end]))
+        if decision_points <= _MAX_METHOD_DECISION_POINTS:
+            continue
+        if baseline.get(match.group("name"), 0) > _MAX_METHOD_DECISION_POINTS:
+            continue
+        line = stripped.count("\n", 0, match.start("name")) + 1
+        errors.append(
+            (
+                line,
+                (
+                    f"complex method ({decision_points} decision points; "
+                    f"limit {_MAX_METHOD_DECISION_POINTS})"
+                ),
+                (
+                    f"Extract focused helpers until `{match.group('name')}` has at most "
+                    f"{_MAX_METHOD_DECISION_POINTS} decision points. This mirrors the external "
+                    "Complex Method gate in the local lint command."
+                ),
+            )
+        )
+    return errors
+
 
 def _looks_like_parameter_list(params: str) -> bool:
     """Return true if `params` looks like C++ parameter declarations, not ctor arguments."""
@@ -405,7 +480,12 @@ def _check_ref_return_types(
     return errors
 
 
-def check_file(path: Path) -> List[Tuple[int, str, str]]:
+def check_file(
+    path: Path,
+    *,
+    check_method_complexity: bool = False,
+    method_complexity_baseline: str | None = None,
+) -> List[Tuple[int, str, str]]:
     """Check a single file; return list of (line_number, description, remediation).
 
     Lines marked `// NOLINT(banned_patterns)` or `// NOLINT(banned_patterns: reason)`
@@ -434,6 +514,8 @@ def check_file(path: Path) -> List[Tuple[int, str, str]]:
             errors.append((line, rule.description, rule.remediation))
 
     errors.extend(_check_ref_return_types(stripped, raw_lines, posix_path))
+    if check_method_complexity:
+        errors.extend(_check_method_complexity(stripped, method_complexity_baseline))
 
     return sorted(errors)
 
@@ -473,6 +555,18 @@ def main(argv: List[str]) -> int:
         nargs="*",
         help="Files or directories to check (default: donner/ and examples/)",
     )
+    parser.add_argument(
+        "--check-method-complexity",
+        action="store_true",
+        help="Apply the local Complex Method decision-point limit to the selected C++ files.",
+    )
+    parser.add_argument(
+        "--complexity-baseline-ref",
+        help=(
+            "Git ref used to suppress methods that already exceeded the complexity limit. "
+            "Requires --check-method-complexity."
+        ),
+    )
     args = parser.parse_args(argv[1:])
 
     inputs = [Path(p) for p in args.paths] if args.paths else [Path("donner"), Path("examples")]
@@ -483,7 +577,22 @@ def main(argv: List[str]) -> int:
 
     total_errors = 0
     for f in files:
-        errors = check_file(f)
+        baseline = None
+        if args.check_method_complexity and args.complexity_baseline_ref:
+            relative_path = os.path.relpath(f, Path.cwd())
+            completed = subprocess.run(
+                ["git", "show", f"{args.complexity_baseline_ref}:{relative_path}"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if completed.returncode == 0:
+                baseline = _strip_comments_and_strings(completed.stdout)
+        errors = check_file(
+            f,
+            check_method_complexity=args.check_method_complexity,
+            method_complexity_baseline=baseline,
+        )
         for line, desc, remediation in errors:
             total_errors += 1
             print(f"{f}:{line}: {desc}")

--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -18,7 +18,8 @@ Rules enforced:
   - No imgui / GLFW / Tracy headers outside `donner/editor/**` (path-scoped)
   - No ImGui `AddImageQuad`: present document textures through direct framebuffer composition
   - No direct TreeComponent structural mutation outside approved low-level code
-  - No new or worsened out-of-line C++ method above the local decision-point complexity limit
+  - No new or worsened supported out-of-line C++ method definition above the local
+    decision-point complexity limit
 
 Usage:
   python3 build_defs/check_banned_patterns.py            # Check all files
@@ -364,7 +365,8 @@ _METHOD_DEFINITION_RE = re.compile(
     (?:[A-Za-z_][A-Za-z0-9_:<>,~*&\[\] ]*[ \t]+)?
     (?P<name>(?:[A-Za-z_][A-Za-z0-9_]*::)+~?[A-Za-z_][A-Za-z0-9_]*)
     \s*\((?P<params>[^;{}]*)\)
-    \s*(?:const\s*)?(?:noexcept(?:\s*\([^)]*\))?\s*)?(?:override\s*)?(?:final\s*)?
+    \s*(?P<cv>(?:(?:const|volatile)\s*)*)(?P<ref>&&?)?\s*
+    (?:noexcept(?:\s*\([^)]*\))?\s*)?(?:override\s*)?(?:final\s*)?
     \{
     """,
     re.MULTILINE | re.VERBOSE,
@@ -390,11 +392,14 @@ def _method_body_end(stripped: str, opening_brace: int) -> int:
 def _method_signature(match: re.Match) -> str:
     """Return a stable-enough signature key that distinguishes method overloads."""
     params = re.sub(r"\s+", " ", match.group("params").strip())
-    return f"{match.group('name')}({params})"
+    cv_qualifiers = " ".join(match.group("cv").split())
+    ref_qualifier = match.group("ref") or ""
+    suffix = " ".join(part for part in (cv_qualifiers, ref_qualifier) if part)
+    return f"{match.group('name')}({params})" + (f" {suffix}" if suffix else "")
 
 
 def _method_complexities(stripped: str) -> Dict[str, int]:
-    """Return the decision-point count for each out-of-line method signature."""
+    """Return decision-point counts for supported out-of-line method definitions."""
     result: Dict[str, int] = {}
     for match in _METHOD_DEFINITION_RE.finditer(stripped):
         opening_brace = stripped.find("{", match.start(), match.end())
@@ -408,7 +413,7 @@ def _method_complexities(stripped: str) -> Dict[str, int]:
 def _check_method_complexity(
     stripped: str, baseline_stripped: str | None = None
 ) -> List[Tuple[int, str, str]]:
-    """Flag out-of-line C++ methods with too many local decision points."""
+    """Flag supported out-of-line C++ method definitions with too many decision points."""
     baseline = _method_complexities(baseline_stripped) if baseline_stripped is not None else {}
     errors: List[Tuple[int, str, str]] = []
     for match in _METHOD_DEFINITION_RE.finditer(stripped):

--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -18,7 +18,7 @@ Rules enforced:
   - No imgui / GLFW / Tracy headers outside `donner/editor/**` (path-scoped)
   - No ImGui `AddImageQuad`: present document textures through direct framebuffer composition
   - No direct TreeComponent structural mutation outside approved low-level code
-  - No C++ method above the local decision-point complexity limit
+  - No new or worsened out-of-line C++ method above the local decision-point complexity limit
 
 Usage:
   python3 build_defs/check_banned_patterns.py            # Check all files
@@ -363,7 +363,7 @@ _METHOD_DEFINITION_RE = re.compile(
     ^[ \t]*
     (?:[A-Za-z_][A-Za-z0-9_:<>,~*&\[\] ]*[ \t]+)?
     (?P<name>(?:[A-Za-z_][A-Za-z0-9_]*::)+~?[A-Za-z_][A-Za-z0-9_]*)
-    \s*\([^;{}]*\)
+    \s*\((?P<params>[^;{}]*)\)
     \s*(?:const\s*)?(?:noexcept(?:\s*\([^)]*\))?\s*)?(?:override\s*)?(?:final\s*)?
     \{
     """,
@@ -387,15 +387,21 @@ def _method_body_end(stripped: str, opening_brace: int) -> int:
     return len(stripped)
 
 
+def _method_signature(match: re.Match) -> str:
+    """Return a stable-enough signature key that distinguishes method overloads."""
+    params = re.sub(r"\s+", " ", match.group("params").strip())
+    return f"{match.group('name')}({params})"
+
+
 def _method_complexities(stripped: str) -> Dict[str, int]:
-    """Return the maximum decision-point count for each out-of-line method name."""
+    """Return the decision-point count for each out-of-line method signature."""
     result: Dict[str, int] = {}
     for match in _METHOD_DEFINITION_RE.finditer(stripped):
         opening_brace = stripped.find("{", match.start(), match.end())
         body_end = _method_body_end(stripped, opening_brace)
         decision_points = len(_METHOD_DECISION_RE.findall(stripped[opening_brace:body_end]))
-        name = match.group("name")
-        result[name] = max(result.get(name, 0), decision_points)
+        signature = _method_signature(match)
+        result[signature] = max(result.get(signature, 0), decision_points)
     return result
 
 
@@ -409,9 +415,8 @@ def _check_method_complexity(
         opening_brace = stripped.find("{", match.start(), match.end())
         body_end = _method_body_end(stripped, opening_brace)
         decision_points = len(_METHOD_DECISION_RE.findall(stripped[opening_brace:body_end]))
-        if decision_points <= _MAX_METHOD_DECISION_POINTS:
-            continue
-        if baseline.get(match.group("name"), 0) > _MAX_METHOD_DECISION_POINTS:
+        baseline_decision_points = baseline.get(_method_signature(match), 0)
+        if decision_points <= max(_MAX_METHOD_DECISION_POINTS, baseline_decision_points):
             continue
         line = stripped.count("\n", 0, match.start("name")) + 1
         errors.append(

--- a/build_defs/check_banned_patterns_tests.py
+++ b/build_defs/check_banned_patterns_tests.py
@@ -212,6 +212,46 @@ class CheckBannedPatternsTests(unittest.TestCase):
 
         self.assertEqual(1, descriptions.count("complex method (11 decision points; limit 10)"))
 
+    def test_const_baseline_overload_does_not_exempt_nonconst_overload(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        baseline = "void Example::run(int value) const {\n" + branches + "\n}\n"
+        current = baseline + "void Example::run(int value) {\n" + branches + "\n}\n"
+        source_path = self._write_source(current)
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    baseline
+                ),
+            )
+        ]
+
+        self.assertEqual(1, descriptions.count("complex method (11 decision points; limit 10)"))
+
+    def test_lvalue_baseline_overload_does_not_exempt_rvalue_overload(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        baseline = "void Example::run(int value) & {\n" + branches + "\n}\n"
+        current = baseline + "void Example::run(int value) && {\n" + branches + "\n}\n"
+        source_path = self._write_source(current)
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    baseline
+                ),
+            )
+        ]
+
+        self.assertEqual(1, descriptions.count("complex method (11 decision points; limit 10)"))
+
     def _run_lint_in_git_repo(
         self, *, current_decision_points: int, provide_origin_main: bool
     ) -> subprocess.CompletedProcess[str]:

--- a/build_defs/check_banned_patterns_tests.py
+++ b/build_defs/check_banned_patterns_tests.py
@@ -94,6 +94,26 @@ class CheckBannedPatternsTests(unittest.TestCase):
                 check_banned_patterns._iter_source_files([source_root]),
             )
 
+    def test_blocks_methods_above_the_local_complexity_limit(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        descriptions = self._descriptions_for(
+            "void Example::run(int value) {\n" + branches + "\n}\n"
+        )
+
+        self.assertIn("complex method (11 decision points; limit 10)", descriptions)
+
+    def test_allows_methods_at_the_local_complexity_limit(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(10)
+        )
+        descriptions = self._descriptions_for(
+            "void Example::run(int value) {\n" + branches + "\n}\n"
+        )
+
+        self.assertNotIn("complex method", "\n".join(descriptions))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_defs/check_banned_patterns_tests.py
+++ b/build_defs/check_banned_patterns_tests.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -166,6 +168,123 @@ class CheckBannedPatternsTests(unittest.TestCase):
         ]
 
         self.assertIn("complex method (11 decision points; limit 10)", descriptions)
+
+    def test_blocks_preexisting_complex_method_that_gets_worse(self):
+        baseline_branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        current_branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(12)
+        )
+        source_path = self._write_source(
+            "void Example::run(int value) {\n" + current_branches + "\n}\n"
+        )
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    "void Example::run(int value) {\n" + baseline_branches + "\n}\n"
+                ),
+            )
+        ]
+
+        self.assertIn("complex method (12 decision points; limit 10)", descriptions)
+
+    def test_complex_baseline_overload_does_not_exempt_new_overload(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        baseline = "void Example::run(int value) {\n" + branches + "\n}\n"
+        current = baseline + "void Example::run(double value) {\n" + branches + "\n}\n"
+        source_path = self._write_source(current)
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    baseline
+                ),
+            )
+        ]
+
+        self.assertEqual(1, descriptions.count("complex method (11 decision points; limit 10)"))
+
+    def _run_lint_in_git_repo(
+        self, *, current_decision_points: int, provide_origin_main: bool
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            (repo / "build_defs").mkdir()
+            (repo / "tools").mkdir()
+            (repo / "donner" / "base").mkdir(parents=True)
+            (repo / "examples").mkdir()
+            shutil.copy2(_CHECKER_PATH, repo / "build_defs" / "check_banned_patterns.py")
+            shutil.copy2(
+                Path(__file__).resolve().parents[1] / "tools" / "lint.sh",
+                repo / "tools" / "lint.sh",
+            )
+
+            def write_source(decision_points: int) -> None:
+                branches = "\n".join(
+                    f"  if (value == {index}) {{ value += {index}; }}"
+                    for index in range(decision_points)
+                )
+                (repo / "donner" / "base" / "Example.cc").write_text(
+                    "void Example::run(int value) {\n" + branches + "\n}\n",
+                    encoding="utf-8",
+                )
+
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "config", "user.email", "lint-test@example.invalid"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Lint Test"], cwd=repo, check=True
+            )
+            write_source(10)
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "baseline"], cwd=repo, check=True, capture_output=True
+            )
+            if provide_origin_main:
+                subprocess.run(
+                    ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+                    cwd=repo,
+                    check=True,
+                )
+            subprocess.run(
+                ["git", "checkout", "--detach"], cwd=repo, check=True, capture_output=True
+            )
+            write_source(current_decision_points)
+
+            return subprocess.run(
+                [str(repo / "tools" / "lint.sh")],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_lint_checks_detached_branch_diff_against_origin_main(self):
+        completed = self._run_lint_in_git_repo(
+            current_decision_points=11, provide_origin_main=True
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("complex method (11 decision points; limit 10)", completed.stdout)
+
+    def test_lint_fails_closed_without_target_baseline(self):
+        completed = self._run_lint_in_git_repo(
+            current_decision_points=10, provide_origin_main=False
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("cannot resolve complexity baseline", completed.stderr)
 
 
 if __name__ == "__main__":

--- a/build_defs/check_banned_patterns_tests.py
+++ b/build_defs/check_banned_patterns_tests.py
@@ -257,10 +257,17 @@ class CheckBannedPatternsTests(unittest.TestCase):
                     cwd=repo,
                     check=True,
                 )
+            write_source(current_decision_points)
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "--allow-empty", "-m", "candidate"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
             subprocess.run(
                 ["git", "checkout", "--detach"], cwd=repo, check=True, capture_output=True
             )
-            write_source(current_decision_points)
 
             return subprocess.run(
                 [str(repo / "tools" / "lint.sh")],

--- a/build_defs/check_banned_patterns_tests.py
+++ b/build_defs/check_banned_patterns_tests.py
@@ -24,10 +24,19 @@ class CheckBannedPatternsTests(unittest.TestCase):
         source_path.write_text(source, encoding="utf-8")
         return source_path
 
-    def _descriptions_for(self, source: str, filename: str = "Example.cc") -> list[str]:
+    def _descriptions_for(
+        self,
+        source: str,
+        filename: str = "Example.cc",
+        *,
+        check_method_complexity: bool = False,
+    ) -> list[str]:
         return [
             error[1]
-            for error in check_banned_patterns.check_file(self._write_source(source, filename))
+            for error in check_banned_patterns.check_file(
+                self._write_source(source, filename),
+                check_method_complexity=check_method_complexity,
+            )
         ]
 
     def test_blocks_typographic_hyphens_and_dashes_in_comments_and_strings(self):
@@ -99,7 +108,8 @@ class CheckBannedPatternsTests(unittest.TestCase):
             f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
         )
         descriptions = self._descriptions_for(
-            "void Example::run(int value) {\n" + branches + "\n}\n"
+            "void Example::run(int value) {\n" + branches + "\n}\n",
+            check_method_complexity=True,
         )
 
         self.assertIn("complex method (11 decision points; limit 10)", descriptions)
@@ -109,10 +119,53 @@ class CheckBannedPatternsTests(unittest.TestCase):
             f"  if (value == {index}) {{ value += {index}; }}" for index in range(10)
         )
         descriptions = self._descriptions_for(
-            "void Example::run(int value) {\n" + branches + "\n}\n"
+            "void Example::run(int value) {\n" + branches + "\n}\n",
+            check_method_complexity=True,
         )
 
         self.assertNotIn("complex method", "\n".join(descriptions))
+
+    def test_allows_preexisting_complex_method_from_baseline(self):
+        branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        source = "void Example::run(int value) {\n" + branches + "\n}\n"
+        source_path = self._write_source(source)
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    source
+                ),
+            )
+        ]
+
+        self.assertNotIn("complex method", "\n".join(descriptions))
+
+    def test_blocks_new_complex_method_against_simple_baseline(self):
+        current_branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(11)
+        )
+        baseline_branches = "\n".join(
+            f"  if (value == {index}) {{ value += {index}; }}" for index in range(10)
+        )
+        source_path = self._write_source(
+            "void Example::run(int value) {\n" + current_branches + "\n}\n"
+        )
+        descriptions = [
+            error[1]
+            for error in check_banned_patterns.check_file(
+                source_path,
+                check_method_complexity=True,
+                method_complexity_baseline=check_banned_patterns._strip_comments_and_strings(
+                    "void Example::run(int value) {\n" + baseline_branches + "\n}\n"
+                ),
+            )
+        ]
+
+        self.assertIn("complex method (11 decision points; limit 10)", descriptions)
 
 
 if __name__ == "__main__":

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -651,6 +651,11 @@ bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile, bool newD
   return dismiss || openFile || newDocument;
 }
 
+bool ShouldAdvanceSampleThumbnails(bool showSamplePicker, bool samplePresentationPending) noexcept {
+  (void)samplePresentationPending;
+  return showSamplePicker;
+}
+
 DeferredRenderAction DeferredRenderActionForState(bool hasDocument, bool penDragFlushed,
                                                   bool rendererBusy) noexcept {
   if (!hasDocument) {
@@ -6666,7 +6671,7 @@ void EditorShell::revealSourceRange(SourceByteRange byteRange) {
 
 void EditorShell::prepareFrame() {
   const ScopedHeapDelta inputHeapDelta(MemoryStage::AppInput);
-  if (showSamplePicker_) {
+  if (internal::ShouldAdvanceSampleThumbnails(showSamplePicker_, samplePresentationPending_)) {
     ensureSampleThumbnails();
   }
 }

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -652,8 +652,7 @@ bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile, bool newD
 }
 
 bool ShouldAdvanceSampleThumbnails(bool showSamplePicker, bool samplePresentationPending) noexcept {
-  (void)samplePresentationPending;
-  return showSamplePicker;
+  return showSamplePicker && !samplePresentationPending;
 }
 
 DeferredRenderAction DeferredRenderActionForState(bool hasDocument, bool penDragFlushed,

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -128,6 +128,8 @@ void PublishSampleThumbnailStats(int requested, int started, int completed, int 
         window['__donnerSampleThumbnailStats'] = ({
           'carouselFrame' : Number(previous['carouselFrame'] || frame),
           'firstRequestFrame' : Number(previous['firstRequestFrame'] || ($0 > 0 ? frame : 0)),
+          'publishedAtMs' : performance.now(),
+          'publicationGeneration' : Number(previous['publicationGeneration'] || 0) + 1,
           'requested' : $0,
           'started' : $1,
           'completed' : $2,
@@ -4392,6 +4394,21 @@ void EditorShell::renderRenderPanePresentation(
   }
 }
 
+void EditorShell::publishSampleThumbnailStats() const {
+#ifdef __EMSCRIPTEN__
+  std::size_t ready = 0u;
+  for (const std::optional<svg::RendererBitmap>& bitmap : sampleThumbnailBitmaps_) {
+    ready += bitmap.has_value() ? 1u : 0u;
+  }
+  const SampleThumbnailRenderStats stats =
+      renderCoordinator_.asyncRenderer().sampleThumbnailRenderStats();
+  PublishSampleThumbnailStats(static_cast<int>(stats.requested), static_cast<int>(stats.started),
+                              static_cast<int>(stats.completed), static_cast<int>(stats.rendered),
+                              static_cast<int>(ready), stats.pending ? 1 : 0, stats.active ? 1 : 0,
+                              stats.resultReady ? 1 : 0);
+#endif
+}
+
 void EditorShell::ensureSampleThumbnails() {
   const std::span<const EditorSample> samples = GetEditorSampleCatalog();
   constexpr int kThumbnailWidthPx = 192;
@@ -4401,25 +4418,12 @@ void EditorShell::ensureSampleThumbnails() {
   }
 
   AsyncRenderer& asyncRenderer = renderCoordinator_.asyncRenderer();
-  const auto publishStats = [&] {
-#ifdef __EMSCRIPTEN__
-    std::size_t ready = 0u;
-    for (const std::optional<svg::RendererBitmap>& bitmap : sampleThumbnailBitmaps_) {
-      ready += bitmap.has_value() ? 1u : 0u;
-    }
-    const SampleThumbnailRenderStats stats = asyncRenderer.sampleThumbnailRenderStats();
-    PublishSampleThumbnailStats(static_cast<int>(stats.requested), static_cast<int>(stats.started),
-                                static_cast<int>(stats.completed), static_cast<int>(stats.rendered),
-                                static_cast<int>(ready), stats.pending ? 1 : 0,
-                                stats.active ? 1 : 0, stats.resultReady ? 1 : 0);
-#endif
-  };
 
   // The first picker frame is presentation-only. Posting even a worker task here can contend with
   // Wasm startup and delay the carousel itself, so arm one explicit follow-up frame and return.
   if (!samplePickerHasPresentedFrame_) {
     samplePickerHasPresentedFrame_ = true;
-    publishStats();
+    publishSampleThumbnailStats();
     window_.wakeEventLoop();
     return;
   }
@@ -4453,13 +4457,13 @@ void EditorShell::ensureSampleThumbnails() {
 
   if (sampleThumbnailGenerationCursor_ >= samples.size()) {
     sampleThumbnailRetryPending_ = false;
-    publishStats();
+    publishSampleThumbnailStats();
     return;
   }
   if (sampleThumbnailInFlightIndex_.has_value() || asyncRenderer.isBusy()) {
     // Work in flight ends in a completion callback, which wakes the loop.
     sampleThumbnailRetryPending_ = false;
-    publishStats();
+    publishSampleThumbnailStats();
     return;
   }
 
@@ -4484,7 +4488,7 @@ void EditorShell::ensureSampleThumbnails() {
     // instead of blocking the frame on worker readiness.
     sampleThumbnailRetryPending_ = true;
   }
-  publishStats();
+  publishSampleThumbnailStats();
 }
 
 void EditorShell::cancelSampleThumbnailGeneration() {
@@ -4495,6 +4499,7 @@ void EditorShell::cancelSampleThumbnailGeneration() {
     pendingFontPreviews_.push_front(std::move(*fontPreviewInFlight_));
     fontPreviewInFlight_.reset();
   }
+  publishSampleThumbnailStats();
 }
 
 void EditorShell::requestFontPreviews(const std::vector<std::string>& families) {
@@ -6672,6 +6677,9 @@ void EditorShell::prepareFrame() {
   const ScopedHeapDelta inputHeapDelta(MemoryStage::AppInput);
   if (internal::ShouldAdvanceSampleThumbnails(showSamplePicker_, samplePresentationPending_)) {
     ensureSampleThumbnails();
+  } else if (showSamplePicker_) {
+    // Keep browser failure diagnostics current without letting carousel work re-enter the worker.
+    publishSampleThumbnailStats();
   }
 }
 

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -455,6 +455,7 @@ private:
   void renderCompactTopBar();
   void renderSidebars();
   void ensureSampleThumbnails();
+  void publishSampleThumbnailStats() const;
   void cancelSampleThumbnailGeneration();
   void requestFontPreviews(const std::vector<std::string>& families);
   void advanceFontPreviewGeneration();

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -127,6 +127,7 @@ template <typename Resolver>
 
 [[nodiscard]] bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile,
                                                         bool newDocument) noexcept;
+/// Background carousel work yields while a selected sample owns the next document render.
 [[nodiscard]] bool ShouldAdvanceSampleThumbnails(bool showSamplePicker,
                                                  bool samplePresentationPending) noexcept;
 [[nodiscard]] DeferredRenderAction DeferredRenderActionForState(bool hasDocument,

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -127,6 +127,8 @@ template <typename Resolver>
 
 [[nodiscard]] bool SamplePickerActionsNeedFollowupFrame(bool dismiss, bool openFile,
                                                         bool newDocument) noexcept;
+[[nodiscard]] bool ShouldAdvanceSampleThumbnails(bool showSamplePicker,
+                                                 bool samplePresentationPending) noexcept;
 [[nodiscard]] DeferredRenderAction DeferredRenderActionForState(bool hasDocument,
                                                                 bool penDragFlushed,
                                                                 bool rendererBusy) noexcept;

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -575,6 +575,30 @@ std::optional<SelectTool::LockedRejectionFlash> SelectTool::lockedRejectionFlash
   };
 }
 
+std::optional<Transform2d> SelectTool::parentFromEntityAfterDocumentGesture(
+    const PerElementDrag& participant, const Transform2d& documentFromStartDocument) {
+  const double determinant = participant.documentFromParent.determinant();
+  if (!IsFinite(determinant) || determinant == 0.0) {
+    return std::nullopt;
+  }
+
+  const Transform2d parentFromDocument = participant.documentFromParent.inverse();
+  if (!IsFinite(parentFromDocument)) {
+    return std::nullopt;
+  }
+
+  Transform2d parentFromEntity;
+  if (documentFromStartDocument.isTranslation()) {
+    const Vector2d translationParent =
+        parentFromDocument.transformVector(documentFromStartDocument.translation());
+    parentFromEntity = participant.startTransform * Transform2d::Translate(translationParent);
+  } else {
+    parentFromEntity = participant.startTransform * participant.documentFromParent *
+                       documentFromStartDocument * parentFromDocument;
+  }
+  return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity) : std::nullopt;
+}
+
 void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) {
   onMouseMove(editor, documentPoint, buttonHeld, MouseModifiers{});
 }
@@ -628,42 +652,16 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
     return;
   }
 
-  const auto parentFromEntityAfterGesture =
-      [&documentFromStartDocument](
-          const PerElementDrag& participant) -> std::optional<Transform2d> {
-    const double determinant = participant.documentFromParent.determinant();
-    if (!IsFinite(determinant) || determinant == 0.0) {
-      return std::nullopt;
-    }
-
-    const Transform2d parentFromDocument = participant.documentFromParent.inverse();
-    if (!IsFinite(parentFromDocument)) {
-      return std::nullopt;
-    }
-    if (documentFromStartDocument->isTranslation()) {
-      const Vector2d translationParent =
-          parentFromDocument.transformVector(documentFromStartDocument->translation());
-      const Transform2d parentFromEntity =
-          participant.startTransform * Transform2d::Translate(translationParent);
-      return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity)
-                                        : std::nullopt;
-    }
-
-    const Transform2d parentFromEntity = participant.startTransform *
-                                         participant.documentFromParent *
-                                         *documentFromStartDocument * parentFromDocument;
-    return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity) : std::nullopt;
-  };
-
   const std::optional<Transform2d> primaryNewTransform =
-      parentFromEntityAfterGesture(dragState_->primary);
+      parentFromEntityAfterDocumentGesture(dragState_->primary, *documentFromStartDocument);
   if (!primaryNewTransform.has_value()) {
     return;
   }
   std::vector<Transform2d> extraNewTransforms;
   extraNewTransforms.reserve(dragState_->extras.size());
   for (const PerElementDrag& extra : dragState_->extras) {
-    const std::optional<Transform2d> extraNewTransform = parentFromEntityAfterGesture(extra);
+    const std::optional<Transform2d> extraNewTransform =
+        parentFromEntityAfterDocumentGesture(extra, *documentFromStartDocument);
     if (!extraNewTransform.has_value()) {
       return;
     }

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -44,6 +44,17 @@ Vector2d CenterOf(const Box2d& box) {
   return (box.topLeft + box.bottomRight) * 0.5;
 }
 
+Transform2d DocumentFromParentTransform(const svg::SVGElement& element) {
+  const std::optional<svg::SVGElement> parent = element.parentElement();
+  if (!parent.has_value()) {
+    return Transform2d();
+  }
+
+  return parent->isa<svg::SVGGraphicsElement>()
+             ? parent->cast<svg::SVGGraphicsElement>().elementFromWorld()
+             : Transform2d();
+}
+
 std::optional<Transform2d> ResizeTransform(const Box2d& startBounds,
                                            SelectionTransformCorner corner,
                                            const Vector2d& documentPoint, bool preserveAspectRatio,
@@ -267,6 +278,7 @@ bool SelectTool::tryStartRedragOnSelected(EditorApp& editor, const Vector2d& doc
               .element = element,
               .startTransform = primaryStartTransform,
               .currentTransform = primaryStartTransform,
+              .documentFromParent = DocumentFromParentTransform(element),
               .writebackTarget = primaryWritebackTarget,
               .sourceTransformAttributeValue = sourceTransformAttributeValue,
           },
@@ -342,6 +354,7 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
         .element = element,
         .startTransform = startTransform,
         .currentTransform = startTransform,
+        .documentFromParent = DocumentFromParentTransform(element),
         .writebackTarget = captureAttributeWritebackTarget(element),
         .sourceTransformAttributeValue = sourceTransformAttributeValue,
     };
@@ -598,9 +611,8 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
   std::optional<Transform2d> documentFromStartDocument;
   switch (dragState_->gestureKind) {
     case DragState::GestureKind::Move:
-      // Donner's Transform2 uses row-vector post-multiply semantics, so
-      // `start * Translate(delta)` applies the element's existing transform
-      // first and then moves the resulting document-space geometry by delta.
+      // Keep the gesture in document coordinates. Each participant converts it to its own
+      // parent coordinate system after the shared gesture has been resolved.
       documentFromStartDocument = Transform2d::Translate(deltaDoc);
       break;
     case DragState::GestureKind::Resize:
@@ -630,9 +642,42 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
 
   dragState_->currentDocumentDelta = deltaDoc;
   dragState_->currentDocumentFromStartDocument = *documentFromStartDocument;
-  const Transform2d primaryNewTransform =
-      dragState_->primary.startTransform * *documentFromStartDocument;
-  dragState_->primary.currentTransform = primaryNewTransform;
+  const auto parentFromEntityAfterGesture =
+      [&documentFromStartDocument](
+          const PerElementDrag& participant) -> std::optional<Transform2d> {
+    if (std::abs(participant.documentFromParent.determinant()) < kMinScaleDenominator) {
+      return std::nullopt;
+    }
+
+    const Transform2d parentFromDocument = participant.documentFromParent.inverse();
+    if (documentFromStartDocument->isTranslation()) {
+      const Vector2d translationParent =
+          parentFromDocument.transformVector(documentFromStartDocument->translation());
+      return participant.startTransform * Transform2d::Translate(translationParent);
+    }
+
+    const Transform2d parentFromEntity = participant.startTransform *
+                                         participant.documentFromParent *
+                                         *documentFromStartDocument * parentFromDocument;
+    return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity) : std::nullopt;
+  };
+
+  const std::optional<Transform2d> primaryNewTransform =
+      parentFromEntityAfterGesture(dragState_->primary);
+  if (!primaryNewTransform.has_value()) {
+    return;
+  }
+  std::vector<Transform2d> extraNewTransforms;
+  extraNewTransforms.reserve(dragState_->extras.size());
+  for (const PerElementDrag& extra : dragState_->extras) {
+    const std::optional<Transform2d> extraNewTransform = parentFromEntityAfterGesture(extra);
+    if (!extraNewTransform.has_value()) {
+      return;
+    }
+    extraNewTransforms.push_back(*extraNewTransform);
+  }
+
+  dragState_->primary.currentTransform = *primaryNewTransform;
   dragState_->hasMoved = true;
 
   // DOM is the source of truth during drag. Every drag frame applies a
@@ -646,9 +691,10 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
   // disagreement was the source of the drag-release "pop back" class of
   // bugs where the cached bitmap offset diverged from the DOM transform.
   editor.applyMutation(
-      EditorCommand::SetTransformCommand(dragState_->primary.element, primaryNewTransform));
-  for (auto& extra : dragState_->extras) {
-    extra.currentTransform = extra.startTransform * *documentFromStartDocument;
+      EditorCommand::SetTransformCommand(dragState_->primary.element, *primaryNewTransform));
+  for (std::size_t i = 0; i < dragState_->extras.size(); ++i) {
+    auto& extra = dragState_->extras[i];
+    extra.currentTransform = extraNewTransforms[i];
     editor.applyMutation(EditorCommand::SetTransformCommand(extra.element, extra.currentTransform));
   }
 }

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -628,32 +628,25 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
     return;
   }
 
-  // When the mutation queue is empty, the DOM represents the previous active preview. Preserve
-  // that baseline before advancing the pointer preview and queueing its next transform. If a
-  // render is already in flight, the queue remains non-empty and this baseline stays at the last
-  // transform that actually reached the registry.
-  const std::uint64_t documentFrameVersion = editor.document().currentFrameVersion();
-  if (!editor.document().hasPendingMutations() ||
-      documentFrameVersion != dragState_->committedDocumentFrameVersion) {
-    dragState_->committedDocumentDelta = dragState_->currentDocumentDelta;
-    dragState_->committedDocumentFromStartDocument = dragState_->currentDocumentFromStartDocument;
-    dragState_->committedDocumentFrameVersion = documentFrameVersion;
-  }
-
-  dragState_->currentDocumentDelta = deltaDoc;
-  dragState_->currentDocumentFromStartDocument = *documentFromStartDocument;
   const auto parentFromEntityAfterGesture =
       [&documentFromStartDocument](
           const PerElementDrag& participant) -> std::optional<Transform2d> {
-    if (std::abs(participant.documentFromParent.determinant()) < kMinScaleDenominator) {
+    const double determinant = participant.documentFromParent.determinant();
+    if (!IsFinite(determinant) || determinant == 0.0) {
       return std::nullopt;
     }
 
     const Transform2d parentFromDocument = participant.documentFromParent.inverse();
+    if (!IsFinite(parentFromDocument)) {
+      return std::nullopt;
+    }
     if (documentFromStartDocument->isTranslation()) {
       const Vector2d translationParent =
           parentFromDocument.transformVector(documentFromStartDocument->translation());
-      return participant.startTransform * Transform2d::Translate(translationParent);
+      const Transform2d parentFromEntity =
+          participant.startTransform * Transform2d::Translate(translationParent);
+      return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity)
+                                        : std::nullopt;
     }
 
     const Transform2d parentFromEntity = participant.startTransform *
@@ -677,6 +670,21 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
     extraNewTransforms.push_back(*extraNewTransform);
   }
 
+  // When the mutation queue is empty, the DOM represents the previous active preview. Preserve
+  // that baseline before advancing the pointer preview and queueing its next transform. If a
+  // render is already in flight, the queue remains non-empty and this baseline stays at the last
+  // transform that actually reached the registry. Conversion must succeed for every participant
+  // first, so an invalid parent cannot advance the overlay without a matching DOM mutation.
+  const std::uint64_t documentFrameVersion = editor.document().currentFrameVersion();
+  if (!editor.document().hasPendingMutations() ||
+      documentFrameVersion != dragState_->committedDocumentFrameVersion) {
+    dragState_->committedDocumentDelta = dragState_->currentDocumentDelta;
+    dragState_->committedDocumentFromStartDocument = dragState_->currentDocumentFromStartDocument;
+    dragState_->committedDocumentFrameVersion = documentFrameVersion;
+  }
+
+  dragState_->currentDocumentDelta = deltaDoc;
+  dragState_->currentDocumentFromStartDocument = *documentFromStartDocument;
   dragState_->primary.currentTransform = *primaryNewTransform;
   dragState_->hasMoved = true;
 

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -575,6 +575,20 @@ std::optional<SelectTool::LockedRejectionFlash> SelectTool::lockedRejectionFlash
   };
 }
 
+std::optional<Transform2d> SelectTool::documentFromStartDocumentForPointer(
+    const DragState& state, const Vector2d& deltaDocument, const Vector2d& documentPoint,
+    MouseModifiers modifiers) {
+  switch (state.gestureKind) {
+    case DragState::GestureKind::Move: return Transform2d::Translate(deltaDocument);
+    case DragState::GestureKind::Resize:
+      return ResizeTransform(state.startBoundsDoc, state.corner, documentPoint, modifiers.shift,
+                             modifiers.option);
+    case DragState::GestureKind::Rotate:
+      return RotateTransform(state.centerDocumentPoint, state.startAngleRadians, documentPoint);
+  }
+  return std::nullopt;
+}
+
 std::optional<Transform2d> SelectTool::parentFromEntityAfterDocumentGesture(
     const PerElementDrag& participant, const Transform2d& documentFromStartDocument) {
   const double determinant = participant.documentFromParent.determinant();
@@ -597,6 +611,28 @@ std::optional<Transform2d> SelectTool::parentFromEntityAfterDocumentGesture(
                        documentFromStartDocument * parentFromDocument;
   }
   return IsFinite(parentFromEntity) ? std::optional<Transform2d>(parentFromEntity) : std::nullopt;
+}
+
+std::optional<SelectTool::ParentFromEntityTransforms>
+SelectTool::parentFromEntityTransformsAfterDocumentGesture(
+    const DragState& state, const Transform2d& documentFromStartDocument) {
+  const std::optional<Transform2d> primary =
+      parentFromEntityAfterDocumentGesture(state.primary, documentFromStartDocument);
+  if (!primary.has_value()) {
+    return std::nullopt;
+  }
+
+  ParentFromEntityTransforms result{.primary = *primary};
+  result.extras.reserve(state.extras.size());
+  for (const PerElementDrag& extra : state.extras) {
+    const std::optional<Transform2d> converted =
+        parentFromEntityAfterDocumentGesture(extra, documentFromStartDocument);
+    if (!converted.has_value()) {
+      return std::nullopt;
+    }
+    result.extras.push_back(*converted);
+  }
+  return result;
 }
 
 void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) {
@@ -632,40 +668,16 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
     return;
   }
 
-  std::optional<Transform2d> documentFromStartDocument;
-  switch (dragState_->gestureKind) {
-    case DragState::GestureKind::Move:
-      // Keep the gesture in document coordinates. Each participant converts it to its own
-      // parent coordinate system after the shared gesture has been resolved.
-      documentFromStartDocument = Transform2d::Translate(deltaDoc);
-      break;
-    case DragState::GestureKind::Resize:
-      documentFromStartDocument = ResizeTransform(dragState_->startBoundsDoc, dragState_->corner,
-                                                  documentPoint, modifiers.shift, modifiers.option);
-      break;
-    case DragState::GestureKind::Rotate:
-      documentFromStartDocument = RotateTransform(dragState_->centerDocumentPoint,
-                                                  dragState_->startAngleRadians, documentPoint);
-      break;
-  }
+  const std::optional<Transform2d> documentFromStartDocument =
+      documentFromStartDocumentForPointer(*dragState_, deltaDoc, documentPoint, modifiers);
   if (!documentFromStartDocument.has_value()) {
     return;
   }
 
-  const std::optional<Transform2d> primaryNewTransform =
-      parentFromEntityAfterDocumentGesture(dragState_->primary, *documentFromStartDocument);
-  if (!primaryNewTransform.has_value()) {
+  const std::optional<ParentFromEntityTransforms> parentFromEntityTransforms =
+      parentFromEntityTransformsAfterDocumentGesture(*dragState_, *documentFromStartDocument);
+  if (!parentFromEntityTransforms.has_value()) {
     return;
-  }
-  std::vector<Transform2d> extraNewTransforms;
-  extraNewTransforms.reserve(dragState_->extras.size());
-  for (const PerElementDrag& extra : dragState_->extras) {
-    const std::optional<Transform2d> extraNewTransform =
-        parentFromEntityAfterDocumentGesture(extra, *documentFromStartDocument);
-    if (!extraNewTransform.has_value()) {
-      return;
-    }
-    extraNewTransforms.push_back(*extraNewTransform);
   }
 
   // When the mutation queue is empty, the DOM represents the previous active preview. Preserve
@@ -683,7 +695,7 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
 
   dragState_->currentDocumentDelta = deltaDoc;
   dragState_->currentDocumentFromStartDocument = *documentFromStartDocument;
-  dragState_->primary.currentTransform = *primaryNewTransform;
+  dragState_->primary.currentTransform = parentFromEntityTransforms->primary;
   dragState_->hasMoved = true;
 
   // DOM is the source of truth during drag. Every drag frame applies a
@@ -696,11 +708,11 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
   // way so the canvas view and the backing document never disagree. That
   // disagreement was the source of the drag-release "pop back" class of
   // bugs where the cached bitmap offset diverged from the DOM transform.
-  editor.applyMutation(
-      EditorCommand::SetTransformCommand(dragState_->primary.element, *primaryNewTransform));
+  editor.applyMutation(EditorCommand::SetTransformCommand(dragState_->primary.element,
+                                                          parentFromEntityTransforms->primary));
   for (std::size_t i = 0; i < dragState_->extras.size(); ++i) {
     auto& extra = dragState_->extras[i];
-    extra.currentTransform = extraNewTransforms[i];
+    extra.currentTransform = parentFromEntityTransforms->extras[i];
     editor.applyMutation(EditorCommand::SetTransformCommand(extra.element, extra.currentTransform));
   }
 }

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -297,6 +297,16 @@ private:
     bool hasMoved = false;
   };
 
+  /**
+   * Convert one participant's document-space gesture into its parent-local transform.
+   *
+   * @param participant Element and parent transform captured at gesture start.
+   * @param documentFromStartDocument Shared document-space gesture transform.
+   * @return Parent-local result, or nullopt when inversion or composition is invalid.
+   */
+  [[nodiscard]] static std::optional<Transform2d> parentFromEntityAfterDocumentGesture(
+      const PerElementDrag& participant, const Transform2d& documentFromStartDocument);
+
   /// Active marquee drag. Records the start point (the document
   /// position of the `onMouseDown` that hit empty space), the
   /// current point (updated on every `onMouseMove`), and whether

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -231,14 +231,15 @@ public:
   void tickLockedRejectionFlash(float deltaSeconds);
 
 private:
-  /// Per-element bookkeeping for one participant in a drag. Carries the
-  /// start transform (for computing `startTransform * translate(delta)`
-  /// on each mouse move), the current preview transform, and the stable
-  /// locator for later canvas→text writeback.
+  /// Per-element bookkeeping for one participant in a drag. Carries the parent-local start and
+  /// current transforms, the parent-to-document transform used to convert the shared gesture, and
+  /// the stable locator for later canvas-to-text writeback.
   struct PerElementDrag {
     svg::SVGElement element;
     Transform2d startTransform;
     Transform2d currentTransform;
+    /// Document-space transform of the element's parent captured at gesture start.
+    Transform2d documentFromParent;
     std::optional<AttributeWritebackTarget> writebackTarget;
     /// Original `transform` attribute value captured at drag start. Used
     /// for `UndoSnapshot::sourceTransformAttributeValue` on release.

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -297,6 +297,24 @@ private:
     bool hasMoved = false;
   };
 
+  struct ParentFromEntityTransforms {
+    Transform2d primary;
+    std::vector<Transform2d> extras;
+  };
+
+  /**
+   * Resolve the active pointer gesture in document coordinates.
+   *
+   * @param state Gesture state captured at pointer-down.
+   * @param deltaDocument Pointer movement from the gesture start.
+   * @param documentPoint Current pointer position in document coordinates.
+   * @param modifiers Current resize modifiers.
+   * @return Document-space gesture transform, or nullopt for an invalid resize.
+   */
+  [[nodiscard]] static std::optional<Transform2d> documentFromStartDocumentForPointer(
+      const DragState& state, const Vector2d& deltaDocument, const Vector2d& documentPoint,
+      MouseModifiers modifiers);
+
   /**
    * Convert one participant's document-space gesture into its parent-local transform.
    *
@@ -306,6 +324,17 @@ private:
    */
   [[nodiscard]] static std::optional<Transform2d> parentFromEntityAfterDocumentGesture(
       const PerElementDrag& participant, const Transform2d& documentFromStartDocument);
+
+  /**
+   * Convert the shared gesture for every selected participant before any mutation is queued.
+   *
+   * @param state Selected participants captured at gesture start.
+   * @param documentFromStartDocument Shared document-space gesture transform.
+   * @return Parent-local transforms for all participants, or nullopt when any conversion fails.
+   */
+  [[nodiscard]] static std::optional<ParentFromEntityTransforms>
+  parentFromEntityTransformsAfterDocumentGesture(const DragState& state,
+                                                 const Transform2d& documentFromStartDocument);
 
   /// Active marquee drag. Records the start point (the document
   /// position of the `onMouseDown` that hit empty space), the

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -499,6 +499,16 @@ TEST(EditorShellInternalTest, LateSamplePickerActionsRequestAHostFollowupFrame) 
                                                              /*newDocument=*/true));
 }
 
+TEST(EditorShellInternalTest, PendingSamplePresentationOwnsTheRenderWorker) {
+  EXPECT_FALSE(internal::ShouldAdvanceSampleThumbnails(/*showSamplePicker=*/false,
+                                                       /*samplePresentationPending=*/false));
+  EXPECT_TRUE(internal::ShouldAdvanceSampleThumbnails(/*showSamplePicker=*/true,
+                                                      /*samplePresentationPending=*/false));
+  EXPECT_FALSE(internal::ShouldAdvanceSampleThumbnails(/*showSamplePicker=*/true,
+                                                       /*samplePresentationPending=*/true))
+      << "A selected sample's first document render must not race a carousel thumbnail.";
+}
+
 TEST(EditorShellInternalTest, BusyDeferredRenderWaitsForWorkerCompletionInsteadOfSpinning) {
   EXPECT_EQ(internal::DeferredRenderActionForState(
                 /*hasDocument=*/true, /*penDragFlushed=*/false, /*rendererBusy=*/true),

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -69,6 +69,22 @@ constexpr std::string_view kTransformedAncestorSvg =
       </g>
     </svg>)svg";
 
+constexpr std::string_view kSmallScaleAncestorSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+      <g transform="scale(0.00001)">
+        <rect id="target" x="1000000" y="1000000" width="2000000" height="1000000"
+              fill="red"/>
+      </g>
+    </svg>)svg";
+
+constexpr std::string_view kSingularExtraAncestorSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+      <rect id="primary" x="10" y="10" width="20" height="20" fill="red"/>
+      <g transform="scale(0)">
+        <rect id="singular" x="1000000" y="1000000" width="20" height="20" fill="blue"/>
+      </g>
+    </svg>)svg";
+
 constexpr std::string_view kDifferentlyTransformedParentsSvg =
     R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
       <g transform="rotate(10) translate(40, 20)">
@@ -999,6 +1015,24 @@ TEST_F(SelectToolTest, DragInsideTransformedAncestorTranslatesInDocumentSpace) {
   EXPECT_THAT(after.bottomRight - before.bottomRight, Vector2NearExact(48.0, 24.0));
 }
 
+TEST_F(SelectToolTest, DragInsideSmallScaleAncestorTranslatesInDocumentSpace) {
+  loadSvg(kSmallScaleAncestorSvg);
+  app.setSelection(elementById("#target"));
+
+  const Box2d before = worldBoundsOf("#target");
+  const Vector2d start = (before.topLeft + before.bottomRight) * 0.5;
+  const Vector2d dragDeltaDoc(10.0, 5.0);
+
+  tool.onMouseDown(app, start, MouseModifiers{});
+  tool.onMouseMove(app, start + dragDeltaDoc, /*buttonHeld=*/true);
+  ASSERT_THAT(app.flushFrame(), testing::IsTrue())
+      << "An invertible small-scale parent must not discard the drag mutation";
+
+  const Box2d after = worldBoundsOf("#target");
+  EXPECT_THAT(after.topLeft - before.topLeft, Vector2NearExact(10.0, 5.0));
+  EXPECT_THAT(after.bottomRight - before.bottomRight, Vector2NearExact(10.0, 5.0));
+}
+
 TEST_F(SelectToolTest, MultiSelectDragUsesEachParticipantsTransformedParent) {
   loadSvg(kDifferentlyTransformedParentsSvg);
   app.setSelection(std::vector<svg::SVGElement>{elementById("#first"), elementById("#second")});
@@ -1025,6 +1059,34 @@ TEST_F(SelectToolTest, MultiSelectDragUsesEachParticipantsTransformedParent) {
               Vector2NearExact(35.0, 18.0));
   EXPECT_THAT(worldBoundsOf("#second").topLeft - secondBoundsBefore.topLeft,
               Vector2NearExact(35.0, 18.0));
+}
+
+TEST_F(SelectToolTest, SingularExtraLeavesMultiSelectDomAndPreviewAtPriorTransform) {
+  loadSvg(kSingularExtraAncestorSvg);
+  app.setSelection(std::vector<svg::SVGElement>{elementById("#primary"), elementById("#singular")});
+
+  const Transform2d primaryBefore = transformOf("#primary");
+  const Transform2d singularBefore = transformOf("#singular");
+  const Vector2d start(20.0, 20.0);
+
+  tool.onMouseDown(app, start, MouseModifiers{});
+  ASSERT_THAT(tool.isDragging(), testing::IsTrue());
+  const std::optional<SelectTool::ActiveDragPreview> activeBefore = tool.activeDragPreview();
+  const std::optional<SelectTool::ActiveDragPreview> committedBefore =
+      tool.documentDragPreview(app);
+  ASSERT_THAT(activeBefore, testing::Optional(testing::_));
+  ASSERT_THAT(committedBefore, testing::Optional(testing::_));
+
+  tool.onMouseMove(app, start + Vector2d(10.0, 5.0), /*buttonHeld=*/true);
+
+  EXPECT_THAT(app.document().hasPendingMutations(), testing::IsFalse());
+  EXPECT_THAT(transformOf("#primary"), TransformEq(primaryBefore));
+  EXPECT_THAT(transformOf("#singular"), TransformEq(singularBefore));
+  EXPECT_THAT(tool.activeDragPreview()->translation, Vector2NearExact(0.0, 0.0));
+  EXPECT_THAT(tool.activeDragPreview()->documentFromCachedDocument, TransformEq(Transform2d()));
+  EXPECT_THAT(tool.documentDragPreview(app)->translation, Vector2NearExact(0.0, 0.0));
+  EXPECT_THAT(tool.documentDragPreview(app)->documentFromCachedDocument,
+              TransformEq(Transform2d()));
 }
 
 TEST_F(SelectToolTest, MultiSelectDragPreservesExtraElementTransforms) {

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -62,6 +62,23 @@ constexpr std::string_view kResizeRectSvg =
          <rect id="target" x="20" y="20" width="40" height="20" fill="red"/>
        </svg>)";
 
+constexpr std::string_view kTransformedAncestorSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+      <g transform="rotate(10) translate(100, 10)">
+        <rect id="target" x="10" y="10" width="80" height="40" fill="red"/>
+      </g>
+    </svg>)svg";
+
+constexpr std::string_view kDifferentlyTransformedParentsSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+      <g transform="rotate(10) translate(40, 20)">
+        <rect id="first" x="10" y="10" width="40" height="30" fill="red"/>
+      </g>
+      <g transform="scale(1.5, 0.75) translate(180, 50)">
+        <rect id="second" x="10" y="10" width="40" height="30" fill="blue"/>
+      </g>
+    </svg>)svg";
+
 constexpr std::string_view kRotateRingNeighborSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
          <rect id="target" x="10" y="10" width="20" height="20" fill="red"/>
@@ -96,6 +113,10 @@ protected:
     auto element = app.document().document().querySelector(id);
     EXPECT_TRUE(element.has_value());
     return element->cast<svg::SVGGraphicsElement>().transform();
+  }
+
+  Transform2d documentFromElementOf(std::string_view id) {
+    return elementById(id).cast<svg::SVGGraphicsElement>().elementFromWorld();
   }
 
   std::vector<std::string> selectedElementIds() {
@@ -960,6 +981,52 @@ TEST_F(SelectToolTest, DragAfterScaleTranslatesInDocumentSpace) {
               TransformIs(2.0, 0.0, 0.0, 2.0, r1Start.data[4] + 30.0, r1Start.data[5] + 15.0));
 }
 
+TEST_F(SelectToolTest, DragInsideTransformedAncestorTranslatesInDocumentSpace) {
+  loadSvg(kTransformedAncestorSvg);
+  app.setSelection(elementById("#target"));
+
+  const Box2d before = worldBoundsOf("#target");
+  const Vector2d start = (before.topLeft + before.bottomRight) * 0.5;
+  const Vector2d dragDeltaDoc(48.0, 24.0);
+
+  tool.onMouseDown(app, start, MouseModifiers{});
+  tool.onMouseMove(app, start + dragDeltaDoc, /*buttonHeld=*/true);
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d after = worldBoundsOf("#target");
+  EXPECT_THAT(after.topLeft - before.topLeft, Vector2NearExact(48.0, 24.0))
+      << "a document-space pointer drag must not be rotated again by the ancestor transform";
+  EXPECT_THAT(after.bottomRight - before.bottomRight, Vector2NearExact(48.0, 24.0));
+}
+
+TEST_F(SelectToolTest, MultiSelectDragUsesEachParticipantsTransformedParent) {
+  loadSvg(kDifferentlyTransformedParentsSvg);
+  app.setSelection(std::vector<svg::SVGElement>{elementById("#first"), elementById("#second")});
+
+  const Transform2d documentFromFirstBefore = documentFromElementOf("#first");
+  const Transform2d documentFromSecondBefore = documentFromElementOf("#second");
+  const Box2d firstBoundsBefore = worldBoundsOf("#first");
+  const Box2d secondBoundsBefore = worldBoundsOf("#second");
+  const Vector2d start = (firstBoundsBefore.topLeft + firstBoundsBefore.bottomRight) * 0.5;
+  const Vector2d dragDeltaDoc(35.0, 18.0);
+
+  tool.onMouseDown(app, start, MouseModifiers{});
+  ASSERT_TRUE(tool.isDragging());
+  tool.onMouseMove(app, start + dragDeltaDoc, /*buttonHeld=*/true);
+  tool.onMouseUp(app, start + dragDeltaDoc);
+  ASSERT_TRUE(app.flushFrame());
+
+  const Transform2d dragDocumentFromDocument = Transform2d::Translate(dragDeltaDoc);
+  EXPECT_THAT(documentFromElementOf("#first"),
+              TransformEq(documentFromFirstBefore * dragDocumentFromDocument));
+  EXPECT_THAT(documentFromElementOf("#second"),
+              TransformEq(documentFromSecondBefore * dragDocumentFromDocument));
+  EXPECT_THAT(worldBoundsOf("#first").topLeft - firstBoundsBefore.topLeft,
+              Vector2NearExact(35.0, 18.0));
+  EXPECT_THAT(worldBoundsOf("#second").topLeft - secondBoundsBefore.topLeft,
+              Vector2NearExact(35.0, 18.0));
+}
+
 TEST_F(SelectToolTest, MultiSelectDragPreservesExtraElementTransforms) {
   // Give r2 a prior transform so we can verify its start transform is
   // captured and delta is composed relative to the right starting point.
@@ -1392,6 +1459,37 @@ TEST_F(SelectToolTest, CornerHandleResizesSelectionFromOppositeCorner) {
   EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Resize element");
 }
 
+TEST_F(SelectToolTest, CornerHandleResizeInsideTransformedAncestorUsesDocumentSpace) {
+  loadSvg(kTransformedAncestorSvg);
+  app.setSelection(elementById("#target"));
+
+  const Transform2d documentFromElementBefore = documentFromElementOf("#target");
+  const Box2d boundsBefore = worldBoundsOf("#target");
+  const Vector2d anchoredCorner = boundsBefore.topLeft;
+  const Vector2d grabbedCorner = boundsBefore.bottomRight;
+  const Vector2d resizeDeltaDoc(30.0, 15.0);
+
+  tool.onMouseDown(app, grabbedCorner, MouseModifiers{});
+  tool.onMouseMove(app, grabbedCorner + resizeDeltaDoc, /*buttonHeld=*/true);
+  const auto resizeGesture = tool.activeGesturePreview();
+  ASSERT_TRUE(resizeGesture.has_value());
+  ASSERT_EQ(resizeGesture->kind, SelectTool::ActiveGestureKind::Resize);
+  tool.onMouseUp(app, grabbedCorner + resizeDeltaDoc);
+  ASSERT_TRUE(app.flushFrame());
+
+  const double scaleX = (boundsBefore.width() + resizeDeltaDoc.x) / boundsBefore.width();
+  const double scaleY = (boundsBefore.height() + resizeDeltaDoc.y) / boundsBefore.height();
+  const Transform2d resizedDocumentFromDocument =
+      TransformDocumentAroundPoint(anchoredCorner, Transform2d::Scale(scaleX, scaleY));
+  EXPECT_THAT(documentFromElementOf("#target"),
+              TransformEq(documentFromElementBefore * resizedDocumentFromDocument));
+
+  const Box2d boundsAfter = worldBoundsOf("#target");
+  EXPECT_THAT(boundsAfter.topLeft, Vector2NearExact(anchoredCorner.x, anchoredCorner.y));
+  EXPECT_THAT(boundsAfter.bottomRight, Vector2NearExact(grabbedCorner.x + resizeDeltaDoc.x,
+                                                        grabbedCorner.y + resizeDeltaDoc.y));
+}
+
 TEST_F(SelectToolTest, CornerHandleResizesTextSelection) {
   constexpr std::string_view kTextSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
@@ -1685,6 +1783,31 @@ TEST_F(SelectToolTest, RotateZoneRotatesAroundSelectionCenter) {
   EXPECT_THAT(transform, TransformIs(0.0, 1.0, -1.0, 0.0, 40.0, 0.0));
   ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
   EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Rotate element");
+}
+
+TEST_F(SelectToolTest, RotateInsideTransformedAncestorUsesDocumentSpace) {
+  loadSvg(kTransformedAncestorSvg);
+  app.setSelection(elementById("#target"));
+
+  const Transform2d documentFromElementBefore = documentFromElementOf("#target");
+  const Box2d boundsBefore = worldBoundsOf("#target");
+  const Vector2d center = (boundsBefore.topLeft + boundsBefore.bottomRight) * 0.5;
+  const Vector2d topRight(boundsBefore.bottomRight.x, boundsBefore.topLeft.y);
+  const Vector2d rotateStart = topRight + Vector2d(14.0, -10.0);
+  const Transform2d rotatedDocumentFromDocument =
+      TransformDocumentAroundPoint(center, Transform2d::Rotate(MathConstants<double>::kHalfPi));
+  const Vector2d rotateEnd = rotatedDocumentFromDocument.transformPosition(rotateStart);
+
+  tool.onMouseDown(app, rotateStart, MouseModifiers{});
+  tool.onMouseMove(app, rotateEnd, /*buttonHeld=*/true);
+  const auto rotateGesture = tool.activeGesturePreview();
+  ASSERT_TRUE(rotateGesture.has_value());
+  ASSERT_EQ(rotateGesture->kind, SelectTool::ActiveGestureKind::Rotate);
+  tool.onMouseUp(app, rotateEnd);
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_THAT(documentFromElementOf("#target"),
+              TransformEq(documentFromElementBefore * rotatedDocumentFromDocument));
 }
 
 TEST_F(SelectToolTest, ActiveRotationBoundsPreviewClearsOnMouseUp) {

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -56,6 +56,8 @@ declare global {
       pointerY: number;
     };
     __donnerSampleThumbnailStats?: {
+      publishedAtMs?: number;
+      publicationGeneration?: number;
       requested: number;
       started: number;
       completed: number;
@@ -416,6 +418,8 @@ interface WorkerHealth {
   gpuWaitTimeoutMs: number;
   publishReason: string;
   sampleThumbnail: Window["__donnerSampleThumbnailStats"] | null;
+  sampleThumbnailPublishedAtMs: number;
+  sampleThumbnailPublicationGeneration: number;
   frameLoop: FrameLoopStats | null;
   interaction: Window["__donnerInteractionStats"] | null;
 }
@@ -431,6 +435,9 @@ async function readWorkerHealth(page: Page): Promise<WorkerHealth> {
     gpuWaitTimeoutMs: window.__donnerWorkerStats?.gpuWaitTimeoutMs ?? -1,
     publishReason: window.__donnerWorkerStats?.publishReason ?? "unpublished",
     sampleThumbnail: window.__donnerSampleThumbnailStats ?? null,
+    sampleThumbnailPublishedAtMs: window.__donnerSampleThumbnailStats?.publishedAtMs ?? -1,
+    sampleThumbnailPublicationGeneration: window.__donnerSampleThumbnailStats?.publicationGeneration
+      ?? -1,
     frameLoop: window.__donnerFrameLoopStats ?? null,
     interaction: window.__donnerInteractionStats ?? null,
   }));

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -4,11 +4,11 @@ import {
   type CssRegion,
   isSplashCaptureUsable,
   type PixelBounds,
-  readEditorBackgroundCoverage,
   readCssPngPixelDifferenceStats,
+  readEditorBackgroundCoverage,
+  readEditorPixelBounds,
   readEditorPixelBoundsFromPng,
   readEditorResizePixelBounds,
-  readEditorPixelBounds,
   readElementColorStats,
   readPngPixelDifferenceStats,
   readSplashCompositeFrameStats,
@@ -54,6 +54,16 @@ declare global {
       workerBusy: boolean;
       pointerX: number;
       pointerY: number;
+    };
+    __donnerSampleThumbnailStats?: {
+      requested: number;
+      started: number;
+      completed: number;
+      rendered: number;
+      ready: number;
+      pending: boolean;
+      active: boolean;
+      resultReady: boolean;
     };
     __donnerFrameLoopStats?: FrameLoopStats;
     __donnerOverlayStats?: {
@@ -405,6 +415,9 @@ interface WorkerHealth {
   gpuWaitTimeoutSite: string;
   gpuWaitTimeoutMs: number;
   publishReason: string;
+  sampleThumbnail: Window["__donnerSampleThumbnailStats"] | null;
+  frameLoop: FrameLoopStats | null;
+  interaction: Window["__donnerInteractionStats"] | null;
 }
 
 // `unpublished` and -1 distinguish "the worker never published stats at all"
@@ -417,6 +430,9 @@ async function readWorkerHealth(page: Page): Promise<WorkerHealth> {
     gpuWaitTimeoutSite: window.__donnerWorkerStats?.gpuWaitTimeoutSite ?? "unpublished",
     gpuWaitTimeoutMs: window.__donnerWorkerStats?.gpuWaitTimeoutMs ?? -1,
     publishReason: window.__donnerWorkerStats?.publishReason ?? "unpublished",
+    sampleThumbnail: window.__donnerSampleThumbnailStats ?? null,
+    frameLoop: window.__donnerFrameLoopStats ?? null,
+    interaction: window.__donnerInteractionStats ?? null,
   }));
 }
 
@@ -628,7 +644,10 @@ async function openBasicShapes(page: Page): Promise<{
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults > beforeSampleResults,
-    { message: "Basic Shapes must have its own document render before capture", timeout: scaledMs(5_000) },
+    {
+      message: "Basic Shapes must have its own document render before capture",
+      timeout: scaledMs(5_000),
+    },
   );
   await waitForBrowserComposite(page);
 
@@ -841,7 +860,10 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults > beforeCompositorResults,
-    { message: "Compositor Tile Overlay must rasterize a fresh document render", timeout: scaledMs(2_000) },
+    {
+      message: "Compositor Tile Overlay must rasterize a fresh document render",
+      timeout: scaledMs(2_000),
+    },
   );
   await waitForBrowserComposite(page);
   const compositorOverlay = await page.screenshot({ clip: documentClip });
@@ -921,7 +943,10 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults > beforeGeometryResults,
-    { message: "Geometry Debug Overlay must schedule a freshly rasterized document render", timeout: scaledMs(2_000) },
+    {
+      message: "Geometry Debug Overlay must schedule a freshly rasterized document render",
+      timeout: scaledMs(2_000),
+    },
   );
   await waitForBrowserComposite(page);
   const geometryOverlay = await page.screenshot({ clip: documentClip });
@@ -933,12 +958,17 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
     geometryOverlay.equals(geometryBaseline),
     "Geometry Debug Overlay was checked and accepted, but contributed no visible canvas pixels",
   ).toBe(false);
-  const edgeDifference = readCssPngPixelDifferenceStats(geometryBaseline, geometryOverlay, documentClip, {
-    x: sharedTriangleEdge.x - 3,
-    y: sharedTriangleEdge.y - 3,
-    width: 7,
-    height: 7,
-  });
+  const edgeDifference = readCssPngPixelDifferenceStats(
+    geometryBaseline,
+    geometryOverlay,
+    documentClip,
+    {
+      x: sharedTriangleEdge.x - 3,
+      y: sharedTriangleEdge.y - 3,
+      width: 7,
+      height: 7,
+    },
+  );
   expect(
     edgeDifference.changedPixels,
     "Geometry Debug Overlay must expose the shared edge from the actual Slug triangles",
@@ -948,10 +978,10 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
     geometryOverlay,
     documentClip,
     {
-    x: dilatedOuterTriangleEdge.x - 4,
-    y: dilatedOuterTriangleEdge.y - 4,
-    width: 9,
-    height: 9,
+      x: dilatedOuterTriangleEdge.x - 4,
+      y: dilatedOuterTriangleEdge.y - 4,
+      width: 9,
+      height: 9,
     },
   );
   expect(
@@ -963,10 +993,10 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
     geometryOverlay,
     documentClip,
     {
-    x: untouchedBlueInterior.x - 6,
-    y: untouchedBlueInterior.y - 6,
-    width: 13,
-    height: 13,
+      x: untouchedBlueInterior.x - 6,
+      y: untouchedBlueInterior.y - 6,
+      width: 13,
+      height: 13,
     },
   );
   expect(
@@ -976,10 +1006,7 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
   expect(failures).toEqual([]);
 });
 
-test("Firefox keeps the dragged shape and its selection outline in every drag frame", async ({
-  browserName,
-  page,
-}) => {
+test("Firefox keeps the dragged shape and its selection outline in every drag frame", async ({ browserName, page }) => {
   // The single-canvas replacement removed the two-surface epoch handoff that used to let a drag
   // frame show the shape at one position and its outline at another. What
   // survives is the user-visible claim: every frame the drag produces shows the
@@ -1154,7 +1181,10 @@ test("Firefox keeps the dragged shape and its selection outline in every drag fr
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults === resultsDuringDrag + 1,
-    { message: "expected the pointer release to commit exactly one document render", timeout: scaledMs(2_000) },
+    {
+      message: "expected the pointer release to commit exactly one document render",
+      timeout: scaledMs(2_000),
+    },
   );
   const centerX = (bounds: PixelBounds) => (bounds.minX + bounds.maxX) * 0.5;
   const centerY = (bounds: PixelBounds) => (bounds.minY + bounds.maxY) * 0.5;
@@ -1180,10 +1210,7 @@ test("Firefox keeps the dragged shape and its selection outline in every drag fr
   expect(failures).toEqual([]);
 });
 
-test("Firefox never exposes the checkerboard while dragging a Splash letter", async ({
-  browserName,
-  page,
-}) => {
+test("Firefox never exposes the checkerboard while dragging a Splash letter", async ({ browserName, page }) => {
   test.skip(browserName !== "firefox", "Firefox Geode regression");
   const failures = await openEditor(page);
   // Open through the shared helper so the sample's first document render has to
@@ -1475,7 +1502,10 @@ test("Firefox never exposes the checkerboard while dragging a Splash letter", as
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults === resultsDuringDrag + 1,
-    { message: "expected the pointer release to commit exactly one Splash document render", timeout: scaledMs(2_000) },
+    {
+      message: "expected the pointer release to commit exactly one Splash document render",
+      timeout: scaledMs(2_000),
+    },
   );
   expect(failures).toEqual([]);
 });
@@ -1498,7 +1528,10 @@ test("WebKit Geode survives a burst of drag wakeups without fatal errors", async
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults > beforeSample,
-    { message: "expected Basic Shapes to finish presenting before the WebKit drag burst", timeout: scaledMs(2_000) },
+    {
+      message: "expected Basic Shapes to finish presenting before the WebKit drag burst",
+      timeout: scaledMs(2_000),
+    },
   );
 
   const dragStart = {
@@ -1518,7 +1551,10 @@ test("WebKit Geode survives a burst of drag wakeups without fatal errors", async
   await expectWorkerResultsToReach(
     page,
     (completedResults) => completedResults > beforeDrag,
-    { message: "expected WebKit to complete a render after the drag wakeup burst", timeout: scaledMs(2_000) },
+    {
+      message: "expected WebKit to complete a render after the drag wakeup burst",
+      timeout: scaledMs(2_000),
+    },
   );
   expect(failures).toEqual([]);
 });
@@ -1591,6 +1627,7 @@ async function openDonnerSplash(page: Page): Promise<{
     (completedResults) => completedResults > beforeSampleResults,
     { message: "Donner Splash must produce a document render", timeout: scaledMs(5_000) },
   );
+  await waitForBrowserComposite(page);
   return { editorBounds };
 }
 
@@ -1882,7 +1919,6 @@ test("browser trackpad pinch matches the desktop zoom identity", async ({ page }
   expect(failures).toEqual([]);
 });
 
-
 // Reads the main-loop frame gate probe published by donner/editor/main.cc.
 async function readFrameLoopStats(page: Page): Promise<FrameLoopStats> {
   const stats = await page.evaluate(() => window.__donnerFrameLoopStats);
@@ -1955,8 +1991,8 @@ test("a gesture storm runs frames only while the gesture is live", async ({ page
   const afterStormDocument = await readDocumentPresentationState(page);
   const inputFrames = afterStorm.inputTriggeredFrames - before.inputTriggeredFrames;
   const stormFrames = afterStorm.renderedFrames - before.renderedFrames;
-  const detail = `frames=${stormFrames} input=${inputFrames}` +
-    ` document=${beforeDocument.completedResults}->${afterStormDocument.completedResults}`;
+  const detail = `frames=${stormFrames} input=${inputFrames}`
+    + ` document=${beforeDocument.completedResults}->${afterStormDocument.completedResults}`;
 
   // The document advanced across the storm, and the frames that carried it were the ones the storm
   // asked for. Every presented frame is a full UI frame in the single-canvas architecture, so the

--- a/donner/editor/wasm/tests/composited-drag-invariants.spec.ts
+++ b/donner/editor/wasm/tests/composited-drag-invariants.spec.ts
@@ -135,23 +135,40 @@ async function openDonnerSplash(page: Page): Promise<{ editorBounds: Rect; docum
   if (editorBounds === null) {
     throw new Error("editor canvas is missing");
   }
+  const beforeSampleResults = await page.evaluate(
+    () =>
+      (window as unknown as { __donnerWorkerStats?: { completedResults?: number } })
+        .__donnerWorkerStats?.completedResults ?? 0,
+  );
   await page.mouse.click(editorBounds.x + editorBounds.width * 0.24, editorBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "donner-splash");
   await expect(editorCanvas).toBeVisible();
   await expect
     .poll(
       () =>
-        page.evaluate(() =>
-          (window as unknown as { __donnerLayerThumbnailStats?: { rowCount?: number } })
-            .__donnerLayerThumbnailStats?.rowCount ?? 0
-        ),
+        page.evaluate((before) => {
+          const diagnostics = window as unknown as {
+            __donnerWorkerStats?: { completedResults?: number };
+            __donnerSampleThumbnailStats?: unknown;
+            __donnerFrameLoopStats?: unknown;
+            __donnerInteractionStats?: unknown;
+          };
+          const worker = diagnostics.__donnerWorkerStats ?? null;
+          return {
+            reached: (worker?.completedResults ?? 0) > before,
+            worker,
+            sampleThumbnail: diagnostics.__donnerSampleThumbnailStats ?? null,
+            frameLoop: diagnostics.__donnerFrameLoopStats ?? null,
+            interaction: diagnostics.__donnerInteractionStats ?? null,
+          };
+        }, beforeSampleResults),
       {
         message: "Donner Splash must become the editor's live document",
         timeout: scaledMs(20_000),
         intervals: [16, 25, 50, 100],
       },
     )
-    .toBeGreaterThan(0);
+    .toEqual(expect.objectContaining({ reached: true }));
   const viewport = await readSettledViewportStats(page);
   await expect
     .poll(() => readDocumentArtWidth(page, visibleDocumentRegion(viewport)), {
@@ -748,7 +765,9 @@ test.describe("dragRegressions classifier (pure)", () => {
     for (let i = 0; i < 18; ++i) {
       const t = 60 + i * 30;
       const laggedT = t - 60;
-      const lagged = laggedT < 300 ? 100 + (laggedT / 10) * 3 : 100 + 90 - ((laggedT - 300) / 10) * 3;
+      const lagged = laggedT < 300
+        ? 100 + (laggedT / 10) * 3
+        : 100 + 90 - ((laggedT - 300) / 10) * 3;
       samples.push(sampleAt(t, lagged));
     }
     expect(dragRegressions(samples, trace)).toEqual([]);
@@ -765,7 +784,9 @@ test.describe("dragRegressions classifier (pure)", () => {
     for (let i = 0; i < 36; ++i) {
       const t = 300 + i * 30;
       const laggedT = t - 300;
-      const lagged = laggedT < 600 ? 100 + (laggedT / 10) * 3 : 100 + 180 - ((laggedT - 600) / 10) * 3;
+      const lagged = laggedT < 600
+        ? 100 + (laggedT / 10) * 3
+        : 100 + 180 - ((laggedT - 600) / 10) * 3;
       samples.push(sampleAt(t, lagged));
     }
     expect(dragRegressions(samples, trace, 1.0, 2.0, 600).length).toBe(0);
@@ -785,7 +806,9 @@ test.describe("dragRegressions classifier (pure)", () => {
     for (let i = 0; i < 30; ++i) {
       const t = 350 + i * 30;
       const laggedT = t - 350;
-      const lagged = laggedT < 600 ? 100 + (laggedT / 10) * 3 : 100 + 180 - ((laggedT - 600) / 10) * 3;
+      const lagged = laggedT < 600
+        ? 100 + (laggedT / 10) * 3
+        : 100 + 180 - ((laggedT - 600) / 10) * 3;
       samples.push(sampleAt(t, lagged));
     }
     expect(dragRegressions(samples, trace, 1.0, 2.0, 600)).toEqual([]);
@@ -801,7 +824,9 @@ test.describe("dragRegressions classifier (pure)", () => {
     for (let i = 0; i < 30; ++i) {
       const t = 60 + i * 30;
       const laggedT = t - 60;
-      const lagged = laggedT < 300 ? 100 + (laggedT / 10) * 3 : 100 + 90 - ((laggedT - 300) / 10) * 3;
+      const lagged = laggedT < 300
+        ? 100 + (laggedT / 10) * 3
+        : 100 + 90 - ((laggedT - 300) / 10) * 3;
       samples.push(sampleAt(t, Math.max(lagged, 40)));
     }
     // Sample 29 (t=930) re-presents a position 20 px to the RIGHT of the

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -265,7 +265,17 @@ test("the presentation regression gates print the worker health they wait on", (
     /async function readWorkerHealth\([\s\S]*?\n\}/,
   );
   assert.ok(health, "expected a worker health snapshot helper");
-  for (const field of ["deviceLost", "gpuWaitTimeoutSite", "gpuWaitTimeoutMs", "publishReason"]) {
+  for (
+    const field of [
+      "deviceLost",
+      "gpuWaitTimeoutSite",
+      "gpuWaitTimeoutMs",
+      "publishReason",
+      "sampleThumbnail",
+      "frameLoop",
+      "interaction",
+    ]
+  ) {
     assert.match(health[0], new RegExp(`${field}:`), `health snapshot must carry ${field}`);
   }
 

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -272,6 +272,8 @@ test("the presentation regression gates print the worker health they wait on", (
       "gpuWaitTimeoutMs",
       "publishReason",
       "sampleThumbnail",
+      "sampleThumbnailPublishedAtMs",
+      "sampleThumbnailPublicationGeneration",
       "frameLoop",
       "interaction",
     ]

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -27,6 +27,10 @@ const presentationRegressionSource = await readFile(
   new URL("./browser-presentation-regression.spec.ts", import.meta.url),
   "utf8",
 );
+const compositedDragSource = await readFile(
+  new URL("./composited-drag-invariants.spec.ts", import.meta.url),
+  "utf8",
+);
 const geodeDeviceSource = await readFile(
   new URL("../../../svg/renderer/geode/GeodeDevice.cc", import.meta.url),
   "utf8",
@@ -288,6 +292,17 @@ test("the presentation regression gates print the worker health they wait on", (
     presentationRegressionSource,
     /\.poll\((?:async )?\(\) => page\.evaluate\(\(\) => window\.__donnerWorkerStats\?\.completedResults/,
   );
+});
+
+test("the composited drag sample gate waits for the document worker, not sidebar thumbnails", () => {
+  const helperStart = compositedDragSource.indexOf("async function openDonnerSplash(");
+  const helperEnd = compositedDragSource.indexOf("* The Donner_D left stem", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "expected the Splash open helper");
+  const helper = compositedDragSource.slice(helperStart, helperEnd);
+
+  assert.match(helper, /__donnerWorkerStats/);
+  assert.match(helper, /\.toEqual\(expect\.objectContaining\(\{ reached: true \}\)\)/);
+  assert.doesNotMatch(helper, /__donnerLayerThumbnailStats/);
 });
 
 test("worker WebGPU startup keeps its browser Promise bridge private and single-purpose", () => {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
+exports_files(["lint.sh"])
+
 refresh_compile_commands(
     name = "refresh_compile_commands",
     targets = "//donner/...",

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import tempfile
 import textwrap
-import time
 import unittest
 
 from python.runfiles import runfiles
@@ -62,13 +61,12 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         self.assertIsNotNone(match, "heartbeat wrapper heredoc not found")
         return textwrap.dedent(match.group("body"))
 
-    def _run_script(self, text, args, env=None, timeout=5):
+    def _run_script(self, text, args, env=None, timeout=10):
         with tempfile.TemporaryDirectory() as temp_dir:
             script = Path(temp_dir) / "fixture.sh"
             script.write_text(text)
             script.chmod(0o755)
-            started = time.monotonic()
-            result = subprocess.run(
+            return subprocess.run(
                 [str(script), *args],
                 check=False,
                 capture_output=True,
@@ -76,18 +74,38 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 env=env,
                 timeout=timeout,
             )
-            return result, time.monotonic() - started
 
     def _inject_pre_publish_signal(self, script, sleep_command, hook):
         """Signal the watcher after sleep forks but before it publishes the PID."""
         self.assertEqual(1, script.count(sleep_command))
-        return script.replace(sleep_command, f'{sleep_command}\n"{hook}"', 1)
+        return script.replace(sleep_command, f'{sleep_command}\n"{hook}" "$!"', 1)
 
     def _write_parent_signal_hook(self, directory):
         hook = directory / "signal-parent.sh"
-        hook.write_text('#!/bin/sh\nprintf x >> "$0.count"\nkill -TERM "$PPID"\n')
+        release = Path(f"{hook}.release")
+        os.mkfifo(release)
+        hook.write_text(
+            '#!/bin/sh\nprintf x >> "$0.count"\nprintf "%s\\n" "$1" >> "$0.pids"\n'
+            'printf "go\\n" > "$0.release"\nkill -TERM "$PPID"\n'
+        )
         hook.chmod(0o755)
-        return hook, Path(f"{hook}.count")
+        return hook, Path(f"{hook}.count"), Path(f"{hook}.pids"), release
+
+    def _write_blocking_sleep(self, directory):
+        """Install a sleep whose PID stays alive until the watcher explicitly stops it."""
+        fake_bin = directory / "bin"
+        fake_bin.mkdir()
+        fake_sleep = fake_bin / "sleep"
+        fake_sleep.write_text("#!/bin/sh\nexec /bin/sleep 300\n")
+        fake_sleep.chmod(0o755)
+        return fake_bin
+
+    def _assert_sleepers_reaped(self, pid_file, expected_count):
+        pids = [int(pid) for pid in pid_file.read_text().splitlines()]
+        self.assertEqual(expected_count, len(pids))
+        for pid in pids:
+            with self.assertRaises(ProcessLookupError):
+                os.kill(pid, 0)
 
     def test_coverage_does_not_expand_ci_config_twice(self):
         """The coverage command inherits its CI config from the runner rc."""
@@ -251,12 +269,11 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            hook, hook_count = self._write_parent_signal_hook(temp_path)
+            hook, hook_count, hook_pids, hook_release = self._write_parent_signal_hook(temp_path)
             script = self._inject_pre_publish_signal(
                 script, 'sleep "$heartbeat_interval" &', hook
             )
-            fake_bin = Path(temp_dir) / "bin"
-            fake_bin.mkdir()
+            fake_bin = self._write_blocking_sleep(temp_path)
             fake_ps = fake_bin / "ps"
             fake_ps.write_text("#!/bin/sh\nexit 127\n")
             fake_ps.chmod(0o755)
@@ -269,22 +286,26 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
             env["PATH"] = f"{fake_bin}:{env['PATH']}"
 
             for iteration in range(4):
-                started = time.monotonic()
                 result = subprocess.run(
-                    [str(wrapper), str(log), "bash", "-c", "exit 17"],
+                    [
+                        str(wrapper),
+                        str(log),
+                        "bash",
+                        "-c",
+                        'read -r _ < "$1"; exit 17',
+                        "_",
+                        str(hook_release),
+                    ],
                     check=False,
                     capture_output=True,
                     text=True,
                     env=env,
-                    timeout=3,
+                    timeout=10,
                 )
-                elapsed = time.monotonic() - started
 
                 self.assertEqual(17, result.returncode, f"iteration {iteration}: {result.stderr}")
-                self.assertLess(
-                    elapsed, 2.0, f"iteration {iteration}: heartbeat sleeper delayed wrapper exit"
-                )
                 self.assertEqual("x" * (iteration + 1), hook_count.read_text())
+                self._assert_sleepers_reaped(hook_pids, iteration + 1)
 
     def test_coverage_cleanup_is_portable_and_prompt_without_ps(self):
         """Coverage remains portable to macOS and owns its heartbeat sleeper."""
@@ -294,7 +315,7 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            hook, hook_count = self._write_parent_signal_hook(temp_path)
+            hook, hook_count, hook_pids, hook_release = self._write_parent_signal_hook(temp_path)
             functions = self._inject_pre_publish_signal(
                 self.coverage_script.split("\nTARGETS=()", 1)[0],
                 'sleep "$progress_interval" &',
@@ -305,18 +326,17 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
 ps() { return 127; }
 DONNER_COVERAGE_PROGRESS_INTERVAL_SECONDS=5
 export DONNER_COVERAGE_PROGRESS_INTERVAL_SECONDS
-run_quiet_with_progress "fixture" "$1" bash -c 'exit 23'
+run_quiet_with_progress "fixture" "$1" bash -c 'read -r _ < "$1"; exit 23' _ "$2"
 """
             log = str(temp_path / "coverage.log")
+            fake_bin = self._write_blocking_sleep(temp_path)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
             for iteration in range(4):
-                result, elapsed = self._run_script(fixture, [log], timeout=3)
+                result = self._run_script(fixture, [log, str(hook_release)], env=env)
                 self.assertEqual(23, result.returncode, f"iteration {iteration}: {result.stderr}")
-                self.assertLess(
-                    elapsed,
-                    2.0,
-                    f"iteration {iteration}: coverage heartbeat sleeper delayed wrapper exit",
-                )
                 self.assertEqual("x" * (iteration + 1), hook_count.read_text())
+                self._assert_sleepers_reaped(hook_pids, iteration + 1)
 
 
 if __name__ == "__main__":

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -14,7 +14,7 @@
 # Checks enforced (see docs/coding_style.md "Language and Library Features" and
 # build_defs/check_banned_patterns.py): no `long long`, no `std::aligned_storage`,
 # no user-defined literal operators, no hidden Unicode whitespace or typographic
-# punctuation.
+# punctuation, and no method above the local decision-point complexity limit.
 #
 # Usage:
 #   tools/lint.sh                 # lint donner/ and examples/
@@ -45,6 +45,7 @@ collect_sources() {
   find "${find_args[@]}"
 }
 
+lint_explicit_roots=$#
 roots=("$@")
 if [[ ${#roots[@]} -eq 0 ]]; then
   roots=(donner examples)
@@ -70,4 +71,33 @@ if [[ ${#sources[@]} -eq 0 ]]; then
   exit 1
 fi
 
-python3 "${kChecker}" donner "${sources[@]}"
+python3 "${kChecker}" "${sources[@]}"
+
+# CodeFactor evaluates complexity only on changed methods. Mirror that locally without making
+# existing repository debt block every lint run: explicit paths are checked directly, while the
+# default command checks C++ files changed from the branch's upstream plus working-tree additions.
+complexity_sources=()
+if [[ ${lint_explicit_roots} -gt 0 ]]; then
+  complexity_sources=("${sources[@]}")
+elif lint_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null); then
+  while IFS= read -r path; do
+    if [[ -f "${path}" ]]; then
+      complexity_sources+=("${path}")
+    fi
+  done < <(
+    {
+      git diff --name-only --diff-filter=ACMR "${lint_upstream}"...HEAD -- \
+        '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
+      git diff --name-only --diff-filter=ACMR HEAD -- '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
+      git ls-files --others --exclude-standard -- '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
+    } | sort -u
+  )
+fi
+
+if [[ ${#complexity_sources[@]} -gt 0 ]]; then
+  complexity_args=(--check-method-complexity)
+  if [[ -n "${lint_upstream:-}" ]]; then
+    complexity_args+=(--complexity-baseline-ref "${lint_upstream}")
+  fi
+  python3 "${kChecker}" "${complexity_args[@]}" "${complexity_sources[@]}"
+fi

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -14,7 +14,8 @@
 # Checks enforced (see docs/coding_style.md "Language and Library Features" and
 # build_defs/check_banned_patterns.py): no `long long`, no `std::aligned_storage`,
 # no user-defined literal operators, no hidden Unicode whitespace or typographic
-# punctuation, and no method above the local decision-point complexity limit.
+# punctuation, and no new or worsened out-of-line method above the local
+# decision-point complexity limit.
 #
 # Usage:
 #   tools/lint.sh                 # lint donner/ and examples/
@@ -74,19 +75,34 @@ fi
 python3 "${kChecker}" "${sources[@]}"
 
 # CodeFactor evaluates complexity only on changed methods. Mirror that locally without making
-# existing repository debt block every lint run: explicit paths are checked directly, while the
-# default command checks C++ files changed from the branch's upstream plus working-tree additions.
+# existing repository debt block every lint run. The target branch can be overridden for stacked
+# work with DONNER_LINT_BASE_REF; GitHub pull-request jobs supply GITHUB_BASE_REF; ordinary local
+# branches compare to origin/main. Never use the feature branch's upstream, because an already
+# pushed regression would then disappear from the next lint run.
+complexity_base_ref="${DONNER_LINT_BASE_REF:-}"
+if [[ -z "${complexity_base_ref}" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  complexity_base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [[ -z "${complexity_base_ref}" ]]; then
+  complexity_base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${complexity_base_ref}^{commit}" >/dev/null; then
+  echo "lint.sh: cannot resolve complexity baseline '${complexity_base_ref}'" >&2
+  echo "lint.sh: fetch the target branch or set DONNER_LINT_BASE_REF to its local ref" >&2
+  exit 1
+fi
+
 complexity_sources=()
 if [[ ${lint_explicit_roots} -gt 0 ]]; then
   complexity_sources=("${sources[@]}")
-elif lint_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null); then
+else
   while IFS= read -r path; do
     if [[ -f "${path}" ]]; then
       complexity_sources+=("${path}")
     fi
   done < <(
     {
-      git diff --name-only --diff-filter=ACMR "${lint_upstream}"...HEAD -- \
+      git diff --name-only --diff-filter=ACMR "${complexity_base_ref}"...HEAD -- \
         '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
       git diff --name-only --diff-filter=ACMR HEAD -- '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
       git ls-files --others --exclude-standard -- '*.cc' '*.cpp' '*.h' '*.hpp' '*.mm'
@@ -95,9 +111,8 @@ elif lint_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream
 fi
 
 if [[ ${#complexity_sources[@]} -gt 0 ]]; then
-  complexity_args=(--check-method-complexity)
-  if [[ -n "${lint_upstream:-}" ]]; then
-    complexity_args+=(--complexity-baseline-ref "${lint_upstream}")
-  fi
-  python3 "${kChecker}" "${complexity_args[@]}" "${complexity_sources[@]}"
+  python3 "${kChecker}" \
+    --check-method-complexity \
+    --complexity-baseline-ref "${complexity_base_ref}" \
+    "${complexity_sources[@]}"
 fi

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -14,8 +14,8 @@
 # Checks enforced (see docs/coding_style.md "Language and Library Features" and
 # build_defs/check_banned_patterns.py): no `long long`, no `std::aligned_storage`,
 # no user-defined literal operators, no hidden Unicode whitespace or typographic
-# punctuation, and no new or worsened out-of-line method above the local
-# decision-point complexity limit.
+# punctuation, and no new or worsened supported out-of-line method definition
+# above the local decision-point complexity limit.
 #
 # Usage:
 #   tools/lint.sh                 # lint donner/ and examples/


### PR DESCRIPTION
Canvas gestures now remain aligned with their overlays when selected elements live beneath transformed ancestors.

- Convert each document-space move, resize, and rotate gesture through the selected element's captured parent-to-document transform before updating its local transform.
- Apply one shared document-space gesture atomically across multi-selections whose elements have different transformed parents.
- Accept invertible parent transforms at small scales when the inverse and resulting local transforms remain finite, and advance the live preview only after every participant can produce a matching DOM transform.
- Preserve the existing fast translation path and source writeback while keeping live and presented drag previews in the same coordinate space.
- Add causal coverage for move, resize, rotate, and mixed-parent multi-selection gestures.
- Extract gesture conversion from mouse-move orchestration and add a target-branch complexity ratchet to the local lint gate.
- Verify heartbeat cleanup by exact sleeper ownership and reaping instead of runner-speed timing.
- Give a selected sample's first document render priority over background carousel thumbnails.
- Wait for the browser composite before pixel baselines and publish fresh thumbnail, frame-loop, and interaction diagnostics for stalled renders.
- Gate composited sample assertions on foreground document-worker completion instead of Layers sidebar thumbnail population.

## Diagnosis

The editor composed a document-space gesture directly into each element's parent-local transform. A transformed ancestor therefore applied the pointer delta a second time: in the lion reproduction, the overlay moved by the requested `(48,24)` while the presented polygon moved by `(43.1032,31.9705)`. Conjugating the gesture through each participant's captured parent transform keeps the DOM, compositor tile, and overlay on the same document-space result. The first implementation also rejected valid small-scale ancestors with a fixed determinant epsilon after advancing the preview. The final guard rejects non-finite or genuinely singular parent transforms, and any non-finite inverse or result, then validates every participant before publishing the preview.

The external complexity check exposed a local verification gap after the first refactor. The local lint command now checks new and worsened supported out-of-line C++ method definitions against the pull request's target branch, distinguishes parameter and cv/ref overloads, and fails closed when the target baseline is unavailable.

The macOS CI failure came from a cleanup regression asserting a fixed two-second wall-clock deadline under concurrent load. The wrapper had reaped its sleeper correctly, but runner scheduling pushed the test beyond that deadline. The replacement fixture uses a deliberately blocking sleeper, records its exact PID at the injected signal boundary, and requires every sleeper to be gone after the wrapper returns.

The Editor WASM browser failure exposed two independent presentation races. A completed worker result does not prove the browser has composited its pixels, so the Splash pinch baseline now waits for the established two-animation-frame composite gate. Separately, frame preparation could restart low-priority carousel work while a newly selected sample was waiting for its first document render. Background thumbnails now yield for that obligation, with a native red-to-green policy test. Lightweight thumbnail telemetry still publishes during the suppressed interval and carries a timestamp and monotonic generation, so a future stall reports current worker, thumbnail, frame-loop, and interaction state.

The follow-up Firefox failure exposed a verification-observable bug. The composited-drag helper had treated Layers sidebar thumbnail rows as proof that the newly selected document rendered, even though that unrelated sidebar state can legitimately remain empty. The helper now snapshots the foreground worker completion count before the sample click and requires a strict post-click increase. It preserves the existing timeout and independent document-pixel assertion while returning the full worker and presentation diagnostics on failure.

## Verification

- `bazel test --test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp //... --test_output=errors` (446 passed, 23 declared platform skips)
- `bazel test //donner/editor/tests:select_tool_tests //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- `bazel test //donner/editor/tests:editor_shell_tests //donner/editor/tests:sample_thumbnail_async_tests --test_output=errors`
- `bazel test //build_defs:check_banned_patterns_tests --test_output=errors`
- `bazel test //tools:ci_runtime_workflow_tests --nocache_test_results --runs_per_test=50 --test_output=errors`
- `npm --prefix donner/editor/wasm/tests run test:selector`
- `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- Exact MCP-driven Geode GL capture of the transformed-ancestor lion drag
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/lint.sh`
- `git diff --check origin/main..HEAD`
