### PR TITLE
Fix shared turnstile workflow resolution

### DIFF
--- a/.github/actions/re-turnstile/action.yml
+++ b/.github/actions/re-turnstile/action.yml
@@ -134,8 +134,10 @@ runs:
               elif all_workflows=$(gh_get "${api}/repos/${repo}/actions/workflows?per_page=100"); then
                 # shellcheck disable=SC2086 # deliberate word splitting into a JSON array
                 wanted=$(printf '%s\n' ${TURNSTILE_POOL_WORKFLOWS} | jq -Rsc 'split("\n") | map(select(length > 0))')
-                workflow_ids=$(printf '%s' "${all_workflows}" | jq -r --argjson wanted "${wanted}" \
-                  '.workflows[]? | . as $w | select([$wanted[] | select($w.path | endswith("/" + .))] | length > 0) | .id' 2>/dev/null)
+                workflow_request=$(printf '%s' "${all_workflows}" | jq -c --argjson wanted "${wanted}" \
+                  '{workflows: (.workflows // []), wanted: $wanted}' 2>/dev/null) || workflow_request=""
+                workflow_ids=$(printf '%s' "${workflow_request}" | \
+                  python3 "${admission}" workflow-ids 2>/dev/null) || workflow_ids=""
               fi
             fi
           fi

--- a/.github/actions/re-turnstile/admission.py
+++ b/.github/actions/re-turnstile/admission.py
@@ -51,6 +51,22 @@ ABSENT = "absent"
 CLEAR = "clear"
 
 
+def workflow_ids(workflows_payload, wanted_names):
+    """Return IDs whose workflow paths end in one of the requested filenames."""
+    wanted = tuple(
+        name for name in wanted_names if isinstance(name, str) and name
+    )
+    matches = []
+    for workflow in workflows_payload.get("workflows") or []:
+        path = workflow.get("path")
+        workflow_id = workflow.get("id")
+        if not isinstance(path, str) or not isinstance(workflow_id, int):
+            continue
+        if any(path.endswith("/" + name) for name in wanted):
+            matches.append(workflow_id)
+    return matches
+
+
 def pool_state(jobs_payload, pool):
     """Reduce one run's jobs payload to how it occupies the pool.
 
@@ -126,6 +142,14 @@ def decide(request):
 
 
 def main():
+    if sys.argv[1:] == ["workflow-ids"]:
+        request = json.load(sys.stdin)
+        for workflow_id in workflow_ids(request, request.get("wanted") or []):
+            print(workflow_id)
+        return 0
+    if len(sys.argv) != 1:
+        return 2
+
     json.dump(decide(json.load(sys.stdin)), sys.stdout)
     sys.stdout.write("\n")
     return 0

--- a/tools/turnstile_admission_tests.py
+++ b/tools/turnstile_admission_tests.py
@@ -200,6 +200,21 @@ class AdmissionTests(unittest.TestCase):
         self.assertEqual(decision["blockers"], ["10 (pending)", "12 (active)"])
 
 
+class WorkflowResolutionTests(unittest.TestCase):
+    def test_matching_pool_workflows_are_resolved_by_filename(self):
+        payload = {
+            "workflows": [
+                {"id": 1413161, "path": ".github/workflows/main.yml"},
+                {"id": 6956149, "path": ".github/workflows/coverage.yml"},
+                {"id": 261869672, "path": ".github/workflows/editor_wasm.yml"},
+            ]
+        }
+        self.assertEqual(
+            admission.workflow_ids(payload, ["main.yml", "coverage.yml"]),
+            [1413161, 6956149],
+        )
+
+
 class TurnstileWiringTests(unittest.TestCase):
     """The rules only help if both lanes actually share one pool."""
 
@@ -267,6 +282,10 @@ class TurnstileWiringTests(unittest.TestCase):
 
     def test_action_defaults_preserve_single_lane_behavior(self):
         self.assertRegex(self.action, r"capacity:\n(?:.*\n)*?\s+default: \"1\"")
+
+    def test_action_uses_tested_workflow_resolution(self):
+        self.assertIn('"${admission}" workflow-ids', self.action)
+        self.assertNotIn('$wanted[] | select($w.path | endswith("/" + .))', self.action)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The shared self-hosted turnstile now resolves every configured pool workflow before evaluating FIFO admission, so eligible runs no longer wait until the safety timeout.

- Move workflow-filename matching into the tested admission module instead of an untested nested jq expression.
- Preserve strict FIFO ordering, shared capacity accounting, two-observation admission, API retry behavior, and the fail-open safety bound.
- Pin both the filename resolver behavior and the composite action's use of that tested path.

## Diagnosis

The jq expression that matched `main.yml` and `coverage.yml` changed its input while evaluating each workflow path, so `.` referred to the path instead of the requested filename. The resolver therefore returned no workflow IDs and every shared-pool turnstile stayed in the metadata-unavailable loop until its 150-minute safety timeout. The admission algorithm itself remained correct.

## Verification

- `bazel test //... --test_output=errors` (449 passed, 20 intentional platform skips)
- `bazel test //tools:turnstile_admission_tests --test_output=errors`
- Live Actions API fixture resolves both configured pool workflow IDs through the repaired helper
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/lint.sh`
- `dprint check .github/actions/re-turnstile/action.yml .github/actions/re-turnstile/admission.py tools/turnstile_admission_tests.py`
- `git diff --check origin/main..HEAD`