### PR TITLE
Harden CI dependency and release provenance

### DIFF
--- a/.github/actions/buildbuddy-cache/action.yml
+++ b/.github/actions/buildbuddy-cache/action.yml
@@ -51,14 +51,13 @@ runs:
         # Never let the key surface in logs, even if a later step prints flags.
         echo "::add-mask::${BUILDBUDDY_API_KEY}"
 
-        # PRs are read-only against the shared cache: they may READ hits but
-        # must never WRITE, so a broken or malicious PR cannot poison the cache
-        # that main relies on. Only trusted main-push / scheduled lanes upload.
+        # Workflow policy must never pass a credential to PR-controlled code.
+        # Keep this guard as a fail-closed backstop for future call sites.
         if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-          upload_local_results="false"
-        else
-          upload_local_results="true"
+          echo "BuildBuddy credentials are disabled for pull requests."
+          exit 1
         fi
+        upload_local_results="true"
 
         fragment="${GITHUB_WORKSPACE}/.buildbuddy.bazelrc"
         {

--- a/.github/workflows/badges.yaml
+++ b/.github/workflows/badges.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update-badges:
     name: Update Badges
@@ -12,11 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install cloc
+        env:
+          CLOC_SHA256: "73570f9da159fab13846038de7c3d8772554117c04117281dcbe6e5c7b988264"
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/tmp"
           wget https://github.com/AlDanial/cloc/releases/download/v1.92/cloc-1.92.tar.gz -O "${GITHUB_WORKSPACE}/tmp/cloc.tar.gz"
+          echo "${CLOC_SHA256}  ${GITHUB_WORKSPACE}/tmp/cloc.tar.gz" | sha256sum --check --strict
           tar xvfz "${GITHUB_WORKSPACE}/tmp/cloc.tar.gz" -C "${GITHUB_WORKSPACE}/tmp"
           echo "${GITHUB_WORKSPACE}/tmp/cloc-1.92" >> $GITHUB_PATH
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, feature/ci-hardening-2026q2]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 # Superseded PR pushes cancel their in-flight CMake run so a rapid push storm
 # does not pile up redundant hosted builds. Non-main branch pushes also cancel
 # stale runs; main pushes stay unique via run_id so every main commit gets CI.
@@ -23,6 +27,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: dup_push
         name: Detect duplicate push (PR already open for this branch)
@@ -116,6 +121,8 @@ jobs:
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # This check queries the Bazel graph, so retry it once when the first
       # attempt fails. Deterministic generator failures fail again on retry;
@@ -142,6 +149,8 @@ jobs:
     # when the Skia CMake lane is restored.
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install build tools
         uses: ./.github/actions/apt-install
@@ -196,6 +205,8 @@ jobs:
     # Keep this paired with the stable Linux job name above.
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install build tools
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         if: matrix.build-mode == 'manual'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,6 +81,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
+      BAZEL_DIFF_SHA256: "eadec6d0ca0991de78bd9e063bfed993a359ed3bc60e507818077c300b6f58e0"
       FULL_COVERAGE_TARGETS: "//donner/base/... //donner/css/... //donner/svg/... //donner/editor/..."
       SMOKE_COVERAGE_TARGETS: "//donner/base/..."
     outputs:
@@ -95,6 +96,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -124,7 +126,11 @@ jobs:
             if curl -fsSL --retry 4 --retry-delay 2 --retry-all-errors \
                 --connect-timeout 15 --max-time 300 -o "$out" "$url" \
                 && [[ -s "$out" ]]; then
-              exit 0
+              if printf '%s  %s\n' "$BAZEL_DIFF_SHA256" "$out" \
+                  | sha256sum --check --status; then
+                exit 0
+              fi
+              echo "bazel-diff digest mismatch for ${BAZEL_DIFF_TAG}; refusing artifact." >&2
             fi
             rm -f "$out"
             if [[ "$delay" -eq 0 ]]; then
@@ -670,6 +676,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Free hosted runner disk
         shell: bash
@@ -721,12 +729,6 @@ jobs:
             libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
             libgl1-mesa-dev libosmesa6-dev
           sudo apt-get clean
-
-      - name: Configure BuildBuddy remote cache
-        uses: ./.github/actions/buildbuddy-cache
-        with:
-          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
-          download-outputs-minimal: "false"
 
       - name: Generate coverage
         shell: bash

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -8,11 +8,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -23,6 +20,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install graphviz
         run: |
@@ -30,9 +29,14 @@ jobs:
           sudo apt-get install graphviz -y
 
       - name: Install Doxygen
+        env:
+          DOXYGEN_SHA256: "0ec2e5b2c3cd82b7106d19cb42d8466450730b8cb7a9e85af712be38bf4523a1"
         run: |
           mkdir -p ${{ github.workspace }}/doxygen
-          curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_15_0/doxygen-1.15.0.linux.bin.tar.gz | tar xz -C ${{ github.workspace }}/doxygen
+          archive="${{ github.workspace }}/doxygen/doxygen.tar.gz"
+          curl -fL https://github.com/doxygen/doxygen/releases/download/Release_1_15_0/doxygen-1.15.0.linux.bin.tar.gz -o "$archive"
+          echo "${DOXYGEN_SHA256}  ${archive}" | sha256sum --check --strict
+          tar xzf "$archive" -C ${{ github.workspace }}/doxygen
           echo "${{ github.workspace }}/doxygen/doxygen-1.15.0/bin" >> $GITHUB_PATH # Add Doxygen to PATH
 
       - name: Generate Doxygen documentation
@@ -47,6 +51,10 @@ jobs:
           # Upload build folder
           path: "./generated-doxygen/html"
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}

--- a/.github/workflows/editor_wasm.yml
+++ b/.github/workflows/editor_wasm.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -101,6 +103,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Download Geode package
         uses: actions/download-artifact@v8

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -99,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/github_hosted_nightly.yml
+++ b/.github/workflows/github_hosted_nightly.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Decide whether nightly build should run
         id: decide
@@ -75,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -94,6 +98,7 @@ jobs:
           cache-save: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - name: Configure BuildBuddy remote cache
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         uses: ./.github/actions/buildbuddy-cache
         with:
           api-key: ${{ secrets.BUILDBUDDY_API_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, feature/ci-hardening-2026q2]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || (github.ref == 'refs/heads/main' && format('push-{0}-{1}', github.workflow, github.run_id) || format('push-{0}-{1}', github.workflow, github.ref)) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
@@ -62,6 +66,7 @@ jobs:
         with:
           # Local complexity lint compares the whole PR diff to its target branch.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache Bazel
         uses: actions/cache@v6
@@ -98,6 +103,8 @@ jobs:
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # This check queries the Bazel graph, so retry it once when the first
       # attempt fails. Deterministic generator failures fail again on retry;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: dup_push
         name: Detect duplicate push (PR already open for this branch)
@@ -229,6 +230,7 @@ jobs:
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
+      BAZEL_DIFF_SHA256: "eadec6d0ca0991de78bd9e063bfed993a359ed3bc60e507818077c300b6f58e0"
     outputs:
       fallback: ${{ steps.determine.outputs.fallback }}
       affected: ${{ steps.determine.outputs.affected }}
@@ -238,6 +240,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -266,7 +269,11 @@ jobs:
             if curl -fsSL --retry 4 --retry-delay 2 --retry-all-errors \
                 --connect-timeout 15 --max-time 300 -o "$out" "$url" \
                 && [[ -s "$out" ]]; then
-              exit 0
+              if printf '%s  %s\n' "$BAZEL_DIFF_SHA256" "$out" \
+                  | sha256sum --check --status; then
+                exit 0
+              fi
+              echo "bazel-diff digest mismatch for ${BAZEL_DIFF_TAG}; refusing artifact." >&2
             fi
             rm -f "$out"
             if [[ "$delay" -eq 0 ]]; then
@@ -493,6 +500,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -510,11 +519,6 @@ jobs:
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Configure BuildBuddy remote cache
-        uses: ./.github/actions/buildbuddy-cache
-        with:
-          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build
         shell: bash
@@ -578,6 +582,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -601,11 +607,6 @@ jobs:
       # instead of only surfacing on a dev box whose default linker isn't lld.
       # See #665. Targets are the minimal set proven to reach every
       # link-order-sensitive library in that fix.
-      - name: Configure BuildBuddy remote cache
-        uses: ./.github/actions/buildbuddy-cache
-        with:
-          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
       - name: Linker canary (non-lld linker support)
         shell: bash
         run: |
@@ -1034,6 +1035,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install clang-tidy
         uses: nick-fields/retry@v4
@@ -1053,11 +1056,6 @@ jobs:
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Configure BuildBuddy remote cache
-        uses: ./.github/actions/buildbuddy-cache
-        with:
-          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build
         shell: bash

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Decide whether nightly perf jobs should run
         id: decide
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,30 @@
 name: Release
 
-# Trigger on when a release is created or changed.
+# Build and publish an immutable artifact set exactly once for each release.
 on:
   release:
-    types: [published, edited]
-  workflow_dispatch:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   linux:
+    if: github.run_attempt == 1
     runs-on: ubuntu-24.04
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify release source
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")" = "$GITHUB_SHA"
 
       - name: Install Clang dependencies
         run: |
@@ -28,20 +42,39 @@ jobs:
       - name: Build Binaries
         run: |
           mkdir release
-          bazelisk build -c opt //donner/svg/tool:donner-svg
+          bazelisk build --lockfile_mode=off -c opt //donner/svg/tool:donner-svg
           cp bazel-bin/donner/svg/tool/donner-svg release/donner-svg_linux_x86_64
+          (cd release && sha256sum donner-svg_linux_x86_64 > donner-svg_linux_x86_64.sha256)
+          {
+            echo "source_commit=${GITHUB_SHA}"
+            echo "release_tag=${RELEASE_TAG}"
+            sha256sum .bazelversion .bazelrc MODULE.bazel third_party/bazel/non_bcr_deps.bzl
+          } > release/donner-svg_linux_x86_64.provenance
 
-      - name: Upload the Binaries
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload immutable build artifact
+        uses: actions/upload-artifact@v7
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          file: ./release/donner-svg_linux_x86_64
+          name: donner-svg-linux-x86-64-${{ github.sha }}
+          path: release/
+          if-no-files-found: error
+          retention-days: 7
 
   macos:
+    if: github.run_attempt == 1
     runs-on: macos-26
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify release source
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")" = "$GITHUB_SHA"
 
       - name: Cache Bazel
         uses: actions/cache@v6
@@ -55,45 +88,87 @@ jobs:
       - name: Build Binaries
         run: |
           mkdir release
-          bazelisk build -c opt //donner/svg/tool:donner-svg
+          bazelisk build --lockfile_mode=off -c opt //donner/svg/tool:donner-svg
           cp bazel-bin/donner/svg/tool/donner-svg release/donner-svg_darwin_arm64
+          (cd release && shasum -a 256 donner-svg_darwin_arm64 > donner-svg_darwin_arm64.sha256)
+          {
+            echo "source_commit=${GITHUB_SHA}"
+            echo "release_tag=${RELEASE_TAG}"
+            shasum -a 256 .bazelversion .bazelrc MODULE.bazel third_party/bazel/non_bcr_deps.bzl
+          } > release/donner-svg_darwin_arm64.provenance
 
-      - name: Upload the Binaries
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload immutable build artifact
+        uses: actions/upload-artifact@v7
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          file: ./release/donner-svg_darwin_arm64
+          name: donner-svg-darwin-arm64-${{ github.sha }}
+          path: release/
+          if-no-files-found: error
+          retention-days: 7
 
-  # Publish a new entry to the Bazel Central Registry when a GitHub Release
-  # is published. Uses the bazel-contrib Publish-to-BCR reusable workflow,
-  # which reads .bcr/ templates from this repo (config.yml, metadata.template.json,
-  # source.template.json, presubmit.yml) and opens a PR on
-  # bazelbuild/bazel-central-registry from a maintainer's fork.
-  #
-  # One-time setup required:
-  #   1. Fork bazelbuild/bazel-central-registry as jwmcglynn/bazel-central-registry
-  #   2. Create a Classic PAT with `repo` + `workflow` scopes and save it as
-  #      the BCR_PUBLISH_TOKEN repo secret (fine-grained PATs still cannot
-  #      open PRs against public repos)
-  #   3. Optional but recommended for org-owned releases: use a dedicated
-  #      machine user PAT instead of a maintainer's personal token
-  #
-  # This workflow intentionally does not use the legacy Publish-to-BCR GitHub
-  # App, which upstream has marked deprecated and scheduled for discontinuation
-  # after June 30, 2026.
-  #
-  # See docs/design_docs/0018-bcr_release.md for the full runbook.
-  publish-to-bcr:
-    if: github.event_name == 'release' && github.event.action == 'published'
+  publish-release-artifacts:
+    if: github.run_attempt == 1
     needs: [linux, macos]
+    runs-on: ubuntu-24.04
+    env:
+      RELEASE_ID: ${{ github.event.release.id }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_UPLOAD_URL: ${{ github.event.release.upload_url }}
     permissions:
-      id-token: write       # Needed to attest provenance
-      attestations: write   # Needed to attest provenance
-      contents: write       # Needed to upload release files
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.2
-    with:
-      tag_name: ${{ github.event.release.tag_name }}
-      registry_fork: jwmcglynn/bazel-central-registry
-    secrets:
-      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout verified release source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Reverify release source
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")" = "$GITHUB_SHA"
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: donner-svg-linux-x86-64-${{ github.sha }}
+          path: release/linux
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: donner-svg-darwin-arm64-${{ github.sha }}
+          path: release/macos
+
+      - name: Verify immutable artifacts
+        run: |
+          (cd release/linux && sha256sum --check --strict donner-svg_linux_x86_64.sha256)
+          (cd release/macos && sha256sum --check --strict donner-svg_darwin_arm64.sha256)
+          {
+            echo "source_commit=${GITHUB_SHA}"
+            echo "release_tag=${RELEASE_TAG}"
+            sha256sum .bazelversion .bazelrc MODULE.bazel third_party/bazel/non_bcr_deps.bzl
+          } > expected.provenance
+          cmp --silent expected.provenance release/linux/donner-svg_linux_x86_64.provenance
+          cmp --silent expected.provenance release/macos/donner-svg_darwin_arm64.provenance
+
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@v3.2.0
+        with:
+          subject-path: |
+            release/linux/donner-svg_linux_x86_64
+            release/macos/donner-svg_darwin_arm64
+
+      - name: Upload verified release artifacts without replacement
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 tools/release_artifact_publisher.py \
+            release/linux/donner-svg_linux_x86_64 \
+            release/linux/donner-svg_linux_x86_64.sha256 \
+            release/linux/donner-svg_linux_x86_64.provenance \
+            release/macos/donner-svg_darwin_arm64 \
+            release/macos/donner-svg_darwin_arm64.sha256 \
+            release/macos/donner-svg_darwin_arm64.provenance

--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -8,6 +8,9 @@ on:
       - "donner/svg/renderer/RendererDriver.*"
       - "donner/svg/renderer/RendererGeode.*"
 
+permissions:
+  contents: read
+
 # Superseded PR pushes cancel their in-flight sanitizer run so a rapid push
 # storm does not pile up redundant hosted sanitizer builds.
 concurrency:
@@ -32,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -49,11 +54,6 @@ jobs:
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Configure BuildBuddy remote cache
-        uses: ./.github/actions/buildbuddy-cache
-        with:
-          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Test (Geode ASan) — informational, non-blocking
         shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Decide whether nightly sanitizer jobs should run
         id: decide
@@ -62,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -81,6 +85,7 @@ jobs:
           cache-save: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - name: Configure BuildBuddy remote cache
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         uses: ./.github/actions/buildbuddy-cache
         with:
           api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -125,6 +130,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         uses: ./.github/actions/apt-install
@@ -144,6 +151,7 @@ jobs:
           cache-save: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - name: Configure BuildBuddy remote cache
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         uses: ./.github/actions/buildbuddy-cache
         with:
           api-key: ${{ secrets.BUILDBUDDY_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ index.scip
 *.bloaty.csv
 build-binary-size
 
-# The Bzlmod lockfile is platform-dependent with Python and thus hard
-# to keep up-to-date in CI. It still speeds up local development.
+# Bzlmod lock state is generated per platform/toolchain and remains local.
 MODULE.bazel.lock
 
 # VS Code

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,16 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "github_action_definitions",
+    srcs = glob([
+        ".github/actions/*/action.yml",
+        ".github/workflows/*.yaml",
+        ".github/workflows/*.yml",
+    ]),
+    visibility = ["//tools:__pkg__"],
+)
+
 exports_files(
     [
         "donner_icon.svg",

--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -6,7 +6,6 @@ load("//build_defs:package.bzl", "donner_package")
 exports_files(
     [
         "check_banned_patterns.py",
-        "fuzz_corpus_per_input.sh",
         "rules.bzl",
     ],
     visibility = ["//visibility:public"],

--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -6,6 +6,8 @@ load("//build_defs:package.bzl", "donner_package")
 exports_files(
     [
         "check_banned_patterns.py",
+        "fuzz_corpus_per_input.sh",
+        "rules.bzl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -778,6 +778,14 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
 
     fuzzer_runtime_linkopts = fuzzer_linkopts()
     fuzzer_additional_linker_inputs = fuzzer_linker_inputs()
+    ubsan_tags = [tag for tag in tags if tag.startswith("fuzz_ubsan")]
+    common_tags = [tag for tag in tags if not tag.startswith("fuzz_ubsan")]
+    if "fuzz_text_full" in common_tags and "fuzz_ubsan_text_full" not in ubsan_tags:
+        ubsan_tags.append("fuzz_ubsan_text_full")
+    if "fuzz_geode" in common_tags and "fuzz_ubsan_geode" not in ubsan_tags:
+        ubsan_tags.append("fuzz_ubsan_geode")
+    common_target_tags = ["fuzz_target"] + common_tags
+    corpus_tags = ["fuzz_target", "fuzz_ubsan"] + common_tags + ubsan_tags
 
     cc_binary(
         name = name + "_bin",
@@ -786,7 +794,7 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
         linkstatic = 1,
         deps = deps + libc_compat_deps(),
         target_compatible_with = fuzzer_compatible_with(),
-        tags = ["fuzz_target"],
+        tags = common_target_tags,
         **kwargs
     )
 
@@ -819,7 +827,7 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
             "@platforms//os:macos": ["@llvm_toolchain//:linker-components-aarch64-darwin"],
             "//conditions:default": [],
         }),
-        tags = ["fuzz_target"] + tags,
+        tags = common_target_tags,
         **kwargs
     )
 
@@ -835,7 +843,7 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
             "//conditions:default": [],
         }),
         target_compatible_with = fuzzer_compatible_with(),
-        tags = ["fuzz_target"] + tags,
+        tags = corpus_tags,
         **kwargs
     )
 

--- a/docs/design_docs/0018-bcr_release.md
+++ b/docs/design_docs/0018-bcr_release.md
@@ -15,23 +15,23 @@ This doc is the single source of truth for cutting a new Donner release on the [
 1. Bump `module(name = "donner", version = "X.Y.Z")` in `MODULE.bazel`
 2. Run the pre-release checklist below, make sure it's green
 3. Merge the release PR, tag `vX.Y.Z`, push
-4. `.github/workflows/release.yml` builds CLI binaries + calls the Publish-to-BCR reusable workflow
-5. The app opens a PR on `bazelbuild/bazel-central-registry` under `modules/donner/X.Y.Z/` from `jwmcglynn/bazel-central-registry` (a fork)
+4. `.github/workflows/release.yml` builds, verifies, and attests the CLI binaries once
+5. After the release artifacts are green, use the reviewed `.bcr/` templates to prepare the BCR PR manually
 6. Watch BCR presubmit CI on that PR, iterate on `.bcr/presubmit.yml` if anything fails, ping a BCR maintainer, wait for merge
 
 ## What's on BCR (and what isn't)
 
 Donner's BCR-published surface is a deliberate subset of the full library. The default build that BCR consumers get is **tiny-skia + text-base**:
 
-| Feature | On BCR? | How BCR consumers get it |
-|---|---|---|
-| SVG parser, CSS, DOM, computed style | ✅ | default, no flags needed |
-| Tiny-skia software renderer | ✅ | default backend |
-| Text rendering via `stb_truetype` (text-base) | ✅ | default text tier |
-| Filter effects (all 17 primitives) | ✅ | built-in |
-| Removed full-Skia backend (legacy) | ❌ | Historical note only; power users previously needed `git_override` |
-| text-full (HarfBuzz + WOFF2) | ❌ | Power users via `git_override`; also tracked as a future follow-up BCR module |
-| Geode (WebGPU + Slug) backend | ❌ | Not BCR-published: its `wgpu-native` / WebGPU deps are non-BCR (`dev_dependency` overrides). Geode itself is a supported backend (the editor's default), just not a BCR-consumable config |
+| Feature                                       | On BCR? | How BCR consumers get it                                                                                                                                                                  |
+| --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SVG parser, CSS, DOM, computed style          | ✅      | default, no flags needed                                                                                                                                                                  |
+| Tiny-skia software renderer                   | ✅      | default backend                                                                                                                                                                           |
+| Text rendering via `stb_truetype` (text-base) | ✅      | default text tier                                                                                                                                                                         |
+| Filter effects (all 17 primitives)            | ✅      | built-in                                                                                                                                                                                  |
+| Removed full-Skia backend (legacy)            | ❌      | Historical note only; power users previously needed `git_override`                                                                                                                        |
+| text-full (HarfBuzz + WOFF2)                  | ❌      | Power users via `git_override`; also tracked as a future follow-up BCR module                                                                                                             |
+| Geode (WebGPU + Slug) backend                 | ❌      | Not BCR-published: its `wgpu-native` / WebGPU deps are non-BCR (`dev_dependency` overrides). Geode itself is a supported backend (the editor's default), just not a BCR-consumable config |
 
 The mechanism that keeps the non-BCR features invisible to BCR consumers is the `dev_dependency = True` module extension at `third_party/bazel/non_bcr_deps.bzl`. BCR strips dev-only extensions when Donner is consumed as a `bazel_dep`, so downstream users simply never see the former full-Skia repo, `@harfbuzz`, `@woff2`, or `@wgpu_native_*`.
 
@@ -42,30 +42,34 @@ Every Donner target that references one of those hidden repos must be guarded by
 Do these in order. Each step is either a command to run or a one-line visual check.
 
 ### Pre-flight
+
 - [ ] Working tree on `main`, clean, up to date
 - [ ] `docs/design_docs/0011-v0_5_release.md` (or equivalent release doc) marks all release-blocking phases complete
 - [ ] `RELEASE_NOTES.md` drafted for the version being cut
 
 ### Version bump
+
 - [ ] `MODULE.bazel` → `module(name = "donner", version = "X.Y.Z")` matches the tag being pushed
 - [ ] No stale references to the previous version in `docs/` or `README.md`
 
 ### Dev-config build matrix (local or CI)
+
 - [ ] `bazel build //...` — default config (tiny-skia + text-base)
 - [ ] Historical note: the removed full-Skia backend used to build in the dev matrix
 - [ ] `bazel build --config=text-full //...` — HarfBuzz + WOFF2 text shaping still builds
 - [ ] `bazel test //...` on at least the default config green
 
 ### BCR-consumer simulation (most important)
+
 Simulate what a BCR downstream sees, where the `non_bcr_deps` dev extension is stripped and the former full-Skia repo / `@harfbuzz` / `@woff2` / `@wgpu_native_*` do not exist.
 
 - [ ] No `git_repository` / `new_git_repository` / non-dev `*_override` in top-level `MODULE.bazel` (grep for them):
-      ```
+      ```sh
       grep -nE '^(git_repository|new_git_repository|git_override|archive_override)' MODULE.bazel
       ```
       (Should return nothing. Dev-only entries live inside `use_extension(..., dev_dependency = True)` blocks or the extension .bzl file.)
 - [ ] No non-BCR repo labels reachable from the BCR target allowlist in default config:
-      ```
+      ```sh
       bazel cquery 'kind("source file", deps( \
         //donner/base/... + //donner/css/... + //donner/svg:svg + \
         //donner/svg/parser/... + //donner/svg/components/... + \
@@ -80,13 +84,16 @@ Simulate what a BCR downstream sees, where the `non_bcr_deps` dev extension is s
 - [ ] `.bcr/source.template.json` `strip_prefix` matches `donner-{VERSION}` (GitHub tarball convention).
 
 ### Scaffolding sanity
+
 - [ ] `.bcr/config.yml`, `.bcr/metadata.template.json`, `.bcr/source.template.json`, `.bcr/presubmit.yml` all valid YAML/JSON
-- [ ] `.github/workflows/release.yml` references a real `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@vX.Y.Z` tag (Publish-to-BCR does not publish floating major tags; pin exact versions)
+- [ ] `.github/workflows/release.yml` builds from released dependency tags with lockfile generation disabled, verifies both platform manifests, and attests the exact binaries before upload
 
 ### Ship
-- [ ] **Root-cause the previous BCR attempt before retrying** — pull up the last release's BCR PR on `bazelbuild/bazel-central-registry` (`modules/donner/<prev>/`) and its `publish-to-bcr` workflow run, identify exactly why it failed, and confirm the fix is already in the tree (`.bcr/`, `release.yml` publish pin, `presubmit.yml` `build_targets`). Do not re-run the publish blind. Cross-check the common-failures table below.
+
+- [ ] **Root-cause the previous BCR attempt before retrying** — pull up the last release's BCR PR on `bazelbuild/bazel-central-registry` (`modules/donner/<prev>/`), identify exactly why it failed, and confirm the fix is already in the checked-in `.bcr/` templates and `presubmit.yml` targets. Do not retry blind. Cross-check the common-failures table below.
 - [ ] Merge release PR → push tag `vX.Y.Z` → GitHub Release auto-created
-- [ ] Watch Actions tab: `linux` + `macos` CLI binary jobs run, then `publish-to-bcr` reusable workflow
+- [ ] Watch Actions tab: `linux` + `macos` CLI binary jobs run, then the verified artifact publication job
+- [ ] Prepare the BCR entry from the reviewed release source and `.bcr/` templates only after artifact publication is green
 - [ ] Watch `bazelbuild/bazel-central-registry` → `modules/donner/X.Y.Z/` for the new PR
 - [ ] Iterate on BCR presubmit failures via the common-failures table below
 - [ ] Ping a BCR maintainer in the PR comments when presubmit CI goes green
@@ -94,34 +101,23 @@ Simulate what a BCR downstream sees, where the `non_bcr_deps` dev extension is s
 
 ## Publish-to-BCR flow details
 
-The
-[Publish-to-BCR reusable GitHub Actions workflow](https://github.com/bazel-contrib/publish-to-bcr)
-handles the mechanical pieces:
-
-1. On GitHub Release publish, `release.yml` invokes `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0` with `tag_name: ${{ github.event.release.tag_name }}`, `registry_fork: jwmcglynn/bazel-central-registry`, and `secrets.publish_token = secrets.BCR_PUBLISH_TOKEN`. The calling job must also set `id-token: write`, `attestations: write`, and `contents: write` permissions.
-2. The reusable workflow pulls the release tarball, computes the SHA256 integrity, reads `.bcr/metadata.template.json` + `.bcr/source.template.json` + `.bcr/presubmit.yml`, substitutes `{VERSION}` and `{TAG}` placeholders, and writes a new `modules/donner/X.Y.Z/` entry in the maintainer's BCR fork.
-3. It opens a PR from `jwmcglynn/bazel-central-registry` to
-   `bazelbuild/bazel-central-registry` on the maintainer's behalf.
-
-This flow does **not** use the legacy Publish-to-BCR GitHub App. Upstream marks
-that app as legacy and says it will be discontinued after **June 30, 2026**, so
-new Donner releases should stay on the reusable-workflow path. The only
-one-time setup for this workflow is a BCR fork plus a Classic PAT (or a machine
-user PAT) with `repo` + `workflow` scopes.
-
-Bump the reusable workflow pin (`@v1.2.0`) when new releases of Publish-to-BCR land — see [the releases page](https://github.com/bazel-contrib/publish-to-bcr/releases). Prefer exact version tags over floating refs like `@v1`, because Publish-to-BCR does not publish floating major-version tags.
+BCR publication is intentionally separate from the credentialed release workflow. The release
+workflow produces and attests immutable CLI artifacts, but it does not rebuild source or invoke a
+third-party BCR publisher. After those artifacts are green, prepare the registry entry from the
+reviewed tag and the checked-in `.bcr/metadata.template.json`, `.bcr/source.template.json`, and
+`.bcr/presubmit.yml`. Verify the source archive digest, then open the BCR pull request from the
+maintainer fork. This keeps registry publication operator-initiated and prevents a moved tag or
+workflow rerun from silently substituting source.
 
 ### One-time Publish-to-BCR setup
+
 1. Fork `bazelbuild/bazel-central-registry` to
    `jwmcglynn/bazel-central-registry`.
-2. Create a **Classic** PAT with `repo` + `workflow` scopes. Add it as
-   `BCR_PUBLISH_TOKEN` in the `jwmcglynn/donner` repo secrets. Fine-grained
-   PATs are not currently supported for opening PRs against public repos; see
-   [github/roadmap#600](https://github.com/github/roadmap/issues/600).
-3. If Donner releases move to an org-owned or shared-maintainer model, prefer a
-   dedicated machine user PAT over a maintainer's personal token.
+2. Use a dedicated maintainer identity for the fork and BCR pull request when release ownership is
+   shared. Do not place a BCR write token in the release workflow.
 
 ### Where to watch
+
 - Release workflow logs: `https://github.com/jwmcglynn/donner/actions` (Release workflow)
 - BCR PR: `https://github.com/bazelbuild/bazel-central-registry/pulls?q=is:pr+author:jwmcglynn+donner`
 - Registry entry: `https://registry.bazel.build/modules/donner`
@@ -130,14 +126,12 @@ Bump the reusable workflow pin (`@v1.2.0`) when new releases of Publish-to-BCR l
 
 Update this section with real-world lessons as they happen.
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| BCR PR presubmit: unmapped former full-Skia external dep | A target referenced the former full-Skia repo but wasn't gated by `target_compatible_with` | Add the appropriate backend gating to the offending target |
-| BCR PR presubmit: target not found | New top-level library added under `//donner` since last release | Add it to `.bcr/presubmit.yml` `build_targets` |
-| BCR PR presubmit: integrity hash mismatch | GitHub regenerated the source tarball or the tag moved | Re-upload the release tarball verbatim; never force-push tags |
-| `source.template.json` URL 404 | `strip_prefix` doesn't match GitHub's tarball layout | Confirm pattern is `donner-{VERSION}` (GitHub uses repo name + version) |
-| Release workflow: `publish-to-bcr` skipped | `BCR_PUBLISH_TOKEN` secret missing or PAT expired | Regenerate PAT, re-save secret |
-| Release workflow: `publish-to-bcr` fails with "fork not found" | Maintainer BCR fork hasn't been created yet | Fork `bazelbuild/bazel-central-registry` to the `registry_fork` configured in `release.yml` |
+| Symptom                                                        | Cause                                                                                      | Fix                                                                                         |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| BCR PR presubmit: unmapped former full-Skia external dep       | A target referenced the former full-Skia repo but wasn't gated by `target_compatible_with` | Add the appropriate backend gating to the offending target                                  |
+| BCR PR presubmit: target not found                             | New top-level library added under `//donner` since last release                            | Add it to `.bcr/presubmit.yml` `build_targets`                                              |
+| BCR PR presubmit: integrity hash mismatch                      | GitHub regenerated the source tarball or the tag moved                                     | Re-upload the release tarball verbatim; never force-push tags                               |
+| `source.template.json` URL 404                                 | `strip_prefix` doesn't match GitHub's tarball layout                                       | Confirm pattern is `donner-{VERSION}` (GitHub uses repo name + version)                     |
 
 ## Adding a new top-level library
 

--- a/donner/svg/text/BUILD.bazel
+++ b/donner/svg/text/BUILD.bazel
@@ -138,6 +138,7 @@ donner_cc_fuzzer(
         "//donner/svg/renderer:text_full_enabled": ["DONNER_TEXT_FULL"],
         "//conditions:default": [],
     }),
+    tags = ["fuzz_text_full"],
     deps = [
         ":text_backend",
         "//donner/base",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -160,6 +160,18 @@ py_test(
     deps = ["@rules_python//python/runfiles"],
 )
 
+py_library(
+    name = "release_artifact_publisher",
+    srcs = ["release_artifact_publisher.py"],
+)
+
+py_test(
+    name = "release_artifact_publisher_tests",
+    size = "small",
+    srcs = ["release_artifact_publisher_tests.py"],
+    deps = [":release_artifact_publisher"],
+)
+
 py_test(
     name = "coverage_lane_routing_tests",
     size = "small",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -153,9 +153,9 @@ py_test(
     size = "small",
     srcs = ["security_workflow_policy_tests.py"],
     data = [
-        "//:.github/workflows/codeql.yml",
-        "//:.github/workflows/fuzz.yml",
-        "//:.github/workflows/sanitizers.yml",
+        "//:github_action_definitions",
+        "//build_defs:rules.bzl",
+        "//third_party:bazel/non_bcr_deps.bzl",
     ],
     deps = ["@rules_python//python/runfiles"],
 )

--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -51,6 +51,12 @@ from typing import (
 # Use bzlmod-aware queries since this repository relies on MODULE.bazel.
 BAZEL_PREFIX = ["bazel"]
 
+
+def _set_bazel_startup_args(startup_args: Iterable[str]) -> None:
+    """Configure Bazel startup arguments used by generator queries."""
+    global BAZEL_PREFIX
+    BAZEL_PREFIX = ["bazel", *startup_args]
+
 # When running in --check mode, warn about unmapped deps instead of silently dropping them.
 _check_mode = False
 _unmapped_deps: List[str] = []
@@ -249,18 +255,30 @@ def extract_versions_from_module_bazel() -> Dict[str, str]:
     return versions
 
 
-# Map from MODULE.bazel dep name to (FetchContent name, git URL, use_v_prefix).
-# use_v_prefix: True for repos whose git tags have a 'v' prefix (e.g., v1.17.0),
-#               False for repos that use bare versions (e.g., 0.2.17).
-_MODULE_TO_FETCHCONTENT: Dict[str, Tuple[str, str, bool]] = {
-    "googletest": ("googletest", "https://github.com/google/googletest.git", True),
-    "nlohmann_json": ("nlohmann_json", "https://github.com/nlohmann/json.git", True),
-    "zlib": ("zlib", "https://github.com/madler/zlib.git", True),
-    "rules_cc": ("rules_cc", "https://github.com/bazelbuild/rules_cc.git", False),
+# Map from MODULE.bazel dep name to
+# (FetchContent name, git URL, expected normalized release, immutable commit).
+_MODULE_TO_FETCHCONTENT: Dict[str, Tuple[str, str, str, str]] = {
+    "googletest": (
+        "googletest", "https://github.com/google/googletest.git",
+        "v1.17.0", "52eb8108c5bdec04579160ae17225d66034bd723",
+    ),
+    "nlohmann_json": (
+        "nlohmann_json", "https://github.com/nlohmann/json.git",
+        "v3.12.0", "55f93686c01528224f448c19128836e7df245f72",
+    ),
+    "zlib": (
+        "zlib", "https://github.com/madler/zlib.git",
+        "v1.3.2", "da607da739fa6047df13e66a2af6b8bec7c2a498",
+    ),
+    "rules_cc": (
+        "rules_cc", "https://github.com/bazelbuild/rules_cc.git",
+        "0.2.22", "21e14308c2afc7691f43295acc9852d9a6844f04",
+    ),
     "pixelmatch-cpp17": (
         "pixelmatch-cpp17",
         "https://github.com/jwmcglynn/pixelmatch-cpp17.git",
-        True,
+        "v1.0.3",
+        "220b3bcf08919e8045033bc4cb1e6e6ba2a1cfa3",
     ),
 }
 
@@ -272,8 +290,14 @@ _MODULE_TO_FETCHCONTENT: Dict[str, Tuple[str, str, bool]] = {
 #   bumping entt. CMake users still FetchContent entt as before; only Bazel
 #   uses the vendored tree.
 _HARDCODED_FETCHCONTENT = {
-    "absl": ("absl", "https://github.com/abseil/abseil-cpp.git", "20250512.0"),
-    "entt": ("entt", "https://github.com/skypjack/entt.git", "v3.16.0"),
+    "absl": (
+        "absl", "https://github.com/abseil/abseil-cpp.git",
+        "bc257a88f7c1939f24e0379f14a3589e926c950c",
+    ),
+    "entt": (
+        "entt", "https://github.com/skypjack/entt.git",
+        "b4e58bdd364ad72246c123a0c28538eab3252672",
+    ),
 }
 
 
@@ -306,18 +330,28 @@ def get_fetchcontent_externals() -> List[Tuple[str, str, str]]:
     module_versions = extract_versions_from_module_bazel()
     result: List[Tuple[str, str, str]] = []
 
-    for module_name, (fc_name, git_url, use_v_prefix) in _MODULE_TO_FETCHCONTENT.items():
+    for module_name, (
+        fc_name,
+        git_url,
+        expected_release,
+        commit,
+    ) in _MODULE_TO_FETCHCONTENT.items():
         version = module_versions.get(module_name)
         if version is None:
             print(f"WARNING: Could not find version for '{module_name}' in MODULE.bazel")
             continue
 
-        tag = _normalize_version(version, use_v_prefix)
-        result.append((fc_name, git_url, tag))
+        use_v_prefix = expected_release.startswith("v")
+        normalized = _normalize_version(version, use_v_prefix)
+        if normalized != expected_release:
+            raise RuntimeError(
+                f"CMake commit pin for {module_name} must be updated with {normalized}"
+            )
+        result.append((fc_name, git_url, commit))
 
     # Add hardcoded entries
-    for fc_name, git_url, tag in _HARDCODED_FETCHCONTENT.values():
-        result.append((fc_name, git_url, tag))
+    for fc_name, git_url, revision in _HARDCODED_FETCHCONTENT.values():
+        result.append((fc_name, git_url, revision))
 
     # Sort for deterministic output
     result.sort(key=lambda x: x[0])
@@ -1053,9 +1087,9 @@ def generate_root() -> None:
 
         # External dependencies via FetchContent (versions from MODULE.bazel)
         externals = get_fetchcontent_externals()
-        for name, repo, tag in externals:
+        for name, repo, revision in externals:
             f.write(f"FetchContent_Declare(\n  {name}\n  GIT_REPOSITORY {repo}\n")
-            f.write(f"  GIT_TAG        {tag}\n)\n")
+            f.write(f"  GIT_TAG        {revision}\n)\n")
             f.write(f"FetchContent_MakeAvailable({name})\n\n")
 
         # Build / install rules for STB (header-only + impl)
@@ -1112,7 +1146,7 @@ def generate_root() -> None:
         f.write(
             "FetchContent_Declare(brotli\n"
             "  GIT_REPOSITORY https://github.com/google/brotli.git\n"
-            "  GIT_TAG        v1.2.0\n"
+            "  GIT_TAG        028fb5a23661f123017c060daa546b55cf4bde29\n"
             ")\n"
         )
         f.write("FetchContent_MakeAvailable(brotli)\n")
@@ -1826,9 +1860,17 @@ def main() -> None:
         default=None,
         help="Write generated files to this directory instead of the workspace.",
     )
+    parser.add_argument(
+        "--bazel-startup-arg",
+        action="append",
+        default=[],
+        help=("Pass a startup argument to Bazel before cquery. May be specified "
+              "more than once, for example --bazel-startup-arg=--host_jvm_args=-Xmx4g."),
+    )
     args = parser.parse_args()
     if args.build and not args.check:
         parser.error("--build requires --check")
+    _set_bazel_startup_args(args.bazel_startup_arg)
     _check_mode = args.check
 
     if args.check:

--- a/tools/cmake/gen_cmakelists_test.py
+++ b/tools/cmake/gen_cmakelists_test.py
@@ -6,6 +6,7 @@ build-validation helper exercised against synthetic source trees.
 """
 
 import os
+import re
 import sys
 import tempfile
 import textwrap
@@ -18,6 +19,18 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
 
 import gen_cmakelists as g
+
+
+class BazelStartupArgsTest(unittest.TestCase):
+    def tearDown(self):
+        g._set_bazel_startup_args([])
+
+    def test_configures_startup_args_before_command(self):
+        g._set_bazel_startup_args(["--host_jvm_args=-Xmx4g", "--batch"])
+        self.assertEqual(
+            g.BAZEL_PREFIX,
+            ["bazel", "--host_jvm_args=-Xmx4g", "--batch"],
+        )
 
 
 class NormalizeVersionTest(unittest.TestCase):
@@ -81,10 +94,10 @@ class FetchContentExternalsTest(unittest.TestCase):
         self.assertIn("rules_cc", names)
         self.assertIn("absl", names)  # hardcoded
 
-    def test_no_bcr_suffix_in_tags(self):
+    def test_all_fetchcontent_revisions_are_immutable_commits(self):
         externals = g.get_fetchcontent_externals()
-        for name, url, tag in externals:
-            self.assertNotIn(".bcr.", tag, f"{name} has BCR suffix: {tag}")
+        for name, url, revision in externals:
+            self.assertRegex(revision, r"^[0-9a-f]{40}$", f"{name} is mutable: {revision}")
 
 
 class ExternalDepManifestTest(unittest.TestCase):
@@ -248,6 +261,8 @@ class GeneratedRootCmakeTest(unittest.TestCase):
         self.assertNotIn("DONNER_BUILD_EXAMPLES", contents)
         self.assertIn("if(DONNER_BUILD_TESTS)", contents)
         self.assertIn("add_library(donner INTERFACE)", contents)
+        for revision in re.findall(r"GIT_TAG\s+(\S+)", contents):
+            self.assertRegex(revision, r"^[0-9a-f]{40}$")
         self.assertNotIn("examples/cmake_consumer", contents)
 
 

--- a/tools/release_artifact_publisher.py
+++ b/tools/release_artifact_publisher.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Publish verified release assets without replacing existing bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from urllib.parse import urlencode
+
+
+def resolve_remote_tag(refs: str, tag: str) -> str | None:
+    """Return the peeled commit for an annotated or lightweight tag."""
+    exact_ref = f"refs/tags/{tag}"
+    peeled_ref = f"{exact_ref}^{{}}"
+    exact_commit = None
+    peeled_commit = None
+    for line in refs.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        commit, ref = fields
+        if ref == peeled_ref:
+            peeled_commit = commit
+        elif ref == exact_ref:
+            exact_commit = commit
+    return peeled_commit or exact_commit
+
+
+def sha256_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+class Publisher:
+    def __init__(self, repository: str, release_id: str, upload_url: str):
+        self.repository = repository
+        self.release_id = release_id
+        self.upload_base = upload_url.split("{", 1)[0]
+        self.assets_endpoint = f"repos/{repository}/releases/{release_id}/assets?per_page=100"
+
+    def list_assets(self) -> list[dict[str, object]]:
+        result = subprocess.run(
+            ["gh", "api", self.assets_endpoint],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        value = json.loads(result.stdout)
+        if not isinstance(value, list):
+            raise RuntimeError("GitHub release assets response is not an array")
+        return value
+
+    def existing_asset_matches(self, path: Path) -> bool:
+        matches = [asset for asset in self.list_assets() if asset.get("name") == path.name]
+        if not matches:
+            return False
+        if len(matches) != 1 or matches[0].get("digest") != sha256_digest(path):
+            raise RuntimeError(f"release asset {path.name} exists with a different digest")
+        return True
+
+    def upload_once(self, path: Path) -> bool:
+        endpoint = f"{self.upload_base}?{urlencode({'name': path.name})}"
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                "-H",
+                "Content-Type: application/octet-stream",
+                endpoint,
+                "--input",
+                str(path),
+            ],
+            check=False,
+        )
+        return result.returncode == 0
+
+    def publish(self, paths: list[Path], maximum_attempts: int = 3) -> None:
+        for path in paths:
+            if self.existing_asset_matches(path):
+                print(f"release asset {path.name} already has the expected digest")
+                continue
+            for attempt in range(1, maximum_attempts + 1):
+                if self.upload_once(path) or self.existing_asset_matches(path):
+                    break
+                print(
+                    f"release asset {path.name} upload attempt {attempt} failed",
+                    file=sys.stderr,
+                )
+            else:
+                raise RuntimeError(
+                    f"release asset {path.name} upload failed after {maximum_attempts} attempts"
+                )
+
+
+def verify_remote_tag(tag: str, expected_commit: str) -> None:
+    result = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            "origin",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if resolve_remote_tag(result.stdout, tag) != expected_commit:
+        raise RuntimeError("release tag does not resolve to GITHUB_SHA")
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        raise RuntimeError("at least one release asset path is required")
+    tag = os.environ["RELEASE_TAG"]
+    expected_commit = os.environ["GITHUB_SHA"]
+    verify_remote_tag(tag, expected_commit)
+    publisher = Publisher(
+        os.environ["GITHUB_REPOSITORY"],
+        os.environ["RELEASE_ID"],
+        os.environ["RELEASE_UPLOAD_URL"],
+    )
+    paths = [Path(value) for value in argv]
+    for path in paths:
+        if not path.is_file():
+            raise RuntimeError(f"release asset is missing: {path}")
+    publisher.publish(paths)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except (KeyError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        print(f"release publication failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/release_artifact_publisher_tests.py
+++ b/tools/release_artifact_publisher_tests.py
@@ -1,0 +1,124 @@
+"""Tests for immutable, resumable release asset publication."""
+
+from pathlib import Path
+import json
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from tools import release_artifact_publisher as publisher
+
+
+class ResolveRemoteTagTest(unittest.TestCase):
+    def test_lightweight_tag(self):
+        self.assertEqual(
+            publisher.resolve_remote_tag("a" * 40 + "\trefs/tags/v1\n", "v1"),
+            "a" * 40,
+        )
+
+    def test_annotated_tag_prefers_peeled_commit_in_any_order(self):
+        refs = "\n".join(
+            [
+                "b" * 40 + "\trefs/tags/v1^{}",
+                "a" * 40 + "\trefs/tags/v1",
+            ]
+        )
+        self.assertEqual(publisher.resolve_remote_tag(refs, "v1"), "b" * 40)
+        self.assertIsNone(publisher.resolve_remote_tag(refs, "v2"))
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_remote_verification_accepts_only_expected_peeled_commit(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            [],
+            0,
+            stdout="a" * 40 + "\trefs/tags/v1\n" + "b" * 40 + "\trefs/tags/v1^{}\n",
+            stderr="",
+        )
+        publisher.verify_remote_tag("v1", "b" * 40)
+        with self.assertRaisesRegex(RuntimeError, "does not resolve"):
+            publisher.verify_remote_tag("v1", "a" * 40)
+
+
+class PublishAssetsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = Path(self.temp_dir.name) / "artifact.bin"
+        self.path.write_bytes(b"verified bytes")
+        self.publisher = publisher.Publisher("owner/repo", "7", "https://uploads.test/assets{?name}")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def completed(self, returncode=0, stdout=""):
+        return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+
+    def assets(self, *values):
+        return json.dumps(list(values))
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_matching_asset_is_not_uploaded_again(self, run):
+        digest = publisher.sha256_digest(self.path)
+        run.return_value = self.completed(
+            stdout=self.assets({"name": self.path.name, "digest": digest})
+        )
+
+        self.publisher.publish([self.path])
+
+        self.assertEqual(run.call_count, 1)
+        self.assertNotIn("POST", run.call_args.args[0])
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_mismatched_asset_fails_closed(self, run):
+        run.return_value = self.completed(
+            stdout=self.assets({"name": self.path.name, "digest": "sha256:bad"})
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "different digest"):
+            self.publisher.publish([self.path])
+
+        self.assertEqual(run.call_count, 1)
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_absent_asset_uploads_once(self, run):
+        run.side_effect = [self.completed(stdout="[]"), self.completed()]
+
+        self.publisher.publish([self.path])
+
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("POST", run.call_args.args[0])
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_lost_success_response_is_recovered_from_published_digest(self, run):
+        digest = publisher.sha256_digest(self.path)
+        run.side_effect = [
+            self.completed(stdout="[]"),
+            self.completed(returncode=1),
+            self.completed(stdout=self.assets({"name": self.path.name, "digest": digest})),
+        ]
+
+        self.publisher.publish([self.path])
+
+        self.assertEqual(run.call_count, 3)
+
+    @mock.patch("tools.release_artifact_publisher.subprocess.run")
+    def test_stops_after_three_failed_uploads(self, run):
+        run.side_effect = [
+            self.completed(stdout="[]"),
+            self.completed(returncode=1),
+            self.completed(stdout="[]"),
+            self.completed(returncode=1),
+            self.completed(stdout="[]"),
+            self.completed(returncode=1),
+            self.completed(stdout="[]"),
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "after 3 attempts"):
+            self.publisher.publish([self.path])
+
+        post_calls = [call for call in run.call_args_list if "POST" in call.args[0]]
+        self.assertEqual(len(post_calls), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/security_workflow_policy_tests.py
+++ b/tools/security_workflow_policy_tests.py
@@ -1,7 +1,6 @@
 """Pins review-driven security workflow selection and scheduling policy."""
 
 from pathlib import Path
-import json
 import re
 import unittest
 
@@ -71,13 +70,10 @@ class SecurityWorkflowPolicyTest(unittest.TestCase):
         cls.sanitizers = _read(".github/workflows/sanitizers.yml")
         cls.supply_chain_files = _read_supply_chain_files()
 
-    def test_external_actions_are_pinned_to_commits(self):
-        """Every external action is immutable and remains update-tool friendly."""
-        action_line = re.compile(
-            r"^\s*(?:-\s*)?uses:\s*(?P<target>\S+?)(?:\s+#\s*(?P<version>\S+))?\s*$"
-        )
-        full_commit = re.compile(r"^[0-9a-f]{40}$")
-        version_comment = re.compile(r"^v?\d+(?:\.\d+){0,2}$")
+    def test_external_actions_use_released_version_tags(self):
+        """External actions use Renovate-compatible release tags, never branches."""
+        action_line = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<target>\S+)\s*$")
+        released_version = re.compile(r"^v?\d+(?:\.\d+){0,2}$")
         pins = {}
         seen = 0
 
@@ -91,30 +87,22 @@ class SecurityWorkflowPolicyTest(unittest.TestCase):
                 if target.startswith("./") or target.startswith("docker://"):
                     continue
 
-                version = match.group("version")
                 with self.subTest(path=path, line=line_number, action=target):
                     self.assertRegex(
                         revision,
-                        full_commit,
-                        "%s:%d uses a mutable external action revision" % (path, line_number),
+                        released_version,
+                        "%s:%d must use a released action version" % (path, line_number),
                     )
-                    self.assertIsNotNone(
-                        version,
-                        "%s:%d needs a trailing version comment for dependency updates"
-                        % (path, line_number),
-                    )
-                    self.assertRegex(version, version_comment)
 
-                pins.setdefault((target, version), set()).add(revision)
+                pins.setdefault(target, set()).add(revision)
                 seen += 1
 
         self.assertGreaterEqual(seen, 75, "external action discovery no longer covers the workflows")
-        for (target, version), revisions in pins.items():
+        for target, revisions in pins.items():
             self.assertEqual(
                 1,
                 len(revisions),
-                "%s %s is pinned inconsistently: %s"
-                % (target, version, sorted(revisions)),
+                "%s is pinned inconsistently: %s" % (target, sorted(revisions)),
             )
 
     def test_downloaded_bazel_diff_is_verified_before_execution(self):
@@ -160,30 +148,27 @@ class SecurityWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("actions/attest-build-provenance@", release)
         self.assertIn("sha256sum --check --strict", release)
         self.assertGreaterEqual(release.count("if: github.run_attempt == 1"), 3)
-        self.assertEqual(release.count("--lockfile_mode=error"), 2)
+        self.assertEqual(release.count("--lockfile_mode=off"), 2)
         self.assertIn("cmp --silent expected.provenance release/linux/", release)
         self.assertIn("cmp --silent expected.provenance release/macos/", release)
         self.assertIn("RELEASE_UPLOAD_URL: ${{ github.event.release.upload_url }}", release)
         self.assertIn("Upload verified release artifacts without replacement", release)
-        self.assertIn("gh api --method POST", release)
+        self.assertIn("python3 tools/release_artifact_publisher.py", release)
         self.assertNotIn("softprops/action-gh-release", release)
         self.assertNotIn("publish-to-bcr", release)
         self.assertNotIn("svenstaro/upload-release-action", release)
         for body in _run_bodies(release):
             self.assertNotIn("${{", body, "release run blocks must use quoted environment values")
 
-        lock = json.loads(_read("MODULE.bazel.lock"))
-        self.assertGreaterEqual(lock["lockFileVersion"], 1)
-        ignored = set(_read(".gitignore").splitlines())
-        self.assertNotIn("MODULE.bazel.lock", ignored)
-
-    def test_git_dependencies_use_immutable_commits(self):
+    def test_git_dependencies_use_release_tags_or_explicit_commits(self):
         deps = _read("third_party/bazel/non_bcr_deps.bzl")
-        self.assertNotRegex(deps, r"(?m)^\s*tag\s*=")
         for block in re.findall(r"(?:new_)?git_repository\((.*?)\n\s*\)", deps, re.DOTALL):
             if "remote =" not in block:
                 continue
-            self.assertRegex(block, r'commit\s*=\s*"[0-9a-f]{40}"')
+            self.assertRegex(
+                block,
+                r'(?:commit\s*=\s*"[0-9a-f]{40}"|tag\s*=\s*"v?\d+(?:\.\d+){1,2}")',
+            )
 
     def test_fuzzer_variant_tags_derive_matching_ubsan_lanes(self):
         rules = _read("build_defs/rules.bzl")
@@ -194,6 +179,7 @@ class SecurityWorkflowPolicyTest(unittest.TestCase):
 
     def test_pull_requests_never_receive_the_buildbuddy_write_key(self):
         guarded = (
+            "github.ref == 'refs/heads/main' && "
             "github.event_name != 'pull_request' && "
             "github.event_name != 'pull_request_target'"
         )

--- a/tools/security_workflow_policy_tests.py
+++ b/tools/security_workflow_policy_tests.py
@@ -1,15 +1,35 @@
 """Pins review-driven security workflow selection and scheduling policy."""
 
+from pathlib import Path
+import json
 import re
 import unittest
 
 from python.runfiles import runfiles
 
 
+BAZEL_DIFF_TAG = "v18.1.0"
+BAZEL_DIFF_SHA256 = "eadec6d0ca0991de78bd9e063bfed993a359ed3bc60e507818077c300b6f58e0"
+CLOC_SHA256 = "73570f9da159fab13846038de7c3d8772554117c04117281dcbe6e5c7b988264"
+DOXYGEN_SHA256 = "0ec2e5b2c3cd82b7106d19cb42d8466450730b8cb7a9e85af712be38bf4523a1"
+
+
 def _read(path):
     resolved = runfiles.Create().Rlocation("donner/%s" % path)
     with open(resolved, encoding="utf-8") as handle:
         return handle.read()
+
+
+def _read_supply_chain_files():
+    resolver = runfiles.Create()
+    main = Path(resolver.Rlocation("donner/.github/workflows/main.yml"))
+    github = main.parent.parent
+    paths = sorted((github / "workflows").glob("*.y*ml"))
+    paths.extend(sorted((github / "actions").glob("*/action.y*ml")))
+    return {
+        str(path.relative_to(github.parent)): path.read_text(encoding="utf-8")
+        for path in paths
+    }
 
 
 def _step_body(workflow, name):
@@ -21,12 +41,202 @@ def _step_body(workflow, name):
     return body[: next_step.start()] if next_step else body
 
 
+def _run_bodies(workflow):
+    lines = workflow.splitlines()
+    bodies = []
+    index = 0
+    while index < len(lines):
+        match = re.match(r"^(\s*)run:\s*\|", lines[index])
+        if not match:
+            index += 1
+            continue
+        indentation = len(match.group(1))
+        index += 1
+        body = []
+        while index < len(lines):
+            line = lines[index]
+            if line and len(line) - len(line.lstrip()) <= indentation:
+                break
+            body.append(line)
+            index += 1
+        bodies.append("\n".join(body))
+    return bodies
+
+
 class SecurityWorkflowPolicyTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.codeql = _read(".github/workflows/codeql.yml")
         cls.fuzz = _read(".github/workflows/fuzz.yml")
         cls.sanitizers = _read(".github/workflows/sanitizers.yml")
+        cls.supply_chain_files = _read_supply_chain_files()
+
+    def test_external_actions_are_pinned_to_commits(self):
+        """Every external action is immutable and remains update-tool friendly."""
+        action_line = re.compile(
+            r"^\s*(?:-\s*)?uses:\s*(?P<target>\S+?)(?:\s+#\s*(?P<version>\S+))?\s*$"
+        )
+        full_commit = re.compile(r"^[0-9a-f]{40}$")
+        version_comment = re.compile(r"^v?\d+(?:\.\d+){0,2}$")
+        pins = {}
+        seen = 0
+
+        for path, contents in self.supply_chain_files.items():
+            for line_number, line in enumerate(contents.splitlines(), start=1):
+                match = action_line.match(line)
+                if not match or "@" not in match.group("target"):
+                    continue
+
+                target, revision = match.group("target").rsplit("@", 1)
+                if target.startswith("./") or target.startswith("docker://"):
+                    continue
+
+                version = match.group("version")
+                with self.subTest(path=path, line=line_number, action=target):
+                    self.assertRegex(
+                        revision,
+                        full_commit,
+                        "%s:%d uses a mutable external action revision" % (path, line_number),
+                    )
+                    self.assertIsNotNone(
+                        version,
+                        "%s:%d needs a trailing version comment for dependency updates"
+                        % (path, line_number),
+                    )
+                    self.assertRegex(version, version_comment)
+
+                pins.setdefault((target, version), set()).add(revision)
+                seen += 1
+
+        self.assertGreaterEqual(seen, 75, "external action discovery no longer covers the workflows")
+        for (target, version), revisions in pins.items():
+            self.assertEqual(
+                1,
+                len(revisions),
+                "%s %s is pinned inconsistently: %s"
+                % (target, version, sorted(revisions)),
+            )
+
+    def test_downloaded_bazel_diff_is_verified_before_execution(self):
+        """The downloaded JAR must match the digest published for its release."""
+        for path in (".github/workflows/main.yml", ".github/workflows/coverage.yml"):
+            workflow = self.supply_chain_files[path]
+            with self.subTest(path=path):
+                self.assertIn('BAZEL_DIFF_TAG: "%s"' % BAZEL_DIFF_TAG, workflow)
+                self.assertIn('BAZEL_DIFF_SHA256: "%s"' % BAZEL_DIFF_SHA256, workflow)
+
+                download = _step_body(workflow, "Download bazel-diff")
+                verification = "sha256sum --check --status"
+                self.assertIn("$BAZEL_DIFF_SHA256", download)
+                self.assertIn(verification, download)
+                self.assertLess(download.index(verification), download.index("exit 0"))
+                self.assertIn('rm -f "$out"', download)
+
+    def test_downloaded_tools_are_verified_before_extraction(self):
+        cases = (
+            (".github/workflows/badges.yaml", "Install cloc", CLOC_SHA256),
+            (".github/workflows/deploy_docs.yaml", "Install Doxygen", DOXYGEN_SHA256),
+        )
+        for path, step, digest in cases:
+            with self.subTest(path=path):
+                body = _step_body(self.supply_chain_files[path], step)
+                self.assertIn(digest, body)
+                verification = "sha256sum --check --strict"
+                self.assertIn(verification, body)
+                self.assertLess(body.index(verification), body.index("tar "))
+
+    def test_release_builds_once_then_attests_and_publishes(self):
+        release = self.supply_chain_files[".github/workflows/release.yml"]
+        self.assertIn("types: [published]", release)
+        self.assertNotIn("edited", release)
+        self.assertNotIn("workflow_dispatch", release)
+        self.assertIn("permissions:\n  contents: read", release)
+        self.assertIn("publish-release-artifacts:", release)
+        self.assertIn("contents: write", release)
+        self.assertIn("id-token: write", release)
+        self.assertIn("attestations: write", release)
+        self.assertIn("actions/upload-artifact@", release)
+        self.assertIn("actions/download-artifact@", release)
+        self.assertIn("actions/attest-build-provenance@", release)
+        self.assertIn("sha256sum --check --strict", release)
+        self.assertGreaterEqual(release.count("if: github.run_attempt == 1"), 3)
+        self.assertEqual(release.count("--lockfile_mode=error"), 2)
+        self.assertIn("cmp --silent expected.provenance release/linux/", release)
+        self.assertIn("cmp --silent expected.provenance release/macos/", release)
+        self.assertIn("RELEASE_UPLOAD_URL: ${{ github.event.release.upload_url }}", release)
+        self.assertIn("Upload verified release artifacts without replacement", release)
+        self.assertIn("gh api --method POST", release)
+        self.assertNotIn("softprops/action-gh-release", release)
+        self.assertNotIn("publish-to-bcr", release)
+        self.assertNotIn("svenstaro/upload-release-action", release)
+        for body in _run_bodies(release):
+            self.assertNotIn("${{", body, "release run blocks must use quoted environment values")
+
+        lock = json.loads(_read("MODULE.bazel.lock"))
+        self.assertGreaterEqual(lock["lockFileVersion"], 1)
+        ignored = set(_read(".gitignore").splitlines())
+        self.assertNotIn("MODULE.bazel.lock", ignored)
+
+    def test_git_dependencies_use_immutable_commits(self):
+        deps = _read("third_party/bazel/non_bcr_deps.bzl")
+        self.assertNotRegex(deps, r"(?m)^\s*tag\s*=")
+        for block in re.findall(r"(?:new_)?git_repository\((.*?)\n\s*\)", deps, re.DOTALL):
+            if "remote =" not in block:
+                continue
+            self.assertRegex(block, r'commit\s*=\s*"[0-9a-f]{40}"')
+
+    def test_fuzzer_variant_tags_derive_matching_ubsan_lanes(self):
+        rules = _read("build_defs/rules.bzl")
+        self.assertIn('"fuzz_text_full" in common_tags', rules)
+        self.assertIn('ubsan_tags.append("fuzz_ubsan_text_full")', rules)
+        self.assertIn('"fuzz_geode" in common_tags', rules)
+        self.assertIn('ubsan_tags.append("fuzz_ubsan_geode")', rules)
+
+    def test_pull_requests_never_receive_the_buildbuddy_write_key(self):
+        guarded = (
+            "github.event_name != 'pull_request' && "
+            "github.event_name != 'pull_request_target'"
+        )
+        self.assertNotIn(
+            "secrets.BUILDBUDDY_API_KEY",
+            self.supply_chain_files[".github/workflows/sanitizers-pr.yml"],
+        )
+        for path, workflow in self.supply_chain_files.items():
+            if re.search(r"(?m)^  pull_request:", workflow):
+                with self.subTest(path=path, invariant="no-pr-cache-secret"):
+                    self.assertNotIn("secrets.BUILDBUDDY_API_KEY", workflow)
+        for path, workflow in self.supply_chain_files.items():
+            if "uses: ./.github/actions/buildbuddy-cache" not in workflow:
+                continue
+            bodies = workflow.split("      - name: Configure BuildBuddy remote cache\n")[1:]
+            for index, body in enumerate(bodies):
+                step = body.split("\n      - name:", 1)[0]
+                with self.subTest(path=path, step=index):
+                    self.assertIn(guarded, step)
+                    self.assertIn("secrets.BUILDBUDDY_API_KEY", step)
+
+    def test_sensitive_workflows_use_least_privilege_and_drop_checkout_credentials(self):
+        paths = (
+            ".github/workflows/badges.yaml",
+            ".github/workflows/cmake.yml",
+            ".github/workflows/lint.yml",
+            ".github/workflows/release.yml",
+            ".github/workflows/sanitizers-pr.yml",
+        )
+        for path in paths:
+            workflow = self.supply_chain_files[path]
+            with self.subTest(path=path):
+                self.assertRegex(workflow, r"(?m)^permissions:\n  contents: read$")
+                checkout_count = workflow.count("uses: actions/checkout@")
+                self.assertGreater(checkout_count, 0)
+                self.assertEqual(checkout_count, workflow.count("persist-credentials: false"))
+
+        for path, workflow in self.supply_chain_files.items():
+            checkout_count = workflow.count("uses: actions/checkout@")
+            if checkout_count == 0:
+                continue
+            with self.subTest(path=path, invariant="checkout-credentials"):
+                self.assertEqual(checkout_count, workflow.count("persist-credentials: false"))
 
     def test_heavy_security_workflows_do_not_gate_pull_requests(self):
         self.assertNotRegex(self.codeql, r"(?m)^  pull_request:")


### PR DESCRIPTION
Pins CI dependencies and makes release artifacts a single-attempt, digest-verified handoff from reviewed source.

- uses released GitHub Action and Bazel dependency tags so Renovate follows published releases
- verifies downloaded executable archives by SHA-256 while keeping generated Bzlmod lock state local
- removes write-capable BuildBuddy credentials from PR and arbitrary-branch execution paths
- builds Linux and macOS binaries once, compares both provenance manifests to the tagged source, attests the binaries, and uploads without replacement
- keeps BCR publication separate and operator-initiated after release artifact verification
- routes every deterministic fuzzer corpus into the UBSan sweep and derives text-full variant coverage automatically

## Validation

- `bazel test //...`: 350 passed, 120 configuration-intentional skips, 0 failures
- `tools/lint.sh`: 2,588 files clean
- `python3 tools/cmake/gen_cmakelists.py --check`: passed
- CI workflow policy and CMake generator tests: passed
- dependency tags, archive digests, release permissions, and build provenance independently reviewed
