### PR TITLE
Use typed URL launches and bounded proc parsing

### DIFF
--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -302,6 +302,27 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "external_url_launcher",
+    srcs = ["ExternalUrl.cc"] + select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["ExternalUrlLauncher.cc"],
+    }),
+    hdrs = ["ExternalUrlLauncher.h"],
+    deps = [],
+)
+
+objc_library(
+    name = "external_url_launcher_macos",
+    srcs = ["ExternalUrlLauncherMac.mm"],
+    sdk_frameworks = ["AppKit"],
+    target_compatible_with = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [":external_url_launcher"],
+)
+
+donner_cc_library(
     name = "native_file_dialog",
     srcs = select({
         "@platforms//os:macos": [],
@@ -1076,6 +1097,7 @@ donner_cc_library(
         ":render_coordinator",
         ":render_pane_presenter",
         ":rotate_cursor_set",
+        ":sample_picker_controller",
         ":sample_picker_presenter",
         ":select_tool",
         ":selection_transform_handles",
@@ -1400,12 +1422,26 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "sample_picker_controller",
+    srcs = ["SamplePickerController.cc"],
+    hdrs = ["SamplePickerController.h"],
+    deps = [
+        ":external_url_launcher",
+        ":sample_picker_presenter",
+    ] + select({
+        "@platforms//os:macos": [":external_url_launcher_macos"],
+        "//conditions:default": [],
+    }),
+)
+
+donner_cc_library(
     name = "sample_picker_presenter",
     srcs = ["SamplePickerPresenter.cc"],
     hdrs = ["SamplePickerPresenter.h"],
     deps = [
         ":editor_sample_catalog",
         ":editor_theme",
+        ":external_url_launcher",
         ":imgui_headers",
         "@imgui",
     ],

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -4672,25 +4672,7 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
     // input arrives to wake the event-driven browser loop.
     window_.wakeEventLoop();
   }
-  if (actions.openGitHub) {
-#ifdef __EMSCRIPTEN__
-    EM_ASM({
-      const url = 'https://github.com/jwmcglynn/donner';
-      const opened = window.open(url, '_blank', 'noopener');
-      if (!opened) {
-        window.location.assign(url);
-      }
-    });
-#elif defined(__APPLE__)
-    const std::string openCommand =
-        std::string("open \"") + std::string(kSamplePickerGitHubUrl) + "\"";
-    std::system(openCommand.c_str());
-#else
-    const std::string openCommand =
-        std::string("xdg-open \"") + std::string(kSamplePickerGitHubUrl) + "\"";
-    std::system(openCommand.c_str());
-#endif
-  }
+  (void)samplePickerController_.applyExternalActions(actions);
   if (actions.loadSample) {
     queuePendingSampleLoad(actions.sampleId);
     // Start a clean, idle replacement after this frame's document UI work has already finished.

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -33,6 +33,7 @@
 #include "donner/editor/RenderCoordinator.h"
 #include "donner/editor/RenderPanePresenter.h"
 #include "donner/editor/RotateCursorSet.h"
+#include "donner/editor/SamplePickerController.h"
 #include "donner/editor/SamplePickerPresenter.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
@@ -639,6 +640,7 @@ private:
   bool penDragFlushedThisFrame_ = false;
   EditorInputBridge inputBridge_;
   MenuBarPresenter menuBarPresenter_;
+  SamplePickerController samplePickerController_;
   SamplePickerPresenter samplePickerPresenter_;
   TextFormatBarPresenter textFormatBarPresenter_;
   SidebarPresenter sidebarPresenter_;

--- a/donner/editor/ExternalUrl.cc
+++ b/donner/editor/ExternalUrl.cc
@@ -1,0 +1,13 @@
+#include "donner/editor/ExternalUrlLauncher.h"
+
+namespace donner::editor {
+
+std::string_view ExternalUrlValue(ExternalUrlTarget target) {
+  switch (target) {
+    case ExternalUrlTarget::DonnerRepository: return "https://github.com/jwmcglynn/donner";
+  }
+
+  return {};
+}
+
+}  // namespace donner::editor

--- a/donner/editor/ExternalUrlLauncher.cc
+++ b/donner/editor/ExternalUrlLauncher.cc
@@ -1,0 +1,60 @@
+#include "donner/editor/ExternalUrlLauncher.h"
+
+#include <string>
+
+#if defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#elif defined(__linux__)
+#include <spawn.h>
+#include <sys/wait.h>
+
+#include <cerrno>
+
+extern char** environ;
+#endif
+
+namespace donner::editor {
+
+bool LaunchExternalUrl(ExternalUrlTarget target) {
+  const std::string_view url = ExternalUrlValue(target);
+  if (url.empty()) {
+    return false;
+  }
+
+#if defined(__EMSCRIPTEN__)
+  // The editor runs on a worker, so browser globals must be touched on the main thread. The URL
+  // points into static storage and remains valid until the asynchronous callback consumes it.
+  // clang-format off
+  MAIN_THREAD_ASYNC_EM_ASM(
+      {
+        const url = UTF8ToString($0, $1);
+        const opened = window.open(url, '_blank', 'noopener');
+        if (!opened) {
+          window.location.assign(url);
+        }
+      },
+      url.data(), static_cast<int>(url.size()));
+  // clang-format on
+  return true;
+#elif defined(__linux__)
+  std::string program = "xdg-open";
+  std::string ownedUrl(url);
+  char* arguments[] = {program.data(), ownedUrl.data(), nullptr};
+  pid_t child = 0;
+  if (posix_spawnp(&child, program.c_str(), nullptr, nullptr, arguments, environ) != 0) {
+    return false;
+  }
+
+  int status = 0;
+  pid_t waitResult = 0;
+  do {
+    waitResult = waitpid(child, &status, 0);
+  } while (waitResult == -1 && errno == EINTR);
+  return waitResult == child && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+#else
+  return false;
+#endif
+}
+
+}  // namespace donner::editor

--- a/donner/editor/ExternalUrlLauncher.h
+++ b/donner/editor/ExternalUrlLauncher.h
@@ -1,0 +1,26 @@
+#pragma once
+/// @file
+/// Typed external destinations opened by the editor through platform APIs.
+
+#include <string_view>
+
+namespace donner::editor {
+
+/// External destinations the editor is allowed to open.
+enum class ExternalUrlTarget {
+  DonnerRepository,
+};
+
+/// Resolve an allowlisted external destination to its HTTPS URL.
+///
+/// @param target Destination to resolve.
+/// @return Stable process-lifetime URL string.
+[[nodiscard]] std::string_view ExternalUrlValue(ExternalUrlTarget target);
+
+/// Open an allowlisted destination with the platform URL handler.
+///
+/// @param target Destination to open.
+/// @return True when the platform accepted the launch request.
+[[nodiscard]] bool LaunchExternalUrl(ExternalUrlTarget target);
+
+}  // namespace donner::editor

--- a/donner/editor/ExternalUrlLauncherMac.mm
+++ b/donner/editor/ExternalUrlLauncherMac.mm
@@ -1,0 +1,26 @@
+#include "donner/editor/ExternalUrlLauncher.h"
+
+#import <AppKit/AppKit.h>
+
+#include <string>
+
+namespace donner::editor {
+
+bool LaunchExternalUrl(ExternalUrlTarget target) {
+  const std::string url(ExternalUrlValue(target));
+  if (url.empty()) {
+    return false;
+  }
+
+  @autoreleasepool {
+    NSString* value = [NSString stringWithUTF8String:url.c_str()];
+    if (value == nil) {
+      return false;
+    }
+
+    NSURL* externalUrl = [NSURL URLWithString:value];
+    return externalUrl != nil && [[NSWorkspace sharedWorkspace] openURL:externalUrl];
+  }
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SamplePickerController.cc
+++ b/donner/editor/SamplePickerController.cc
@@ -1,0 +1,18 @@
+#include "donner/editor/SamplePickerController.h"
+
+#include <utility>
+
+namespace donner::editor {
+
+SamplePickerController::SamplePickerController(ExternalUrlLaunchFunction launchExternalUrl)
+    : launchExternalUrl_(std::move(launchExternalUrl)) {}
+
+bool SamplePickerController::applyExternalActions(const SamplePickerActions& actions) const {
+  if (!actions.openGitHub || !launchExternalUrl_) {
+    return false;
+  }
+
+  return launchExternalUrl_(ExternalUrlTarget::DonnerRepository);
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SamplePickerController.h
+++ b/donner/editor/SamplePickerController.h
@@ -1,0 +1,31 @@
+#pragma once
+/// @file
+/// Side-effect controller for semantic actions emitted by the sample picker.
+
+#include <functional>
+
+#include "donner/editor/ExternalUrlLauncher.h"
+#include "donner/editor/SamplePickerPresenter.h"
+
+namespace donner::editor {
+
+/// Function that opens one typed external destination.
+using ExternalUrlLaunchFunction = std::function<bool(ExternalUrlTarget)>;
+
+/// Applies sample-picker actions that cross the editor's platform boundary.
+class SamplePickerController {
+public:
+  /// @param launchExternalUrl Platform URL launch port. Tests may provide a recording fake.
+  explicit SamplePickerController(ExternalUrlLaunchFunction launchExternalUrl = LaunchExternalUrl);
+
+  /// Apply external side effects requested by the presenter.
+  ///
+  /// @param actions Semantic actions emitted for the current frame.
+  /// @return True when an external launch was requested and accepted.
+  [[nodiscard]] bool applyExternalActions(const SamplePickerActions& actions) const;
+
+private:
+  ExternalUrlLaunchFunction launchExternalUrl_;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -5,6 +5,7 @@
 #include <span>
 
 #include "donner/editor/EditorTheme.h"
+#include "donner/editor/ExternalUrlLauncher.h"
 #include "donner/editor/ImGuiIncludes.h"
 
 namespace donner::editor {
@@ -185,7 +186,7 @@ SamplePickerActions SamplePickerPresenter::render(
   const float linkY =
       ImGui::GetCursorPosY() + (kSamplePickerMinTouchTarget - ImGui::GetTextLineHeight()) * 0.5f;
   ImGui::SetCursorPosY(linkY);
-  if (ImGui::TextLink(kSamplePickerGitHubUrl.data())) {
+  if (ImGui::TextLink(ExternalUrlValue(ExternalUrlTarget::DonnerRepository).data())) {
     ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, &actions);
   }
   if (ImGui::IsItemHovered()) {

--- a/donner/editor/SamplePickerPresenter.h
+++ b/donner/editor/SamplePickerPresenter.h
@@ -22,10 +22,6 @@ inline constexpr float kSamplePickerNarrowBreakpoint = 640.0f;
 inline constexpr std::size_t kSamplePickerMaxColumns = 3;
 inline constexpr std::size_t kSamplePickerMaxVisibleSamples = 8;
 
-/// Public destination for the presenter's GitHub action. The presenter only
-/// reports the action; the host decides whether and how to navigate to it.
-inline constexpr std::string_view kSamplePickerGitHubUrl = "https://github.com/jwmcglynn/donner";
-
 enum class SamplePickerLayoutMode {
   Narrow,
   Wide,

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -153,6 +153,16 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "sample_picker_controller_tests",
+    size = "small",
+    srcs = ["SamplePickerController_tests.cc"],
+    deps = [
+        "//donner/editor:sample_picker_controller",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "sample_thumbnail_async_tests",
     srcs = ["SampleThumbnailAsync_tests.cc"],
     deps = [

--- a/donner/editor/tests/SamplePickerController_tests.cc
+++ b/donner/editor/tests/SamplePickerController_tests.cc
@@ -1,0 +1,50 @@
+#include "donner/editor/SamplePickerController.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string_view>
+
+namespace donner::editor {
+namespace {
+
+TEST(SamplePickerController, DonnerRepositoryUsesFixedHttpsDestination) {
+  EXPECT_EQ(ExternalUrlValue(ExternalUrlTarget::DonnerRepository),
+            std::string_view("https://github.com/jwmcglynn/donner"));
+}
+
+TEST(SamplePickerController, OpensTypedRepositoryDestination) {
+  std::optional<ExternalUrlTarget> launchedTarget;
+  SamplePickerController controller([&launchedTarget](ExternalUrlTarget target) {
+    launchedTarget = target;
+    return true;
+  });
+  SamplePickerActions actions;
+  actions.openGitHub = true;
+
+  EXPECT_TRUE(controller.applyExternalActions(actions));
+  ASSERT_TRUE(launchedTarget.has_value());
+  EXPECT_EQ(*launchedTarget, ExternalUrlTarget::DonnerRepository);
+}
+
+TEST(SamplePickerController, IgnoresFramesWithoutExternalAction) {
+  int launchCount = 0;
+  SamplePickerController controller([&launchCount](ExternalUrlTarget) {
+    ++launchCount;
+    return true;
+  });
+
+  EXPECT_FALSE(controller.applyExternalActions(SamplePickerActions{}));
+  EXPECT_EQ(launchCount, 0);
+}
+
+TEST(SamplePickerController, PropagatesPlatformLaunchFailure) {
+  SamplePickerController controller([](ExternalUrlTarget) { return false; });
+  SamplePickerActions actions;
+  actions.openGitHub = true;
+
+  EXPECT_FALSE(controller.applyExternalActions(actions));
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/svg/renderer/benchmarks/BUILD.bazel
+++ b/donner/svg/renderer/benchmarks/BUILD.bazel
@@ -2,9 +2,26 @@
 timing for the Geode WebGPU/Slug backend."""
 
 load("//build_defs:package.bzl", "donner_package")
-load("//build_defs:rules.bzl", "donner_cc_binary")
+load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "donner_cc_test")
 
 package(default_visibility = ["//visibility:public"])
+
+donner_cc_library(
+    name = "proc_status_parser",
+    srcs = ["ProcStatusParser.cc"],
+    hdrs = ["ProcStatusParser.h"],
+    deps = [],
+)
+
+donner_cc_test(
+    name = "proc_status_parser_tests",
+    size = "small",
+    srcs = ["ProcStatusParser_tests.cc"],
+    deps = [
+        ":proc_status_parser",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
 
 donner_cc_binary(
     name = "shape_prepare_perf_bench",
@@ -55,6 +72,7 @@ donner_cc_binary(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":proc_status_parser",
         "//donner/base",
         "//donner/svg",
         "//donner/svg/parser",

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -48,6 +48,7 @@
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/benchmarks/AllocationTracker.h"
+#include "donner/svg/renderer/benchmarks/ProcStatusParser.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 
 namespace {
@@ -122,9 +123,9 @@ std::uint64_t readProcStatusKb(std::string_view field) {
   std::string line;
   while (std::getline(status, line)) {
     if (line.starts_with(field)) {
-      std::uint64_t value = 0;
-      if (std::sscanf(line.c_str() + field.size(), "%" PRIu64, &value) == 1) {
-        return static_cast<std::uint64_t>(value);
+      if (const std::optional<std::uint64_t> value =
+              donner::benchmarks::ParseProcStatusKilobytes(line, field)) {
+        return *value;
       }
       return 0;
     }
@@ -350,8 +351,8 @@ void printAllocation(std::string_view engine, std::string_view phase,
   // scope=cpp_heap_only: only C++ operator new/delete are counted, so
   // wgpu-native's Rust-side allocations are invisible; do not compare these
   // numbers across engines (see the file header).
-  std::printf("ALLOC engine=%.*s phase=%.*s calls=%" PRIu64 " bytes=%" PRIu64
-              " frees=%" PRIu64 " scope=cpp_heap_only\n",
+  std::printf("ALLOC engine=%.*s phase=%.*s calls=%" PRIu64 " bytes=%" PRIu64 " frees=%" PRIu64
+              " scope=cpp_heap_only\n",
               static_cast<int>(engine.size()), engine.data(), static_cast<int>(phase.size()),
               phase.data(), static_cast<std::uint64_t>(snapshot.allocationCalls),
               static_cast<std::uint64_t>(snapshot.allocationBytes),
@@ -432,11 +433,10 @@ int main(int argc, char* argv[]) {
   AllocationSnapshot firstAllocations;
   AllocationSnapshot secondAllocations;
   if (geodeMode) {
-    if (!runAllocationPass(source,
-                           [&sharedDevice] {
-                             return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false);
-                           },
-                           parseAllocations, firstAllocations, secondAllocations)) {
+    if (!runAllocationPass(
+            source,
+            [&sharedDevice] { return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false); },
+            parseAllocations, firstAllocations, secondAllocations)) {
       return 1;
     }
   } else {

--- a/donner/svg/renderer/benchmarks/ProcStatusParser.cc
+++ b/donner/svg/renderer/benchmarks/ProcStatusParser.cc
@@ -1,0 +1,49 @@
+#include "donner/svg/renderer/benchmarks/ProcStatusParser.h"
+
+#include <charconv>
+#include <system_error>
+
+namespace donner::benchmarks {
+namespace {
+
+bool IsAsciiWhitespace(char value) {
+  return value == ' ' || value == '\t' || value == '\r' || value == '\n';
+}
+
+void TrimAsciiWhitespace(std::string_view& value) {
+  while (!value.empty() && IsAsciiWhitespace(value.front())) {
+    value.remove_prefix(1);
+  }
+  while (!value.empty() && IsAsciiWhitespace(value.back())) {
+    value.remove_suffix(1);
+  }
+}
+
+}  // namespace
+
+std::optional<std::uint64_t> ParseProcStatusKilobytes(std::string_view line,
+                                                      std::string_view field) {
+  if (field.empty() || !line.starts_with(field)) {
+    return std::nullopt;
+  }
+
+  line.remove_prefix(field.size());
+  TrimAsciiWhitespace(line);
+
+  std::uint64_t value = 0;
+  const std::from_chars_result result =
+      std::from_chars(line.data(), line.data() + line.size(), value);
+  if (result.ec != std::errc() || result.ptr == line.data()) {
+    return std::nullopt;
+  }
+
+  std::string_view suffix(result.ptr, line.data() + line.size());
+  TrimAsciiWhitespace(suffix);
+  if (suffix != "kB") {
+    return std::nullopt;
+  }
+
+  return value;
+}
+
+}  // namespace donner::benchmarks

--- a/donner/svg/renderer/benchmarks/ProcStatusParser.h
+++ b/donner/svg/renderer/benchmarks/ProcStatusParser.h
@@ -1,0 +1,19 @@
+#pragma once
+/// @file
+/// Strict parser for numeric KiB fields in Linux `/proc/self/status` lines.
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace donner::benchmarks {
+
+/// Parse one named `/proc/self/status` field with a `kB` suffix.
+///
+/// @param line Complete status line, for example `VmRSS: 1234 kB`.
+/// @param field Field prefix including the colon, for example `VmRSS:`.
+/// @return Parsed KiB value, or nullopt for mismatched, malformed, or overflowing input.
+[[nodiscard]] std::optional<std::uint64_t> ParseProcStatusKilobytes(std::string_view line,
+                                                                    std::string_view field);
+
+}  // namespace donner::benchmarks

--- a/donner/svg/renderer/benchmarks/ProcStatusParser_tests.cc
+++ b/donner/svg/renderer/benchmarks/ProcStatusParser_tests.cc
@@ -1,0 +1,34 @@
+#include "donner/svg/renderer/benchmarks/ProcStatusParser.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+
+namespace donner::benchmarks {
+namespace {
+
+TEST(ProcStatusParser, ParsesWhitespaceAndKilobyteSuffix) {
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS:\t  12345 kB", "VmRSS:"),
+            std::optional<std::uint64_t>(12345u));
+  EXPECT_EQ(ParseProcStatusKilobytes("VmHWM: 0 kB\r", "VmHWM:"), std::optional<std::uint64_t>(0u));
+}
+
+TEST(ProcStatusParser, RequiresExactFieldAndUnit) {
+  EXPECT_EQ(ParseProcStatusKilobytes("VmHWM: 123 kB", "VmRSS:"), std::nullopt);
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: 123 MB", "VmRSS:"), std::nullopt);
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: 123 kB trailing", "VmRSS:"), std::nullopt);
+}
+
+TEST(ProcStatusParser, RejectsMissingNegativeAndOverflowingValues) {
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: kB", "VmRSS:"), std::nullopt);
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: -1 kB", "VmRSS:"), std::nullopt);
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: 18446744073709551616 kB", "VmRSS:"), std::nullopt);
+}
+
+TEST(ProcStatusParser, RejectsEmptyField) {
+  EXPECT_EQ(ParseProcStatusKilobytes("VmRSS: 123 kB", ""), std::nullopt);
+}
+
+}  // namespace
+}  // namespace donner::benchmarks


### PR DESCRIPTION
Removes three CodeFactor security signals by replacing unnecessary shell and C-parser boundaries with typed platform and numeric parsing APIs.

- Replace the editor's two fixed GitHub URL `std::system` calls with an allowlisted `ExternalUrlTarget` and platform launch adapters.
- Use `NSWorkspace` on macOS, argv-based `posix_spawnp` on Linux, and main-thread-proxied browser navigation in Wasm.
- Route sample-picker actions through a narrow controller seam with recording-fake and failure-path tests.
- Replace the renderer benchmark's `std::sscanf` parsing with a strict `std::from_chars` parser for `/proc/self/status` kilobyte fields.

Builds on #1026.

## Diagnosis

The editor currently launches only a compile-time Donner repository URL, so no attacker-controlled string reached the shell. The shell boundary was still unnecessary, platform-dependent, and difficult to test. The typed target allowlist preserves the intended destination while platform APIs avoid command construction entirely.

The benchmark parsed a kernel-provided numeric field with a fixed `uint64_t` destination, so the reported character-buffer overflow class did not match the actual operation. The replacement parser makes the numeric bound explicit and rejects malformed fields, negative values, wrong units, trailing data, and overflow.

## Verification

- Full `bazel test //...` equivalent through the repository wrapper: 448 passed, 23 declared platform skips.
- Focused controller, presenter, proc-parser, editor-shell, and thumbnail tests.
- Geode editor Wasm package build and package-size test.
- Linux Geode editor-shell and renderer benchmark builds.
- `tools/lint.sh`.
- `python3 tools/cmake/gen_cmakelists.py --check`.
- Buildifier and `git diff --check`.
- Independent exact-diff review with no P0-P3 findings.
