### PR TITLE
Bound external resource admission and caching

### DIFF
--- a/donner/editor/repro/ReproFile_tests.cc
+++ b/donner/editor/repro/ReproFile_tests.cc
@@ -1304,10 +1304,9 @@ TEST(ReproFileTest, ReadsWhitespacePrefixedNestedBlocksAndEmptyArrays) {
       R"("left_mouse_down_ordinal":1,"frame_offset_after_left_mouse_down":2,)"
       R"("min_frame_index":3,"max_frame_index":4,"target_selector":"#target",)"
       R"("crop_mode":"document","crop": 	{"x":5,"y":6,"w":7,"h":8})";
-  WriteTextFile(path,
-                MetadataLineWith(std::string(R"(,"expect": 	{)") + expect + "}") +
-                    FrameLineWith(std::string(R"(,"vp": 	{)") + viewport +
-                                  R"(},"a":[],"e":[{"k":"mdown","hit": 	{"tag":"rect"}}])"));
+  WriteTextFile(path, MetadataLineWith(std::string(R"(,"expect": 	{)") + expect + "}") +
+                          FrameLineWith(std::string(R"(,"vp": 	{)") + viewport +
+                                        R"(},"a":[],"e":[{"k":"mdown","hit": 	{"tag":"rect"}}])"));
 
   auto loaded = ReadReproFile(path);
   ASSERT_TRUE(loaded.has_value());
@@ -1484,6 +1483,13 @@ TEST(ReproFileTest, ReadsExternalSvgOnlyWithinReplayDirectory) {
 
   EXPECT_FALSE(ReadReproSvgFile(rnrPath, "../outside.svg").has_value());
   EXPECT_FALSE(ReadReproSvgFile(rnrPath, svgPath.string()).has_value());
+
+  std::error_code symlinkError;
+  const std::filesystem::path symlinkPath = root / "linked.svg";
+  std::filesystem::create_symlink(svgPath, symlinkPath, symlinkError);
+  if (!symlinkError) {
+    EXPECT_FALSE(ReadReproSvgFile(rnrPath, "linked.svg").has_value());
+  }
 
   std::error_code cleanupError;
   std::filesystem::remove_all(root, cleanupError);

--- a/donner/svg/components/resources/BUILD.bazel
+++ b/donner/svg/components/resources/BUILD.bazel
@@ -42,6 +42,7 @@ donner_cc_library(
         "//donner/base/encoding:decompress",
         "//donner/css:core",
         "//donner/svg:svg_document_handle",
+        "//donner/svg/components:components_core",
         "//donner/svg/resources:image_loader",
         "//donner/svg/resources:resource_loader_interface",
         "//donner/svg/resources:url_loader",

--- a/donner/svg/components/resources/ImageComponent.h
+++ b/donner/svg/components/resources/ImageComponent.h
@@ -23,6 +23,9 @@ struct ImageComponent {
  * raster image (PNG, JPEG, GIF).
  */
 struct LoadedImageComponent {
+  LoadedImageComponent() = default;
+  explicit LoadedImageComponent(ImageResource loadedImage) : image(std::move(loadedImage)) {}
+
   std::optional<ImageResource> image;  //!< Loaded image resource.
 };
 

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -13,6 +13,7 @@
 #include "donner/css/FontFace.h"
 #include "donner/svg/components/ParsedPayloadResourceBudget.h"
 #include "donner/svg/components/SVGDocumentContext.h"
+#include "donner/svg/components/StylesheetComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/resources/SubDocumentCache.h"
 #include "donner/svg/resources/ImageLoader.h"
@@ -329,7 +330,14 @@ ResourceManagerContext::ResourceManagerContext(Registry& registry,
                                                size_t maximumExternalFetchAttempts)
     : registry_(registry),
       remainingResourceBytes_(maximumAggregateResourceSize),
-      remainingResourceFetchAttempts_(maximumExternalFetchAttempts) {}
+      remainingResourceFetchAttempts_(maximumExternalFetchAttempts) {
+  registry_.on_destroy<StylesheetComponent>().connect<&ResourceManagerContext::onStylesheetDestroy>(
+      this);
+}
+
+void ResourceManagerContext::onStylesheetDestroy(Registry&, Entity entity) {
+  stylesheetFontFaceRegistrations_.erase(entity);
+}
 
 void ResourceManagerContext::setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader) {
   failedImageUrls_.clear();
@@ -466,12 +474,23 @@ void ResourceManagerContext::synchronizeStylesheetFontFaces(
   if (registration.data == fontFaces.data() && registration.size == fontFaces.size()) return;
   registration = {.data = fontFaces.data(), .size = fontFaces.size()};
 
-  const size_t remaining =
-      kMaximumStylesheetFontFaces - std::min(stylesheetFontFaceCount_, kMaximumStylesheetFontFaces);
-  const size_t insertCount = std::min(fontFaces.size(), remaining);
-  addFontFaces(fontFaces.first(insertCount));
-  stylesheetFontFaceCount_ += insertCount;
-  if (insertCount != fontFaces.size()) stylesheetFontFaceLimitRejected_ = true;
+  for (const css::FontFace& fontFace : fontFaces) {
+    std::string identity = css::FontFaceIdentityKey(fontFace);
+    if (const auto it = fontFaceIndexByIdentity_.find(identity);
+        it != fontFaceIndexByIdentity_.end()) {
+      fontFaceIndexesToLoad_.push_back(it->second);
+      continue;
+    }
+    if (stylesheetFontFaceCount_ >= kMaximumStylesheetFontFaces) {
+      stylesheetFontFaceLimitRejected_ = true;
+      break;
+    }
+
+    fontFaceIndexByIdentity_.emplace(std::move(identity), fontFaces_.size());
+    fontFaceIndexesToLoad_.push_back(fontFaces_.size());
+    fontFaces_.push_back(fontFace);
+    ++stylesheetFontFaceCount_;
+  }
 }
 
 std::optional<Vector2i> ResourceManagerContext::getImageSize(Entity entity) const {

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -116,8 +116,11 @@ SubDocumentCache::ParseCallback GuardSvgParseCallback(
 }  // namespace
 
 ResourceManagerContext::ResourceManagerContext(Registry& registry,
-                                               size_t maximumAggregateResourceSize)
-    : registry_(registry), remainingResourceBytes_(maximumAggregateResourceSize) {}
+                                               size_t maximumAggregateResourceSize,
+                                               size_t maximumExternalFetchAttempts)
+    : registry_(registry),
+      remainingResourceBytes_(maximumAggregateResourceSize),
+      remainingResourceFetchAttempts_(maximumExternalFetchAttempts) {}
 
 void ResourceManagerContext::setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader) {
   failedImageUrls_.clear();
@@ -301,7 +304,8 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
 }
 
 std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
-    const RcString& url, ParseWarningSink& warningSink) {
+    std::string_view url, ParseWarningSink& warningSink) {
+  const RcString boundedUrl(url);
   // In secure modes, external resource loading is disabled.
   if (processingMode_ == ProcessingMode::SecureStatic ||
       processingMode_ == ProcessingMode::SecureAnimated) {
@@ -329,10 +333,10 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
   auto& cache = registry_.ctx().get<SubDocumentCache>();
 
   // Check if already cached.
-  if (auto cached = cache.get(url)) {
+  if (auto cached = cache.get(boundedUrl)) {
     return cached;
   }
-  if (cache.isRejected(url)) {
+  if (cache.isRejected(boundedUrl)) {
     return std::nullopt;
   }
 
@@ -349,14 +353,14 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     err.reason = std::string("Failed to load external SVG '") + std::string(url) +
                  "': " + std::string(ToString(loaderError));
     warningSink.add(std::move(err));
-    cache.rememberFailure(url);
+    cache.rememberFailure(boundedUrl);
     return std::nullopt;
   }
 
   auto& data = std::get<UrlLoader::Result>(fetchResult).data;
   SubDocumentCache::ParseCallback guardedParseCallback =
       GuardSvgParseCallback(registry_, svgParseCallback_, remainingResourceBytes_);
-  return cache.getOrParse(url, data, guardedParseCallback, warningSink);
+  return cache.getOrParse(boundedUrl, data, guardedParseCallback, warningSink);
 }
 
 void ResourceManagerContext::addFontFaces(std::span<const css::FontFace> fontFaces) {

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -11,6 +11,7 @@
 #include "donner/base/Utils.h"
 #include "donner/base/encoding/Decompress.h"
 #include "donner/css/FontFace.h"
+#include "donner/svg/components/ParsedPayloadResourceBudget.h"
 #include "donner/svg/components/SVGDocumentContext.h"
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/resources/SubDocumentCache.h"
@@ -47,28 +48,69 @@ private:
   ResourceLoaderInterface& loader_;
 };
 
-class BoundedResourceLoader : public ResourceLoaderInterface {
+class BudgetedCachingResourceLoader : public ResourceLoaderInterface {
 public:
-  BoundedResourceLoader(ResourceLoaderInterface& loader, size_t& remainingAttempts,
-                        size_t& remainingResourceBytes)
+  using CachedFetchResult = std::variant<std::vector<uint8_t>, ResourceLoaderError>;
+
+  BudgetedCachingResourceLoader(ResourceLoaderInterface& loader,
+                                std::unordered_map<std::string, CachedFetchResult>& cache,
+                                ResourceManagerContext::FetchSecurityStats& securityStats,
+                                size_t& remainingAttempts, size_t maximumResourceSize,
+                                size_t& remainingResourceBytes)
       : loader_(loader),
+        cache_(cache),
+        securityStats_(securityStats),
         remainingAttempts_(remainingAttempts),
+        maximumResourceSize_(maximumResourceSize),
         remainingResourceBytes_(remainingResourceBytes) {}
 
   std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
       std::string_view url) override {
+    const std::string key(url);
+    if (const auto it = cache_.find(key); it != cache_.end()) {
+      ++securityStats_.cacheHits;
+      if (const auto* bytes = std::get_if<std::vector<uint8_t>>(&it->second);
+          bytes != nullptr &&
+          (bytes->size() > maximumResourceSize_ || bytes->size() > remainingResourceBytes_)) {
+        // Inspect the resident vector before returning the variant by value. Otherwise a resource
+        // that fit earlier in the document can be copied on every cache hit after the remaining
+        // aggregate budget has fallen below its size, even though UrlLoader rejects each copy.
+        securityStats_.rejected = true;
+        return ResourceLoaderError::TooLarge;
+      }
+      return it->second;
+    }
+
     if (remainingAttempts_ == 0 || remainingResourceBytes_ == 0) {
       remainingResourceBytes_ = 0;
+      securityStats_.rejected = true;
       return ResourceLoaderError::TooLarge;
     }
 
     --remainingAttempts_;
-    return loader_.fetchExternalResource(url);
+    ++securityStats_.attempts;
+    CachedFetchResult result = loader_.fetchExternalResource(url);
+    if (const auto* bytes = std::get_if<std::vector<uint8_t>>(&result);
+        bytes != nullptr &&
+        (bytes->size() > maximumResourceSize_ || bytes->size() > remainingResourceBytes_)) {
+      // Validate before transferring ownership into the persistent cache. UrlLoader performs the
+      // authoritative byte charge after this callback returns, but rejected positive results must
+      // not remain resident merely because they never consume that downstream budget.
+      securityStats_.rejected = true;
+      result = ResourceLoaderError::TooLarge;
+    } else if (bytes != nullptr) {
+      securityStats_.cachedBytes += bytes->size();
+    }
+    cache_.emplace(key, result);
+    return result;
   }
 
 private:
   ResourceLoaderInterface& loader_;
+  std::unordered_map<std::string, CachedFetchResult>& cache_;
+  ResourceManagerContext::FetchSecurityStats& securityStats_;
   size_t& remainingAttempts_;
+  size_t maximumResourceSize_;
   size_t& remainingResourceBytes_;
 };
 
@@ -113,6 +155,173 @@ SubDocumentCache::ParseCallback GuardSvgParseCallback(
   };
 }
 
+bool NeedsExternalLoader(std::string_view uri) {
+  return !uri.empty() && !uri.starts_with("data:") && !uri.starts_with("#");
+}
+
+bool HasExternalImagesToLoad(Registry& registry) {
+  for (auto view = registry.view<ImageComponent>(); auto entity : view) {
+    if (registry.all_of<LoadedImageComponent>(entity) ||
+        registry.all_of<LoadedSVGImageComponent>(entity)) {
+      continue;
+    }
+    if (NeedsExternalLoader(view.get<ImageComponent>(entity).href)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasExternalFontFacesToLoad(std::span<const css::FontFace> fontFaces,
+                                std::span<const size_t> indexes) {
+  for (const size_t index : indexes) {
+    for (const css::FontFaceSource& source : fontFaces[index].sources) {
+      if (source.kind == css::FontFaceSource::Kind::Url &&
+          NeedsExternalLoader(std::get<RcString>(source.payload))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void RememberImageFailure(std::unordered_set<RcString>& failedUrls, const RcString& href) {
+  if (failedUrls.size() < ResourceManagerContext::kMaximumResourceFetchAttempts) {
+    failedUrls.insert(href);
+  }
+}
+
+SubDocumentCache& PrepareSubDocumentCache(Registry& registry) {
+  if (!registry.ctx().contains<SubDocumentCache>()) {
+    registry.ctx().emplace<SubDocumentCache>();
+  }
+  auto& cache = registry.ctx().get<SubDocumentCache>();
+  cache.setRootEntityCount(registry.storage<Entity>().size());
+  if (const auto* payload = registry.ctx().find<ParsedPayloadResourceBudget>()) {
+    cache.setRootPayloadBytes(payload->securityStats().retainedBytes);
+  }
+  return cache;
+}
+
+bool AttachCachedSubDocument(Registry& registry, Entity entity, const RcString& href) {
+  auto* cache = registry.ctx().find<SubDocumentCache>();
+  if (!cache) {
+    return false;
+  }
+  auto cachedDocument = cache->get(href);
+  if (!cachedDocument) {
+    return false;
+  }
+  registry.emplace<LoadedSVGImageComponent>(entity, std::move(*cachedDocument));
+  return true;
+}
+
+void LoadSvgImage(Registry& registry, Entity entity, const ImageComponent& image,
+                  SvgImageContent& svgContent,
+                  const SubDocumentCache::ParseCallback& svgParseCallback,
+                  size_t& remainingResourceBytes, std::unordered_set<RcString>& failedUrls,
+                  ParseWarningSink& warningSink) {
+  if (!svgParseCallback) {
+    warningSink.add(ParseDiagnostic::Error("SVG image references require an SVG parse callback",
+                                           FileOffset::Offset(0)));
+    RememberImageFailure(failedUrls, image.href);
+    registry.emplace<LoadedImageComponent>(entity);
+    return;
+  }
+
+  auto& cache = PrepareSubDocumentCache(registry);
+  auto guardedParseCallback =
+      GuardSvgParseCallback(registry, svgParseCallback, remainingResourceBytes);
+  auto subDocument =
+      cache.getOrParse(image.href, svgContent.data, guardedParseCallback, warningSink);
+  if (subDocument) {
+    registry.emplace<LoadedSVGImageComponent>(entity, std::move(*subDocument));
+    return;
+  }
+  RememberImageFailure(failedUrls, image.href);
+  registry.emplace<LoadedImageComponent>(entity);
+}
+
+void LoadImageEntity(Registry& registry, Entity entity, ResourceLoaderInterface& loader,
+                     const SubDocumentCache::ParseCallback& svgParseCallback,
+                     size_t& remainingResourceBytes, std::unordered_set<RcString>& failedUrls,
+                     ResourceManagerContext::FetchSecurityStats& securityStats,
+                     ParseWarningSink& warningSink) {
+  if (registry.all_of<LoadedImageComponent>(entity) ||
+      registry.all_of<LoadedSVGImageComponent>(entity)) {
+    return;
+  }
+  const auto& image = registry.get<ImageComponent>(entity);
+  if (image.href.empty() || std::string_view(image.href).starts_with("#")) {
+    return;
+  }
+  if (failedUrls.contains(image.href)) {
+    ++securityStats.cacheHits;
+    registry.emplace<LoadedImageComponent>(entity);
+    return;
+  }
+  if (AttachCachedSubDocument(registry, entity, image.href)) {
+    return;
+  }
+
+  ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+  auto imageResult = imageLoader.fromUri(image.href);
+  if (const auto* error = std::get_if<UrlLoaderError>(&imageResult)) {
+    warningSink.add(
+        ParseDiagnostic::Error(RcString(std::string(ToString(*error))), FileOffset::Offset(0)));
+    RememberImageFailure(failedUrls, image.href);
+    registry.emplace<LoadedImageComponent>(entity);
+    return;
+  }
+  if (auto* svgContent = std::get_if<SvgImageContent>(&imageResult)) {
+    LoadSvgImage(registry, entity, image, *svgContent, svgParseCallback, remainingResourceBytes,
+                 failedUrls, warningSink);
+    return;
+  }
+  registry.emplace<LoadedImageComponent>(entity, std::get<ImageResource>(std::move(imageResult)));
+}
+
+void LoadImages(Registry& registry, ResourceLoaderInterface& loader,
+                const SubDocumentCache::ParseCallback& svgParseCallback,
+                size_t& remainingResourceBytes, std::unordered_set<RcString>& failedUrls,
+                ResourceManagerContext::FetchSecurityStats& securityStats,
+                ParseWarningSink& warningSink) {
+  for (auto view = registry.view<ImageComponent>(); auto entity : view) {
+    LoadImageEntity(registry, entity, loader, svgParseCallback, remainingResourceBytes, failedUrls,
+                    securityStats, warningSink);
+  }
+}
+
+void LoadFontFaces(std::vector<css::FontFace>& fontFaces, std::span<const size_t> indexes,
+                   bool loaderAvailable, ResourceLoaderInterface& loader,
+                   size_t& remainingResourceBytes, ParseWarningSink& warningSink) {
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+  for (const size_t index : indexes) {
+    for (css::FontFaceSource& source : fontFaces[index].sources) {
+      if (source.kind == css::FontFaceSource::Kind::Url) {
+        const RcString& url = std::get<RcString>(source.payload);
+        if (!loaderAvailable && NeedsExternalLoader(url)) {
+          continue;
+        }
+        auto maybeFontData = urlLoader.fromUri(url);
+        if (const auto* error = std::get_if<UrlLoaderError>(&maybeFontData)) {
+          warningSink.add(
+              ParseDiagnostic::Error(RcString(std::string("Could not load font ") + url + ": " +
+                                              std::string(ToString(*error))),
+                                     FileOffset::Offset(0)));
+          continue;
+        }
+        UrlLoader::Result fontData = std::get<UrlLoader::Result>(std::move(maybeFontData));
+        source.kind = css::FontFaceSource::Kind::Data;
+        source.payload = std::make_shared<const std::vector<uint8_t>>(std::move(fontData.data));
+      } else if (source.kind != css::FontFaceSource::Kind::Data) {
+        warningSink.add(
+            ParseDiagnostic::Error("Unsupported font face source kind", FileOffset::Offset(0)));
+      }
+    }
+  }
+}
+
 }  // namespace
 
 ResourceManagerContext::ResourceManagerContext(Registry& registry,
@@ -124,6 +333,7 @@ ResourceManagerContext::ResourceManagerContext(Registry& registry,
 
 void ResourceManagerContext::setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader) {
   failedImageUrls_.clear();
+  externalFetchCache_.clear();
   if (auto* cache = registry_.ctx().find<SubDocumentCache>()) {
     cache->clearFailures();
   }
@@ -137,174 +347,41 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
     return;
   }
 
-  auto imageView = registry_.view<ImageComponent>();
-
   NullResourceLoader nullLoader;
   WriteAccessGuardedResourceLoader guardedLoader(
       registry_, loader_ ? *loader_ : static_cast<ResourceLoaderInterface&>(nullLoader));
   ResourceLoaderInterface& uncappedLoader =
       loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
               : static_cast<ResourceLoaderInterface&>(nullLoader);
-  BoundedResourceLoader boundedLoader(uncappedLoader, remainingResourceFetchAttempts_,
-                                      remainingResourceBytes_);
-  ResourceLoaderInterface& loader = boundedLoader;
+  BudgetedCachingResourceLoader cachedLoader(
+      uncappedLoader, externalFetchCache_, fetchSecurityStats_, remainingResourceFetchAttempts_,
+      UrlLoader::kDefaultMaximumResourceSize, remainingResourceBytes_);
 
-  // Only warn about a missing loader if we actually have something that
-  // would need one. `data:` URLs are decoded inline in `UrlLoader::fromUri`
-  // without touching the resource loader, so their presence alone doesn't
-  // justify the warning.
-  const auto needsExternalLoader = [](std::string_view uri) {
-    return !uri.empty() && !uri.starts_with("data:");
-  };
-
-  const bool hasExternalImage = [&] {
-    for (auto entity : imageView) {
-      if (registry_.all_of<LoadedImageComponent>(entity) ||
-          registry_.all_of<LoadedSVGImageComponent>(entity)) {
-        continue;
-      }
-      if (needsExternalLoader(imageView.get<ImageComponent>(entity).href)) {
-        return true;
-      }
-    }
-    return false;
-  }();
-  const bool hasExternalFontFace = [&] {
-    for (const size_t fontFaceIndex : fontFaceIndexesToLoad_) {
-      const css::FontFace& fontFace = fontFaces_[fontFaceIndex];
-      for (const css::FontFaceSource& source : fontFace.sources) {
-        if (source.kind == css::FontFaceSource::Kind::Url &&
-            needsExternalLoader(std::get<RcString>(source.payload))) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }();
-
-  if (!loader_ && (hasExternalImage || hasExternalFontFace)) {
-    ParseDiagnostic err;
-    err.reason = "Could not load external resources, no ResourceLoader provided";
-    warningSink.add(std::move(err));
+  if (!loader_ && (HasExternalImagesToLoad(registry_) ||
+                   HasExternalFontFacesToLoad(fontFaces_, fontFaceIndexesToLoad_))) {
+    warningSink.add(ParseDiagnostic::Error(
+        "Could not load external resources, no ResourceLoader provided", FileOffset::Offset(0)));
   }
 
-  // Iterate over all ImageComponents and load them.
-  for (auto view = imageView; auto entity : view) {
-    // Skip entities that already have a loaded image or SVG sub-document.
-    if (registry_.all_of<LoadedImageComponent>(entity) ||
-        registry_.all_of<LoadedSVGImageComponent>(entity)) {
-      continue;
-    }
-
-    auto [image] = view.get(entity);
-    if (image.href.empty()) {
-      continue;
-    }
-
-    if (failedImageUrls_.contains(image.href)) {
-      registry_.emplace<LoadedImageComponent>(entity);
-      continue;
-    }
-
-    if (auto* cache = registry_.ctx().find<SubDocumentCache>()) {
-      if (auto cachedDocument = cache->get(image.href)) {
-        registry_.emplace<LoadedSVGImageComponent>(entity, std::move(*cachedDocument));
-        continue;
-      }
-    }
-
-    ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize,
-                            &remainingResourceBytes_);
-
-    auto imageResult = imageLoader.fromUri(image.href);
-    if (std::holds_alternative<UrlLoaderError>(imageResult)) {
-      ParseDiagnostic err;
-      err.reason = std::string(ToString(std::get<UrlLoaderError>(imageResult)));
-      warningSink.add(std::move(err));
-
-      if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
-        failedImageUrls_.insert(image.href);
-      }
-
-      // Create an empty LoadedImageComponent to prevent loading again.
-      registry_.emplace<LoadedImageComponent>(entity);
-    } else if (std::holds_alternative<SvgImageContent>(imageResult)) {
-      if (!svgParseCallback_) {
-        // No SVG parser available - skip.
-        ParseDiagnostic err;
-        err.reason = "SVG image references require an SVG parse callback";
-        warningSink.add(std::move(err));
-        if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
-          failedImageUrls_.insert(image.href);
-        }
-        registry_.emplace<LoadedImageComponent>(entity);
-        continue;
-      }
-
-      auto& svgContent = std::get<SvgImageContent>(imageResult);
-
-      // Get or create the SubDocumentCache on this registry.
-      if (!registry_.ctx().contains<SubDocumentCache>()) {
-        registry_.ctx().emplace<SubDocumentCache>();
-      }
-      auto& cache = registry_.ctx().get<SubDocumentCache>();
-
-      SubDocumentCache::ParseCallback guardedParseCallback =
-          GuardSvgParseCallback(registry_, svgParseCallback_, remainingResourceBytes_);
-      auto subDoc =
-          cache.getOrParse(image.href, svgContent.data, guardedParseCallback, warningSink);
-      if (subDoc) {
-        registry_.emplace<LoadedSVGImageComponent>(entity, std::move(*subDoc));
-      } else {
-        // Parse failed - create an empty LoadedImageComponent to prevent retrying.
-        if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
-          failedImageUrls_.insert(image.href);
-        }
-        registry_.emplace<LoadedImageComponent>(entity);
-      }
-    } else {
-      ImageResource imageResource = std::get<ImageResource>(std::move(imageResult));
-      registry_.emplace<LoadedImageComponent>(entity, std::move(imageResource));
-    }
-  }
-
-  // Hydrate URL font sources into data sources. FontManager owns parsing and caches decoded font
-  // handles on demand; ResourceManager only resolves bytes while the document resource loader is
-  // available.
-  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes_);
-  for (const size_t fontFaceIndex : fontFaceIndexesToLoad_) {
-    css::FontFace& fontFace = fontFaces_[fontFaceIndex];
-    for (css::FontFaceSource& source : fontFace.sources) {
-      if (source.kind == css::FontFaceSource::Kind::Url) {
-        const RcString& url = std::get<RcString>(source.payload);
-        if (!loader_ && needsExternalLoader(url)) {
-          continue;
-        }
-
-        auto maybeFontData = urlLoader.fromUri(url);
-        if (std::holds_alternative<UrlLoaderError>(maybeFontData)) {
-          ParseDiagnostic err;
-          err.reason = std::string("Could not load font ") + url + ": " +
-                       std::string(ToString(std::get<UrlLoaderError>(maybeFontData)));
-          warningSink.add(std::move(err));
-        } else {
-          UrlLoader::Result fontData = std::get<UrlLoader::Result>(std::move(maybeFontData));
-          source.kind = css::FontFaceSource::Kind::Data;
-          source.payload = std::make_shared<const std::vector<uint8_t>>(std::move(fontData.data));
-        }
-      } else if (source.kind != css::FontFaceSource::Kind::Data) {
-        ParseDiagnostic err;
-        err.reason = "Unsupported font face source kind";
-        warningSink.add(std::move(err));
-      }
-    }
-  }
+  LoadImages(registry_, cachedLoader, svgParseCallback_, remainingResourceBytes_, failedImageUrls_,
+             fetchSecurityStats_, warningSink);
+  LoadFontFaces(fontFaces_, fontFaceIndexesToLoad_, loader_ != nullptr, cachedLoader,
+                remainingResourceBytes_, warningSink);
 
   fontFaceIndexesToLoad_.clear();
 }
 
 std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     std::string_view url, ParseWarningSink& warningSink) {
+  if (UrlLoader::validateExternalUriRepresentation(url)) {
+    fetchSecurityStats_.rejected = true;
+    warningSink.add([] {
+      ParseDiagnostic err;
+      err.reason = "Rejected external SVG reference with an invalid or oversized URL";
+      return err;
+    });
+    return std::nullopt;
+  }
   const RcString boundedUrl(url);
   // In secure modes, external resource loading is disabled.
   if (processingMode_ == ProcessingMode::SecureStatic ||
@@ -331,6 +408,10 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     registry_.ctx().emplace<SubDocumentCache>();
   }
   auto& cache = registry_.ctx().get<SubDocumentCache>();
+  cache.setRootEntityCount(registry_.storage<Entity>().size());
+  if (const auto* payload = registry_.ctx().find<ParsedPayloadResourceBudget>()) {
+    cache.setRootPayloadBytes(payload->securityStats().retainedBytes);
+  }
 
   // Check if already cached.
   if (auto cached = cache.get(boundedUrl)) {
@@ -342,9 +423,10 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
 
   // Fetch the file content using the same per-resource and aggregate budgets as images and fonts.
   WriteAccessGuardedResourceLoader guardedLoader(registry_, *loader_);
-  BoundedResourceLoader boundedLoader(guardedLoader, remainingResourceFetchAttempts_,
-                                      remainingResourceBytes_);
-  UrlLoader urlLoader(boundedLoader, UrlLoader::kDefaultMaximumResourceSize,
+  BudgetedCachingResourceLoader cachedLoader(
+      guardedLoader, externalFetchCache_, fetchSecurityStats_, remainingResourceFetchAttempts_,
+      UrlLoader::kDefaultMaximumResourceSize, remainingResourceBytes_);
+  UrlLoader urlLoader(cachedLoader, UrlLoader::kDefaultMaximumResourceSize,
                       &remainingResourceBytes_);
   auto fetchResult = urlLoader.fromUri(url);
   if (std::holds_alternative<UrlLoaderError>(fetchResult)) {
@@ -356,7 +438,6 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     cache.rememberFailure(boundedUrl);
     return std::nullopt;
   }
-
   auto& data = std::get<UrlLoader::Result>(fetchResult).data;
   SubDocumentCache::ParseCallback guardedParseCallback =
       GuardSvgParseCallback(registry_, svgParseCallback_, remainingResourceBytes_);
@@ -384,7 +465,13 @@ void ResourceManagerContext::synchronizeStylesheetFontFaces(
   auto& registration = stylesheetFontFaceRegistrations_[stylesheetEntity];
   if (registration.data == fontFaces.data() && registration.size == fontFaces.size()) return;
   registration = {.data = fontFaces.data(), .size = fontFaces.size()};
-  addFontFaces(fontFaces);
+
+  const size_t remaining =
+      kMaximumStylesheetFontFaces - std::min(stylesheetFontFaceCount_, kMaximumStylesheetFontFaces);
+  const size_t insertCount = std::min(fontFaces.size(), remaining);
+  addFontFaces(fontFaces.first(insertCount));
+  stylesheetFontFaceCount_ += insertCount;
+  if (insertCount != fontFaces.size()) stylesheetFontFaceLimitRejected_ = true;
 }
 
 std::optional<Vector2i> ResourceManagerContext::getImageSize(Entity entity) const {
@@ -407,6 +494,7 @@ const LoadedImageComponent* ResourceManagerContext::getLoadedImageComponent(Enti
     return nullptr;
   }
   if (failedImageUrls_.contains(image->href)) {
+    ++fetchSecurityStats_.cacheHits;
     return nullptr;
   }
 
@@ -416,10 +504,11 @@ const LoadedImageComponent* ResourceManagerContext::getLoadedImageComponent(Enti
   ResourceLoaderInterface& uncappedLoader =
       loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
               : static_cast<ResourceLoaderInterface&>(nullLoader);
-  BoundedResourceLoader boundedLoader(uncappedLoader, remainingResourceFetchAttempts_,
-                                      remainingResourceBytes_);
-  ResourceLoaderInterface& loader = boundedLoader;
-  ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes_);
+  BudgetedCachingResourceLoader cachedLoader(
+      uncappedLoader, externalFetchCache_, fetchSecurityStats_, remainingResourceFetchAttempts_,
+      UrlLoader::kDefaultMaximumResourceSize, remainingResourceBytes_);
+  ImageLoader imageLoader(cachedLoader, UrlLoader::kDefaultMaximumResourceSize,
+                          &remainingResourceBytes_);
 
   auto imageResult = imageLoader.fromUri(image->href);
   if (std::holds_alternative<ImageResource>(imageResult)) {

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "donner/base/EcsRegistry_fwd.h"
@@ -31,9 +32,23 @@ public:
   /// Maximum number of application resource-loader calls for one document.
   static constexpr size_t kMaximumResourceFetchAttempts = 256;
 
+  /// Default number of unique external resource callbacks allowed per document.
+  static constexpr size_t kDefaultMaximumExternalFetchAttempts = kMaximumResourceFetchAttempts;
+
+  /// Maximum stylesheet-provided font faces retained by one untrusted document.
+  static constexpr size_t kMaximumStylesheetFontFaces = 1024;
+
+  struct FetchSecurityStats {
+    size_t attempts = 0;
+    size_t cacheHits = 0;
+    size_t cachedBytes = 0;
+    bool rejected = false;
+  };
   /// Constructor.
-  explicit ResourceManagerContext(Registry& registry, size_t maximumAggregateResourceSize =
-                                                          kDefaultMaximumAggregateResourceSize);
+  explicit ResourceManagerContext(
+      Registry& registry,
+      size_t maximumAggregateResourceSize = kDefaultMaximumAggregateResourceSize,
+      size_t maximumExternalFetchAttempts = kDefaultMaximumExternalFetchAttempts);
 
   /**
    * Load resources such as images. Note that this doesn't issue network calls directly, but relies
@@ -51,6 +66,9 @@ public:
    * again with \c nullptr to unset.
    */
   void setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader);
+
+  /// Return external callback/cache resource-limit accounting.
+  const FetchSecurityStats& fetchSecurityStats() const { return fetchSecurityStats_; }
 
   /**
    * Set the processing mode for this document. In secure modes (\ref ProcessingMode::SecureStatic,
@@ -79,7 +97,7 @@ public:
    * @param warningSink Sink to collect warnings.
    * @return Parsed document handle, or `std::nullopt` on failure.
    */
-  std::optional<SVGDocumentHandle> loadExternalSVG(const RcString& url,
+  std::optional<SVGDocumentHandle> loadExternalSVG(std::string_view url,
                                                    ParseWarningSink& warningSink);
 
   /**
@@ -103,7 +121,7 @@ public:
    */
   void addFontFaces(std::span<const css::FontFace> fontFaces);
 
-  /** Register one stylesheet's current font-face storage once per parsed generation. */
+  /** Register a stylesheet's font faces once for its current parsed storage. */
   void synchronizeStylesheetFontFaces(Entity stylesheetEntity,
                                       std::span<const css::FontFace> fontFaces);
 
@@ -111,6 +129,8 @@ public:
    * Get all registered `@font-face` declarations.
    */
   const std::vector<css::FontFace>& fontFaces() const { return fontFaces_; }
+  size_t pendingFontFaceCount() const { return fontFaceIndexesToLoad_.size(); }
+  bool stylesheetFontFaceLimitRejected() const { return stylesheetFontFaceLimitRejected_; }
 
 private:
   /**
@@ -145,6 +165,8 @@ private:
     size_t size = 0;
   };
   std::unordered_map<Entity, StylesheetFontFaceRegistration> stylesheetFontFaceRegistrations_;
+  size_t stylesheetFontFaceCount_ = 0;
+  bool stylesheetFontFaceLimitRejected_ = false;
 
   /// Processing mode for this document.
   ProcessingMode processingMode_ = ProcessingMode::DynamicInteractive;
@@ -159,7 +181,15 @@ private:
   mutable std::unordered_set<RcString> failedImageUrls_;
 
   /// Remaining application fetch calls before external loading latches closed.
-  mutable size_t remainingResourceFetchAttempts_ = kMaximumResourceFetchAttempts;
+  mutable size_t remainingResourceFetchAttempts_;
+
+  using CachedFetchResult = std::variant<std::vector<uint8_t>, ResourceLoaderError>;
+
+  /// Positive and negative external fetch cache, shared by images, fonts, and subdocuments.
+  mutable std::unordered_map<std::string, CachedFetchResult> externalFetchCache_;
+
+  /// External fetch resource-limit accounting.
+  mutable FetchSecurityStats fetchSecurityStats_;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -137,6 +137,8 @@ public:
   }
 
 private:
+  void onStylesheetDestroy(Registry& registry, Entity entity);
+
   /**
    * Get the \ref LoadedImageComponent for an entity. This will synchronously load the image if it
    * hasn't been loaded yet.

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -131,6 +131,10 @@ public:
   const std::vector<css::FontFace>& fontFaces() const { return fontFaces_; }
   size_t pendingFontFaceCount() const { return fontFaceIndexesToLoad_.size(); }
   bool stylesheetFontFaceLimitRejected() const { return stylesheetFontFaceLimitRejected_; }
+  size_t stylesheetFontFaceCountForTesting() const { return stylesheetFontFaceCount_; }
+  size_t stylesheetFontFaceRegistrationCountForTesting() const {
+    return stylesheetFontFaceRegistrations_.size();
+  }
 
 private:
   /**

--- a/donner/svg/components/resources/SubDocumentCache.cc
+++ b/donner/svg/components/resources/SubDocumentCache.cc
@@ -1,6 +1,29 @@
 #include "donner/svg/components/resources/SubDocumentCache.h"
 
+#include "donner/base/EcsRegistry.h"
+#include "donner/svg/components/ParsedPayloadResourceBudget.h"
+
 namespace donner::svg::components {
+
+bool SubDocumentCache::admissionAvailable() const {
+  if (securityStats_.rejected || cache_.size() >= limits_.maximumDocuments ||
+      securityStats_.parseAttempts >= limits_.maximumParseAttempts) {
+    return false;
+  }
+  if (rootEntityCount_ > limits_.maximumAggregateEntities ||
+      securityStats_.entities > limits_.maximumAggregateEntities - rootEntityCount_) {
+    return false;
+  }
+  return rootPayloadBytes_ <= limits_.maximumAggregatePayloadBytes &&
+         securityStats_.payloadBytes <= limits_.maximumAggregatePayloadBytes - rootPayloadBytes_;
+}
+
+bool SubDocumentCache::candidateFits(size_t entityCount, size_t payloadBytes) const {
+  const size_t retainedBefore = rootEntityCount_ + securityStats_.entities;
+  const size_t payloadBefore = rootPayloadBytes_ + securityStats_.payloadBytes;
+  return entityCount <= limits_.maximumAggregateEntities - retainedBefore &&
+         payloadBytes <= limits_.maximumAggregatePayloadBytes - payloadBefore;
+}
 
 std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
     const RcString& resolvedUrl, const std::vector<uint8_t>& svgContent,
@@ -10,6 +33,13 @@ std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
     return it->second;
   }
   if (isRejected(resolvedUrl)) {
+    ++securityStats_.negativeCacheHits;
+    return std::nullopt;
+  }
+
+  if (!admissionAvailable()) {
+    securityStats_.rejected = true;
+    rememberFailure(resolvedUrl);
     return std::nullopt;
   }
 
@@ -24,6 +54,7 @@ std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
   // Mark as loading to guard against recursion.
   loading_.insert(resolvedUrl);
 
+  ++securityStats_.parseAttempts;
   auto maybeDocument = parseCallback(svgContent, warningSink);
 
   loading_.erase(resolvedUrl);
@@ -33,7 +64,22 @@ std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
     return std::nullopt;
   }
 
+  const size_t entityCount = (*maybeDocument)->registry().storage<Entity>().size();
+  const auto* payloadBudget =
+      (*maybeDocument)->registry().ctx().find<ParsedPayloadResourceBudget>();
+  const size_t payloadBytes = payloadBudget ? payloadBudget->securityStats().retainedBytes : 0;
+  if (!candidateFits(entityCount, payloadBytes)) {
+    securityStats_.rejected = true;
+    rememberFailure(resolvedUrl);
+    return std::nullopt;
+  }
+
   auto [it, inserted] = cache_.emplace(resolvedUrl, std::move(*maybeDocument));
+  if (inserted) {
+    securityStats_.documents = cache_.size();
+    securityStats_.entities += entityCount;
+    securityStats_.payloadBytes += payloadBytes;
+  }
   return it->second;
 }
 

--- a/donner/svg/components/resources/SubDocumentCache.h
+++ b/donner/svg/components/resources/SubDocumentCache.h
@@ -26,6 +26,22 @@ namespace donner::svg::components {
  */
 class SubDocumentCache {
 public:
+  struct Limits {
+    size_t maximumDocuments = 64;
+    size_t maximumParseAttempts = 128;
+    size_t maximumAggregateEntities = 32 * 1024;
+    size_t maximumAggregatePayloadBytes = 64 * 1024 * 1024;
+  };
+
+  struct SecurityStats {
+    size_t parseAttempts = 0;
+    size_t documents = 0;
+    size_t entities = 0;
+    size_t payloadBytes = 0;
+    size_t negativeCacheHits = 0;
+    bool rejected = false;
+  };
+
   /**
    * Callback type for parsing SVG content into a document. Called by \ref getOrParse when the URL
    * is not cached. Should return an \ref SVGDocumentHandle on success, or `std::nullopt` on
@@ -36,6 +52,7 @@ public:
 
   /// Constructor.
   SubDocumentCache() = default;
+  explicit SubDocumentCache(Limits limits) : limits_(limits) {}
 
   /// Destructor.
   ~SubDocumentCache() = default;
@@ -87,8 +104,19 @@ public:
   /// Returns the number of cached sub-documents.
   size_t size() const { return cache_.size(); }
 
+  /// Include root-document entities in the aggregate retained-node envelope.
+  void setRootEntityCount(size_t count) { rootEntityCount_ = count; }
+
+  /// Include root-document parsed payload in the aggregate retained-payload envelope.
+  void setRootPayloadBytes(size_t count) { rootPayloadBytes_ = count; }
+
+  const SecurityStats& securityStats() const { return securityStats_; }
+
 private:
   static constexpr size_t kMaximumRejectedEntries = 256;
+
+  bool admissionAvailable() const;
+  bool candidateFits(size_t entityCount, size_t payloadBytes) const;
 
   /// Cached sub-documents keyed by resolved URL.
   std::unordered_map<RcString, SVGDocumentHandle> cache_;
@@ -101,6 +129,11 @@ private:
 
   /// True after the bounded negative cache fills, rejecting every uncached URL.
   bool rejectAll_ = false;
+
+  Limits limits_;
+  SecurityStats securityStats_;
+  size_t rootEntityCount_ = 0;
+  size_t rootPayloadBytes_ = 0;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/tests/BUILD.bazel
+++ b/donner/svg/components/resources/tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//build_defs:package.bzl", "donner_package")
-load("//build_defs:rules.bzl", "donner_cc_test")
+load("//build_defs:rules.bzl", "donner_cc_fuzzer", "donner_cc_test")
 
 donner_cc_test(
     name = "sub_document_cache_tests",
@@ -20,6 +20,17 @@ donner_cc_test(
         "//donner/svg/components/resources:resource_manager_context",
         "//donner/svg/parser",
         "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_fuzzer(
+    name = "resource_manager_context_fuzzer",
+    srcs = ["ResourceManagerContext_fuzzer.cc"],
+    corpus = "resource_manager_context_corpus",
+    deps = [
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/components/resources:resource_manager_context",
     ],
 )
 

--- a/donner/svg/components/resources/tests/ResourceManagerContext_fuzzer.cc
+++ b/donner/svg/components/resources/tests/ResourceManagerContext_fuzzer.cc
@@ -1,0 +1,166 @@
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/components/ParsedPayloadResourceBudget.h"
+#include "donner/svg/components/resources/ImageComponent.h"
+#include "donner/svg/components/resources/ResourceManagerContext.h"
+#include "donner/svg/components/resources/SubDocumentCache.h"
+
+namespace donner::svg::components {
+namespace {
+
+class CountingResourceLoader : public ResourceLoaderInterface {
+public:
+  enum class Mode { NotFound, Oversized, CachedLargerThanRemaining, Svg };
+
+  CountingResourceLoader(size_t& count, Mode mode) : count_(count), mode_(mode) {}
+
+  std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
+      std::string_view) override {
+    ++count_;
+    if (mode_ == Mode::Oversized) {
+      return std::vector<uint8_t>(1024 * 1024 + 1, 0x41);
+    } else if (mode_ == Mode::CachedLargerThanRemaining) {
+      return std::vector<uint8_t>(768, 0x41);
+    } else if (mode_ == Mode::Svg) {
+      return std::vector<uint8_t>{'<', 's', 'v', 'g', '/', '>'};
+    }
+    return ResourceLoaderError::NotFound;
+  }
+
+private:
+  size_t& count_;
+  Mode mode_;
+};
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  const std::string_view input(reinterpret_cast<const char*>(data), size);
+  const bool cachedLargerThanRemaining =
+      input.starts_with("external-fetch-cached-larger-than-remaining");
+  const bool repeated = !cachedLargerThanRemaining && input.starts_with("external-fetch-cache");
+  const bool crossesLimit = input.starts_with("external-fetch-attempt-budget");
+  const bool oversizedPositive = input.starts_with("external-fetch-oversized-positive");
+  const bool subdocumentSuccess = input.starts_with("subdocument-node-budget");
+  const bool subdocumentPayload = input.starts_with("subdocument-payload-budget");
+  const bool subdocumentFailure = input.starts_with("subdocument-negative-cache");
+  const size_t maximumAttempts = 8;
+  const size_t imageCount =
+      (repeated || oversizedPositive || cachedLargerThanRemaining || subdocumentFailure)
+          ? 16
+          : ((subdocumentSuccess || subdocumentPayload)
+                 ? 4
+                 : (crossesLimit ? maximumAttempts + 1 : size % 8));
+
+  Registry registry;
+  if (subdocumentSuccess || subdocumentPayload || subdocumentFailure) {
+    registry.ctx().emplace<SubDocumentCache>(SubDocumentCache::Limits{
+        .maximumDocuments = 4,
+        .maximumParseAttempts = 4,
+        .maximumAggregateEntities = (subdocumentFailure || subdocumentPayload) ? 64u : 10u,
+        .maximumAggregatePayloadBytes = subdocumentPayload ? 10u : 64 * 1024 * 1024u,
+    });
+  }
+  const std::size_t aggregateResourceBytes = cachedLargerThanRemaining ? 1024 : 1024 * 1024;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(
+      registry, aggregateResourceBytes, maximumAttempts);
+  size_t callbackCount = 0;
+  const auto loaderMode =
+      oversizedPositive ? CountingResourceLoader::Mode::Oversized
+                        : (cachedLargerThanRemaining
+                               ? CountingResourceLoader::Mode::CachedLargerThanRemaining
+                               : ((subdocumentSuccess || subdocumentPayload || subdocumentFailure)
+                                      ? CountingResourceLoader::Mode::Svg
+                                      : CountingResourceLoader::Mode::NotFound));
+  resourceManager.setResourceLoader(
+      std::make_unique<CountingResourceLoader>(callbackCount, loaderMode));
+  size_t parseCount = 0;
+  if (subdocumentSuccess || subdocumentPayload || subdocumentFailure) {
+    resourceManager.setSvgParseCallback(
+        [&](const std::vector<uint8_t>&, ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+          ++parseCount;
+          if (subdocumentFailure) {
+            return std::nullopt;
+          }
+          SVGDocument subdocument;
+          for (int i = 0; i < 4; ++i) {
+            (void)subdocument.registry().create();
+          }
+          if (subdocumentPayload) {
+            auto& budget = subdocument.registry().ctx().emplace<ParsedPayloadResourceBudget>(
+                ParsedPayloadResourceBudget::Limits{.maximumRetainedBytes = 64});
+            if (!budget.reserve(6, ParsedPayloadResourceBudget::Category::Attribute)) {
+              std::abort();
+            }
+          }
+          return subdocument.handle();
+        });
+  } else if (cachedLargerThanRemaining) {
+    resourceManager.setSvgParseCallback(
+        [&](const std::vector<uint8_t>&, ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+          ++parseCount;
+          return std::nullopt;
+        });
+  }
+
+  for (size_t i = 0; i < imageCount; ++i) {
+    const bool sameUrl =
+        repeated || oversizedPositive || cachedLargerThanRemaining || subdocumentFailure;
+    const std::string suffix =
+        (subdocumentSuccess || subdocumentPayload || subdocumentFailure) ? ".svg" : ".png";
+    const std::string url = sameUrl ? "same" + suffix : "image-" + std::to_string(i) + suffix;
+    const Entity entity = registry.create();
+    registry.emplace<ImageComponent>(entity, ImageComponent{RcString(url)});
+  }
+
+  ParseWarningSink warnings;
+  resourceManager.loadResources(warnings);
+  if (cachedLargerThanRemaining) {
+    // The first image fetch leaves its positive result in the shared cache but consumes most of
+    // the aggregate byte budget. A cross-kind lookup must reject that cached vector before copying
+    // it, even though the failed-image cache suppresses repeated image decode attempts.
+    (void)resourceManager.loadExternalSVG("same.png", warnings);
+  }
+  const auto& stats = resourceManager.fetchSecurityStats();
+  auto* subdocumentCache = registry.ctx().find<SubDocumentCache>();
+  if (subdocumentFailure && subdocumentCache != nullptr) {
+    const std::vector<uint8_t> svgContent{'<', 's', 'v', 'g', '/', '>'};
+    const SubDocumentCache::ParseCallback fail =
+        [](const std::vector<uint8_t>&, ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+      return std::nullopt;
+    };
+    for (std::size_t i = 1; i < imageCount; ++i) {
+      (void)subdocumentCache->getOrParse("same.svg", svgContent, fail, warnings);
+    }
+  }
+  if (callbackCount > maximumAttempts || stats.attempts > maximumAttempts ||
+      (crossesLimit && !stats.rejected) ||
+      (repeated && (callbackCount != 1 || stats.cacheHits != imageCount - 1)) ||
+      (oversizedPositive && (callbackCount != 1 || stats.cacheHits != imageCount - 1 ||
+                             stats.cachedBytes != 0 || !stats.rejected)) ||
+      (cachedLargerThanRemaining &&
+       (callbackCount != 1 || parseCount != 0 || stats.cacheHits != imageCount ||
+        stats.cachedBytes != 768 || !stats.rejected)) ||
+      (subdocumentSuccess && (subdocumentCache == nullptr || parseCount != 2 ||
+                              subdocumentCache->securityStats().documents != 1 ||
+                              subdocumentCache->securityStats().entities != 5 ||
+                              !subdocumentCache->securityStats().rejected)) ||
+      (subdocumentPayload && (subdocumentCache == nullptr || parseCount != 2 ||
+                              subdocumentCache->securityStats().documents != 1 ||
+                              subdocumentCache->securityStats().payloadBytes != 6 ||
+                              !subdocumentCache->securityStats().rejected)) ||
+      (subdocumentFailure &&
+       (subdocumentCache == nullptr || parseCount != 1 ||
+        subdocumentCache->securityStats().negativeCacheHits < imageCount - 1))) {
+    std::abort();
+  }
+  return 0;
+}
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -10,6 +10,7 @@
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/encoding/Base64.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/components/ParsedPayloadResourceBudget.h"
 #define private public
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #undef private
@@ -199,6 +200,7 @@ TEST(SubDocumentCacheTest, ParseFailureIsNegativeCached) {
   EXPECT_FALSE(cache.getOrParse("bad.svg", content, callback, warnings).has_value());
   EXPECT_EQ(parseCount, 1);
   EXPECT_TRUE(cache.isRejected("bad.svg"));
+  EXPECT_EQ(cache.securityStats().negativeCacheHits, 1u);
 }
 
 TEST(SubDocumentCacheTest, NegativeCacheLatchesAfterBoundedEntries) {
@@ -209,6 +211,59 @@ TEST(SubDocumentCacheTest, NegativeCacheLatchesAfterBoundedEntries) {
   }
 
   EXPECT_TRUE(cache.isRejected("never-seen.svg"));
+}
+
+TEST(SubDocumentCacheTest, EnforcesAggregateEntityBudget) {
+  SubDocumentCache cache(SubDocumentCache::Limits{
+      .maximumDocuments = 4,
+      .maximumParseAttempts = 4,
+      .maximumAggregateEntities = 10,
+  });
+  cache.setRootEntityCount(4);
+  const std::vector<uint8_t> content{'x'};
+  int parseCount = 0;
+  const SubDocumentCache::ParseCallback callback =
+      [&parseCount](const std::vector<uint8_t>&,
+                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+    ++parseCount;
+    SVGDocument document;
+    for (int i = 0; i < 4; ++i) {
+      (void)document.registry().create();
+    }
+    return document.handle();
+  };
+
+  ParseWarningSink disabledSink = ParseWarningSink::Disabled();
+  EXPECT_TRUE(cache.getOrParse("one.svg", content, callback, disabledSink).has_value());
+  EXPECT_FALSE(cache.getOrParse("two.svg", content, callback, disabledSink).has_value());
+  EXPECT_EQ(parseCount, 2);
+  EXPECT_EQ(cache.securityStats().documents, 1u);
+  EXPECT_EQ(cache.securityStats().entities, 5u);
+  EXPECT_TRUE(cache.securityStats().rejected);
+}
+
+TEST(SubDocumentCacheTest, EnforcesAggregateParsedPayloadBudget) {
+  SubDocumentCache cache(SubDocumentCache::Limits{
+      .maximumDocuments = 4,
+      .maximumParseAttempts = 4,
+      .maximumAggregateEntities = 100,
+      .maximumAggregatePayloadBytes = 10,
+  });
+  ParseWarningSink warnings;
+  const SubDocumentCache::ParseCallback callback =
+      [](const std::vector<uint8_t>&, ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+    SVGDocument document;
+    auto& budget = document.registry().ctx().emplace<ParsedPayloadResourceBudget>(
+        ParsedPayloadResourceBudget::Limits{.maximumRetainedBytes = 64});
+    EXPECT_TRUE(budget.reserve(6, ParsedPayloadResourceBudget::Category::Attribute));
+    return document.handle();
+  };
+
+  EXPECT_TRUE(cache.getOrParse("one.svg", {}, callback, warnings));
+  EXPECT_FALSE(cache.getOrParse("two.svg", {}, callback, warnings));
+  EXPECT_EQ(cache.securityStats().documents, 1u);
+  EXPECT_EQ(cache.securityStats().payloadBytes, 6u);
+  EXPECT_TRUE(cache.securityStats().rejected);
 }
 
 TEST(SubDocumentCacheTest, RecursionDetection) {
@@ -455,6 +510,25 @@ TEST_F(ResourceManagerContextTest, FailedExternalSvgProbeDoesNotSuppressRasterIm
   EXPECT_TRUE(registry_.get<LoadedImageComponent>(image).image.has_value());
 }
 
+TEST_F(ResourceManagerContextTest, RejectsOversizedExternalSvgUrlBeforeCacheOrCallback) {
+  int fetchCount = 0;
+  setResourceLoader(std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; }));
+  setSvgParseCallback(
+      [](const std::vector<uint8_t>&, ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+        ADD_FAILURE() << "oversized URL reached the SVG parser callback";
+        return std::nullopt;
+      });
+
+  ParseWarningSink warnings;
+  const std::string oversized(UrlLoader::kMaximumExternalUriSize + 1, 'a');
+  EXPECT_FALSE(resourceManager_->loadExternalSVG(oversized, warnings).has_value());
+  EXPECT_EQ(fetchCount, 0);
+  EXPECT_EQ(resourceManager_->fetchSecurityStats().attempts, 0u);
+  EXPECT_TRUE(resourceManager_->fetchSecurityStats().rejected);
+  ASSERT_TRUE(warnings.hasWarnings());
+  EXPECT_LT(warnings.warnings().front().reason.size(), 256u);
+}
+
 TEST_F(ResourceManagerContextTest, LoadExternalSVGSuccess) {
   auto loader = std::make_unique<TestResourceLoader>();
   const std::vector<uint8_t> svgContent{'<', 's', 'v', 'g', '>'};
@@ -690,7 +764,6 @@ TEST(ResourceManagerContextAggregateBudgetTest,
   EXPECT_EQ(registry.ctx().get<SubDocumentCache>().size(), 0u);
   EXPECT_TRUE(warnings.hasWarnings());
 }
-
 TEST_F(ResourceManagerContextTest, UserCallbacksRunOutsideDocumentWriteAccess) {
   SVGDocument document;
   document.setThreadingMode(ThreadingMode::ConcurrentDom);
@@ -780,6 +853,39 @@ TEST_F(ResourceManagerContextTest, LoadResourcesWithoutLoaderWarnsForExternalIma
 
   EXPECT_TRUE(registry_.all_of<LoadedImageComponent>(imageEntity));
   EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST_F(ResourceManagerContextTest, CachesFailedExternalImageFetches) {
+  int fetchCount = 0;
+  setResourceLoader(std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; }));
+  addImage("same-missing.png");
+  addImage("same-missing.png");
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_EQ(fetchCount, 1);
+  EXPECT_EQ(resourceManager_->fetchSecurityStats().attempts, 1u);
+  EXPECT_EQ(resourceManager_->fetchSecurityStats().cacheHits, 1u);
+}
+
+TEST(ResourceManagerContextFetchBudgetTest, CapsUniqueExternalFetchAttempts) {
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, 1024 * 1024, 2);
+  int fetchCount = 0;
+  resourceManager.setResourceLoader(
+      std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; }));
+  for (std::string_view url : {"a.png", "b.png", "c.png"}) {
+    const Entity entity = registry.create();
+    registry.emplace<ImageComponent>(entity, ImageComponent{RcString(url)});
+  }
+
+  ParseWarningSink warnings;
+  resourceManager.loadResources(warnings);
+
+  EXPECT_EQ(fetchCount, 2);
+  EXPECT_EQ(resourceManager.fetchSecurityStats().attempts, 2u);
+  EXPECT_TRUE(resourceManager.fetchSecurityStats().rejected);
 }
 
 TEST_F(ResourceManagerContextTest, LoadResourcesSkipsEmptyImageHref) {
@@ -982,6 +1088,24 @@ TEST_F(ResourceManagerContextTest, AddFontFacesHydratesUrlFontSources) {
   ASSERT_EQ(faces[1].sources.size(), 1u);
   EXPECT_EQ(faces[1].sources[0].kind, css::FontFaceSource::Kind::Data);
   EXPECT_FALSE(warnings.hasWarnings());
+}
+
+TEST_F(ResourceManagerContextTest, StylesheetFontFacesAreIdempotentForStableParsedStorage) {
+  css::FontFace face;
+  face.familyName = "StableFont";
+  css::FontFaceSource source;
+  source.kind = css::FontFaceSource::Kind::Local;
+  source.payload = RcString("StableFont");
+  face.sources.push_back(std::move(source));
+  const std::array<css::FontFace, 1> faces{std::move(face)};
+  const Entity stylesheetEntity = registry_.create();
+
+  resourceManager_->synchronizeStylesheetFontFaces(stylesheetEntity, faces);
+  resourceManager_->synchronizeStylesheetFontFaces(stylesheetEntity, faces);
+
+  EXPECT_EQ(resourceManager_->fontFaces().size(), 1u);
+  EXPECT_EQ(resourceManager_->pendingFontFaceCount(), 1u);
+  EXPECT_FALSE(resourceManager_->stylesheetFontFaceLimitRejected());
 }
 
 TEST_F(ResourceManagerContextTest, LoadResourcesWarnsForUnsupportedAndMissingFontSources) {

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/attempts
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/attempts
@@ -1,0 +1,1 @@
+external-fetch-attempt-budget

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/cache
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/cache
@@ -1,0 +1,1 @@
+external-fetch-cache

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/cached_larger_than_remaining
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/cached_larger_than_remaining
@@ -1,0 +1,1 @@
+external-fetch-cached-larger-than-remaining

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/oversized_positive
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/oversized_positive
@@ -1,0 +1,1 @@
+external-fetch-oversized-positive

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_negative
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_negative
@@ -1,0 +1,1 @@
+subdocument-negative-cache

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_nodes
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_nodes
@@ -1,0 +1,1 @@
+subdocument-node-budget

--- a/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_payload
+++ b/donner/svg/components/resources/tests/resource_manager_context_corpus/subdocument_payload
@@ -1,0 +1,1 @@
+subdocument-payload-budget

--- a/donner/svg/components/style/tests/StyleSystem_tests.cc
+++ b/donner/svg/components/style/tests/StyleSystem_tests.cc
@@ -583,6 +583,60 @@ TEST_F(StyleSystemTest, RepeatedStylePassesRegisterEachFontFaceOnce) {
   }
 }
 
+TEST_F(StyleSystemTest, EquivalentStylesheetReparseCountsOnlyNewFontFaces) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style>@font-face { font-family: TestFont; src: local(TestFont); }</style>
+      <rect id="r"/>
+    </svg>
+  )");
+  auto style = document.querySelector("style");
+  auto element = document.querySelector("#r")->entityHandle();
+  ASSERT_TRUE(style.has_value());
+  auto& stylesheet = style->entityHandle().get<StylesheetComponent>();
+  auto& resourceManager = document.registry().ctx().get<ResourceManagerContext>();
+  ParseWarningSink warningSink;
+
+  for (int pass = 0; pass < 5; ++pass) {
+    stylesheet.parseStylesheet(pass % 2 == 0
+                                   ? "@font-face { font-family: TestFont; src: local(TestFont); }"
+                                   : " @font-face{font-family:TestFont;src:local(TestFont)}");
+    SetRenderTreeState(document.registry(), RenderTreeState{.needsFullRebuild = false,
+                                                            .needsFullStyleRecompute = false,
+                                                            .hasBeenBuilt = true});
+    document.registry()
+        .emplace_or_replace<DirtyFlagsComponent>(element.entity())
+        .mark(DirtyFlagsComponent::Style);
+    styleSystem.computeAllStyles(document.registry(), warningSink);
+  }
+
+  EXPECT_EQ(resourceManager.fontFaces().size(), 1u);
+  EXPECT_EQ(resourceManager.stylesheetFontFaceCountForTesting(), 1u);
+}
+
+TEST_F(StyleSystemTest, DestroyedStylesheetRemovesRegistrationState) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style>@font-face { font-family: TestFont; src: local(TestFont); }</style>
+    </svg>
+  )");
+  std::optional<SVGElement> style = document.querySelector("style");
+  ASSERT_TRUE(style.has_value());
+  auto root = document.svgElement();
+  ParseWarningSink warningSink;
+  styleSystem.computeAllStyles(document.registry(), warningSink);
+  auto& resourceManager = document.registry().ctx().get<ResourceManagerContext>();
+  const std::size_t registrationsBeforeRemoval =
+      resourceManager.stylesheetFontFaceRegistrationCountForTesting();
+  ASSERT_GT(registrationsBeforeRemoval, 0u);
+
+  root.removeChild(*style);
+  style.reset();
+
+  EXPECT_EQ(resourceManager.stylesheetFontFaceRegistrationCountForTesting(),
+            registrationsBeforeRemoval - 1);
+}
+
 TEST_F(StyleSystemTest, ComputeStylesForSubsetOnlyComputesRequestedEntities) {
   auto document = ParseSVG(R"(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">

--- a/donner/svg/resources/SandboxedFileResourceLoader.cc
+++ b/donner/svg/resources/SandboxedFileResourceLoader.cc
@@ -1,25 +1,87 @@
 #include "donner/svg/resources/SandboxedFileResourceLoader.h"
 
+#include <cassert>
+#include <cerrno>
 #include <cstdint>
-#include <fstream>
+#include <cstdio>
 #include <limits>
+#include <memory>
+#include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
-#include "donner/base/Utils.h"
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include "donner/base/Utf8.h"
 #include "donner/svg/resources/ResourceLoaderInterface.h"
 
 namespace donner::svg {
 
-struct SandboxedFileResourceLoader::RootDirectoryHandle {};
+struct SandboxedFileResourceLoader::RootDirectoryHandle {
+#ifdef _WIN32
+  HANDLE handle = INVALID_HANDLE_VALUE;
 
-SandboxedFileResourceLoader::~SandboxedFileResourceLoader() = default;
+  ~RootDirectoryHandle() {
+    if (handle != INVALID_HANDLE_VALUE) {
+      CloseHandle(handle);
+    }
+  }
+#else
+  int fd = -1;
 
-bool SandboxedFileResourceLoader::hasValidRootHandle() const {
-  return false;
-}
+  ~RootDirectoryHandle() {
+    if (fd >= 0) {
+      close(fd);
+    }
+  }
+#endif
+};
 
 namespace {
+
+bool PathComponentsEqual(const std::filesystem::path& lhs, const std::filesystem::path& rhs) {
+#ifdef _WIN32
+  return _wcsicmp(lhs.c_str(), rhs.c_str()) == 0;
+#else
+  return lhs == rhs;
+#endif
+}
+
+bool PathContainsNull(const std::filesystem::path& path) {
+  return path.native().find(std::filesystem::path::value_type{}) !=
+         std::filesystem::path::string_type::npos;
+}
+
+bool IsBoundedUrlPath(std::string_view url) {
+  if (url.size() > SandboxedFileResourceLoader::kMaximumPathBytes ||
+      url.find('\0') != std::string_view::npos || !Utf8::IsValidString(url)) {
+    return false;
+  }
+
+  std::size_t components = 0;
+  bool inComponent = false;
+  for (const char ch : url) {
+    if (ch == '/' || ch == '\\') {
+      inComponent = false;
+    } else if (!inComponent) {
+      inComponent = true;
+      if (++components > SandboxedFileResourceLoader::kMaximumPathComponents) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 bool IsPathUnderRoot(const std::filesystem::path& root, const std::filesystem::path& path) {
   assert(root.is_absolute());
@@ -28,11 +90,242 @@ bool IsPathUnderRoot(const std::filesystem::path& root, const std::filesystem::p
   auto rootIt = root.begin();
   auto pathIt = path.begin();
   for (; rootIt != root.end() && pathIt != path.end(); ++rootIt, ++pathIt) {
-    if (*rootIt != *pathIt) {
+    if (!PathComponentsEqual(*rootIt, *pathIt)) {
       return false;
     }
   }
   return rootIt == root.end();
+}
+
+struct FileCloser {
+  void operator()(std::FILE* file) const { std::fclose(file); }
+};
+
+using FilePtr = std::unique_ptr<std::FILE, FileCloser>;
+
+#ifdef _WIN32
+
+std::optional<std::filesystem::path> FinalPathForHandle(HANDLE handle) {
+  const DWORD required = GetFinalPathNameByHandleW(handle, nullptr, 0, FILE_NAME_NORMALIZED);
+  if (required == 0) {
+    return std::nullopt;
+  }
+
+  std::vector<wchar_t> buffer(static_cast<size_t>(required) + 1);
+  const DWORD written =
+      GetFinalPathNameByHandleW(handle, buffer.data(), required + 1, FILE_NAME_NORMALIZED);
+  if (written == 0 || written > required) {
+    return std::nullopt;
+  }
+  return std::filesystem::path(std::wstring(buffer.data(), written));
+}
+
+std::variant<FilePtr, ResourceLoaderError> OpenSandboxedBinaryFile(
+    HANDLE rootHandle, const std::filesystem::path& path) {
+  // Omitting FILE_SHARE_DELETE pins the opened file and the root directory at their current names
+  // while the handle-based containment decision and read are in progress.
+  HANDLE handle = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return ResourceLoaderError::NotFound;
+  }
+
+  const auto rootPath = FinalPathForHandle(rootHandle);
+  const auto openedPath = FinalPathForHandle(handle);
+  if (!rootPath || !openedPath || !IsPathUnderRoot(*rootPath, *openedPath)) {
+    CloseHandle(handle);
+    return ResourceLoaderError::SandboxViolation;
+  }
+
+  const int fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), _O_BINARY | _O_RDONLY);
+  if (fd < 0) {
+    CloseHandle(handle);
+    return ResourceLoaderError::NotFound;
+  }
+  std::FILE* file = _fdopen(fd, "rb");
+  if (file == nullptr) {
+    _close(fd);
+    return ResourceLoaderError::NotFound;
+  }
+  return FilePtr(file);
+}
+
+#else
+
+std::variant<FilePtr, ResourceLoaderError> OpenSandboxedBinaryFile(
+    int rootFd, const std::filesystem::path& relativePath) {
+  std::vector<std::filesystem::path> components;
+  for (const auto& component : relativePath) {
+    if (component.empty() || component == ".") {
+      continue;
+    }
+    if (component == "..") {
+      return ResourceLoaderError::SandboxViolation;
+    }
+    if (PathContainsNull(component)) {
+      return ResourceLoaderError::SandboxViolation;
+    }
+    components.push_back(component);
+  }
+  if (components.empty()) {
+    return ResourceLoaderError::NotFound;
+  }
+
+  int currentFd = dup(rootFd);
+  if (currentFd < 0) {
+    return ResourceLoaderError::NotFound;
+  }
+  (void)fcntl(currentFd, F_SETFD, FD_CLOEXEC);
+
+  for (size_t i = 0; i < components.size(); ++i) {
+    const bool isLast = i + 1 == components.size();
+    struct stat linkStatus{};
+    if (fstatat(currentFd, components[i].c_str(), &linkStatus, AT_SYMLINK_NOFOLLOW) != 0) {
+      close(currentFd);
+      return ResourceLoaderError::NotFound;
+    }
+    if (S_ISLNK(linkStatus.st_mode)) {
+      close(currentFd);
+      return ResourceLoaderError::SandboxViolation;
+    }
+
+    int flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW;
+    if (!isLast) {
+      flags |= O_DIRECTORY;
+    } else {
+      // Avoid blocking indefinitely if an attacker replaces the final entry with a FIFO or device.
+      // O_NONBLOCK is inert for regular files, which are verified after opening.
+      flags |= O_NONBLOCK;
+    }
+    const int nextFd = openat(currentFd, components[i].c_str(), flags);
+    const int openError = errno;
+    close(currentFd);
+    if (nextFd < 0) {
+      return openError == ELOOP ? ResourceLoaderError::SandboxViolation
+                                : ResourceLoaderError::NotFound;
+    }
+    currentFd = nextFd;
+  }
+
+  std::FILE* file = fdopen(currentFd, "rb");
+  if (file == nullptr) {
+    close(currentFd);
+    return ResourceLoaderError::NotFound;
+  }
+  return FilePtr(file);
+}
+
+#endif
+
+struct OpenedFileInfo {
+  uintmax_t size = 0;
+  bool regular = false;
+};
+
+std::optional<OpenedFileInfo> GetOpenedFileInfo(std::FILE* file) {
+#ifdef _WIN32
+  struct _stat64 status{};
+  if (_fstat64(_fileno(file), &status) != 0 || status.st_size < 0) {
+    return std::nullopt;
+  }
+  return OpenedFileInfo{
+      .size = static_cast<uintmax_t>(status.st_size),
+      .regular = (status.st_mode & _S_IFMT) == _S_IFREG,
+  };
+#else
+  struct stat status{};
+  if (fstat(fileno(file), &status) != 0 || status.st_size < 0) {
+    return std::nullopt;
+  }
+  return OpenedFileInfo{
+      .size = static_cast<uintmax_t>(status.st_size),
+      .regular = S_ISREG(status.st_mode),
+  };
+#endif
+}
+
+std::optional<std::filesystem::path> ResolveCanonicalRoot(const std::filesystem::path& root) {
+  if (PathContainsNull(root)) {
+    return std::nullopt;
+  }
+  std::error_code error;
+  if (!std::filesystem::is_directory(root, error) || error) {
+    return std::nullopt;
+  }
+  std::filesystem::path canonicalRoot = std::filesystem::canonical(root, error);
+  if (error || !canonicalRoot.is_absolute()) {
+    return std::nullopt;
+  }
+  return canonicalRoot;
+}
+
+std::optional<std::filesystem::path> ResolveDocumentDirectory(
+    const std::filesystem::path& root, const std::filesystem::path& documentPath) {
+  if (PathContainsNull(documentPath)) {
+    return std::nullopt;
+  }
+  std::error_code error;
+  const std::filesystem::path absoluteDocumentPath =
+      std::filesystem::absolute(documentPath, error).lexically_normal();
+  if (error || !absoluteDocumentPath.is_absolute()) {
+    return std::nullopt;
+  }
+
+  std::filesystem::path directory;
+  const std::filesystem::path canonicalDocumentPath =
+      std::filesystem::canonical(absoluteDocumentPath, error);
+  if (!error) {
+    directory = canonicalDocumentPath.parent_path();
+  } else {
+    error.clear();
+    directory = std::filesystem::canonical(absoluteDocumentPath.parent_path(), error);
+  }
+  if (error || !directory.is_absolute() || !IsPathUnderRoot(root, directory)) {
+    return std::nullopt;
+  }
+  return directory;
+}
+
+std::variant<std::filesystem::path, ResourceLoaderError> ResolveSandboxedPath(
+    const std::filesystem::path& root, const std::filesystem::path& documentPath,
+    std::string_view url) {
+  if (!IsBoundedUrlPath(url)) {
+    return ResourceLoaderError::SandboxViolation;
+  }
+  std::filesystem::path path(url);
+  if (!path.is_absolute()) {
+    path = documentPath / path;
+  }
+  std::error_code error;
+  path = std::filesystem::absolute(path, error).lexically_normal();
+  if (error) {
+    return ResourceLoaderError::NotFound;
+  }
+  if (!IsPathUnderRoot(root, path)) {
+    return ResourceLoaderError::SandboxViolation;
+  }
+  return path;
+}
+
+std::variant<std::vector<uint8_t>, ResourceLoaderError> ReadBoundedFile(FilePtr file,
+                                                                        size_t maximumSize) {
+  const auto opened = GetOpenedFileInfo(file.get());
+  if (!opened || !opened->regular || opened->size > std::numeric_limits<size_t>::max()) {
+    return ResourceLoaderError::NotFound;
+  }
+  if (opened->size > maximumSize) {
+    return ResourceLoaderError::TooLarge;
+  }
+
+  std::vector<uint8_t> data(static_cast<size_t>(opened->size));
+  const size_t bytesRead = std::fread(data.data(), 1, data.size(), file.get());
+  if (bytesRead != data.size() || std::ferror(file.get())) {
+    return ResourceLoaderError::NotFound;
+  }
+  if (std::fgetc(file.get()) != EOF) {
+    return ResourceLoaderError::TooLarge;
+  }
+  return data;
 }
 
 }  // namespace
@@ -40,63 +333,67 @@ bool IsPathUnderRoot(const std::filesystem::path& root, const std::filesystem::p
 SandboxedFileResourceLoader::SandboxedFileResourceLoader(const std::filesystem::path& root,
                                                          const std::filesystem::path& documentPath,
                                                          size_t maximumResourceSize)
-    : root_(root), documentPath_(documentPath), maximumResourceSize_(maximumResourceSize) {
-  UTILS_RELEASE_ASSERT_MSG(std::filesystem::is_directory(root_), "Root directory does not exist");
+    : maximumResourceSize_(maximumResourceSize),
+      rootHandle_(std::make_unique<RootDirectoryHandle>()) {
+  const auto canonicalRoot = ResolveCanonicalRoot(root);
+  if (!canonicalRoot) {
+    return;
+  }
+  root_ = *canonicalRoot;
+  const auto documentDirectory = ResolveDocumentDirectory(root_, documentPath);
+  if (!documentDirectory) {
+    root_.clear();
+    return;
+  }
+  documentPath_ = *documentDirectory;
+#ifdef _WIN32
+  rootHandle_->handle = CreateFileW(
+      root_.c_str(), FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+      OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+  if (rootHandle_->handle == INVALID_HANDLE_VALUE) {
+    root_.clear();
+  }
+#else
+  rootHandle_->fd = open(root_.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  if (rootHandle_->fd < 0) {
+    root_.clear();
+  }
+#endif
+}
 
-  root_ = std::filesystem::canonical(root_);
-  documentPath_ =
-      std::filesystem::weakly_canonical(std::filesystem::absolute(documentPath)).parent_path();
+SandboxedFileResourceLoader::~SandboxedFileResourceLoader() = default;
+
+bool SandboxedFileResourceLoader::hasValidRootHandle() const {
+#ifdef _WIN32
+  return rootHandle_->handle != INVALID_HANDLE_VALUE;
+#else
+  return rootHandle_->fd >= 0;
+#endif
 }
 
 std::variant<std::vector<uint8_t>, ResourceLoaderError>
 SandboxedFileResourceLoader::fetchExternalResource(std::string_view url) {
-  // Convert the url to a path, make it absolute, and make sure it's relative to the root.
-  std::filesystem::path path(url);
-  if (!path.is_absolute()) {
-    path = documentPath_ / path;
-  }
-
-  std::error_code canonicalError;
-  path = std::filesystem::canonical(path, canonicalError);
-  if (canonicalError) {
+  if (root_.empty()) {
     return ResourceLoaderError::NotFound;
   }
-
-  if (!IsPathUnderRoot(root_, path)) {
-    return ResourceLoaderError::SandboxViolation;
-  }
-
-  std::error_code statusError;
-  if (!std::filesystem::is_regular_file(path, statusError) || statusError) {
+  if (!hasValidRootHandle()) {
     return ResourceLoaderError::NotFound;
   }
+  auto maybePath = ResolveSandboxedPath(root_, documentPath_, url);
+  if (const auto* error = std::get_if<ResourceLoaderError>(&maybePath)) {
+    return *error;
+  }
+  const std::filesystem::path& path = std::get<std::filesystem::path>(maybePath);
 
-  const uintmax_t fileSize = std::filesystem::file_size(path, statusError);
-  if (statusError || fileSize > std::numeric_limits<size_t>::max()) {
-    return ResourceLoaderError::NotFound;
+#ifdef _WIN32
+  auto openResult = OpenSandboxedBinaryFile(rootHandle_->handle, path);
+#else
+  auto openResult = OpenSandboxedBinaryFile(rootHandle_->fd, path.lexically_relative(root_));
+#endif
+  if (const auto* error = std::get_if<ResourceLoaderError>(&openResult)) {
+    return *error;
   }
-  if (fileSize > maximumResourceSize_) {
-    return ResourceLoaderError::TooLarge;
-  }
-
-  // Open the canonical path rather than the attacker-controlled symlink path.
-  std::ifstream file(path, std::ios::binary);
-  if (!file.is_open()) {
-    return ResourceLoaderError::NotFound;
-  }
-
-  std::vector<uint8_t> data;
-  data.resize(static_cast<size_t>(fileSize));
-  file.read(reinterpret_cast<char*>(data.data()),
-            static_cast<std::streamsize>(fileSize));  // NOLINT
-  if (file.bad() || file.gcount() != static_cast<std::streamsize>(fileSize)) {
-    return ResourceLoaderError::NotFound;
-  }
-  if (file.peek() != std::char_traits<char>::eof()) {
-    return ResourceLoaderError::TooLarge;
-  }
-
-  return data;
+  return ReadBoundedFile(std::move(std::get<FilePtr>(openResult)), maximumResourceSize_);
 }
 
 }  // namespace donner::svg

--- a/donner/svg/resources/SandboxedFileResourceLoader.cc
+++ b/donner/svg/resources/SandboxedFileResourceLoader.cc
@@ -11,6 +11,14 @@
 
 namespace donner::svg {
 
+struct SandboxedFileResourceLoader::RootDirectoryHandle {};
+
+SandboxedFileResourceLoader::~SandboxedFileResourceLoader() = default;
+
+bool SandboxedFileResourceLoader::hasValidRootHandle() const {
+  return false;
+}
+
 namespace {
 
 bool IsPathUnderRoot(const std::filesystem::path& root, const std::filesystem::path& path) {

--- a/donner/svg/resources/SandboxedFileResourceLoader.h
+++ b/donner/svg/resources/SandboxedFileResourceLoader.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <memory>
 
 #include "donner/svg/resources/ResourceLoaderInterface.h"
 
@@ -15,6 +16,10 @@ class SandboxedFileResourceLoader : public ResourceLoaderInterface {
 public:
   /// Default maximum size of one external resource.
   static constexpr size_t kDefaultMaximumResourceSize = 16 * 1024 * 1024;
+  /// Maximum byte length accepted for an untrusted filesystem URL.
+  static constexpr size_t kMaximumPathBytes = 4096;
+  /// Maximum number of components accepted for an untrusted filesystem URL.
+  static constexpr size_t kMaximumPathComponents = 256;
 
   /**
    * Create a new resource loader that loads files sandboxed within the given root directory.
@@ -37,7 +42,7 @@ public:
   SandboxedFileResourceLoader& operator=(SandboxedFileResourceLoader&&) = delete;
 
   /// Destructor.
-  ~SandboxedFileResourceLoader() override = default;
+  ~SandboxedFileResourceLoader() override;
 
   /**
    * Fetch external resource from a given URL.
@@ -49,9 +54,14 @@ public:
       std::string_view url) override;
 
 private:
-  std::filesystem::path root_;          //!< Root directory of the sandbox.
-  std::filesystem::path documentPath_;  //!< Path to the document being loaded.
-  size_t maximumResourceSize_;          //!< Maximum bytes accepted from one resource.
+  struct RootDirectoryHandle;
+
+  bool hasValidRootHandle() const;
+
+  std::filesystem::path root_;                       //!< Root directory of the sandbox.
+  std::filesystem::path documentPath_;               //!< Path to the document being loaded.
+  size_t maximumResourceSize_;                       //!< Maximum bytes accepted from one resource.
+  std::unique_ptr<RootDirectoryHandle> rootHandle_;  //!< Pinned sandbox root.
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/UrlLoader.cc
+++ b/donner/svg/resources/UrlLoader.cc
@@ -145,6 +145,7 @@ std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_v
   // because their payload is the resource itself and is bounded again after decoding.
   if (!uri.starts_with("data:")) {
     if (const auto representationError = validateExternalUriRepresentation(uri)) {
+      LatchAggregateRejection(*representationError, remainingResourceBytes_);
       return *representationError;
     }
   }

--- a/donner/svg/resources/UrlLoader.cc
+++ b/donner/svg/resources/UrlLoader.cc
@@ -63,6 +63,11 @@ std::string MimeTypeFromUrl(std::string_view url) {
 
 }  // namespace
 
+std::optional<UrlLoaderError> UrlLoader::validateExternalUriRepresentation(std::string_view uri) {
+  (void)uri;
+  return std::nullopt;
+}
+
 bool UrlLoader::consumeResourceBytes(size_t size) {
   if (size > maximumResourceSize_ ||
       (remainingResourceBytes_ != nullptr && size > *remainingResourceBytes_)) {

--- a/donner/svg/resources/UrlLoader.cc
+++ b/donner/svg/resources/UrlLoader.cc
@@ -1,9 +1,13 @@
 #include "donner/svg/resources/UrlLoader.h"
 
 #include "donner/base/StringUtils.h"
+#include "donner/base/Utf8.h"
 #include "donner/base/parser/DataUrlParser.h"
 
 namespace donner::svg {
+
+static_assert(UrlLoader::kMaximumExternalUriSize ==
+              parser::DataUrlParser::kDefaultMaximumExternalUrlSize);
 
 using parser::DataUrlParser;
 using parser::DataUrlParserError;
@@ -61,26 +65,74 @@ std::string MimeTypeFromUrl(std::string_view url) {
   return "";
 }
 
-}  // namespace
-
-std::optional<UrlLoaderError> UrlLoader::validateExternalUriRepresentation(std::string_view uri) {
-  (void)uri;
-  return std::nullopt;
-}
-
-bool UrlLoader::consumeResourceBytes(size_t size) {
-  if (size > maximumResourceSize_ ||
-      (remainingResourceBytes_ != nullptr && size > *remainingResourceBytes_)) {
-    if (remainingResourceBytes_ != nullptr) {
-      *remainingResourceBytes_ = 0;
+bool ConsumeResourceBytes(size_t size, size_t maximumResourceSize, size_t* remainingResourceBytes) {
+  if (size > maximumResourceSize ||
+      (remainingResourceBytes != nullptr && size > *remainingResourceBytes)) {
+    if (remainingResourceBytes != nullptr) {
+      *remainingResourceBytes = 0;
     }
     return false;
   }
 
-  if (remainingResourceBytes_ != nullptr) {
-    *remainingResourceBytes_ -= size;
+  if (remainingResourceBytes != nullptr) {
+    *remainingResourceBytes -= size;
   }
   return true;
+}
+
+void LatchAggregateRejection(UrlLoaderError error, size_t* remainingResourceBytes) {
+  if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes != nullptr) {
+    *remainingResourceBytes = 0;
+  }
+}
+
+std::variant<UrlLoader::Result, UrlLoaderError> LoadDataUrl(DataUrlParser::Result& parsedUrl,
+                                                            size_t maximumResourceSize,
+                                                            size_t* remainingResourceBytes) {
+  UrlLoader::Result result;
+  result.data = std::move(std::get<std::vector<uint8_t>>(parsedUrl.payload));
+  if (!ConsumeResourceBytes(result.data.size(), maximumResourceSize, remainingResourceBytes)) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
+  result.mimeType = parsedUrl.mimeType;
+  return result;
+}
+
+std::variant<UrlLoader::Result, UrlLoaderError> LoadExternalUrl(
+    DataUrlParser::Result& parsedUrl, ResourceLoaderInterface& resourceLoader,
+    size_t maximumResourceSize, size_t* remainingResourceBytes) {
+  if (maximumResourceSize == 0 ||
+      (remainingResourceBytes != nullptr && *remainingResourceBytes == 0)) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
+
+  const RcString& url = std::get<RcString>(parsedUrl.payload);
+  auto maybeLoadedData = resourceLoader.fetchExternalResource(url);
+  if (std::holds_alternative<ResourceLoaderError>(maybeLoadedData)) {
+    const UrlLoaderError error = MapError(std::get<ResourceLoaderError>(maybeLoadedData));
+    LatchAggregateRejection(error, remainingResourceBytes);
+    return error;
+  }
+
+  UrlLoader::Result result;
+  result.data = std::get<std::vector<uint8_t>>(std::move(maybeLoadedData));
+  if (!ConsumeResourceBytes(result.data.size(), maximumResourceSize, remainingResourceBytes)) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
+  result.mimeType = MimeTypeFromUrl(url);
+  return result;
+}
+
+}  // namespace
+
+std::optional<UrlLoaderError> UrlLoader::validateExternalUriRepresentation(std::string_view uri) {
+  if (uri.size() > kMaximumExternalUriSize) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
+  if (uri.find('\0') != std::string_view::npos || !Utf8::IsValidString(uri)) {
+    return UrlLoaderError::InvalidDataUrl;
+  }
+  return std::nullopt;
 }
 
 std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_view uri) {
@@ -88,49 +140,29 @@ std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_v
     return UrlLoaderError::ResourceTooLarge;
   }
 
-  Result result;
+  // Reject attacker-sized external identifiers before DataUrlParser copies them into RcString and
+  // before caching loaders copy/hash them again. Data URLs retain the larger encoded-input limit
+  // because their payload is the resource itself and is bounded again after decoding.
+  if (!uri.starts_with("data:")) {
+    if (const auto representationError = validateExternalUriRepresentation(uri)) {
+      return *representationError;
+    }
+  }
 
   std::variant<DataUrlParser::Result, DataUrlParserError> maybeParsedUrl =
       DataUrlParser::Parse(uri);
 
   if (std::holds_alternative<DataUrlParserError>(maybeParsedUrl)) {
     const UrlLoaderError error = MapError(std::get<DataUrlParserError>(maybeParsedUrl));
-    if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes_ != nullptr) {
-      *remainingResourceBytes_ = 0;
-    }
+    LatchAggregateRejection(error, remainingResourceBytes_);
     return error;
   }
 
   DataUrlParser::Result& parsedUrl = std::get<DataUrlParser::Result>(maybeParsedUrl);
-
   if (parsedUrl.kind == DataUrlParser::Result::Kind::Data) {
-    result.data = std::move(std::get<std::vector<uint8_t>>(parsedUrl.payload));
-    if (!consumeResourceBytes(result.data.size())) {
-      return UrlLoaderError::ResourceTooLarge;
-    }
-    result.mimeType = parsedUrl.mimeType;
-    return result;
-  } else {
-    const RcString& url = std::get<RcString>(parsedUrl.payload);
-
-    // It's an external URL, fetch it.
-    auto maybeLoadedData = resourceLoader_.fetchExternalResource(url);
-    if (std::holds_alternative<ResourceLoaderError>(maybeLoadedData)) {
-      const UrlLoaderError error = MapError(std::get<ResourceLoaderError>(maybeLoadedData));
-      if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes_ != nullptr) {
-        *remainingResourceBytes_ = 0;
-      }
-      return error;
-    }
-
-    result.data = std::get<std::vector<uint8_t>>(std::move(maybeLoadedData));
-    if (!consumeResourceBytes(result.data.size())) {
-      return UrlLoaderError::ResourceTooLarge;
-    }
-    result.mimeType = MimeTypeFromUrl(url);
+    return LoadDataUrl(parsedUrl, maximumResourceSize_, remainingResourceBytes_);
   }
-
-  return result;
+  return LoadExternalUrl(parsedUrl, resourceLoader_, maximumResourceSize_, remainingResourceBytes_);
 }
 
 }  // namespace donner::svg

--- a/donner/svg/resources/UrlLoader.h
+++ b/donner/svg/resources/UrlLoader.h
@@ -2,6 +2,7 @@
 /// @file
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "donner/base/Utils.h"
@@ -46,6 +47,12 @@ class UrlLoader {
 public:
   /// Default maximum decoded or fetched resource size.
   static constexpr size_t kDefaultMaximumResourceSize = 16 * 1024 * 1024;
+
+  /// Maximum external URI bytes accepted before copying, hashing, or invoking a callback.
+  static constexpr size_t kMaximumExternalUriSize = 4096;
+
+  /// Validate an external URI before any copy, hash, cache lookup, or callback.
+  static std::optional<UrlLoaderError> validateExternalUriRepresentation(std::string_view uri);
 
   /**
    * Result of loading a URI or decoding a data URL.

--- a/donner/svg/resources/UrlLoader.h
+++ b/donner/svg/resources/UrlLoader.h
@@ -96,8 +96,6 @@ public:
   std::variant<Result, UrlLoaderError> fromUri(std::string_view uri);
 
 private:
-  bool consumeResourceBytes(size_t size);
-
   /// Resource loader to use for fetching external resources.
   ResourceLoaderInterface& resourceLoader_;  // NOLINT
 

--- a/donner/svg/resources/tests/SandboxedFileResourceLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/SandboxedFileResourceLoader_structured_fuzzer.cc
@@ -78,6 +78,7 @@ void CheckResult(const std::variant<std::vector<uint8_t>, ResourceLoaderError>& 
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   static SandboxFixture fixture;
+  const std::string_view input(reinterpret_cast<const char*>(data), size);  // NOLINT
   FuzzedDataProvider provider(data, size);
 
   CheckResult(fixture.loader().fetchExternalResource("inside.bin"));
@@ -85,6 +86,36 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   CheckResult(fixture.loader().fetchExternalResource("../root-sibling/secret.bin"));
   if (fixture.hasSymlink()) {
     CheckResult(fixture.loader().fetchExternalResource("escape-link/secret.bin"));
+  }
+  if (input.starts_with("embedded-null-path")) {
+    constexpr char kEmbeddedNullPath[] = "..\0ignored/root-sibling/secret.bin";
+    const std::string path(kEmbeddedNullPath, sizeof(kEmbeddedNullPath) - 1);
+    const auto result = fixture.loader().fetchExternalResource(path);
+    CheckResult(result);
+    const auto* error = std::get_if<ResourceLoaderError>(&result);
+    if (error == nullptr || *error != ResourceLoaderError::SandboxViolation) {
+      std::abort();
+    }
+  }
+  if (input.starts_with("path-representation-bounds")) {
+    std::string path;
+    for (std::size_t i = 0; i <= SandboxedFileResourceLoader::kMaximumPathComponents; ++i) {
+      path += "a/";
+    }
+    const auto result = fixture.loader().fetchExternalResource(path);
+    const auto* error = std::get_if<ResourceLoaderError>(&result);
+    if (error == nullptr || *error != ResourceLoaderError::SandboxViolation) {
+      std::abort();
+    }
+  }
+  if (input.starts_with("invalid-utf8-path")) {
+    constexpr char kInvalidUtf8Path[] = "invalid-\xED\xA0\x80.bin";
+    const auto result = fixture.loader().fetchExternalResource(
+        std::string_view(kInvalidUtf8Path, sizeof(kInvalidUtf8Path) - 1));
+    const auto* error = std::get_if<ResourceLoaderError>(&result);
+    if (error == nullptr || *error != ResourceLoaderError::SandboxViolation) {
+      std::abort();
+    }
   }
   CheckResult(fixture.loader().fetchExternalResource(provider.ConsumeRandomLengthString(256)));
   return 0;

--- a/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
+++ b/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
@@ -5,6 +5,10 @@
 
 #include <fstream>
 
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
+
 namespace donner::svg {
 
 class SandboxedFileResourceLoaderTests : public testing::Test {
@@ -39,9 +43,9 @@ TEST_F(SandboxedFileResourceLoaderTests, LoadFileFromRoot) {
 }
 
 TEST_F(SandboxedFileResourceLoaderTests, RootDoesNotExit) {
-  EXPECT_DEATH(
-      { SandboxedFileResourceLoader loader(root_ / "doesnotexist", root_ / "doc.svg"); },
-      "Root directory does not exist");
+  SandboxedFileResourceLoader loader(root_ / "doesnotexist", root_ / "doc.svg");
+  EXPECT_THAT(loader.fetchExternalResource("test.txt"),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::NotFound));
 }
 
 TEST_F(SandboxedFileResourceLoaderTests, LoadFileFromSubdirectory) {
@@ -68,6 +72,17 @@ TEST_F(SandboxedFileResourceLoaderTests, AccessDirectoryReturnsNotFound) {
   EXPECT_THAT(data, testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::NotFound));
 }
 
+#ifndef _WIN32
+TEST_F(SandboxedFileResourceLoaderTests, AccessFifoReturnsWithoutBlocking) {
+  const std::filesystem::path fifoPath = root_ / "resource.fifo";
+  ASSERT_EQ(mkfifo(fifoPath.c_str(), 0600), 0);
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+
+  EXPECT_THAT(loader.fetchExternalResource("resource.fifo"),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::NotFound));
+}
+#endif
+
 TEST_F(SandboxedFileResourceLoaderTests, AccessOutsideSandbox) {
   createTestFileUnder(secondaryDir_, "test.txt");
   SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
@@ -76,6 +91,36 @@ TEST_F(SandboxedFileResourceLoaderTests, AccessOutsideSandbox) {
               testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
 
   EXPECT_THAT(loader.fetchExternalResource((secondaryDir_ / "test.txt").string()),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+}
+
+TEST_F(SandboxedFileResourceLoaderTests, RejectsEmbeddedNullBeforeFilesystemTraversal) {
+  createTestFileUnder(secondaryDir_, "secret.txt");
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+  constexpr char kEmbeddedNullPath[] = "..\0ignored/secondary/secret.txt";
+  const std::string path(kEmbeddedNullPath, sizeof(kEmbeddedNullPath) - 1);
+
+  EXPECT_THAT(loader.fetchExternalResource(path),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+}
+
+TEST_F(SandboxedFileResourceLoaderTests, RejectsInvalidUtf8BeforeFilesystemConversion) {
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+  EXPECT_THAT(loader.fetchExternalResource(std::string("invalid-\xED\xA0\x80.bin", 15)),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+}
+
+TEST_F(SandboxedFileResourceLoaderTests, RejectsOversizedPathRepresentations) {
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+  EXPECT_THAT(loader.fetchExternalResource(
+                  std::string(SandboxedFileResourceLoader::kMaximumPathBytes + 1, 'a')),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+
+  std::string components;
+  for (std::size_t i = 0; i <= SandboxedFileResourceLoader::kMaximumPathComponents; ++i) {
+    components += "a/";
+  }
+  EXPECT_THAT(loader.fetchExternalResource(components),
               testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
 }
 

--- a/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
@@ -20,11 +20,15 @@ public:
 
   std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
       std::string_view /*url*/) override {
+    ++fetchCount_;
     return payload_;
   }
 
+  size_t fetchCount() const { return fetchCount_; }
+
 private:
   std::vector<uint8_t> payload_;
+  size_t fetchCount_ = 0;
 };
 
 std::string PercentEncode(std::span<const uint8_t> data) {
@@ -42,6 +46,8 @@ std::string PercentEncode(std::span<const uint8_t> data) {
 }  // namespace
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  const std::string_view input(reinterpret_cast<const char*>(data), size);  // NOLINT
+  const bool forceExternalUriLimit = input.starts_with("external-uri-representation-budget");
   FuzzedDataProvider provider(data, size);
   const size_t maximumResourceSize = provider.ConsumeIntegralInRange<size_t>(0, 128);
   size_t remainingResourceBytes = provider.ConsumeIntegralInRange<size_t>(0, 256);
@@ -53,6 +59,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   UrlLoader urlLoader(resourceLoader, maximumResourceSize, &remainingResourceBytes);
   const std::string externalUrl = "asset/" + provider.ConsumeRandomLengthString(32);
   const std::string dataUrl = PercentEncode(payload);
+
+  if (forceExternalUriLimit) {
+    const auto result = urlLoader.fromUri(std::string(UrlLoader::kMaximumExternalUriSize + 1, 'a'));
+    if (!std::holds_alternative<UrlLoaderError>(result) ||
+        std::get<UrlLoaderError>(result) != UrlLoaderError::ResourceTooLarge ||
+        resourceLoader.fetchCount() != 0) {
+      std::abort();
+    }
+  }
 
   for (std::string_view uri :
        {std::string_view(externalUrl), std::string_view(dataUrl), std::string_view(externalUrl)}) {

--- a/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
@@ -48,12 +48,17 @@ std::string PercentEncode(std::span<const uint8_t> data) {
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   const std::string_view input(reinterpret_cast<const char*>(data), size);  // NOLINT
   const bool forceExternalUriLimit = input.starts_with("external-uri-representation-budget");
+  const bool forceZeroPerResourceLimit = input.starts_with("zero-per-resource-limit");
   FuzzedDataProvider provider(data, size);
-  const size_t maximumResourceSize = provider.ConsumeIntegralInRange<size_t>(0, 128);
-  size_t remainingResourceBytes = provider.ConsumeIntegralInRange<size_t>(0, 256);
+  const size_t maximumResourceSize =
+      forceZeroPerResourceLimit ? 0 : provider.ConsumeIntegralInRange<size_t>(0, 128);
+  size_t remainingResourceBytes =
+      forceZeroPerResourceLimit ? 44 : provider.ConsumeIntegralInRange<size_t>(0, 256);
   const std::vector<uint8_t> payload =
-      provider.ConsumeBytes<uint8_t>(provider.ConsumeIntegralInRange<size_t>(
-          0, std::min<size_t>(128, provider.remaining_bytes())));
+      forceZeroPerResourceLimit
+          ? std::vector<uint8_t>{}
+          : provider.ConsumeBytes<uint8_t>(provider.ConsumeIntegralInRange<size_t>(
+                0, std::min<size_t>(128, provider.remaining_bytes())));
 
   PayloadResourceLoader resourceLoader(payload);
   UrlLoader urlLoader(resourceLoader, maximumResourceSize, &remainingResourceBytes);

--- a/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
@@ -77,6 +77,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   for (std::string_view uri :
        {std::string_view(externalUrl), std::string_view(dataUrl), std::string_view(externalUrl)}) {
     const size_t before = remainingResourceBytes;
+    const size_t fetchCountBefore = resourceLoader.fetchCount();
     auto result = urlLoader.fromUri(uri);
     if (const auto* loaded = std::get_if<UrlLoader::Result>(&result)) {
       if (loaded->data.size() > maximumResourceSize || loaded->data.size() > before ||
@@ -85,7 +86,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       }
     } else {
       const UrlLoaderError error = std::get<UrlLoaderError>(result);
-      if ((error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes != 0) ||
+      const bool zeroPerResourceLimitRejectedBeforeFetch =
+          error == UrlLoaderError::ResourceTooLarge && maximumResourceSize == 0 &&
+          !uri.starts_with("data:") && remainingResourceBytes == before &&
+          resourceLoader.fetchCount() == fetchCountBefore;
+      if ((error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes != 0 &&
+           !zeroPerResourceLimitRejectedBeforeFetch) ||
           (error != UrlLoaderError::ResourceTooLarge && remainingResourceBytes != before)) {
         std::abort();
       }

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -161,10 +161,12 @@ TEST(UrlLoader, ExhaustedAggregateBudgetDoesNotFetchExternalResource) {
 }
 TEST(UrlLoader, RejectsOversizedOrInvalidExternalUriBeforeCallback) {
   InProcResourceLoader loader;
-  UrlLoader urlLoader(loader);
+  size_t remainingResourceBytes = 16;
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
 
   EXPECT_THAT(urlLoader.fromUri(std::string(UrlLoader::kMaximumExternalUriSize + 1, 'a')),
               VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(remainingResourceBytes, 0u);
   constexpr char kInvalidUtf8[] = "invalid-\xED\xA0\x80.png";
   EXPECT_THAT(urlLoader.fromUri(std::string_view(kInvalidUtf8, sizeof(kInvalidUtf8) - 1)),
               VariantWith<UrlLoaderError>(UrlLoaderError::InvalidDataUrl));

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -167,11 +167,12 @@ TEST(UrlLoader, RejectsOversizedOrInvalidExternalUriBeforeCallback) {
   EXPECT_THAT(urlLoader.fromUri(std::string(UrlLoader::kMaximumExternalUriSize + 1, 'a')),
               VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
   EXPECT_EQ(remainingResourceBytes, 0u);
+  UrlLoader freshUrlLoader(loader);
   constexpr char kInvalidUtf8[] = "invalid-\xED\xA0\x80.png";
-  EXPECT_THAT(urlLoader.fromUri(std::string_view(kInvalidUtf8, sizeof(kInvalidUtf8) - 1)),
+  EXPECT_THAT(freshUrlLoader.fromUri(std::string_view(kInvalidUtf8, sizeof(kInvalidUtf8) - 1)),
               VariantWith<UrlLoaderError>(UrlLoaderError::InvalidDataUrl));
   constexpr char kEmbeddedNull[] = "prefix\0suffix.png";
-  EXPECT_THAT(urlLoader.fromUri(std::string_view(kEmbeddedNull, sizeof(kEmbeddedNull) - 1)),
+  EXPECT_THAT(freshUrlLoader.fromUri(std::string_view(kEmbeddedNull, sizeof(kEmbeddedNull) - 1)),
               VariantWith<UrlLoaderError>(UrlLoaderError::InvalidDataUrl));
   EXPECT_EQ(loader.fetchCount(), 0u);
 }

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -159,6 +159,18 @@ TEST(UrlLoader, ExhaustedAggregateBudgetDoesNotFetchExternalResource) {
               VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
   EXPECT_EQ(loader.fetchCount(), 0u);
 }
+
+TEST(UrlLoader, ZeroPerResourceLimitDoesNotConsumeAggregateBudget) {
+  InProcResourceLoader loader;
+  size_t remainingResourceBytes = 44;
+  UrlLoader urlLoader(loader, /*maximumResourceSize=*/0, &remainingResourceBytes);
+
+  EXPECT_THAT(urlLoader.fromUri("asset/"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(loader.fetchCount(), 0u);
+  EXPECT_EQ(remainingResourceBytes, 44u);
+}
+
 TEST(UrlLoader, RejectsOversizedOrInvalidExternalUriBeforeCallback) {
   InProcResourceLoader loader;
   size_t remainingResourceBytes = 16;

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -150,6 +150,29 @@ TEST(UrlLoader, LoaderReportedOverageLatchesAggregateBudget) {
   EXPECT_EQ(remainingResourceBytes, 0u);
 }
 
+TEST(UrlLoader, ExhaustedAggregateBudgetDoesNotFetchExternalResource) {
+  InProcResourceLoader loader;
+  size_t remainingResourceBytes = 0;
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+
+  EXPECT_THAT(urlLoader.fromUri("test.txt"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(loader.fetchCount(), 0u);
+}
+TEST(UrlLoader, RejectsOversizedOrInvalidExternalUriBeforeCallback) {
+  InProcResourceLoader loader;
+  UrlLoader urlLoader(loader);
+
+  EXPECT_THAT(urlLoader.fromUri(std::string(UrlLoader::kMaximumExternalUriSize + 1, 'a')),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  constexpr char kInvalidUtf8[] = "invalid-\xED\xA0\x80.png";
+  EXPECT_THAT(urlLoader.fromUri(std::string_view(kInvalidUtf8, sizeof(kInvalidUtf8) - 1)),
+              VariantWith<UrlLoaderError>(UrlLoaderError::InvalidDataUrl));
+  constexpr char kEmbeddedNull[] = "prefix\0suffix.png";
+  EXPECT_THAT(urlLoader.fromUri(std::string_view(kEmbeddedNull, sizeof(kEmbeddedNull) - 1)),
+              VariantWith<UrlLoaderError>(UrlLoaderError::InvalidDataUrl));
+  EXPECT_EQ(loader.fetchCount(), 0u);
+}
 /// @test that a valid URL-encoded data URL with an explicit MIME type is decoded.
 TEST(UrlLoader, FetchDataUrlUrlEncodedWithMime) {
   InProcResourceLoader loader;

--- a/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/embedded_null_path
+++ b/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/embedded_null_path
@@ -1,0 +1,1 @@
+embedded-null-path

--- a/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/invalid_utf8_path
+++ b/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/invalid_utf8_path
@@ -1,0 +1,1 @@
+invalid-utf8-path

--- a/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/path_representation_bounds
+++ b/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/path_representation_bounds
@@ -1,0 +1,1 @@
+path-representation-bounds

--- a/donner/svg/resources/tests/url_loader_structured_corpus/external_uri_representation_budget
+++ b/donner/svg/resources/tests/url_loader_structured_corpus/external_uri_representation_budget
@@ -1,0 +1,1 @@
+external-uri-representation-budget

--- a/donner/svg/resources/tests/url_loader_structured_corpus/zero_per_resource_limit
+++ b/donner/svg/resources/tests/url_loader_structured_corpus/zero_per_resource_limit
@@ -1,0 +1,1 @@
+zero-per-resource-limit


### PR DESCRIPTION
Bounds external resource fetch, decode, sandbox, cache, and subdocument admission before expensive or retained work occurs.

- limits URL and data-URL representation and decode work, file paths and reads, fetch attempts, decoded bytes, subdocument nodes, and retained payloads
- latches aggregate rejection and caches bounded failures so repeated over-budget references cannot refetch or redecode the same resource
- keeps image and external-SVG failure namespaces separate and clears the correct state when a loader is replaced
- strengthens canonical component-aware filesystem containment without widening the document's resource root
- adds causal loader-callback, repeated-reference, positive-cache, cross-kind, sandbox, and structured-fuzzer regressions

## Validation

- exact top-of-stack `bazel test //...`: 356 passed, 129 configuration-intentional skips, 0 failures
- focused URL, sandboxed-file, resource-manager, and subdocument-cache targets: passed
- URL, file-loader, and resource-manager corpora under ASan/libFuzzer and UBSan: passed
- lint, CMake validation, formatting, diff, privacy, and no-lockfile checks: clean
