### PR TITLE
Harden CLI input and terminal handling

### DIFF
--- a/donner/svg/parser/BUILD.bazel
+++ b/donner/svg/parser/BUILD.bazel
@@ -25,7 +25,16 @@ donner_cc_binary(
     name = "svg_parser_tool",
     srcs = ["svg_parser_tool.cc"],
     tags = ["codeql_default"],
-    deps = [":parser"],
+    deps = [
+        ":parser",
+        "//donner/base",
+    ],
+)
+
+sh_test(
+    name = "svg_parser_tool_tests",
+    srcs = ["tests/svg_parser_tool_tests.sh"],
+    data = [":svg_parser_tool"],
 )
 
 ##

--- a/donner/svg/parser/svg_parser_tool.cc
+++ b/donner/svg/parser/svg_parser_tool.cc
@@ -1,8 +1,9 @@
-#include <fstream>
 #include <iostream>
-#include <vector>
+#include <sstream>
 
+#include "donner/base/FileUtils.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/TerminalEscape.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/parser/SVGParser.h"
 
@@ -13,7 +14,7 @@ void DumpTree(SVGElement element, int depth) {
     std::cout << "  ";
   }
 
-  std::cout << element.type() << ", id: '" << element.id() << "'";
+  std::cout << element.type() << ", id: '" << EscapeTerminalText(element.id()) << "'";
   if (element.type() == ElementType::SVG) {
     if (auto viewBox = element.cast<SVGSVGElement>().viewBox()) {
       std::cout << ", viewBox: " << *viewBox;
@@ -34,25 +35,22 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  std::ifstream file(argv[1]);
-  if (!file) {
-    std::cerr << "Could not open file " << argv[1] << "\n";
+  auto fileResult =
+      donner::ReadFileBounded(argv[1], donner::svg::parser::SVGParser::kDefaultMaximumInputSize);
+  const auto* fileData = std::get_if<std::string>(&fileResult);
+  if (fileData == nullptr) {
+    std::cerr << donner::FileReadErrorMessage(std::get<donner::FileReadError>(fileResult)) << ": "
+              << donner::EscapeTerminalText(argv[1]) << "\n";
     return 2;
   }
 
-  file.seekg(0, std::ios::end);
-  const std::streamsize fileLength = file.tellg();
-  file.seekg(0);
-
-  std::string fileData;
-  fileData.resize(fileLength);
-  file.read(fileData.data(), fileLength);
-
   donner::ParseWarningSink warnings;
-  auto maybeResult = donner::svg::parser::SVGParser::ParseSVG(fileData, warnings);
+  auto maybeResult = donner::svg::parser::SVGParser::ParseSVG(*fileData, warnings);
   if (maybeResult.hasError()) {
     const auto& e = maybeResult.error();
-    std::cerr << "Parse Error " << e << "\n";
+    std::ostringstream diagnostic;
+    diagnostic << e;
+    std::cerr << "Parse Error " << donner::EscapeTerminalText(diagnostic.str()) << "\n";
     return 3;
   }
 
@@ -61,7 +59,9 @@ int main(int argc, char* argv[]) {
   if (warnings.hasWarnings()) {
     std::cout << "Warnings:\n";
     for (auto& w : warnings.warnings()) {
-      std::cout << "  " << w << "\n";
+      std::ostringstream diagnostic;
+      diagnostic << w;
+      std::cout << "  " << donner::EscapeTerminalText(diagnostic.str()) << "\n";
     }
   }
 

--- a/donner/svg/parser/tests/svg_parser_tool_tests.sh
+++ b/donner/svg/parser/tests/svg_parser_tool_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly tool="${TEST_SRCDIR}/_main/donner/svg/parser/svg_parser_tool"
+readonly bidi_control="$(printf '\342\200\256')"
+readonly input="${TEST_TMPDIR}/safe.svg"
+printf '<svg xmlns="http://www.w3.org/2000/svg"><g id="safe%sevil"/></svg>' \
+  "${bidi_control}" >"${input}"
+
+output="$("${tool}" "${input}" 2>&1)"
+if [[ "${output}" != *'safe\u202eevil'* ]]; then
+  echo "svg_parser_tool did not escape a bidi control in an element id" >&2
+  exit 1
+fi
+if [[ "${output}" == *"${bidi_control}"* ]]; then
+  echo "svg_parser_tool emitted a raw bidi control" >&2
+  exit 1
+fi

--- a/donner/svg/tool/BUILD.bazel
+++ b/donner/svg/tool/BUILD.bazel
@@ -1,6 +1,12 @@
-load("//build_defs:package.bzl", "donner_package")
 load("//build_defs:dep_audit.bzl", "forbidden_transitive_dep_test")
-load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "donner_cc_test")
+load("//build_defs:package.bzl", "donner_package")
+load(
+    "//build_defs:rules.bzl",
+    "donner_cc_binary",
+    "donner_cc_fuzzer",
+    "donner_cc_library",
+    "donner_cc_test",
+)
 
 alias(
     name = "tool",
@@ -62,6 +68,13 @@ donner_cc_test(
         "//donner/svg/renderer:terminal_image_viewer",
         "@com_google_gtest//:gtest_main",
     ],
+)
+
+donner_cc_fuzzer(
+    name = "donner_svg_tool_utils_fuzzer",
+    srcs = ["DonnerSvgToolUtils_fuzzer.cc"],
+    corpus = "testdata/donner_svg_tool_utils_corpus",
+    deps = [":donner_svg_tool_utils"],
 )
 
 donner_cc_test(

--- a/donner/svg/tool/DonnerSvgTool.cc
+++ b/donner/svg/tool/DonnerSvgTool.cc
@@ -11,7 +11,6 @@
 #include <charconv>
 #include <chrono>
 #include <filesystem>
-#include <fstream>
 #include <limits>
 #include <optional>
 #include <ostream>
@@ -19,10 +18,12 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "donner/base/Box.h"
 #include "donner/base/DiagnosticRenderer.h"
+#include "donner/base/FileUtils.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Utils.h"
@@ -138,6 +139,12 @@ bool TryParseIntWithMin(std::string_view value, int minimumValue, int* outValue)
   return true;
 }
 
+std::string TerminalDiagnostic(const ParseDiagnostic& diagnostic) {
+  std::ostringstream formatted;
+  formatted << diagnostic;
+  return EscapeTerminalText(formatted.str(), /*preserveNewlines=*/true);
+}
+
 /**
  * Parse command line arguments.
  *
@@ -197,12 +204,12 @@ bool ParseArgs(int argc, char* argv[], CliOptions* options, std::ostream& out, s
         options->outputFileSet = true;
       } else if (arg == "--width") {
         if (!TryParseIntWithMin(value, 1, &options->width)) {
-          err << "Invalid --width value: " << value << "\n";
+          err << "Invalid --width value: " << EscapeTerminalText(value) << "\n";
           return false;
         }
       } else {
         if (!TryParseIntWithMin(value, 1, &options->height)) {
-          err << "Invalid --height value: " << value << "\n";
+          err << "Invalid --height value: " << EscapeTerminalText(value) << "\n";
           return false;
         }
       }
@@ -210,7 +217,7 @@ bool ParseArgs(int argc, char* argv[], CliOptions* options, std::ostream& out, s
     }
 
     if (!arg.empty() && arg[0] == '-') {
-      err << "Unknown option: " << arg << "\n";
+      err << "Unknown option: " << EscapeTerminalText(arg) << "\n";
       return false;
     }
 
@@ -231,25 +238,12 @@ bool ParseArgs(int argc, char* argv[], CliOptions* options, std::ostream& out, s
 
 /** Read an input file into memory. */
 std::optional<std::string> ReadFile(std::string_view filename) {
-  std::ifstream file(std::string(filename), std::ios::binary);
-  if (!file) {
+  FileReadResult result =
+      ReadFileBounded(std::string(filename), parser::SVGParser::kDefaultMaximumInputSize);
+  if (!std::holds_alternative<std::string>(result)) {
     return std::nullopt;
   }
-
-  file.seekg(0, std::ios::end);
-  const std::streamsize length = file.tellg();
-  file.seekg(0);
-
-  if (length <= 0) {
-    return std::string();
-  }
-  if (static_cast<uint64_t>(length) > parser::SVGParser::kDefaultMaximumInputSize) {
-    return std::nullopt;
-  }
-
-  std::string data(static_cast<size_t>(length), '\0');
-  file.read(data.data(), length);
-  return data;
+  return std::move(std::get<std::string>(result));
 }
 
 /** Parse SVG data into an SVGDocument. */
@@ -260,20 +254,30 @@ std::optional<SVGDocument> ParseDocument(const CliOptions& options, const std::s
   parserOptions.enableExperimental = options.experimental;
 
   SVGDocument::Settings settings;
-  settings.resourceLoader = std::make_unique<SandboxedFileResourceLoader>(
-      std::filesystem::current_path(), options.inputFile);
+  std::error_code pathError;
+  const std::filesystem::path absoluteInputPath =
+      std::filesystem::absolute(options.inputFile, pathError).lexically_normal();
+  const auto sandboxRoot =
+      pathError ? std::nullopt : ResourceSandboxRootForAbsoluteInput(absoluteInputPath);
+  if (sandboxRoot) {
+    // An input document grants access only to resources beside or below that document. The
+    // process working directory may contain unrelated files and is not a trust boundary.
+    settings.resourceLoader =
+        std::make_unique<SandboxedFileResourceLoader>(*sandboxRoot, absoluteInputPath);
+  }
 
   auto result =
       parser::SVGParser::ParseSVG(fileData, warningSink, parserOptions, std::move(settings));
   if (result.hasError()) {
-    err << "Parse error: " << result.error() << "\n";
+    err << "Parse error: " << TerminalDiagnostic(result.error()) << "\n";
     return std::nullopt;
   }
 
   if (!options.quiet && warningSink.hasWarnings()) {
     out << "Parse warnings:\n";
-    out << DiagnosticRenderer::formatAll(fileData, warningSink,
-                                         {.filename = options.inputFile, .colorize = true});
+    const std::string formatted = DiagnosticRenderer::formatAll(
+        fileData, warningSink, {.filename = options.inputFile, .colorize = false});
+    out << EscapeTerminalText(formatted, /*preserveNewlines=*/true);
   }
 
   return std::move(result.result());
@@ -554,7 +558,7 @@ void RunInteractiveSelection(SVGDocument document, RendererTinySkia& renderer,
       const TerminalImageView highlightView = MakeView(highlighted);
 
       RedrawImage(highlightView, imageInfo.rows, out, viewerConfig);
-      out << "\r\x1b[2KSelected: " << BuildCssSelectorPath(*selected);
+      out << "\r\x1b[2KSelected: " << EscapeTerminalText(BuildCssSelectorPath(*selected));
       out.flush();
 
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
@@ -570,7 +574,7 @@ void RunInteractiveSelection(SVGDocument document, RendererTinySkia& renderer,
       const TerminalImageView selectedImageView = MakeView(selectedView);
 
       RedrawImage(selectedImageView, imageInfo.rows, out, viewerConfig);
-      out << "\r\x1b[2KSelected: " << BuildCssSelectorPath(*selected);
+      out << "\r\x1b[2KSelected: " << EscapeTerminalText(BuildCssSelectorPath(*selected));
       out.flush();
     }
   }
@@ -594,7 +598,7 @@ int RunDonnerSvgTool(int argc, char* argv[], std::ostream& out, std::ostream& er
 
   const auto fileData = ReadFile(options.inputFile);
   if (!fileData) {
-    err << "Failed to read input SVG: " << options.inputFile << "\n";
+    err << "Failed to read input SVG: " << EscapeTerminalText(options.inputFile) << "\n";
     return 2;
   }
 
@@ -618,11 +622,13 @@ int RunDonnerSvgTool(int argc, char* argv[], std::ostream& out, std::ostream& er
   if (shouldSavePng) {
     const bool saved = renderer.save(options.outputFile.c_str());
     if (!saved) {
-      err << "Failed to save PNG: " << std::filesystem::absolute(options.outputFile) << "\n";
+      err << "Failed to save PNG: "
+          << EscapeTerminalText(std::filesystem::absolute(options.outputFile).string()) << "\n";
       return 4;
     }
 
-    out << "Saved PNG: " << std::filesystem::absolute(options.outputFile) << "\n";
+    out << "Saved PNG: "
+        << EscapeTerminalText(std::filesystem::absolute(options.outputFile).string()) << "\n";
   }
 
   out << "Rendered size: " << renderer.width() << "x" << renderer.height() << "\n";

--- a/donner/svg/tool/DonnerSvgToolUtils.cc
+++ b/donner/svg/tool/DonnerSvgToolUtils.cc
@@ -1,6 +1,9 @@
 #include "donner/svg/tool/DonnerSvgToolUtils.h"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -68,6 +71,19 @@ std::vector<SVGElement> ElementChain(const SVGElement& element) {
 
 }  // namespace
 
+std::optional<std::filesystem::path> ResourceSandboxRootForAbsoluteInput(
+    const std::filesystem::path& absoluteInputPath) {
+  if (!absoluteInputPath.is_absolute() || !absoluteInputPath.has_filename()) {
+    return std::nullopt;
+  }
+
+  const std::filesystem::path root = absoluteInputPath.lexically_normal().parent_path();
+  if (root.empty() || !root.is_absolute()) {
+    return std::nullopt;
+  }
+  return root;
+}
+
 std::string BuildCssSelectorPath(const SVGElement& element) {
   const std::vector<SVGElement> chain = ElementChain(element);
 
@@ -87,9 +103,21 @@ void CompositeAABBRect(RendererBitmap& bitmap, const Box2d& bounds,
                        const SampledImageInfo& imageInfo) {
   const int imgW = bitmap.dimensions.x;
   const int imgH = bitmap.dimensions.y;
-  const size_t stride = bitmap.rowBytes / 4;
   const double sx = imageInfo.xScale;
   const double sy = imageInfo.yScale;
+
+  if (imgW <= 0 || imgH <= 0 || imageInfo.columns <= 0 || imageInfo.rows <= 0 ||
+      imageInfo.columns > std::numeric_limits<int>::max() / 2 ||
+      imageInfo.rows > std::numeric_limits<int>::max() / 2 || !std::isfinite(sx) || sx <= 0.0 ||
+      !std::isfinite(sy) || sy <= 0.0 || !std::isfinite(bounds.topLeft.x) ||
+      !std::isfinite(bounds.topLeft.y) || !std::isfinite(bounds.bottomRight.x) ||
+      !std::isfinite(bounds.bottomRight.y) || bitmap.rowBytes < static_cast<size_t>(imgW) * 4 ||
+      static_cast<size_t>(imgH) > std::numeric_limits<size_t>::max() / bitmap.rowBytes ||
+      bitmap.pixels.size() < bitmap.rowBytes * static_cast<size_t>(imgH)) {
+    return;
+  }
+
+  const size_t stride = bitmap.rowBytes / 4;
   const int totalSubX = imageInfo.columns * 2;
   const int totalSubY = imageInfo.rows * 2;
 
@@ -98,33 +126,41 @@ void CompositeAABBRect(RendererBitmap& bitmap, const Box2d& bounds,
   //   sub-pixel s within cell has offset (s % 2)
   //   so sub-pixel s maps to image pixel: int(floor(s/2) * 2 * scale) + (s % 2)
 
-  auto subPixelToImgX = [&](int s) -> int {
-    return static_cast<int>(static_cast<double>(s / 2) * 2.0 * sx) + (s % 2);
+  const auto subPixelToImage = [](int subPixel, double scale, int imageSize) -> int {
+    const double mapped = static_cast<double>(subPixel / 2) * 2.0 * scale + (subPixel % 2);
+    if (!std::isfinite(mapped) || mapped >= static_cast<double>(imageSize - 1)) {
+      return imageSize - 1;
+    }
+    return mapped <= 0.0 ? 0 : static_cast<int>(mapped);
   };
-  auto subPixelToImgY = [&](int s) -> int {
-    return static_cast<int>(static_cast<double>(s / 2) * 2.0 * sy) + (s % 2);
-  };
+  auto subPixelToImgX = [&](int s) -> int { return subPixelToImage(s, sx, imgW); };
+  auto subPixelToImgY = [&](int s) -> int { return subPixelToImage(s, sy, imgH); };
 
   // Find the sub-pixel index containing an image coordinate.
   // We need the inverse: given pixel p, find s such that subPixelToImg(s) == p.
   // For the cell: cell = floor(p / (2 * scale)), but the offset within the cell matters.
   // Simpler: brute-force search within a small range, or compute from the cell.
-  auto imgToSubPixelX = [&](double p) -> int {
-    const int cell = static_cast<int>(std::floor(p / (2.0 * sx)));
-    const int s0 = std::clamp(cell * 2, 0, totalSubX - 1);
+  const auto imageToSubPixel = [](double imagePosition, double scale, int imageSize,
+                                  int totalSubPixels, const auto& subPixelToImage) -> int {
+    const double boundedPosition =
+        std::clamp(imagePosition, 0.0, static_cast<double>(imageSize - 1));
+    const double rawCell = std::floor(boundedPosition / (2.0 * scale));
+    const double boundedCell =
+        std::clamp(rawCell, 0.0, static_cast<double>((totalSubPixels - 1) / 2));
+    const int cell = static_cast<int>(boundedCell);
+    const int s0 = std::clamp(cell * 2, 0, totalSubPixels - 1);
     // Check if the coordinate is closer to sub-pixel s0 or s0+1.
-    if (s0 + 1 < totalSubX && static_cast<double>(subPixelToImgX(s0 + 1)) <= p) {
+    if (s0 + 1 < totalSubPixels &&
+        static_cast<double>(subPixelToImage(s0 + 1)) <= boundedPosition) {
       return s0 + 1;
     }
     return s0;
   };
+  auto imgToSubPixelX = [&](double p) -> int {
+    return imageToSubPixel(p, sx, imgW, totalSubX, subPixelToImgX);
+  };
   auto imgToSubPixelY = [&](double p) -> int {
-    const int cell = static_cast<int>(std::floor(p / (2.0 * sy)));
-    const int s0 = std::clamp(cell * 2, 0, totalSubY - 1);
-    if (s0 + 1 < totalSubY && static_cast<double>(subPixelToImgY(s0 + 1)) <= p) {
-      return s0 + 1;
-    }
-    return s0;
+    return imageToSubPixel(p, sy, imgH, totalSubY, subPixelToImgY);
   };
 
   // Sub-pixel indices for the AABB edges. For the max edges, use the last sub-pixel

--- a/donner/svg/tool/DonnerSvgToolUtils.h
+++ b/donner/svg/tool/DonnerSvgToolUtils.h
@@ -1,9 +1,13 @@
 #pragma once
 /// @file
 
+#include <filesystem>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include "donner/base/Box.h"
+#include "donner/base/TerminalEscape.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/renderer/RendererInterface.h"
 
@@ -16,6 +20,19 @@ namespace donner::svg {
  * @return Selector path from the root to the element.
  */
 std::string BuildCssSelectorPath(const SVGElement& element);
+
+/** Return the sandbox root selected for an absolute input document path. */
+inline std::optional<std::filesystem::path> ResourceSandboxRootForAbsoluteInput(
+    const std::filesystem::path& absoluteInputPath) {
+  if (!absoluteInputPath.is_absolute() || !absoluteInputPath.has_filename()) {
+    return std::nullopt;
+  }
+  std::error_code error;
+  const std::filesystem::path root = std::filesystem::current_path(error);
+  return error ? std::nullopt : std::optional<std::filesystem::path>(root);
+}
+
+using ::donner::EscapeTerminalText;
 
 /** Sampled image dimensions and scaling for coordinate mapping. */
 struct SampledImageInfo {

--- a/donner/svg/tool/DonnerSvgToolUtils.h
+++ b/donner/svg/tool/DonnerSvgToolUtils.h
@@ -21,16 +21,14 @@ namespace donner::svg {
  */
 std::string BuildCssSelectorPath(const SVGElement& element);
 
-/** Return the sandbox root selected for an absolute input document path. */
-inline std::optional<std::filesystem::path> ResourceSandboxRootForAbsoluteInput(
-    const std::filesystem::path& absoluteInputPath) {
-  if (!absoluteInputPath.is_absolute() || !absoluteInputPath.has_filename()) {
-    return std::nullopt;
-  }
-  std::error_code error;
-  const std::filesystem::path root = std::filesystem::current_path(error);
-  return error ? std::nullopt : std::optional<std::filesystem::path>(root);
-}
+/**
+ * Return the narrowest sandbox root for an absolute input document path.
+ *
+ * A document grants access only to its containing directory, never to an ambient process working
+ * directory.
+ */
+std::optional<std::filesystem::path> ResourceSandboxRootForAbsoluteInput(
+    const std::filesystem::path& absoluteInputPath);
 
 using ::donner::EscapeTerminalText;
 

--- a/donner/svg/tool/DonnerSvgToolUtils_fuzzer.cc
+++ b/donner/svg/tool/DonnerSvgToolUtils_fuzzer.cc
@@ -1,0 +1,55 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <string_view>
+
+#include "donner/svg/tool/DonnerSvgToolUtils.h"
+
+namespace donner::svg {
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  const std::string_view input(reinterpret_cast<const char*>(data), size);  // NOLINT
+  const bool forceExtreme = input.starts_with("extreme-aabb-bounds");
+  if (input.starts_with("cli-resource-root-boundary")) {
+    const std::filesystem::path document =
+        std::filesystem::path("/workspace") / "untrusted" / "document.svg";
+    const auto root = ResourceSandboxRootForAbsoluteInput(document);
+    if (!root || *root != std::filesystem::path("/workspace") / "untrusted" ||
+        *root == std::filesystem::path("/workspace")) {
+      std::abort();
+    }
+  }
+  FuzzedDataProvider provider(data, size);
+
+  RendererBitmap bitmap;
+  bitmap.dimensions = Vector2i(64, 64);
+  bitmap.rowBytes = 64 * 4;
+  bitmap.pixels.assign(bitmap.rowBytes * 64, 0);
+
+  SampledImageInfo imageInfo{
+      provider.ConsumeIntegralInRange<int>(1, 64),
+      provider.ConsumeIntegralInRange<int>(1, 64),
+      provider.ConsumeFloatingPointInRange<double>(0.001, 1000.0),
+      provider.ConsumeFloatingPointInRange<double>(0.001, 1000.0),
+  };
+  Box2d bounds(
+      Vector2d(provider.ConsumeFloatingPoint<double>(), provider.ConsumeFloatingPoint<double>()),
+      Vector2d(provider.ConsumeFloatingPoint<double>(), provider.ConsumeFloatingPoint<double>()));
+  if (forceExtreme) {
+    bounds =
+        Box2d(Vector2d(-std::numeric_limits<double>::max(), -std::numeric_limits<double>::max()),
+              Vector2d(std::numeric_limits<double>::max(), std::numeric_limits<double>::max()));
+  }
+
+  CompositeAABBRect(bitmap, bounds, imageInfo);
+  if (bitmap.pixels.size() != bitmap.rowBytes * 64) {
+    std::abort();
+  }
+  return 0;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/tool/DonnerSvgToolUtils_tests.cc
+++ b/donner/svg/tool/DonnerSvgToolUtils_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/svg/tool/DonnerSvgToolUtils.h"
 
+#include <limits>
 #include <span>
 
 #include "donner/base/ParseWarningSink.h"
@@ -11,6 +12,15 @@
 
 namespace donner::svg {
 namespace {
+
+TEST(DonnerSvgToolUtils, EscapesTerminalControlCharactersAndInvalidUtf8) {
+  const std::string input = std::string("safe\x1b") + "[31m\n" + "\xc2\x9b" + "\xff" +
+                            "\xe2\x80\xae" + "reordered" + "\xe2\x81\xa6";
+
+  EXPECT_EQ(EscapeTerminalText(input), R"(safe\x1b[31m\x0a\u009b\xff\u202ereordered\u2066)");
+  EXPECT_EQ(EscapeTerminalText(input, /*preserveNewlines=*/true),
+            std::string(R"(safe\x1b[31m)") + "\n" + R"(\u009b\xff\u202ereordered\u2066)");
+}
 
 using testing::Eq;
 using testing::Optional;
@@ -180,6 +190,24 @@ TEST(CompositeAABBRect, NonAlignedBoundsSnapToNearestSubPixel) {
 ....................
 ....................
 )"));
+}
+
+TEST(CompositeAABBRect, ExtremeOrNonFiniteBoundsFailSafely) {
+  const SampledImageInfo info{10, 10, 5.0, 5.0};
+  RendererBitmap bmp = MakeBlackBitmap(100, 100);
+
+  CompositeAABBRect(
+      bmp, Box2d(Vector2d(std::numeric_limits<double>::infinity(), 0.0), Vector2d(10.0, 10.0)),
+      info);
+  EXPECT_THAT(bmp.pixels, testing::Each(0));
+
+  CompositeAABBRect(
+      bmp,
+      Box2d(Vector2d(-std::numeric_limits<double>::max(), -std::numeric_limits<double>::max()),
+            Vector2d(std::numeric_limits<double>::max(), std::numeric_limits<double>::max())),
+      info);
+  EXPECT_EQ(bmp.pixels.size(), 100u * 100u * 4u);
+  EXPECT_THAT(bmp.pixels, testing::Contains(0xff));
 }
 
 }  // namespace

--- a/donner/svg/tool/DonnerSvgTool_tests.cc
+++ b/donner/svg/tool/DonnerSvgTool_tests.cc
@@ -66,6 +66,11 @@ protected:
     return magic;
   }
 
+  std::string ReadFile(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+  }
+
   std::filesystem::path tmpDir_;
 };
 
@@ -116,6 +121,22 @@ private:
   bool active_ = false;
 };
 
+class ScopedWorkingDirectory {
+public:
+  explicit ScopedWorkingDirectory(const std::filesystem::path& path)
+      : previous_(std::filesystem::current_path()) {
+    std::filesystem::current_path(path);
+  }
+
+  ~ScopedWorkingDirectory() {
+    std::error_code error;
+    std::filesystem::current_path(previous_, error);
+  }
+
+private:
+  std::filesystem::path previous_;
+};
+
 constexpr std::string_view kSimpleSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="3" viewBox="0 0 4 3">
          <rect width="4" height="3" fill="#ff0000"/>
@@ -142,6 +163,18 @@ TEST(DonnerSvgTool, UnknownFlagReturnsOne) {
   std::ostringstream err;
   EXPECT_EQ(RunDonnerSvgTool(2, argv, out, err), 1);
   EXPECT_THAT(err.str(), testing::HasSubstr("Unknown option: --bogus"));
+}
+
+TEST(DonnerSvgTool, EscapesTerminalControlsInRejectedArguments) {
+  std::ostringstream out;
+  std::ostringstream err;
+
+  const std::string argument =
+      std::string("--bad\x1b]8;;https://example.test\a") + "\xe2\x80\xae" + "txt";
+  EXPECT_EQ(RunTool({argument}, &out, &err), 1);
+  EXPECT_THAT(err.str(), testing::HasSubstr(R"(--bad\x1b]8;;https://example.test\x07\u202etxt)"));
+  EXPECT_THAT(err.str(), testing::Not(testing::HasSubstr("\x1b]8")));
+  EXPECT_THAT(err.str(), testing::Not(testing::HasSubstr(std::string("\xe2\x80\xae", 3))));
 }
 
 TEST(DonnerSvgTool, MissingInputFileReturnsUsageError) {
@@ -236,6 +269,60 @@ TEST_F(DonnerSvgToolFileTest, RendersSvgToPngWithCanvasOverrides) {
               testing::ElementsAre(0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'));
 }
 
+TEST_F(DonnerSvgToolFileTest, ResourcesAreSandboxedToTheInputDocumentsDirectory) {
+  const std::filesystem::path untrustedDirectory = tmpDir_ / "untrusted";
+  const std::filesystem::path privateDirectory = tmpDir_ / "private";
+  std::filesystem::create_directories(untrustedDirectory);
+  std::filesystem::create_directories(privateDirectory);
+
+  const std::filesystem::path privateSvg = privateDirectory / "secret.svg";
+  {
+    std::ofstream file(privateSvg, std::ios::binary);
+    file << R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">
+                  <rect width="4" height="4" fill="#ff0000"/>
+                </svg>)";
+  }
+
+  const std::filesystem::path inputPath = untrustedDirectory / "input.svg";
+  {
+    std::ofstream file(inputPath, std::ios::binary);
+    file << R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">
+                  <image href="../private/secret.svg" width="4" height="4"/>
+                </svg>)";
+  }
+  const std::filesystem::path blankPath = untrustedDirectory / "blank.svg";
+  {
+    std::ofstream file(blankPath, std::ios::binary);
+    file << R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"/>)";
+  }
+  const std::filesystem::path inlinePath = untrustedDirectory / "inline.svg";
+  {
+    std::ofstream file(inlinePath, std::ios::binary);
+    file << R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">
+                  <rect width="4" height="4" fill="#ff0000"/>
+                </svg>)";
+  }
+
+  const std::filesystem::path escapedOutput = tmpDir_ / "escaped.png";
+  const std::filesystem::path blankOutput = tmpDir_ / "blank.png";
+  const std::filesystem::path inlineOutput = tmpDir_ / "inline.png";
+  {
+    ScopedWorkingDirectory workingDirectory(tmpDir_);
+    std::ostringstream out;
+    std::ostringstream err;
+    EXPECT_EQ(RunTool({"--output", escapedOutput.string(), "untrusted/input.svg"}, &out, &err), 0);
+    out.str("");
+    err.str("");
+    EXPECT_EQ(RunTool({"--output", blankOutput.string(), "untrusted/blank.svg"}, &out, &err), 0);
+    out.str("");
+    err.str("");
+    EXPECT_EQ(RunTool({"--output", inlineOutput.string(), "untrusted/inline.svg"}, &out, &err), 0);
+  }
+
+  EXPECT_EQ(ReadFile(escapedOutput), ReadFile(blankOutput));
+  EXPECT_NE(ReadFile(escapedOutput), ReadFile(inlineOutput));
+}
+
 TEST_F(DonnerSvgToolFileTest, HeightOnlyOverrideIsAccepted) {
   const std::filesystem::path inputPath = WriteSvg("input.svg", kSimpleSvg);
   const std::filesystem::path outputPath = tmpDir_ / "height-only.png";
@@ -300,6 +387,21 @@ TEST_F(DonnerSvgToolFileTest, ParseWarningsArePrintedUnlessQuiet) {
   EXPECT_TRUE(quietErr.str().empty());
   EXPECT_THAT(quietOut.str(), testing::Not(testing::HasSubstr("Parse warnings:")));
   EXPECT_THAT(quietOut.str(), testing::HasSubstr("Rendered size: 4x4"));
+}
+
+TEST_F(DonnerSvgToolFileTest, ParseWarningsEscapeUnicodeTerminalControls) {
+  std::string source = R"(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect x=")";
+  source.append("\xc2\x9b", 2);
+  source += R"(" width="2" height="2"/></svg>)";
+  const std::filesystem::path inputPath = WriteSvg("terminal-control.svg", source);
+
+  std::ostringstream out;
+  std::ostringstream err;
+  EXPECT_EQ(RunTool({"--preview", inputPath.string()}, &out, &err), 0);
+
+  EXPECT_TRUE(err.str().empty());
+  EXPECT_THAT(out.str(), testing::HasSubstr(R"(\u009b)"));
+  EXPECT_THAT(out.str(), testing::Not(testing::HasSubstr(std::string("\xc2\x9b", 2))));
 }
 
 TEST_F(DonnerSvgToolFileTest, SaveFailureReturnsDistinctExitCode) {

--- a/donner/svg/tool/testdata/donner_svg_tool_utils_corpus/cli_resource_root_boundary
+++ b/donner/svg/tool/testdata/donner_svg_tool_utils_corpus/cli_resource_root_boundary
@@ -1,0 +1,1 @@
+cli-resource-root-boundary

--- a/donner/svg/tool/testdata/donner_svg_tool_utils_corpus/extreme_aabb_bounds
+++ b/donner/svg/tool/testdata/donner_svg_tool_utils_corpus/extreme_aabb_bounds
@@ -1,0 +1,1 @@
+extreme-aabb-bounds

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -20,6 +20,7 @@ donner_cc_binary(
         "codeql_text_full",
     ],
     deps = [
+        "//donner/base",
         "@donner",
     ],
 )
@@ -74,6 +75,7 @@ donner_cc_binary(
     }),
     deps = [
         "//:donner",
+        "//donner/base",
         # The viewer is intentionally minimal: donner core for the DOM,
         # parser, hit-test, and renderer; glad/glfw/imgui for the ImGui
         # shell; and exactly one library from //donner/editor — the
@@ -166,6 +168,7 @@ donner_cc_binary(
     deps = [
         ":geode_embed_surface",
         "//:donner",
+        "//donner/base",
         "//donner/svg/renderer:renderer_geode",
         "//donner/svg/renderer/geode:geode_device",
         "//donner/svg/renderer/geode:geode_wgpu_util",

--- a/examples/geode_embed.cc
+++ b/examples/geode_embed.cc
@@ -37,11 +37,15 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <webgpu/webgpu.hpp>
 
+#include "donner/base/FileUtils.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/TerminalEscape.h"
 #include "donner/svg/SVG.h"
+#include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/RendererGeode.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
@@ -60,18 +64,13 @@ void GlfwErrorCallback(int error, const char* description) {
   std::fprintf(stderr, "GLFW error %d: %s\n", error, description);
 }
 
-/// Slurp a file into a string. Matches the idiom in `svg_to_png.cc`.
 std::string LoadFile(const char* path) {
-  std::ifstream file(path, std::ios::binary);
-  if (!file) {
-    return {};
+  auto result =
+      donner::ReadFileBounded(path, donner::svg::parser::SVGParser::kDefaultMaximumInputSize);
+  if (const auto* contents = std::get_if<std::string>(&result)) {
+    return *contents;
   }
-  std::string data;
-  file.seekg(0, std::ios::end);
-  data.resize(static_cast<size_t>(file.tellg()));
-  file.seekg(0);
-  file.read(data.data(), static_cast<std::streamsize>(data.size()));
-  return data;
+  return {};
 }
 
 /// Pick a surface format. The first entry in `formats` is the adapter's
@@ -103,14 +102,17 @@ int main(int argc, char* argv[]) {
   // --- Parse the SVG once up front ---
   const std::string svgData = LoadFile(argv[1]);
   if (svgData.empty()) {
-    std::fprintf(stderr, "Failed to open or empty SVG: %s\n", argv[1]);
+    const std::string safePath = donner::EscapeTerminalText(argv[1]);
+    std::fprintf(stderr, "Failed to open or empty SVG: %s\n", safePath.c_str());
     return 1;
   }
 
   donner::ParseWarningSink warnings;
   auto maybeDocument = donner::svg::parser::SVGParser::ParseSVG(svgData, warnings);
   if (maybeDocument.hasError()) {
-    std::cerr << "SVG parse error: " << maybeDocument.error() << "\n";
+    std::ostringstream diagnostic;
+    diagnostic << maybeDocument.error();
+    std::cerr << "SVG parse error: " << donner::EscapeTerminalText(diagnostic.str()) << "\n";
     return 1;
   }
   donner::svg::SVGDocument document = std::move(maybeDocument.result());

--- a/examples/svg_to_png.cc
+++ b/examples/svg_to_png.cc
@@ -14,11 +14,12 @@
 
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <vector>
+#include <sstream>
 
+#include "donner/base/FileUtils.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/TerminalEscape.h"
 #include "donner/svg/SVG.h"
 #include "donner/svg/renderer/Renderer.h"
 
@@ -43,20 +44,13 @@ int main(int argc, char* argv[]) {
   }
 
   //! [load_file]
-  // Load the file and store it in a mutable std::vector<char>.
-  std::ifstream file(argv[1]);
-  if (!file) {
-    std::cerr << "Could not open file " << argv[1] << "\n";
+  auto fileResult = ReadFileBounded(argv[1], SVGParser::kDefaultMaximumInputSize);
+  const auto* fileData = std::get_if<std::string>(&fileResult);
+  if (fileData == nullptr) {
+    std::cerr << FileReadErrorMessage(std::get<FileReadError>(fileResult)) << ": "
+              << EscapeTerminalText(argv[1]) << "\n";
     return 1;  // Return an error code from main.
   }
-
-  std::string fileData;
-  file.seekg(0, std::ios::end);
-  const size_t fileLength = file.tellg();
-  file.seekg(0);
-
-  fileData.resize(fileLength);
-  file.read(fileData.data(), static_cast<std::streamsize>(fileLength));
   //! [load_file]
 
   // Parse the SVG. Note that the lifetime of the vector must be longer than the returned
@@ -69,13 +63,15 @@ int main(int argc, char* argv[]) {
 
   ParseWarningSink warnings;
   // warnings and options are optional, call ParseSVG(fileData) to use defaults and ignore warnings.
-  ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(fileData, warnings, options);
+  ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(*fileData, warnings, options);
   //! [parse]
 
   //! [handle_errors]
   // ParseResult either contains an SVGDocument or an error.
   if (maybeDocument.hasError()) {
-    std::cerr << "Parse Error: " << maybeDocument.error() << "\n";
+    std::ostringstream diagnostic;
+    diagnostic << maybeDocument.error();
+    std::cerr << "Parse Error: " << EscapeTerminalText(diagnostic.str()) << "\n";
     return 1;  // Return an error code from main.
   }
 
@@ -84,7 +80,9 @@ int main(int argc, char* argv[]) {
   if (warnings.hasWarnings()) {
     std::cout << "Warnings:\n";
     for (const ParseDiagnostic& w : warnings.warnings()) {
-      std::cout << "  " << w << "\n";
+      std::ostringstream diagnostic;
+      diagnostic << w;
+      std::cout << "  " << EscapeTerminalText(diagnostic.str()) << "\n";
     }
   }
 

--- a/examples/svg_viewer.cc
+++ b/examples/svg_viewer.cc
@@ -29,8 +29,10 @@
 
 #include "donner/base/Box.h"
 #include "donner/base/FileOffset.h"
+#include "donner/base/FileUtils.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/TerminalEscape.h"
 #include "donner/base/Vector2.h"
 #include "donner/base/xml/XMLNode.h"
 #include "donner/editor/TextBuffer.h"
@@ -65,14 +67,15 @@ void GlfwErrorCallback(int error, const char* description) {
 }
 
 std::string LoadFile(const std::string& filename) {
-  std::ifstream file(filename, std::ios::binary);
-  if (!file) {
-    std::cerr << "Could not open file " << filename << "\n";
+  auto result =
+      donner::ReadFileBounded(filename, donner::svg::parser::SVGParser::kDefaultMaximumInputSize);
+  if (const auto* contents = std::get_if<std::string>(&result)) {
+    return *contents;
+  } else {
+    std::cerr << donner::FileReadErrorMessage(std::get<donner::FileReadError>(result)) << ": "
+              << donner::EscapeTerminalText(filename) << "\n";
     return {};
   }
-  std::ostringstream out;
-  out << file.rdbuf();
-  return std::move(out).str();
 }
 
 /// Bundles the loaded document with its hit-test controller and the


### PR DESCRIPTION
Bounds public CLI file, resource, geometry, diagnostic, and terminal-output handling for attacker-controlled SVG inputs.

- reuses the shared terminal escaping contract for parser diagnostics, element identifiers, filenames, warnings, and example-tool errors
- constrains resource-root resolution so relative references cannot escape the explicitly selected input directory
- rejects non-finite or out-of-range raster geometry before bitmap conversion and allocation
- adds causal shell, unit, and structured-fuzzer regressions for terminal controls, ambient resource escapes, and extreme bounds

## Validation

- exact top-of-stack `bazel test //...`: 356 passed, 129 configuration-intentional skips, 0 failures
- CLI/parser/tool focused tests: passed
- DonnerSvgToolUtils corpus under ASan/libFuzzer: passed
- `svg_parser_tool`, `donner-svg`, `svg_to_png`, and `svg_viewer` builds: passed
- lint, CMake validation, formatting, diff, privacy, and no-lockfile checks: clean

This layer is stacked on #1038 and contains only public executable and CLI boundary hardening.
