### PR TITLE
Bound filter preparation and execution resources

### DIFF
--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -493,8 +493,10 @@ TEST_F(RnrReplayTest, FilterDisappearRepro3MatchesGoldenAfterSecondMouseUp) {
   ASSERT_GE(snapshot.mouseUpCount, kTargetMouseUpCount)
       << "Replay ended before the second mouse-up checkpoint";
   ASSERT_FALSE(snapshot.bitmap.empty()) << "Replay produced an empty final bitmap";
-  EXPECT_GT(snapshot.filterBudgetChunks, 0u)
-      << "Large valid filter frames must submit a bounded budget chunk instead of rejecting";
+  if (snapshot.usesTexturePresentation) {
+    EXPECT_GT(snapshot.filterBudgetChunks, 0u)
+        << "Large valid Geode filter frames must chunk instead of rejecting";
+  }
 
   // Both backends have a bounded rounding difference in this filtered image, but of different
   // kinds, so each arm gets its own documented allowance.

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -318,6 +318,7 @@ protected:
     std::uint64_t frameIndex = 0;
     std::size_t mouseUpCount = 0;
     bool stoppedForBisection = false;
+    std::uint64_t filterBudgetChunks = 0;
     std::filesystem::path diagnosticPath;
     std::uint64_t compositorReconstructCount = 0;
     bool usesTexturePresentation = false;
@@ -467,6 +468,7 @@ protected:
     }
 
     out->compositorReconstructCount = asyncRenderer.compositorReconstructCountForTesting();
+    out->filterBudgetChunks = renderer.filterBudgetChunksForTesting();
 
     if (out->stoppedForBisection) {
       out->diagnosticPath = DiagnosticOutputDir() /
@@ -491,6 +493,8 @@ TEST_F(RnrReplayTest, FilterDisappearRepro3MatchesGoldenAfterSecondMouseUp) {
   ASSERT_GE(snapshot.mouseUpCount, kTargetMouseUpCount)
       << "Replay ended before the second mouse-up checkpoint";
   ASSERT_FALSE(snapshot.bitmap.empty()) << "Replay produced an empty final bitmap";
+  EXPECT_GT(snapshot.filterBudgetChunks, 0u)
+      << "Large valid filter frames must submit a bounded budget chunk instead of rejecting";
 
   // Both backends have a bounded rounding difference in this filtered image, but of different
   // kinds, so each arm gets its own documented allowance.

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -347,20 +347,26 @@ py_test(
         # handoff add deliberate shipped code. Measured at this layer: wasm
         # 12,911,112 raw / 5,120,158 gzip, js 174,731 raw / 49,206 gzip,
         # and package 13,127,399 raw. Budgets retain about 1 percent headroom.
+        #
+        # Filter security-controls retune: graph retention, backend execution
+        # accounting, and numeric admission add deliberate renderer code.
+        # Measured at this layer: wasm 12,946,259 raw / 5,134,972 gzip,
+        # js 174,773 raw / 49,217 gzip, and package 13,162,588 raw. Budgets
+        # retain about 1 percent headroom.
         "--max-wasm-raw-bytes",
-        "13041000",
+        "13076000",
         "--max-wasm-gzip-bytes",
-        "5172000",
+        "5187000",
         "--max-wasm-function-body-bytes",
         "46000",
         "--max-wasm-data-segments",
         "64",
         "--max-js-raw-bytes",
-        "176500",
+        "176600",
         "--max-js-gzip-bytes",
-        "49700",
+        "49710",
         "--max-total-raw-bytes",
-        "13259000",
+        "13295000",
         "--expected-js-property",
         "__donnerLastScrollEvent",
         # SHIP BLOCKER, tracked with the deferred WebKit decision: the WebGPU diagnostic

--- a/donner/svg/components/DocumentResourceFamilyBudget.h
+++ b/donner/svg/components/DocumentResourceFamilyBudget.h
@@ -12,11 +12,12 @@ class DocumentResourceFamilyBudget {
 public:
   static constexpr std::size_t kDefaultMaximumTotalRetainedBytes = 128 * 1024 * 1024;
 
-  enum class Kind : std::size_t { ParsedPayload, Geometry, ComputedStyle, Count };
+  enum class Kind : std::size_t { ParsedPayload, Geometry, ComputedFilter, ComputedStyle, Count };
 
   struct Limits {
     std::size_t parsedPayloadBytes = 64 * 1024 * 1024;
     std::size_t geometryBytes = 64 * 1024 * 1024;
+    std::size_t computedFilterBytes = 64 * 1024 * 1024;
     std::size_t computedStyleBytes = 64 * 1024 * 1024;
     std::size_t maximumTotalRetainedBytes = kDefaultMaximumTotalRetainedBytes;
   };
@@ -80,6 +81,7 @@ private:
     switch (kind) {
       case Kind::ParsedPayload: return limits_.parsedPayloadBytes;
       case Kind::Geometry: return limits_.geometryBytes;
+      case Kind::ComputedFilter: return limits_.computedFilterBytes;
       case Kind::ComputedStyle: return limits_.computedStyleBytes;
       case Kind::Count: return 0;
     }

--- a/donner/svg/components/ReferenceResolutionBudget.h
+++ b/donner/svg/components/ReferenceResolutionBudget.h
@@ -6,22 +6,31 @@
 
 namespace donner::svg::components {
 
-/** Bounds document-wide href inheritance traversal for gradients and patterns. */
+/** Bounds document-wide href inheritance traversal for filters, gradients, and patterns. */
 class ReferenceResolutionBudget {
 public:
-  enum class Kind : std::size_t { Gradient, Pattern, Count };
+  enum class Kind : std::size_t { Filter, Gradient, Pattern, Count };
 
   static constexpr std::size_t kMaximumReferenceDepth = 64;
   static constexpr std::size_t kMaximumHopsPerKind = 64 * 1024;
+
+  struct Limits {
+    std::size_t maximumReferenceDepth = kMaximumReferenceDepth;
+    std::size_t maximumHopsPerKind = kMaximumHopsPerKind;
+  };
 
   struct Stats {
     std::size_t hops = 0;
     bool rejected = false;
   };
 
+  ReferenceResolutionBudget() = default;
+  explicit ReferenceResolutionBudget(Limits limits) : limits_(limits) {}
+
   bool reserve(Kind kind, std::size_t depth) {
     Stats& current = stats_[static_cast<std::size_t>(kind)];
-    if (current.rejected || depth > kMaximumReferenceDepth || current.hops >= kMaximumHopsPerKind) {
+    if (current.rejected || depth > limits_.maximumReferenceDepth ||
+        current.hops >= limits_.maximumHopsPerKind) {
       current.rejected = true;
       return false;
     }
@@ -34,6 +43,7 @@ public:
   const Stats& stats(Kind kind) const { return stats_[static_cast<std::size_t>(kind)]; }
 
 private:
+  Limits limits_;
   std::array<Stats, static_cast<std::size_t>(Kind::Count)> stats_{};
 };
 

--- a/donner/svg/components/filter/BUILD.bazel
+++ b/donner/svg/components/filter/BUILD.bazel
@@ -45,12 +45,21 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "computed_filter_resource_budget",
+    hdrs = ["ComputedFilterResourceBudget.h"],
+    visibility = ["//donner/svg:__subpackages__"],
+    deps = [
+        "//donner/base",
+        "//donner/svg/components:components_core",
+    ],
+)
+
+donner_cc_library(
     name = "filter_system",
     srcs = [
         "FilterSystem.cc",
     ],
     hdrs = [
-        "ComputedFilterResourceBudget.h",
         "FilterSystem.h",
     ],
     visibility = [
@@ -58,9 +67,11 @@ donner_cc_library(
     ],
     deps = [
         ":components",
+        ":computed_filter_resource_budget",
         "//donner/base",
         "//donner/css/parser",
         "//donner/svg/components:components_core",
+        "//donner/svg/components:reference_resolution_budget",
         "//donner/svg/components/resources:components",
         "//donner/svg/components/style:components",
         "//donner/svg/properties:property_parsing",

--- a/donner/svg/components/filter/BUILD.bazel
+++ b/donner/svg/components/filter/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
 
 donner_cc_library(
     name = "components",
@@ -50,6 +50,7 @@ donner_cc_library(
         "FilterSystem.cc",
     ],
     hdrs = [
+        "ComputedFilterResourceBudget.h",
         "FilterSystem.h",
     ],
     visibility = [

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "donner/base/EcsRegistry.h"
@@ -11,7 +12,7 @@
 
 namespace donner::svg::components {
 
-/** Compile seam for computed-filter accounting; enforcement is added by the green commit. */
+/** Owns computed-filter structural reservations and shared raster payload admission. */
 class ComputedFilterResourceBudget {
 public:
   static constexpr std::size_t kMaximumBytes = 16 * 1024 * 1024;
@@ -24,25 +25,217 @@ public:
       : family_(std::move(family)) {}
   ComputedFilterResourceBudget(std::shared_ptr<DocumentResourceFamilyBudget> family, Limits limits)
       : family_(std::move(family)), limits_(limits) {}
+  ~ComputedFilterResourceBudget() { releaseFamilyBytes(structuralBytes_); }
 
-  bool reserve(Entity, std::size_t) { return true; }
-  void release(Entity) {}
+  ComputedFilterResourceBudget(const ComputedFilterResourceBudget&) = delete;
+  ComputedFilterResourceBudget& operator=(const ComputedFilterResourceBudget&) = delete;
+  ComputedFilterResourceBudget(ComputedFilterResourceBudget&& other) noexcept
+      : family_(std::move(other.family_)),
+        structuralBytes_(other.structuralBytes_),
+        sharedImageBytes_(other.sharedImageBytes_),
+        sharedImageMaterializations_(other.sharedImageMaterializations_),
+        rejected_(other.rejected_),
+        limits_(other.limits_),
+        reservations_(std::move(other.reservations_)),
+        sharedImages_(std::move(other.sharedImages_)) {
+    other.structuralBytes_ = 0;
+    other.sharedImageBytes_ = 0;
+  }
+  ComputedFilterResourceBudget& operator=(ComputedFilterResourceBudget&&) = delete;
 
-  std::shared_ptr<const std::vector<std::uint8_t>> shareImage(
-      Entity, const std::vector<std::uint8_t>& sourcePixels) {
-    ++sharedImageMaterializations_;
-    return std::make_shared<const std::vector<std::uint8_t>>(sourcePixels);
+  bool reserve(Entity entity, std::size_t bytes) {
+    pruneExpiredSharedImages();
+    const auto existing = reservations_.find(entity);
+    const std::size_t previous = existing == reservations_.end() ? 0 : existing->second;
+    if (bytes <= previous) {
+      const std::size_t released = previous - bytes;
+      structuralBytes_ -= released;
+      if (bytes == 0) {
+        reservations_.erase(entity);
+      } else {
+        reservations_.insert_or_assign(entity, bytes);
+      }
+      releaseFamilyBytes(released);
+      return true;
+    }
+    if (rejected_) {
+      return false;
+    }
+
+    const std::size_t additional = bytes - previous;
+    if (!canReserveLocal(additional) ||
+        (family_ &&
+         !family_->reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, additional))) {
+      rejected_ = true;
+      return false;
+    }
+    structuralBytes_ += additional;
+    reservations_.insert_or_assign(entity, bytes);
+    return true;
   }
 
-  std::size_t retainedBytes() const { return 0; }
+  void release(Entity entity) {
+    const auto existing = reservations_.find(entity);
+    if (existing != reservations_.end()) {
+      const std::size_t bytes = existing->second;
+      reservations_.erase(existing);
+      structuralBytes_ -= bytes;
+      releaseFamilyBytes(bytes);
+    }
+    pruneExpiredSharedImages();
+  }
+
+  /**
+   * Return one immutable copy of a loaded image, shared by every graph using the same source.
+   *
+   * The family reservation is captured by the allocation's deleter, so accounting remains live
+   * until the final computed graph or render snapshot releases the pixels.
+   *
+   * @param sourceEntity Entity that owns the decoded image.
+   * @param sourcePixels Decoded straight-alpha RGBA pixels.
+   * @return Shared immutable pixels, or null when admission fails.
+   */
+  std::shared_ptr<const std::vector<std::uint8_t>> shareImage(
+      Entity sourceEntity, const std::vector<std::uint8_t>& sourcePixels) {
+    pruneExpiredSharedImages();
+    if (sourcePixels.empty()) {
+      return nullptr;
+    }
+
+    const SharedImageKey key{sourceEntity, sourcePixels.data(), sourcePixels.size()};
+    if (const auto existing = sharedImages_.find(key); existing != sharedImages_.end()) {
+      if (auto pixels = existing->second.pixels.lock()) {
+        return pixels;
+      }
+      sharedImages_.erase(existing);
+    }
+
+    const std::size_t bytes = sourcePixels.size();
+    if (rejected_ || !canReserveLocal(bytes) ||
+        (family_ && !family_->reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, bytes))) {
+      rejected_ = true;
+      return nullptr;
+    }
+
+    auto pixels = makeSharedPixels(std::vector<std::uint8_t>(sourcePixels));
+    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
+    return pixels;
+  }
+
+  /**
+   * Adopt a transient renderer-produced image after reserving its full retained lifetime.
+   *
+   * @param sourcePixels Tightly packed straight-alpha RGBA pixels.
+   * @return Shared immutable pixels, or null when admission fails.
+   */
+  std::shared_ptr<const std::vector<std::uint8_t>> adoptImage(
+      std::vector<std::uint8_t>&& sourcePixels) {
+    pruneExpiredSharedImages();
+    if (sourcePixels.empty()) {
+      return nullptr;
+    }
+
+    const std::size_t bytes = sourcePixels.size();
+    if (rejected_ || !canReserveLocal(bytes) ||
+        (family_ && !family_->reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, bytes))) {
+      rejected_ = true;
+      return nullptr;
+    }
+
+    auto pixels = makeSharedPixels(std::move(sourcePixels));
+    const SharedImageKey key{entt::null, pixels->data(), pixels->size()};
+    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
+    return pixels;
+  }
+
+  std::size_t retainedBytes() const {
+    pruneExpiredSharedImages();
+    return structuralBytes_ + sharedImageBytes_;
+  }
   std::size_t sharedImageMaterializations() const { return sharedImageMaterializations_; }
-  bool rejected() const { return false; }
+  bool rejected() const { return rejected_; }
   const Limits& limits() const { return limits_; }
 
 private:
+  struct FamilyReservation {
+    FamilyReservation(std::shared_ptr<DocumentResourceFamilyBudget> family, std::size_t bytes)
+        : family(std::move(family)), bytes(bytes) {}
+    ~FamilyReservation() {
+      if (family) {
+        family->release(DocumentResourceFamilyBudget::Kind::ComputedFilter, bytes);
+      }
+    }
+    std::shared_ptr<DocumentResourceFamilyBudget> family;
+    std::size_t bytes = 0;
+  };
+
+  struct SharedImageKey {
+    Entity entity = entt::null;
+    const std::uint8_t* data = nullptr;
+    std::size_t size = 0;
+    bool operator==(const SharedImageKey&) const = default;
+  };
+
+  struct SharedImageKeyHash {
+    std::size_t operator()(const SharedImageKey& key) const {
+      std::size_t result = std::hash<Entity>{}(key.entity);
+      result ^=
+          std::hash<const std::uint8_t*>{}(key.data) + 0x9e3779b9 + (result << 6) + (result >> 2);
+      result ^= std::hash<std::size_t>{}(key.size) + 0x9e3779b9 + (result << 6) + (result >> 2);
+      return result;
+    }
+  };
+
+  struct SharedImageEntry {
+    std::weak_ptr<const std::vector<std::uint8_t>> pixels;
+    std::size_t bytes = 0;
+  };
+
+  bool canReserveLocal(std::size_t additional) const {
+    const std::size_t retained = structuralBytes_ + sharedImageBytes_;
+    return retained <= limits_.maximumBytes && additional <= limits_.maximumBytes - retained;
+  }
+
+  std::shared_ptr<const std::vector<std::uint8_t>> makeSharedPixels(
+      std::vector<std::uint8_t>&& sourcePixels) {
+    const std::size_t bytes = sourcePixels.size();
+    auto familyReservation = std::make_shared<FamilyReservation>(family_, bytes);
+    auto pixels = std::shared_ptr<const std::vector<std::uint8_t>>(
+        new std::vector<std::uint8_t>(std::move(sourcePixels)),
+        [reservation = std::move(familyReservation)](const std::vector<std::uint8_t>* value) {
+          (void)reservation;
+          delete value;
+        });
+    sharedImageBytes_ += bytes;
+    ++sharedImageMaterializations_;
+    return pixels;
+  }
+
+  void pruneExpiredSharedImages() const {
+    for (auto it = sharedImages_.begin(); it != sharedImages_.end();) {
+      if (!it->second.pixels.expired()) {
+        ++it;
+        continue;
+      }
+      sharedImageBytes_ -= it->second.bytes;
+      it = sharedImages_.erase(it);
+    }
+  }
+
+  void releaseFamilyBytes(std::size_t bytes) {
+    if (family_) {
+      family_->release(DocumentResourceFamilyBudget::Kind::ComputedFilter, bytes);
+    }
+  }
+
   std::shared_ptr<DocumentResourceFamilyBudget> family_;
-  Limits limits_;
+  std::size_t structuralBytes_ = 0;
+  mutable std::size_t sharedImageBytes_ = 0;
   std::size_t sharedImageMaterializations_ = 0;
+  bool rejected_ = false;
+  Limits limits_;
+  std::unordered_map<Entity, std::size_t> reservations_;
+  mutable std::unordered_map<SharedImageKey, SharedImageEntry, SharedImageKeyHash> sharedImages_;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -3,7 +3,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -35,6 +34,7 @@ public:
         structuralBytes_(other.structuralBytes_),
         sharedImageBytes_(other.sharedImageBytes_),
         sharedImageMaterializations_(other.sharedImageMaterializations_),
+        sharedImageComparedBytes_(other.sharedImageComparedBytes_),
         rejected_(other.rejected_),
         limits_(other.limits_),
         reservations_(std::move(other.reservations_)),
@@ -93,35 +93,25 @@ public:
    * until the final computed graph or render snapshot releases the pixels.
    *
    * @param sourceEntity Entity that owns the decoded image.
+   * @param sourceRevision Monotonic identity of the decoded image payload.
    * @param sourcePixels Decoded straight-alpha RGBA pixels.
    * @return Shared immutable pixels, or null when admission fails.
    */
   std::shared_ptr<const std::vector<std::uint8_t>> shareImage(
-      Entity sourceEntity, const std::vector<std::uint8_t>& sourcePixels) {
+      Entity sourceEntity, std::uint64_t sourceRevision,
+      const std::vector<std::uint8_t>& sourcePixels) {
     pruneExpiredSharedImages();
     if (sourcePixels.empty()) {
       return nullptr;
     }
 
-    const SharedImageKey key{sourceEntity, sourcePixels.data(), sourcePixels.size()};
+    const SharedImageKey key{sourceEntity, sourceRevision, nullptr, sourcePixels.size()};
     if (const auto existing = sharedImages_.find(key); existing != sharedImages_.end()) {
-      for (auto entry = existing->second.begin(); entry != existing->second.end();) {
-        if (auto pixels = entry->pixels.lock()) {
-          if (*pixels == sourcePixels) {
-            if (sourcePixels.size() >
-                std::numeric_limits<std::size_t>::max() - sharedImageComparedBytes_) {
-              sharedImageComparedBytes_ = std::numeric_limits<std::size_t>::max();
-            } else {
-              sharedImageComparedBytes_ += sourcePixels.size();
-            }
-            return pixels;
-          }
-          ++entry;
-        } else {
-          sharedImageBytes_ -= entry->bytes;
-          entry = existing->second.erase(entry);
-        }
+      if (auto pixels = existing->second.pixels.lock()) {
+        return pixels;
       }
+      sharedImageBytes_ -= existing->second.bytes;
+      sharedImages_.erase(existing);
     }
 
     const std::size_t bytes = sourcePixels.size();
@@ -132,7 +122,7 @@ public:
     }
 
     auto pixels = makeSharedPixels(std::vector<std::uint8_t>(sourcePixels));
-    sharedImages_[key].push_back(SharedImageEntry{pixels, bytes});
+    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
     return pixels;
   }
 
@@ -157,8 +147,8 @@ public:
     }
 
     auto pixels = makeSharedPixels(std::move(sourcePixels));
-    const SharedImageKey key{entt::null, pixels->data(), pixels->size()};
-    sharedImages_[key].push_back(SharedImageEntry{pixels, bytes});
+    const SharedImageKey key{entt::null, 0, pixels->data(), pixels->size()};
+    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
     return pixels;
   }
 
@@ -186,6 +176,7 @@ private:
 
   struct SharedImageKey {
     Entity entity = entt::null;
+    std::uint64_t revision = 0;
     const std::uint8_t* data = nullptr;
     std::size_t size = 0;
     bool operator==(const SharedImageKey&) const = default;
@@ -194,6 +185,8 @@ private:
   struct SharedImageKeyHash {
     std::size_t operator()(const SharedImageKey& key) const {
       std::size_t result = std::hash<Entity>{}(key.entity);
+      result ^=
+          std::hash<std::uint64_t>{}(key.revision) + 0x9e3779b9 + (result << 6) + (result >> 2);
       result ^=
           std::hash<const std::uint8_t*>{}(key.data) + 0x9e3779b9 + (result << 6) + (result >> 2);
       result ^= std::hash<std::size_t>{}(key.size) + 0x9e3779b9 + (result << 6) + (result >> 2);
@@ -228,19 +221,11 @@ private:
 
   void pruneExpiredSharedImages() const {
     for (auto it = sharedImages_.begin(); it != sharedImages_.end();) {
-      auto& entries = it->second;
-      for (auto entry = entries.begin(); entry != entries.end();) {
-        if (!entry->pixels.expired()) {
-          ++entry;
-          continue;
-        }
-        sharedImageBytes_ -= entry->bytes;
-        entry = entries.erase(entry);
-      }
-      if (!entries.empty()) {
+      if (!it->second.pixels.expired()) {
         ++it;
         continue;
       }
+      sharedImageBytes_ -= it->second.bytes;
       it = sharedImages_.erase(it);
     }
   }
@@ -259,8 +244,7 @@ private:
   bool rejected_ = false;
   Limits limits_;
   std::unordered_map<Entity, std::size_t> reservations_;
-  mutable std::unordered_map<SharedImageKey, std::vector<SharedImageEntry>, SharedImageKeyHash>
-      sharedImages_;
+  mutable std::unordered_map<SharedImageKey, SharedImageEntry, SharedImageKeyHash> sharedImages_;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -1,0 +1,48 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
+
+namespace donner::svg::components {
+
+/** Compile seam for computed-filter accounting; enforcement is added by the green commit. */
+class ComputedFilterResourceBudget {
+public:
+  static constexpr std::size_t kMaximumBytes = 16 * 1024 * 1024;
+  struct Limits {
+    std::size_t maximumBytes = kMaximumBytes;
+  };
+
+  explicit ComputedFilterResourceBudget(
+      std::shared_ptr<DocumentResourceFamilyBudget> family = nullptr)
+      : family_(std::move(family)) {}
+  ComputedFilterResourceBudget(std::shared_ptr<DocumentResourceFamilyBudget> family, Limits limits)
+      : family_(std::move(family)), limits_(limits) {}
+
+  bool reserve(Entity, std::size_t) { return true; }
+  void release(Entity) {}
+
+  std::shared_ptr<const std::vector<std::uint8_t>> shareImage(
+      Entity, const std::vector<std::uint8_t>& sourcePixels) {
+    ++sharedImageMaterializations_;
+    return std::make_shared<const std::vector<std::uint8_t>>(sourcePixels);
+  }
+
+  std::size_t retainedBytes() const { return 0; }
+  std::size_t sharedImageMaterializations() const { return sharedImageMaterializations_; }
+  bool rejected() const { return false; }
+  const Limits& limits() const { return limits_; }
+
+private:
+  std::shared_ptr<DocumentResourceFamilyBudget> family_;
+  Limits limits_;
+  std::size_t sharedImageMaterializations_ = 0;
+};
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -107,6 +108,12 @@ public:
       for (auto entry = existing->second.begin(); entry != existing->second.end();) {
         if (auto pixels = entry->pixels.lock()) {
           if (*pixels == sourcePixels) {
+            if (sourcePixels.size() >
+                std::numeric_limits<std::size_t>::max() - sharedImageComparedBytes_) {
+              sharedImageComparedBytes_ = std::numeric_limits<std::size_t>::max();
+            } else {
+              sharedImageComparedBytes_ += sourcePixels.size();
+            }
             return pixels;
           }
           ++entry;
@@ -160,6 +167,7 @@ public:
     return structuralBytes_ + sharedImageBytes_;
   }
   std::size_t sharedImageMaterializations() const { return sharedImageMaterializations_; }
+  std::size_t sharedImageComparedBytes() const { return sharedImageComparedBytes_; }
   bool rejected() const { return rejected_; }
   const Limits& limits() const { return limits_; }
 
@@ -247,6 +255,7 @@ private:
   std::size_t structuralBytes_ = 0;
   mutable std::size_t sharedImageBytes_ = 0;
   std::size_t sharedImageMaterializations_ = 0;
+  std::size_t sharedImageComparedBytes_ = 0;
   bool rejected_ = false;
   Limits limits_;
   std::unordered_map<Entity, std::size_t> reservations_;

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -104,10 +104,17 @@ public:
 
     const SharedImageKey key{sourceEntity, sourcePixels.data(), sourcePixels.size()};
     if (const auto existing = sharedImages_.find(key); existing != sharedImages_.end()) {
-      if (auto pixels = existing->second.pixels.lock()) {
-        return pixels;
+      for (auto entry = existing->second.begin(); entry != existing->second.end();) {
+        if (auto pixels = entry->pixels.lock()) {
+          if (*pixels == sourcePixels) {
+            return pixels;
+          }
+          ++entry;
+        } else {
+          sharedImageBytes_ -= entry->bytes;
+          entry = existing->second.erase(entry);
+        }
       }
-      sharedImages_.erase(existing);
     }
 
     const std::size_t bytes = sourcePixels.size();
@@ -118,7 +125,7 @@ public:
     }
 
     auto pixels = makeSharedPixels(std::vector<std::uint8_t>(sourcePixels));
-    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
+    sharedImages_[key].push_back(SharedImageEntry{pixels, bytes});
     return pixels;
   }
 
@@ -144,7 +151,7 @@ public:
 
     auto pixels = makeSharedPixels(std::move(sourcePixels));
     const SharedImageKey key{entt::null, pixels->data(), pixels->size()};
-    sharedImages_.insert_or_assign(key, SharedImageEntry{pixels, bytes});
+    sharedImages_[key].push_back(SharedImageEntry{pixels, bytes});
     return pixels;
   }
 
@@ -213,11 +220,19 @@ private:
 
   void pruneExpiredSharedImages() const {
     for (auto it = sharedImages_.begin(); it != sharedImages_.end();) {
-      if (!it->second.pixels.expired()) {
+      auto& entries = it->second;
+      for (auto entry = entries.begin(); entry != entries.end();) {
+        if (!entry->pixels.expired()) {
+          ++entry;
+          continue;
+        }
+        sharedImageBytes_ -= entry->bytes;
+        entry = entries.erase(entry);
+      }
+      if (!entries.empty()) {
         ++it;
         continue;
       }
-      sharedImageBytes_ -= it->second.bytes;
       it = sharedImages_.erase(it);
     }
   }
@@ -235,7 +250,8 @@ private:
   bool rejected_ = false;
   Limits limits_;
   std::unordered_map<Entity, std::size_t> reservations_;
-  mutable std::unordered_map<SharedImageKey, SharedImageEntry, SharedImageKeyHash> sharedImages_;
+  mutable std::unordered_map<SharedImageKey, std::vector<SharedImageEntry>, SharedImageKeyHash>
+      sharedImages_;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -96,6 +96,9 @@ inline constexpr double kMaximumFilterTurbulenceFrequency = 1024.0;
 /// Maximum accepted feTurbulence seed magnitude (Park-Miller modulus minus one).
 inline constexpr double kMaximumFilterTurbulenceSeed = 2147483646.0;
 
+/// Maximum accepted feTurbulence octave count.
+inline constexpr int kMaximumFilterTurbulenceOctaves = 16;
+
 /**
  * Standard named inputs available to filter primitives.
  *
@@ -543,7 +546,7 @@ inline bool FilterGraphExecutionCost(const FilterGraph& graph, std::uint64_t pix
                        4;
     } else if (const auto* turbulence =
                    std::get_if<filter_primitive::Turbulence>(&node.primitive)) {
-      if (turbulence->numOctaves > 16) {
+      if (turbulence->numOctaves > kMaximumFilterTurbulenceOctaves) {
         return false;
       }
       const std::uint64_t octaves = static_cast<std::uint64_t>(std::max(turbulence->numOctaves, 1));

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -855,6 +855,7 @@ public:
   }
   [[nodiscard]] std::uint64_t captureBytesReserved() const { return captureBytesReserved_; }
   [[nodiscard]] std::uint64_t activeGpuReservations() const { return activeGpuReservations_; }
+  [[nodiscard]] std::uint64_t retainedGpuBytes() const { return intermediateBytes_; }
   /// Ordered GPU chunks submitted since this budget was constructed.
   [[nodiscard]] std::uint64_t chunks() const { return chunks_; }
   [[nodiscard]] bool rejected() const { return rejected_; }

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -38,6 +38,13 @@ inline constexpr int kMaximumFilterPixelOffset = 4096;
 /// Maximum blur standard deviation or morphology radius after conversion to device pixels.
 inline constexpr int kMaximumFilterPixelRadius = 256;
 
+/// Geode decomposes morphology into shader passes whose per-axis radius is at most 31.
+inline constexpr std::uint64_t kMaximumFilterMorphologyPassesPerAxis = 9;
+inline constexpr std::uint64_t kMaximumFilterMorphologyWorkMultiplier =
+    2 * (2 * kMaximumFilterPixelRadius + kMaximumFilterMorphologyPassesPerAxis) + 5;
+inline constexpr std::uint64_t kMaximumFilterMorphologyRetainedBuffers =
+    2 * kMaximumFilterMorphologyPassesPerAxis + 3;
+
 /// Maximum dimension of a filter-specific intermediate surface.
 inline constexpr int kMaximumFilterSurfaceDimension = 4096;
 
@@ -572,6 +579,11 @@ inline bool FilterGraphExecutionCost(const FilterGraph& graph, std::uint64_t pix
       // Drop shadow adds alpha extraction, flood, composite, offset, and merge passes around the
       // blur, with additional color conversions in linear RGB.
       workMultiplier = shadow->stdDeviationX > 0.0 || shadow->stdDeviationY > 0.0 ? 20 : 12;
+    } else if (const auto* morphology =
+                   std::get_if<filter_primitive::Morphology>(&node.primitive)) {
+      workMultiplier = morphology->radiusX > 0.0 || morphology->radiusY > 0.0
+                           ? kMaximumFilterMorphologyWorkMultiplier
+                           : 5;
     } else if (const auto* image = std::get_if<filter_primitive::Image>(&node.primitive)) {
       // TinySkia's default Mitchell sampling visits a 4x4 source footprint for each of four
       // channels. Pixelated sampling and Geode use a single-sample GPU path plus clipping.
@@ -668,6 +680,10 @@ inline bool FilterGraphExecutionCost(const FilterGraph& graph, std::uint64_t pix
         retainedBuffers += linearRgb ? 9 : 7;
       } else if (std::holds_alternative<filter_primitive::DropShadow>(node.primitive)) {
         retainedBuffers += 8;
+      } else if (const auto* morphology =
+                     std::get_if<filter_primitive::Morphology>(&node.primitive);
+                 morphology && (morphology->radiusX > 0.0 || morphology->radiusY > 0.0)) {
+        retainedBuffers += kMaximumFilterMorphologyRetainedBuffers;
       } else {
         // Linear two-input primitives retain up to four conversion/primitive textures, followed
         // by the mandatory per-node subregion clip.

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -753,9 +753,11 @@ public:
 
   /** Release GPU-retained accounting after submitting one ordered command-buffer chunk. */
   bool beginChunkAfterSubmit() {
+    if (rejectionReason_ != RejectionReason::MemoryLimit || activeGpuReservations_ != 0) {
+      return false;
+    }
     intermediateBytes_ = 0;
     liveCpuCaptureBytes_ = 0;
-    activeGpuReservations_ = 0;
     rejectionReason_ = RejectionReason::None;
     rejected_ = false;
     ++chunks_;
@@ -824,7 +826,7 @@ public:
     }
     if (reservation.memoryModel == FilterMemoryModel::CpuFloatNamedResults) {
       liveCpuCaptureBytes_ -= reservation.captureBytes;
-    } else {
+    } else if (activeGpuReservations_ != 0) {
       --activeGpuReservations_;
     }
     reservation.active = false;

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -740,6 +740,14 @@ public:
     rejected_ = false;
   }
 
+  /** Release GPU-retained accounting after submitting one ordered command-buffer chunk. */
+  void beginChunkAfterSubmit() {
+    intermediateBytes_ = 0;
+    liveCpuCaptureBytes_ = 0;
+    rejected_ = false;
+    ++chunks_;
+  }
+
   /**
    * Reserve graph execution and capture memory before allocating the capture surface.
    *
@@ -810,6 +818,8 @@ public:
     return intermediateBytes_ + liveCpuCaptureBytes_;
   }
   [[nodiscard]] std::uint64_t captureBytesReserved() const { return captureBytesReserved_; }
+  /// Ordered GPU chunks submitted since this budget was constructed.
+  [[nodiscard]] std::uint64_t chunks() const { return chunks_; }
   [[nodiscard]] bool rejected() const { return rejected_; }
 
 private:
@@ -818,6 +828,7 @@ private:
   std::uint64_t intermediateBytes_ = 0;
   std::uint64_t liveCpuCaptureBytes_ = 0;
   std::uint64_t captureBytesReserved_ = 0;
+  std::uint64_t chunks_ = 0;
   bool rejected_ = false;
 };
 

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -1,9 +1,12 @@
 #pragma once
 /// @file
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -19,6 +22,79 @@
 #include "donner/svg/core/PreserveAspectRatio.h"
 
 namespace donner::svg::components {
+
+/// Maximum accepted user-space filter offset magnitude.
+inline constexpr double kMaximumFilterOffset = 4096.0;
+
+/// Maximum accepted user-space blur standard deviation.
+inline constexpr double kMaximumFilterStdDeviation = 256.0;
+
+/// Maximum accepted user-space morphology radius.
+inline constexpr double kMaximumFilterMorphologyRadius = 256.0;
+
+/// Maximum filter offset after conversion to device pixels.
+inline constexpr int kMaximumFilterPixelOffset = 4096;
+
+/// Maximum blur standard deviation or morphology radius after conversion to device pixels.
+inline constexpr int kMaximumFilterPixelRadius = 256;
+
+/// Maximum dimension of a filter-specific intermediate surface.
+inline constexpr int kMaximumFilterSurfaceDimension = 4096;
+
+/// Maximum pixel area of a filter-specific intermediate surface.
+///
+/// CPU filter execution expands each pixel into several float buffers. Keep the limit below a
+/// 4096-by-4096 surface while retaining the established high-zoom rendering envelope.
+inline constexpr std::size_t kMaximumFilterSurfacePixels = 12 * 1024 * 1024;
+
+/// Maximum number of primitives retained in one computed filter graph.
+inline constexpr std::size_t kMaximumFilterGraphNodes = 32;
+
+/// Maximum number of inputs composited by one feMerge primitive.
+inline constexpr std::size_t kMaximumFilterMergeInputs = 16;
+
+/// Maximum number of samples accepted for one feComponentTransfer channel table.
+inline constexpr std::size_t kMaximumFilterTableValues = 1024;
+
+/// Maximum numeric payload accepted for feColorMatrix (the 5-by-4 matrix form).
+inline constexpr std::size_t kMaximumFilterColorMatrixValues = 20;
+
+/// Maximum convolve order on either axis and aggregate kernel payload.
+inline constexpr int kMaximumFilterConvolveOrder = 64;
+inline constexpr std::size_t kMaximumFilterKernelValues =
+    static_cast<std::size_t>(kMaximumFilterConvolveOrder) * kMaximumFilterConvolveOrder;
+
+/// Maximum aggregate pixel operations accepted for one filter execution.
+inline constexpr std::uint64_t kMaximumFilterWorkUnits = 256ULL * 1024 * 1024;
+
+/// Maximum aggregate pixel operations accepted across one rendered frame.
+///
+/// The established splash asset contains three independent high-zoom blur layers. This allows
+/// that bounded workload while rejecting a fourth full-envelope blur and large repeated graphs.
+inline constexpr std::uint64_t kMaximumFilterFrameWorkUnits = 512ULL * 1024 * 1024;
+
+/// Maximum estimated bytes retained by filter intermediates during one execution.
+///
+/// This keeps ordinary production-sized filters available while preventing one graph from
+/// consuming a large fraction of the desktop or Wasm heap.
+inline constexpr std::uint64_t kMaximumFilterIntermediateBytes = 256ULL * 1024 * 1024;
+
+/// Maximum filter memory reserved across one frame, including RGBA capture surfaces.
+///
+/// Native builds allow one established high-zoom blur capture plus its in-place float surface.
+/// Wasm retains the lower ceiling because its fixed heap cannot safely admit that desktop-only
+/// workload. Renderer surfaces and decoded resources remain separately bounded.
+#ifdef __EMSCRIPTEN__
+inline constexpr std::uint64_t kMaximumFilterFrameBytes = 128ULL * 1024 * 1024;
+#else
+inline constexpr std::uint64_t kMaximumFilterFrameBytes = 256ULL * 1024 * 1024;
+#endif
+
+/// Maximum accepted feTurbulence base-frequency magnitude.
+inline constexpr double kMaximumFilterTurbulenceFrequency = 1024.0;
+
+/// Maximum accepted feTurbulence seed magnitude (Park-Miller modulus minus one).
+inline constexpr double kMaximumFilterTurbulenceSeed = 2147483646.0;
 
 /**
  * Standard named inputs available to filter primitives.
@@ -255,10 +331,16 @@ struct Image {
   RcString href;  ///< Image URL or fragment reference.
   PreserveAspectRatio preserveAspectRatio = PreserveAspectRatio::Default();
 
-  /// Loaded image data (RGBA, straight alpha). Empty if loading failed or href is a fragment.
-  std::vector<uint8_t> imageData;
+  /// Shared loaded image data (RGBA, straight alpha). Null if loading failed or href is a fragment.
+  ///
+  /// Prepared filter graphs are copied once per rendering instance. Sharing immutable decoded
+  /// pixels prevents one referenced raster from being duplicated for every filtered element.
+  std::shared_ptr<const std::vector<uint8_t>> imageData;
   int imageWidth = 0;   ///< Width of loaded image in pixels.
   int imageHeight = 0;  ///< Height of loaded image in pixels.
+
+  [[nodiscard]] bool hasImageData() const { return imageData && !imageData->empty(); }
+  [[nodiscard]] std::size_t imageDataSize() const { return imageData ? imageData->size() : 0; }
 
   /// Shared handle to an external SVG sub-document. The renderer pre-renders this to pixel data
   /// before filter execution.
@@ -347,6 +429,26 @@ using FilterPrimitive =
                  filter_primitive::Image, filter_primitive::DisplacementMap,
                  filter_primitive::DiffuseLighting, filter_primitive::SpecularLighting>;
 
+/// Dynamic numeric storage retained by one primitive payload.
+inline std::uint64_t FilterPrimitivePayloadBytes(const FilterPrimitive& primitive) {
+  return std::visit(
+      [](const auto& value) -> std::uint64_t {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, filter_primitive::ColorMatrix>) {
+          return value.values.capacity() * sizeof(double);
+        } else if constexpr (std::is_same_v<T, filter_primitive::ConvolveMatrix>) {
+          return value.kernelMatrix.capacity() * sizeof(double);
+        } else if constexpr (std::is_same_v<T, filter_primitive::ComponentTransfer>) {
+          return (value.funcR.tableValues.capacity() + value.funcG.tableValues.capacity() +
+                  value.funcB.tableValues.capacity() + value.funcA.tableValues.capacity()) *
+                 sizeof(double);
+        } else {
+          return 0;
+        }
+      },
+      primitive);
+}
+
 /**
  * A single node in the filter graph, representing one filter primitive.
  *
@@ -364,11 +466,11 @@ struct FilterNode {
   /// second input, never the source graphic.
   std::vector<FilterInput> inputs;
 
-  std::optional<RcString> result;   ///< Named output (for `result` attribute).
-  std::optional<Lengthd> x;         ///< Primitive subregion X.
-  std::optional<Lengthd> y;         ///< Primitive subregion Y.
-  std::optional<Lengthd> width;     ///< Primitive subregion width.
-  std::optional<Lengthd> height;    ///< Primitive subregion height.
+  std::optional<RcString> result;  ///< Named output (for `result` attribute).
+  std::optional<Lengthd> x;        ///< Primitive subregion X.
+  std::optional<Lengthd> y;        ///< Primitive subregion Y.
+  std::optional<Lengthd> width;    ///< Primitive subregion width.
+  std::optional<Lengthd> height;   ///< Primitive subregion height.
 
   /// Per-primitive color-interpolation-filters. When set, overrides the graph-level default.
   std::optional<ColorInterpolationFilters> colorInterpolationFilters;
@@ -403,6 +505,301 @@ struct FilterGraph {
 
   /// Returns true if the graph has no nodes.
   [[nodiscard]] bool empty() const { return nodes.empty(); }
+};
+
+/// Intermediate-retention behavior used to estimate backend memory before filter execution.
+enum class FilterMemoryModel : std::uint8_t {
+  CpuFloatNamedResults,  ///< TinySkia retains named float RGBA results (16 bytes per pixel).
+  GpuAllNodes,           ///< Geode may retain several RGBA textures for every graph node.
+};
+
+/**
+ * Estimate a filter graph's aggregate execution cost for a pixel surface.
+ *
+ * This rejects attacker-controlled graphs before allocating per-node buffers or starting
+ * convolution loops. The estimate is intentionally conservative: GPU primitives may need up to
+ * four intermediate RGBA textures, while the CPU backend retains every named float result.
+ */
+inline bool FilterGraphExecutionCost(const FilterGraph& graph, std::uint64_t pixelCount,
+                                     FilterMemoryModel memoryModel, std::uint64_t& workUnitsOut,
+                                     std::uint64_t& intermediateBytesOut) {
+  if (pixelCount > kMaximumFilterSurfacePixels || graph.nodes.size() > kMaximumFilterGraphNodes) {
+    return false;
+  }
+
+  std::uint64_t workUnits = 0;
+  std::uint64_t totalMergeInputs = 0;
+  for (const FilterNode& node : graph.nodes) {
+    // Every executed node performs its primitive pass plus a mandatory subregion clip. Default
+    // linearRGB processing can add input/output conversion passes, and binary primitives convert
+    // both inputs. Five full-surface passes is a conservative baseline for the generic case.
+    std::uint64_t workMultiplier = 5;
+    if (const auto* convolve = std::get_if<filter_primitive::ConvolveMatrix>(&node.primitive)) {
+      if (convolve->orderX <= 0 || convolve->orderY <= 0) {
+        return false;
+      }
+      workMultiplier = static_cast<std::uint64_t>(convolve->orderX) *
+                           static_cast<std::uint64_t>(convolve->orderY) +
+                       4;
+    } else if (const auto* turbulence =
+                   std::get_if<filter_primitive::Turbulence>(&node.primitive)) {
+      if (turbulence->numOctaves > 16) {
+        return false;
+      }
+      const std::uint64_t octaves = static_cast<std::uint64_t>(std::max(turbulence->numOctaves, 1));
+      // TinySkia evaluates four lattice gradients and interpolates four color channels for every
+      // octave. Geode runs the same octave loop in a compute shader. Charge the CPU scalar work
+      // conservatively and retain a lower, still octave-weighted GPU estimate.
+      const std::uint64_t workPerOctave =
+          memoryModel == FilterMemoryModel::CpuFloatNamedResults ? 16 : 4;
+      workMultiplier = octaves * workPerOctave + 5;
+    } else if (std::holds_alternative<filter_primitive::Merge>(node.primitive)) {
+      if (node.inputs.size() > kMaximumFilterMergeInputs) {
+        return false;
+      }
+      const std::uint64_t mergeInputs = static_cast<std::uint64_t>(node.inputs.size());
+      // Linear merge converts and composites each input, then clips the node output.
+      workMultiplier = std::max<std::uint64_t>(mergeInputs * 3 + 2, 5);
+      totalMergeInputs += mergeInputs;
+    } else if (const auto* blur = std::get_if<filter_primitive::GaussianBlur>(&node.primitive)) {
+      // Two-axis large-sigma blur uses six convolution passes plus two transposes. Include the
+      // node copy and linear-RGB conversions in the conservative full-surface work estimate.
+      workMultiplier = blur->stdDeviationX > 0.0 || blur->stdDeviationY > 0.0 ? 12 : 5;
+    } else if (const auto* shadow = std::get_if<filter_primitive::DropShadow>(&node.primitive)) {
+      // Drop shadow adds alpha extraction, flood, composite, offset, and merge passes around the
+      // blur, with additional color conversions in linear RGB.
+      workMultiplier = shadow->stdDeviationX > 0.0 || shadow->stdDeviationY > 0.0 ? 20 : 12;
+    } else if (const auto* image = std::get_if<filter_primitive::Image>(&node.primitive)) {
+      // TinySkia's default Mitchell sampling visits a 4x4 source footprint for each of four
+      // channels. Pixelated sampling and Geode use a single-sample GPU path plus clipping.
+      workMultiplier = memoryModel == FilterMemoryModel::CpuFloatNamedResults &&
+                               image->imageRendering != ImageRendering::Pixelated
+                           ? 68
+                           : 5;
+    }
+
+    if (workMultiplier > kMaximumFilterWorkUnits ||
+        (workMultiplier != 0 && pixelCount > kMaximumFilterWorkUnits / workMultiplier)) {
+      return false;
+    }
+    const std::uint64_t nodeWork = pixelCount * workMultiplier;
+    if (nodeWork > kMaximumFilterWorkUnits - workUnits) {
+      return false;
+    }
+    workUnits += nodeWork;
+  }
+
+  std::uint64_t retainedBuffers = 0;
+  if (memoryModel == FilterMemoryModel::CpuFloatNamedResults) {
+    bool usesSourceAlpha = false;
+    bool usesFillPaint = false;
+    bool usesStrokePaint = false;
+    for (const FilterNode& node : graph.nodes) {
+      for (const FilterInput& input : node.inputs) {
+        if (const auto* standard = std::get_if<FilterStandardInput>(&input.value)) {
+          usesSourceAlpha |= *standard == FilterStandardInput::SourceAlpha;
+          usesFillPaint |= *standard == FilterStandardInput::FillPaint;
+          usesStrokePaint |= *standard == FilterStandardInput::StrokePaint;
+        }
+      }
+    }
+
+    // TinySkia retains SourceGraphic and any materialized standard inputs for the execution. Track
+    // the maximum live transient set per node instead of charging every possible optional buffer
+    // to every graph: a single blur at the established high-zoom envelope needs only source and
+    // output, while multi-node, named-result, merge, and color-conversion graphs retain more.
+    const std::uint64_t fixedBuffers = 1 + static_cast<std::uint64_t>(usesSourceAlpha) +
+                                       static_cast<std::uint64_t>(usesFillPaint) +
+                                       static_cast<std::uint64_t>(usesStrokePaint);
+    std::uint64_t priorNamedResults = 0;
+    for (std::size_t index = 0; index < graph.nodes.size(); ++index) {
+      const FilterNode& node = graph.nodes[index];
+      const bool linearRgb =
+          node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
+          ColorInterpolationFilters::SRGB;
+      std::uint64_t transientBuffers = 1;
+      if (std::holds_alternative<filter_primitive::GaussianBlur>(node.primitive)) {
+        const bool implicitSource =
+            node.inputs.empty() ||
+            std::holds_alternative<FilterInput::Previous>(node.inputs.front().value) ||
+            (std::holds_alternative<FilterStandardInput>(node.inputs.front().value) &&
+             std::get<FilterStandardInput>(node.inputs.front().value) ==
+                 FilterStandardInput::SourceGraphic);
+        // A sole SourceGraphic blur consumes its float source in place and uses bounded line
+        // scratch. A blur inside a larger graph must retain its input and one output buffer.
+        transientBuffers = graph.nodes.size() == 1 && implicitSource ? 0 : 1;
+      } else if (std::holds_alternative<filter_primitive::Merge>(node.primitive)) {
+        transientBuffers = linearRgb ? static_cast<std::uint64_t>(node.inputs.size()) + 1 : 1;
+      } else if (std::holds_alternative<filter_primitive::Blend>(node.primitive) ||
+                 std::holds_alternative<filter_primitive::Composite>(node.primitive) ||
+                 std::holds_alternative<filter_primitive::DisplacementMap>(node.primitive)) {
+        transientBuffers = linearRgb ? 3 : 1;
+      } else if (std::holds_alternative<filter_primitive::ConvolveMatrix>(node.primitive) ||
+                 std::holds_alternative<filter_primitive::Morphology>(node.primitive) ||
+                 std::holds_alternative<filter_primitive::DiffuseLighting>(node.primitive) ||
+                 std::holds_alternative<filter_primitive::SpecularLighting>(node.primitive)) {
+        transientBuffers = linearRgb ? 2 : 1;
+      } else if (std::holds_alternative<filter_primitive::DropShadow>(node.primitive)) {
+        transientBuffers = linearRgb ? 6 : 5;
+      }
+
+      const std::uint64_t previousOutput = index == 0 ? 0 : 1;
+      const std::uint64_t namedResultCopy = node.result.has_value() ? 1 : 0;
+      retainedBuffers =
+          std::max(retainedBuffers, fixedBuffers + previousOutput + priorNamedResults +
+                                        transientBuffers + namedResultCopy);
+      priorNamedResults += namedResultCopy;
+    }
+  } else {
+    // Geode's arena retains per-node textures and every merge conversion and accumulator until
+    // execution completes.
+    retainedBuffers = 2 + totalMergeInputs * 2;
+    for (const FilterNode& node : graph.nodes) {
+      if (std::holds_alternative<filter_primitive::GaussianBlur>(node.primitive)) {
+        const bool linearRgb =
+            node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
+            ColorInterpolationFilters::SRGB;
+        // A two-axis box blur retains up to six pass textures. The default linearRGB path also
+        // retains its input and output color-conversion textures, and every node retains its
+        // subregion-clipped output in the frame arena.
+        retainedBuffers += linearRgb ? 9 : 7;
+      } else if (std::holds_alternative<filter_primitive::DropShadow>(node.primitive)) {
+        retainedBuffers += 8;
+      } else {
+        // Linear two-input primitives retain up to four conversion/primitive textures, followed
+        // by the mandatory per-node subregion clip.
+        retainedBuffers += 5;
+      }
+    }
+  }
+  const std::uint64_t bytesPerPixel =
+      memoryModel == FilterMemoryModel::CpuFloatNamedResults ? 16 : 4;
+  if (retainedBuffers != 0 &&
+      (pixelCount > kMaximumFilterIntermediateBytes / bytesPerPixel / retainedBuffers)) {
+    return false;
+  }
+
+  workUnitsOut = workUnits;
+  intermediateBytesOut = pixelCount * bytesPerPixel * retainedBuffers;
+  return true;
+}
+
+/// Return whether one filter graph fits the execution budget for a pixel surface.
+inline bool FilterGraphFitsExecutionBudget(const FilterGraph& graph, std::uint64_t pixelCount,
+                                           FilterMemoryModel memoryModel) {
+  std::uint64_t workUnits = 0;
+  std::uint64_t intermediateBytes = 0;
+  return FilterGraphExecutionCost(graph, pixelCount, memoryModel, workUnits, intermediateBytes);
+}
+
+/**
+ * Shared per-frame filter budget.
+ *
+ * A graph that is safe in isolation can still exhaust memory or CPU when an SVG repeats it across
+ * many elements or `<use>` instances. Renderers reset this object at `beginFrame()` and consume it
+ * before every graph execution.
+ */
+class FilterExecutionBudget {
+public:
+  /// Maximum number of graph executions, including zero-area and otherwise inexpensive graphs.
+  static constexpr std::uint64_t kMaximumExecutions = 1024;
+
+  /// Successful preflight reservation made before allocating a filter capture surface.
+  struct Reservation {
+    std::uint64_t captureBytes = 0;
+    FilterMemoryModel memoryModel = FilterMemoryModel::CpuFloatNamedResults;
+    bool active = false;
+  };
+
+  /// Reset all per-frame accounting.
+  void reset() {
+    executions_ = 0;
+    workUnits_ = 0;
+    intermediateBytes_ = 0;
+    liveCpuCaptureBytes_ = 0;
+    captureBytesReserved_ = 0;
+    rejected_ = false;
+  }
+
+  /**
+   * Reserve graph execution and capture memory before allocating the capture surface.
+   *
+   * Rejection latches the frame closed, preventing a document from repeatedly attempting large
+   * allocations that were never charged. CPU capture bytes are released at pop; GPU capture and
+   * intermediate textures remain charged until frame reset because command buffers retain them.
+   */
+  std::optional<Reservation> reserve(const FilterGraph& graph, std::uint64_t pixelCount,
+                                     FilterMemoryModel memoryModel, std::uint64_t captureBytes) {
+    std::uint64_t graphWorkUnits = 0;
+    std::uint64_t graphIntermediateBytes = 0;
+    if (rejected_ || !FilterGraphExecutionCost(graph, pixelCount, memoryModel, graphWorkUnits,
+                                               graphIntermediateBytes)) {
+      rejected_ = true;
+      return std::nullopt;
+    }
+
+    const bool gpu = memoryModel == FilterMemoryModel::GpuAllNodes;
+    const std::uint64_t retainedBeforeExecution = gpu ? intermediateBytes_ : liveCpuCaptureBytes_;
+    if (executions_ >= kMaximumExecutions || workUnits_ > kMaximumFilterFrameWorkUnits ||
+        graphWorkUnits > kMaximumFilterFrameWorkUnits - workUnits_ ||
+        retainedBeforeExecution > kMaximumFilterFrameBytes ||
+        captureBytes > kMaximumFilterFrameBytes - retainedBeforeExecution ||
+        graphIntermediateBytes >
+            kMaximumFilterFrameBytes - retainedBeforeExecution - captureBytes) {
+      rejected_ = true;
+      return std::nullopt;
+    }
+
+    ++executions_;
+    workUnits_ += graphWorkUnits;
+    captureBytesReserved_ += captureBytes;
+    if (gpu) {
+      intermediateBytes_ += captureBytes + graphIntermediateBytes;
+    } else {
+      liveCpuCaptureBytes_ += captureBytes;
+    }
+    return Reservation{captureBytes, memoryModel, true};
+  }
+
+  /// Release a successful CPU capture reservation after its filter layer is popped.
+  void release(Reservation& reservation) {
+    if (!reservation.active) {
+      return;
+    }
+    if (reservation.memoryModel == FilterMemoryModel::CpuFloatNamedResults) {
+      liveCpuCaptureBytes_ -= reservation.captureBytes;
+    }
+    reservation.active = false;
+  }
+
+  /// Consume a graph at execution time for direct callers without a capture preflight.
+  bool consume(const FilterGraph& graph, std::uint64_t pixelCount, FilterMemoryModel memoryModel) {
+    std::optional<Reservation> reservation = reserve(graph, pixelCount, memoryModel, 0);
+    if (!reservation.has_value()) {
+      return false;
+    }
+    release(*reservation);
+    return true;
+  }
+
+  /// Latch the frame closed after an allocation or other external preflight failure.
+  void reject() { rejected_ = true; }
+
+  [[nodiscard]] std::uint64_t executions() const { return executions_; }
+  [[nodiscard]] std::uint64_t workUnits() const { return workUnits_; }
+  [[nodiscard]] std::uint64_t retainedBytes() const {
+    return intermediateBytes_ + liveCpuCaptureBytes_;
+  }
+  [[nodiscard]] std::uint64_t captureBytesReserved() const { return captureBytesReserved_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+private:
+  std::uint64_t executions_ = 0;
+  std::uint64_t workUnits_ = 0;
+  std::uint64_t intermediateBytes_ = 0;
+  std::uint64_t liveCpuCaptureBytes_ = 0;
+  std::uint64_t captureBytesReserved_ = 0;
+  bool rejected_ = false;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -753,7 +753,8 @@ public:
 
   /** Release GPU-retained accounting after submitting one ordered command-buffer chunk. */
   bool beginChunkAfterSubmit() {
-    if (rejectionReason_ != RejectionReason::MemoryLimit || activeGpuReservations_ != 0) {
+    if (rejectionReason_ != RejectionReason::MemoryLimit || activeGpuReservations_ != 0 ||
+        intermediateBytes_ == 0) {
       return false;
     }
     intermediateBytes_ = 0;

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -720,6 +720,15 @@ inline bool FilterGraphFitsExecutionBudget(const FilterGraph& graph, std::uint64
  */
 class FilterExecutionBudget {
 public:
+  enum class RejectionReason : std::uint8_t {
+    None,
+    InvalidGraph,
+    ExecutionLimit,
+    WorkLimit,
+    MemoryLimit,
+    External,
+  };
+
   /// Maximum number of graph executions, including zero-area and otherwise inexpensive graphs.
   static constexpr std::uint64_t kMaximumExecutions = 1024;
 
@@ -736,16 +745,21 @@ public:
     workUnits_ = 0;
     intermediateBytes_ = 0;
     liveCpuCaptureBytes_ = 0;
+    activeGpuReservations_ = 0;
     captureBytesReserved_ = 0;
+    rejectionReason_ = RejectionReason::None;
     rejected_ = false;
   }
 
   /** Release GPU-retained accounting after submitting one ordered command-buffer chunk. */
-  void beginChunkAfterSubmit() {
+  bool beginChunkAfterSubmit() {
     intermediateBytes_ = 0;
     liveCpuCaptureBytes_ = 0;
+    activeGpuReservations_ = 0;
+    rejectionReason_ = RejectionReason::None;
     rejected_ = false;
     ++chunks_;
+    return true;
   }
 
   /**
@@ -759,20 +773,34 @@ public:
                                      FilterMemoryModel memoryModel, std::uint64_t captureBytes) {
     std::uint64_t graphWorkUnits = 0;
     std::uint64_t graphIntermediateBytes = 0;
-    if (rejected_ || !FilterGraphExecutionCost(graph, pixelCount, memoryModel, graphWorkUnits,
-                                               graphIntermediateBytes)) {
+    if (rejected_) {
+      return std::nullopt;
+    }
+    if (!FilterGraphExecutionCost(graph, pixelCount, memoryModel, graphWorkUnits,
+                                  graphIntermediateBytes)) {
+      rejectionReason_ = RejectionReason::InvalidGraph;
       rejected_ = true;
       return std::nullopt;
     }
 
     const bool gpu = memoryModel == FilterMemoryModel::GpuAllNodes;
     const std::uint64_t retainedBeforeExecution = gpu ? intermediateBytes_ : liveCpuCaptureBytes_;
-    if (executions_ >= kMaximumExecutions || workUnits_ > kMaximumFilterFrameWorkUnits ||
-        graphWorkUnits > kMaximumFilterFrameWorkUnits - workUnits_ ||
-        retainedBeforeExecution > kMaximumFilterFrameBytes ||
+    if (executions_ >= kMaximumExecutions) {
+      rejectionReason_ = RejectionReason::ExecutionLimit;
+      rejected_ = true;
+      return std::nullopt;
+    }
+    if (workUnits_ > kMaximumFilterFrameWorkUnits ||
+        graphWorkUnits > kMaximumFilterFrameWorkUnits - workUnits_) {
+      rejectionReason_ = RejectionReason::WorkLimit;
+      rejected_ = true;
+      return std::nullopt;
+    }
+    if (retainedBeforeExecution > kMaximumFilterFrameBytes ||
         captureBytes > kMaximumFilterFrameBytes - retainedBeforeExecution ||
         graphIntermediateBytes >
             kMaximumFilterFrameBytes - retainedBeforeExecution - captureBytes) {
+      rejectionReason_ = RejectionReason::MemoryLimit;
       rejected_ = true;
       return std::nullopt;
     }
@@ -782,6 +810,7 @@ public:
     captureBytesReserved_ += captureBytes;
     if (gpu) {
       intermediateBytes_ += captureBytes + graphIntermediateBytes;
+      ++activeGpuReservations_;
     } else {
       liveCpuCaptureBytes_ += captureBytes;
     }
@@ -795,6 +824,8 @@ public:
     }
     if (reservation.memoryModel == FilterMemoryModel::CpuFloatNamedResults) {
       liveCpuCaptureBytes_ -= reservation.captureBytes;
+    } else {
+      --activeGpuReservations_;
     }
     reservation.active = false;
   }
@@ -810,7 +841,10 @@ public:
   }
 
   /// Latch the frame closed after an allocation or other external preflight failure.
-  void reject() { rejected_ = true; }
+  void reject() {
+    rejectionReason_ = RejectionReason::External;
+    rejected_ = true;
+  }
 
   [[nodiscard]] std::uint64_t executions() const { return executions_; }
   [[nodiscard]] std::uint64_t workUnits() const { return workUnits_; }
@@ -818,17 +852,21 @@ public:
     return intermediateBytes_ + liveCpuCaptureBytes_;
   }
   [[nodiscard]] std::uint64_t captureBytesReserved() const { return captureBytesReserved_; }
+  [[nodiscard]] std::uint64_t activeGpuReservations() const { return activeGpuReservations_; }
   /// Ordered GPU chunks submitted since this budget was constructed.
   [[nodiscard]] std::uint64_t chunks() const { return chunks_; }
   [[nodiscard]] bool rejected() const { return rejected_; }
+  [[nodiscard]] RejectionReason rejectionReason() const { return rejectionReason_; }
 
 private:
   std::uint64_t executions_ = 0;
   std::uint64_t workUnits_ = 0;
   std::uint64_t intermediateBytes_ = 0;
   std::uint64_t liveCpuCaptureBytes_ = 0;
+  std::uint64_t activeGpuReservations_ = 0;
   std::uint64_t captureBytesReserved_ = 0;
   std::uint64_t chunks_ = 0;
+  RejectionReason rejectionReason_ = RejectionReason::None;
   bool rejected_ = false;
 };
 

--- a/donner/svg/components/filter/FilterSystem.cc
+++ b/donner/svg/components/filter/FilterSystem.cc
@@ -344,12 +344,11 @@ Entity NextFilterChild(Registry& registry, Entity current, std::size_t retainedN
 void AppendColorMatrixNode(FilterGraph& graph, const FEColorMatrixComponent& component,
                            const FilterPrimitiveComponent& attributes,
                            std::optional<ColorInterpolationFilters> colorInterpolation) {
-  if (component.values.size() > kMaximumFilterColorMatrixValues) {
-    return;
-  }
   filter_primitive::ColorMatrix primitive;
   primitive.type = static_cast<filter_primitive::ColorMatrix::Type>(component.type);
-  primitive.values = component.values;
+  if (component.values.size() <= kMaximumFilterColorMatrixValues) {
+    primitive.values = component.values;
+  }
   graph.nodes.push_back(makeFilterNode(std::move(primitive), attributes, colorInterpolation));
 }
 

--- a/donner/svg/components/filter/FilterSystem.cc
+++ b/donner/svg/components/filter/FilterSystem.cc
@@ -1,7 +1,12 @@
 #include "donner/svg/components/filter/FilterSystem.h"
 
+#include <limits>
+
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/css/parser/ColorParser.h"
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
+#include "donner/svg/components/ReferenceResolutionBudget.h"
+#include "donner/svg/components/filter/ComputedFilterResourceBudget.h"
 #include "donner/svg/components/filter/FilterPrimitiveComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
@@ -12,6 +17,89 @@
 namespace donner::svg::components {
 
 namespace {
+
+struct ComputedFilterBudgetListenerInstalled {};
+
+void OnComputedFilterDestroyed(Registry& registry, Entity entity) {
+  if (auto* budget = registry.ctx().find<ComputedFilterResourceBudget>()) {
+    budget->release(entity);
+  }
+}
+
+ReferenceResolutionBudget& GetReferenceResolutionBudget(Registry& registry) {
+  if (!registry.ctx().contains<ReferenceResolutionBudget>()) {
+    registry.ctx().emplace<ReferenceResolutionBudget>();
+  }
+  return registry.ctx().get<ReferenceResolutionBudget>();
+}
+
+ComputedFilterResourceBudget& GetComputedFilterResourceBudget(Registry& registry) {
+  if (!registry.ctx().contains<ComputedFilterResourceBudget>()) {
+    std::shared_ptr<DocumentResourceFamilyBudget> family;
+    if (const auto* context = registry.ctx().find<DocumentResourceFamilyContext>()) {
+      family = context->budget;
+    }
+    registry.ctx().emplace<ComputedFilterResourceBudget>(std::move(family));
+  }
+  if (!registry.ctx().contains<ComputedFilterBudgetListenerInstalled>()) {
+    registry.ctx().emplace<ComputedFilterBudgetListenerInstalled>();
+    static_cast<void>(registry.storage<ComputedFilterComponent>());
+    registry.on_destroy<ComputedFilterComponent>().connect<&OnComputedFilterDestroyed>();
+  }
+  return registry.ctx().get<ComputedFilterResourceBudget>();
+}
+
+bool AddRetainedBytes(std::size_t& total, std::size_t additional) {
+  if (additional > std::numeric_limits<std::size_t>::max() - total) {
+    return false;
+  }
+  total += additional;
+  return true;
+}
+
+bool AddRetainedProduct(std::size_t& total, std::size_t count, std::size_t elementSize) {
+  if (elementSize != 0 && count > std::numeric_limits<std::size_t>::max() / elementSize) {
+    return false;
+  }
+  return AddRetainedBytes(total, count * elementSize);
+}
+
+std::optional<std::size_t> ComputedFilterRetainedBytes(
+    const FilterGraph& graph, const std::vector<FilterEffect>& effectChain) {
+  std::size_t bytes = sizeof(ComputedFilterComponent);
+  if (!AddRetainedProduct(bytes, effectChain.capacity(), sizeof(FilterEffect)) ||
+      !AddRetainedProduct(bytes, graph.nodes.capacity(), sizeof(FilterNode))) {
+    return std::nullopt;
+  }
+  for (const FilterNode& node : graph.nodes) {
+    if (!AddRetainedProduct(bytes, node.inputs.capacity(), sizeof(FilterInput)) ||
+        !AddRetainedBytes(bytes,
+                          static_cast<std::size_t>(FilterPrimitivePayloadBytes(node.primitive)))) {
+      return std::nullopt;
+    }
+    for (const FilterInput& input : node.inputs) {
+      if (const auto* named = std::get_if<FilterInput::Named>(&input.value);
+          named && !AddRetainedBytes(bytes, named->name.size())) {
+        return std::nullopt;
+      }
+    }
+    if (node.result.has_value() && !AddRetainedBytes(bytes, node.result->size())) {
+      return std::nullopt;
+    }
+    if (const auto* image = std::get_if<filter_primitive::Image>(&node.primitive)) {
+      if (!AddRetainedBytes(bytes, image->href.size()) ||
+          !AddRetainedBytes(bytes, image->fragmentId.size())) {
+        return std::nullopt;
+      }
+    }
+  }
+  return bytes;
+}
+
+void RemoveComputedFilter(EntityHandle handle) {
+  GetComputedFilterResourceBudget(*handle.registry());
+  handle.remove<ComputedFilterComponent>();
+}
 
 /// Parse the `in` attribute from a FilterPrimitiveComponent into a FilterInput.
 FilterInput toFilterInput(const FilterPrimitiveComponent& primitive) {
@@ -192,6 +280,7 @@ bool hasFilterPrimitiveChildren(const Registry& registry, EntityHandle handle) {
 
 std::vector<EntityHandle> getInheritanceChain(EntityHandle handle, ParseWarningSink& warningSink) {
   Registry& registry = *handle.registry();
+  auto& budget = GetReferenceResolutionBudget(registry);
 
   std::vector<EntityHandle> inheritanceChain;
   inheritanceChain.push_back(handle);
@@ -202,6 +291,14 @@ std::vector<EntityHandle> getInheritanceChain(EntityHandle handle, ParseWarningS
   EntityHandle current = handle;
   while (const auto* filter = current.try_get<FilterComponent>()) {
     if (!filter->href.has_value()) {
+      break;
+    }
+    const bool alreadyRejected = budget.stats(ReferenceResolutionBudget::Kind::Filter).rejected;
+    if (!budget.reserve(ReferenceResolutionBudget::Kind::Filter, inheritanceChain.size())) {
+      if (!alreadyRejected) {
+        warningSink.add(ParseDiagnostic::Warning("Filter inheritance resource limit exceeded",
+                                                 FileOffset::Offset(0)));
+      }
       break;
     }
 
@@ -237,13 +334,176 @@ std::vector<EntityHandle> getInheritanceChain(EntityHandle handle, ParseWarningS
   return inheritanceChain;
 }
 
+Entity NextFilterChild(Registry& registry, Entity current, std::size_t retainedNodeCount) {
+  if (retainedNodeCount >= kMaximumFilterGraphNodes) {
+    return entt::null;
+  }
+  return registry.get<donner::components::TreeComponent>(current).nextSibling();
+}
+
+void AppendColorMatrixNode(FilterGraph& graph, const FEColorMatrixComponent& component,
+                           const FilterPrimitiveComponent& attributes,
+                           std::optional<ColorInterpolationFilters> colorInterpolation) {
+  if (component.values.size() > kMaximumFilterColorMatrixValues) {
+    return;
+  }
+  filter_primitive::ColorMatrix primitive;
+  primitive.type = static_cast<filter_primitive::ColorMatrix::Type>(component.type);
+  primitive.values = component.values;
+  graph.nodes.push_back(makeFilterNode(std::move(primitive), attributes, colorInterpolation));
+}
+
+void AppendComponentTransferNode(Registry& registry, Entity current, FilterGraph& graph,
+                                 const FilterPrimitiveComponent& attributes,
+                                 std::optional<ColorInterpolationFilters> colorInterpolation) {
+  filter_primitive::ComponentTransfer primitive;
+  const auto& tree = registry.get<donner::components::TreeComponent>(current);
+  for (Entity child = tree.firstChild(); child != entt::null;
+       child = registry.get<donner::components::TreeComponent>(child).nextSibling()) {
+    const auto* function = registry.try_get<FEFuncComponent>(child);
+    if (!function || function->tableValues.size() > kMaximumFilterTableValues) {
+      continue;
+    }
+    filter_primitive::ComponentTransfer::Func value;
+    value.type = static_cast<filter_primitive::ComponentTransfer::FuncType>(function->type);
+    value.tableValues = function->tableValues;
+    value.slope = function->slope;
+    value.intercept = function->intercept;
+    value.amplitude = function->amplitude;
+    value.exponent = function->exponent;
+    value.offset = function->offset;
+    switch (function->channel) {
+      case FEFuncComponent::Channel::R: primitive.funcR = std::move(value); break;
+      case FEFuncComponent::Channel::G: primitive.funcG = std::move(value); break;
+      case FEFuncComponent::Channel::B: primitive.funcB = std::move(value); break;
+      case FEFuncComponent::Channel::A: primitive.funcA = std::move(value); break;
+    }
+  }
+  graph.nodes.push_back(makeFilterNode(std::move(primitive), attributes, colorInterpolation));
+}
+
+void AppendMergeNode(Registry& registry, Entity current, FilterGraph& graph,
+                     const FilterPrimitiveComponent& attributes,
+                     std::optional<ColorInterpolationFilters> colorInterpolation) {
+  FilterNode node;
+  node.primitive = filter_primitive::Merge{};
+  node.result = attributes.result;
+  node.x = attributes.x;
+  node.y = attributes.y;
+  node.width = attributes.width;
+  node.height = attributes.height;
+  node.colorInterpolationFilters = colorInterpolation;
+  const auto& tree = registry.get<donner::components::TreeComponent>(current);
+  for (Entity child = tree.firstChild();
+       child != entt::null && node.inputs.size() < kMaximumFilterMergeInputs;
+       child = registry.get<donner::components::TreeComponent>(child).nextSibling()) {
+    if (const auto* mergeNode = registry.try_get<FEMergeNodeComponent>(child)) {
+      node.inputs.push_back(mergeNode->in.value_or(FilterInput{FilterInput::Previous{}}));
+    }
+  }
+  graph.nodes.push_back(std::move(node));
+}
+
+void AppendConvolveNode(FilterGraph& graph, const FEConvolveMatrixComponent& component,
+                        const FilterPrimitiveComponent& attributes,
+                        std::optional<ColorInterpolationFilters> colorInterpolation) {
+  if (component.orderX <= 0 || component.orderY <= 0 ||
+      component.orderX > kMaximumFilterConvolveOrder ||
+      component.orderY > kMaximumFilterConvolveOrder ||
+      component.kernelMatrix.size() > kMaximumFilterKernelValues) {
+    return;
+  }
+  filter_primitive::ConvolveMatrix primitive;
+  primitive.orderX = component.orderX;
+  primitive.orderY = component.orderY;
+  primitive.kernelMatrix = component.kernelMatrix;
+  primitive.divisor = component.divisor;
+  primitive.bias = component.bias;
+  primitive.targetX = component.targetX;
+  primitive.targetY = component.targetY;
+  primitive.edgeMode = static_cast<filter_primitive::ConvolveMatrix::EdgeMode>(component.edgeMode);
+  primitive.preserveAlpha = component.preserveAlpha;
+  graph.nodes.push_back(makeFilterNode(std::move(primitive), attributes, colorInterpolation));
+}
+
+void AppendImageNode(Registry& registry, Entity current, FilterGraph& graph,
+                     const FEImageComponent& component, const FilterPrimitiveComponent& attributes,
+                     std::optional<ColorInterpolationFilters> colorInterpolation,
+                     ComputedFilterResourceBudget& budget) {
+  filter_primitive::Image primitive;
+  primitive.href = component.href;
+  primitive.preserveAspectRatio = component.preserveAspectRatio;
+  if (const auto* style = registry.try_get<ComputedStyleComponent>(current);
+      style && style->properties.has_value()) {
+    primitive.imageRendering = style->properties->imageRendering.get().value();
+  }
+  if (const auto* loaded = registry.try_get<LoadedImageComponent>(current);
+      loaded && loaded->image.has_value()) {
+    primitive.imageData = budget.shareImage(current, loaded->image->data);
+    if (!primitive.imageData) {
+      return;
+    }
+    primitive.imageWidth = loaded->image->width;
+    primitive.imageHeight = loaded->image->height;
+  } else if (const auto* svgLoaded = registry.try_get<LoadedSVGImageComponent>(current);
+             svgLoaded && svgLoaded->subDocument) {
+    primitive.svgSubDocument = svgLoaded->subDocument;
+  } else if (const std::string_view hrefView(component.href);
+             !hrefView.empty() && hrefView[0] == '#') {
+    primitive.fragmentId = RcString(hrefView.substr(1));
+    primitive.isFragmentReference = true;
+  }
+  FilterNode node;
+  node.primitive = std::move(primitive);
+  node.result = attributes.result;
+  node.x = attributes.x;
+  node.y = attributes.y;
+  node.width = attributes.width;
+  node.height = attributes.height;
+  node.colorInterpolationFilters = colorInterpolation;
+  graph.nodes.push_back(std::move(node));
+}
+
+void StoreComputedFilter(EntityHandle handle, ComputedFilterResourceBudget& budget,
+                         std::vector<FilterEffect> effects, FilterGraph graph, Lengthd x, Lengthd y,
+                         Lengthd width, Lengthd height, FilterUnits filterUnits,
+                         PrimitiveUnits primitiveUnits,
+                         ColorInterpolationFilters colorInterpolation) {
+  if (budget.rejected()) {
+    RemoveComputedFilter(handle);
+    return;
+  }
+  if (effects.empty() && graph.empty()) {
+    RemoveComputedFilter(handle);
+    return;
+  }
+  const auto retainedBytes = ComputedFilterRetainedBytes(graph, effects);
+  if (!retainedBytes.has_value() || !budget.reserve(handle.entity(), *retainedBytes)) {
+    RemoveComputedFilter(handle);
+    return;
+  }
+  ComputedFilterComponent& computed = handle.emplace_or_replace<ComputedFilterComponent>();
+  computed.effectChain = std::move(effects);
+  computed.filterGraph = std::move(graph);
+  computed.x = x;
+  computed.y = y;
+  computed.width = width;
+  computed.height = height;
+  computed.filterUnits = filterUnits;
+  computed.primitiveUnits = primitiveUnits;
+  computed.colorInterpolationFilters = colorInterpolation;
+  computed.filterGraph.colorInterpolationFilters = colorInterpolation;
+  computed.filterGraph.primitiveUnits = primitiveUnits;
+}
+
 }  // namespace
 
 void FilterSystem::createComputedFilter(EntityHandle handle, const FilterComponent& component,
                                         ParseWarningSink& warningSink) {
   (void)component;
 
-  const Registry& registry = *handle.registry();
+  Registry& registry = *handle.registry();
+  auto& computedBudget = GetComputedFilterResourceBudget(registry);
 
   const std::vector<EntityHandle> inheritanceChain = getInheritanceChain(handle, warningSink);
 
@@ -256,7 +516,7 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
   }
 
   if (!primitiveSource.valid()) {
-    handle.remove<ComputedFilterComponent>();
+    RemoveComputedFilter(handle);
     return;
   }
 
@@ -300,7 +560,7 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
   const donner::components::TreeComponent& tree =
       primitiveSource.get<donner::components::TreeComponent>();
   for (auto cur = tree.firstChild(); cur != entt::null;
-       cur = registry.get<donner::components::TreeComponent>(cur).nextSibling()) {
+       cur = NextFilterChild(registry, cur, filterGraph.nodes.size())) {
     const auto* primitive = registry.try_get<FilterPrimitiveComponent>(cur);
     if (!primitive) {
       continue;
@@ -343,74 +603,15 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
       prim.k4 = comp->k4;
       filterGraph.nodes.push_back(makeFilterNode2(std::move(prim), *primitive, primitiveCIF));
     } else if (const auto* colorMatrix = registry.try_get<FEColorMatrixComponent>(cur)) {
-      filter_primitive::ColorMatrix prim;
-      prim.type = static_cast<filter_primitive::ColorMatrix::Type>(colorMatrix->type);
-      prim.values = colorMatrix->values;
-      filterGraph.nodes.push_back(makeFilterNode(std::move(prim), *primitive, primitiveCIF));
+      AppendColorMatrixNode(filterGraph, *colorMatrix, *primitive, primitiveCIF);
     } else if (const auto* blend = registry.try_get<FEBlendComponent>(cur)) {
       filter_primitive::Blend prim;
       prim.mode = static_cast<filter_primitive::Blend::Mode>(blend->mode);
       filterGraph.nodes.push_back(makeFilterNode2(std::move(prim), *primitive, primitiveCIF));
     } else if (registry.try_get<FEComponentTransferComponent>(cur)) {
-      // feComponentTransfer: collect feFuncR/G/B/A children.
-      filter_primitive::ComponentTransfer prim;
-
-      const auto& curTree = registry.get<donner::components::TreeComponent>(cur);
-      for (auto child = curTree.firstChild(); child != entt::null;
-           child = registry.get<donner::components::TreeComponent>(child).nextSibling()) {
-        const auto* func = registry.try_get<FEFuncComponent>(child);
-        if (!func) {
-          continue;
-        }
-
-        auto toFuncType = [](FEFuncComponent::FuncType t) {
-          return static_cast<filter_primitive::ComponentTransfer::FuncType>(t);
-        };
-
-        filter_primitive::ComponentTransfer::Func f;
-        f.type = toFuncType(func->type);
-        f.tableValues = func->tableValues;
-        f.slope = func->slope;
-        f.intercept = func->intercept;
-        f.amplitude = func->amplitude;
-        f.exponent = func->exponent;
-        f.offset = func->offset;
-
-        switch (func->channel) {
-          case FEFuncComponent::Channel::R: prim.funcR = std::move(f); break;
-          case FEFuncComponent::Channel::G: prim.funcG = std::move(f); break;
-          case FEFuncComponent::Channel::B: prim.funcB = std::move(f); break;
-          case FEFuncComponent::Channel::A: prim.funcA = std::move(f); break;
-        }
-      }
-
-      filterGraph.nodes.push_back(makeFilterNode(std::move(prim), *primitive, primitiveCIF));
+      AppendComponentTransferNode(registry, cur, filterGraph, *primitive, primitiveCIF);
     } else if (registry.try_get<FEMergeComponent>(cur)) {
-      // feMerge: collect inputs from feMergeNode children.
-      FilterNode node;
-      node.primitive = filter_primitive::Merge{};
-      node.result = primitive->result;
-      node.x = primitive->x;
-      node.y = primitive->y;
-      node.width = primitive->width;
-      node.height = primitive->height;
-      node.colorInterpolationFilters = primitiveCIF;
-
-      // Walk feMergeNode children to collect inputs.
-      const auto& curTree = registry.get<donner::components::TreeComponent>(cur);
-      for (auto child = curTree.firstChild(); child != entt::null;
-           child = registry.get<donner::components::TreeComponent>(child).nextSibling()) {
-        const auto* mergeNode = registry.try_get<FEMergeNodeComponent>(child);
-        if (mergeNode) {
-          if (mergeNode->in.has_value()) {
-            node.inputs.push_back(mergeNode->in.value());
-          } else {
-            node.inputs.push_back(FilterInput{FilterInput::Previous{}});
-          }
-        }
-      }
-
-      filterGraph.nodes.push_back(std::move(node));
+      AppendMergeNode(registry, cur, filterGraph, *primitive, primitiveCIF);
     } else if (const auto* dropShadow = registry.try_get<FEDropShadowComponent>(cur)) {
       filter_primitive::DropShadow prim;
       prim.dx = dropShadow->dx;
@@ -471,17 +672,7 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
       prim.radiusY = morph->radiusY;
       filterGraph.nodes.push_back(makeFilterNode(prim, *primitive, primitiveCIF));
     } else if (const auto* convolve = registry.try_get<FEConvolveMatrixComponent>(cur)) {
-      filter_primitive::ConvolveMatrix prim;
-      prim.orderX = convolve->orderX;
-      prim.orderY = convolve->orderY;
-      prim.kernelMatrix = convolve->kernelMatrix;
-      prim.divisor = convolve->divisor;
-      prim.bias = convolve->bias;
-      prim.targetX = convolve->targetX;
-      prim.targetY = convolve->targetY;
-      prim.edgeMode = static_cast<filter_primitive::ConvolveMatrix::EdgeMode>(convolve->edgeMode);
-      prim.preserveAlpha = convolve->preserveAlpha;
-      filterGraph.nodes.push_back(makeFilterNode(prim, *primitive, primitiveCIF));
+      AppendConvolveNode(filterGraph, *convolve, *primitive, primitiveCIF);
     } else if (registry.try_get<FETileComponent>(cur)) {
       filterGraph.nodes.push_back(
           makeFilterNode(filter_primitive::Tile{}, *primitive, primitiveCIF));
@@ -566,64 +757,20 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
 
       filterGraph.nodes.push_back(makeFilterNode(std::move(prim), *primitive, primitiveCIF));
     } else if (const auto* feImage = registry.try_get<FEImageComponent>(cur)) {
-      filter_primitive::Image prim;
-      prim.href = feImage->href;
-      prim.preserveAspectRatio = feImage->preserveAspectRatio;
-
-      if (const auto* feStyle = registry.try_get<ComputedStyleComponent>(cur);
-          feStyle && feStyle->properties.has_value()) {
-        prim.imageRendering = feStyle->properties->imageRendering.get().value();
-      }
-
-      // Load the referenced image if available.
-      if (const auto* loaded = registry.try_get<LoadedImageComponent>(cur);
-          loaded && loaded->image.has_value()) {
-        prim.imageData = loaded->image->data;
-        prim.imageWidth = loaded->image->width;
-        prim.imageHeight = loaded->image->height;
-      } else if (const auto* svgLoaded = registry.try_get<LoadedSVGImageComponent>(cur);
-                 svgLoaded && svgLoaded->subDocument) {
-        prim.svgSubDocument = svgLoaded->subDocument;
-      } else if (const std::string_view hrefView(feImage->href);
-                 !hrefView.empty() && hrefView[0] == '#') {
-        // Same-document fragment reference - store the fragment ID for the renderer to resolve.
-        prim.fragmentId = RcString(hrefView.substr(1));
-        prim.isFragmentReference = true;
-      }
-
-      // feImage has no standard input (it generates its own content).
-      FilterNode node;
-      node.primitive = std::move(prim);
-      node.result = primitive->result;
-      node.x = primitive->x;
-      node.y = primitive->y;
-      node.width = primitive->width;
-      node.height = primitive->height;
-      node.colorInterpolationFilters = primitiveCIF;
-      filterGraph.nodes.push_back(std::move(node));
+      AppendImageNode(registry, cur, filterGraph, *feImage, *primitive, primitiveCIF,
+                      computedBudget);
     }
   }
 
-  if (!effectChain.empty() || !filterGraph.empty()) {
-    ComputedFilterComponent& computed = handle.emplace_or_replace<ComputedFilterComponent>();
-    computed.effectChain = std::move(effectChain);
-    computed.filterGraph = std::move(filterGraph);
-    computed.x = computedX;
-    computed.y = computedY;
-    computed.width = computedWidth;
-    computed.height = computedHeight;
-    computed.filterUnits = computedFilterUnits;
-    computed.primitiveUnits = computedPrimitiveUnits;
-    computed.colorInterpolationFilters = computedColorInterpolationFilters;
-    computed.filterGraph.colorInterpolationFilters = computedColorInterpolationFilters;
-    computed.filterGraph.primitiveUnits = computedPrimitiveUnits;
-  } else {
-    handle.remove<ComputedFilterComponent>();
-  }
+  StoreComputedFilter(handle, computedBudget, std::move(effectChain), std::move(filterGraph),
+                      computedX, computedY, computedWidth, computedHeight, computedFilterUnits,
+                      computedPrimitiveUnits, computedColorInterpolationFilters);
 }
 
 void FilterSystem::instantiateAllComputedComponents(Registry& registry,
                                                     ParseWarningSink& warningSink) {
+  GetReferenceResolutionBudget(registry).reset(ReferenceResolutionBudget::Kind::Filter);
+  GetComputedFilterResourceBudget(registry);
   for (auto entity : registry.view<FilterComponent>()) {
     createComputedFilter(EntityHandle(registry, entity), registry.get<FilterComponent>(entity),
                          warningSink);

--- a/donner/svg/components/filter/FilterSystem.cc
+++ b/donner/svg/components/filter/FilterSystem.cc
@@ -438,7 +438,7 @@ void AppendImageNode(Registry& registry, Entity current, FilterGraph& graph,
   }
   if (const auto* loaded = registry.try_get<LoadedImageComponent>(current);
       loaded && loaded->image.has_value()) {
-    primitive.imageData = budget.shareImage(current, loaded->image->data);
+    primitive.imageData = budget.shareImage(current, loaded->revision(), loaded->image->data);
     if (!primitive.imageData) {
       return;
     }

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -607,8 +607,8 @@ TEST_F(FilterSystemTest, SharedImageReservationFollowsSharedAllocationLifetime) 
   const Entity source = registry.create();
   const std::vector<uint8_t> pixels(24, 0x7f);
 
-  auto first = budget.shareImage(source, pixels);
-  auto second = budget.shareImage(source, pixels);
+  auto first = budget.shareImage(source, 1, pixels);
+  auto second = budget.shareImage(source, 1, pixels);
   ASSERT_THAT(first, NotNull());
   ASSERT_THAT(second, NotNull());
   EXPECT_EQ(first.get(), second.get());
@@ -634,15 +634,16 @@ TEST_F(FilterSystemTest, SharedImageIdentityTracksInPlacePixelChanges) {
   ComputedFilterResourceBudget budget(family);
   Registry registry;
   const Entity source = registry.create();
-  std::vector<uint8_t> pixels = {0xff, 0, 0, 0xff};
+  LoadedImageComponent loaded(ImageResource{{0xff, 0, 0, 0xff}, 1, 1});
 
-  auto first = budget.shareImage(source, pixels);
+  auto first = budget.shareImage(source, loaded.revision(), loaded.image->data);
   ASSERT_THAT(first, NotNull());
   EXPECT_THAT(*first, ElementsAre(0xff, 0, 0, 0xff));
 
-  pixels[0] = 0;
-  pixels[1] = 0xff;
-  auto second = budget.shareImage(source, pixels);
+  loaded.image->data[0] = 0;
+  loaded.image->data[1] = 0xff;
+  loaded.markImageModified();
+  auto second = budget.shareImage(source, loaded.revision(), loaded.image->data);
   ASSERT_THAT(second, NotNull());
   EXPECT_NE(first.get(), second.get());
   EXPECT_THAT(*first, ElementsAre(0xff, 0, 0, 0xff));
@@ -658,7 +659,7 @@ TEST_F(FilterSystemTest, SharedImageBudgetRejectsBeforeMaterializingPixels) {
   const Entity source = registry.create();
   const std::vector<uint8_t> pixels(4, 0xff);
 
-  EXPECT_EQ(budget.shareImage(source, pixels), nullptr);
+  EXPECT_EQ(budget.shareImage(source, 1, pixels), nullptr);
   EXPECT_TRUE(budget.rejected());
   EXPECT_EQ(budget.sharedImageMaterializations(), 0u);
   EXPECT_EQ(budget.retainedBytes(), 0u);

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -10,10 +10,14 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
+#include "donner/svg/components/ReferenceResolutionBudget.h"
+#include "donner/svg/components/filter/ComputedFilterResourceBudget.h"
 #include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/style/StyleSystem.h"
@@ -502,6 +506,124 @@ TEST_F(FilterSystemTest, HrefWarningsForInvalidAndCircularReferences) {
               testing::AllOf(testing::HasSubstr("failed to resolve"),
                              testing::HasSubstr("does not reference a <filter>"),
                              testing::HasSubstr("Circular filter inheritance detected")));
+}
+
+TEST_F(FilterSystemTest, FilterHrefTraversalRespectsDepthLimit) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg"><defs>
+      <filter id="base"><feFlood/></filter>
+      <filter id="middle" href="#base"/>
+      <filter id="deep" href="#middle"/>
+    </defs></svg>
+  )");
+  auto& registry = document.registry();
+  registry.ctx().emplace<ReferenceResolutionBudget>(
+      ReferenceResolutionBudget::Limits{.maximumReferenceDepth = 1, .maximumHopsPerKind = 8});
+
+  ParseWarningSink warningSink;
+  StyleSystem().computeAllStyles(registry, warningSink);
+  filterSystem.instantiateAllComputedComponents(registry, warningSink);
+
+  const auto& budget = registry.ctx().get<ReferenceResolutionBudget>();
+  EXPECT_EQ(budget.stats(ReferenceResolutionBudget::Kind::Filter).hops, 2u);
+  EXPECT_TRUE(budget.stats(ReferenceResolutionBudget::Kind::Filter).rejected);
+  EXPECT_THAT(testing::PrintToString(warningSink.warnings()),
+              testing::HasSubstr("Filter inheritance resource limit exceeded"));
+  ASSERT_TRUE(document.querySelector("#middle").has_value());
+  EXPECT_TRUE(document.querySelector("#middle")->entityHandle().all_of<ComputedFilterComponent>());
+  ASSERT_TRUE(document.querySelector("#deep").has_value());
+  EXPECT_FALSE(document.querySelector("#deep")->entityHandle().all_of<ComputedFilterComponent>());
+}
+
+TEST_F(FilterSystemTest, FilterHrefTraversalSharesAggregateHopLimit) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg"><defs>
+      <filter id="base"><feFlood/></filter>
+      <filter id="first" href="#base"/>
+      <filter id="second" href="#base"/>
+    </defs></svg>
+  )");
+  auto& registry = document.registry();
+  registry.ctx().emplace<ReferenceResolutionBudget>(
+      ReferenceResolutionBudget::Limits{.maximumReferenceDepth = 8, .maximumHopsPerKind = 1});
+
+  ParseWarningSink warningSink;
+  StyleSystem().computeAllStyles(registry, warningSink);
+  filterSystem.instantiateAllComputedComponents(registry, warningSink);
+
+  const auto& stats = registry.ctx().get<ReferenceResolutionBudget>().stats(
+      ReferenceResolutionBudget::Kind::Filter);
+  EXPECT_EQ(stats.hops, 1u);
+  EXPECT_TRUE(stats.rejected);
+  EXPECT_THAT(testing::PrintToString(warningSink.warnings()),
+              testing::HasSubstr("Filter inheritance resource limit exceeded"));
+  ASSERT_TRUE(document.querySelector("#first").has_value());
+  EXPECT_TRUE(document.querySelector("#first")->entityHandle().all_of<ComputedFilterComponent>());
+  ASSERT_TRUE(document.querySelector("#second").has_value());
+  EXPECT_FALSE(document.querySelector("#second")->entityHandle().all_of<ComputedFilterComponent>());
+}
+
+TEST_F(FilterSystemTest, ComputedFilterStructuralReservationsReleaseFamilyBytes) {
+  DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.computedFilterBytes = 64;
+  familyLimits.maximumTotalRetainedBytes = 64;
+  auto family = std::make_shared<DocumentResourceFamilyBudget>(familyLimits);
+  Registry registry;
+  const Entity filter = registry.create();
+
+  {
+    ComputedFilterResourceBudget budget(family,
+                                        ComputedFilterResourceBudget::Limits{.maximumBytes = 64});
+    ASSERT_TRUE(budget.reserve(filter, 32));
+    EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 32u);
+    ASSERT_TRUE(budget.reserve(filter, 8));
+    EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 8u);
+    budget.release(filter);
+    EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+    ASSERT_TRUE(budget.reserve(filter, 16));
+  }
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, SharedImageReservationFollowsSharedAllocationLifetime) {
+  DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.computedFilterBytes = 64;
+  familyLimits.maximumTotalRetainedBytes = 64;
+  auto family = std::make_shared<DocumentResourceFamilyBudget>(familyLimits);
+  ComputedFilterResourceBudget budget(family,
+                                      ComputedFilterResourceBudget::Limits{.maximumBytes = 64});
+  Registry registry;
+  const Entity source = registry.create();
+  const std::vector<uint8_t> pixels(24, 0x7f);
+
+  auto first = budget.shareImage(source, pixels);
+  auto second = budget.shareImage(source, pixels);
+  ASSERT_THAT(first, NotNull());
+  ASSERT_THAT(second, NotNull());
+  EXPECT_EQ(first.get(), second.get());
+  EXPECT_EQ(budget.sharedImageMaterializations(), 1u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 24u);
+
+  first.reset();
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 24u);
+  second.reset();
+  EXPECT_EQ(budget.retainedBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, SharedImageBudgetRejectsBeforeMaterializingPixels) {
+  auto family = std::make_shared<DocumentResourceFamilyBudget>();
+  ComputedFilterResourceBudget budget(family,
+                                      ComputedFilterResourceBudget::Limits{.maximumBytes = 3});
+  Registry registry;
+  const Entity source = registry.create();
+  const std::vector<uint8_t> pixels(4, 0xff);
+
+  EXPECT_EQ(budget.shareImage(source, pixels), nullptr);
+  EXPECT_TRUE(budget.rejected());
+  EXPECT_EQ(budget.sharedImageMaterializations(), 0u);
+  EXPECT_EQ(budget.retainedBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
 }
 
 TEST_F(FilterSystemTest, FeImageUsesLoadedSvgSubDocument) {

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -522,17 +522,22 @@ TEST_F(FilterSystemTest, FilterHrefTraversalRespectsDepthLimit) {
 
   ParseWarningSink warningSink;
   StyleSystem().computeAllStyles(registry, warningSink);
-  filterSystem.instantiateAllComputedComponents(registry, warningSink);
+  auto middle = document.querySelector("#middle");
+  auto deep = document.querySelector("#deep");
+  ASSERT_TRUE(middle.has_value());
+  ASSERT_TRUE(deep.has_value());
+  filterSystem.createComputedFilter(middle->entityHandle(),
+                                    middle->entityHandle().get<FilterComponent>(), warningSink);
+  filterSystem.createComputedFilter(deep->entityHandle(),
+                                    deep->entityHandle().get<FilterComponent>(), warningSink);
 
   const auto& budget = registry.ctx().get<ReferenceResolutionBudget>();
   EXPECT_EQ(budget.stats(ReferenceResolutionBudget::Kind::Filter).hops, 2u);
   EXPECT_TRUE(budget.stats(ReferenceResolutionBudget::Kind::Filter).rejected);
   EXPECT_THAT(testing::PrintToString(warningSink.warnings()),
               testing::HasSubstr("Filter inheritance resource limit exceeded"));
-  ASSERT_TRUE(document.querySelector("#middle").has_value());
-  EXPECT_TRUE(document.querySelector("#middle")->entityHandle().all_of<ComputedFilterComponent>());
-  ASSERT_TRUE(document.querySelector("#deep").has_value());
-  EXPECT_FALSE(document.querySelector("#deep")->entityHandle().all_of<ComputedFilterComponent>());
+  EXPECT_TRUE(middle->entityHandle().all_of<ComputedFilterComponent>());
+  EXPECT_FALSE(deep->entityHandle().all_of<ComputedFilterComponent>());
 }
 
 TEST_F(FilterSystemTest, FilterHrefTraversalSharesAggregateHopLimit) {
@@ -549,7 +554,14 @@ TEST_F(FilterSystemTest, FilterHrefTraversalSharesAggregateHopLimit) {
 
   ParseWarningSink warningSink;
   StyleSystem().computeAllStyles(registry, warningSink);
-  filterSystem.instantiateAllComputedComponents(registry, warningSink);
+  auto first = document.querySelector("#first");
+  auto second = document.querySelector("#second");
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  filterSystem.createComputedFilter(first->entityHandle(),
+                                    first->entityHandle().get<FilterComponent>(), warningSink);
+  filterSystem.createComputedFilter(second->entityHandle(),
+                                    second->entityHandle().get<FilterComponent>(), warningSink);
 
   const auto& stats = registry.ctx().get<ReferenceResolutionBudget>().stats(
       ReferenceResolutionBudget::Kind::Filter);
@@ -557,10 +569,8 @@ TEST_F(FilterSystemTest, FilterHrefTraversalSharesAggregateHopLimit) {
   EXPECT_TRUE(stats.rejected);
   EXPECT_THAT(testing::PrintToString(warningSink.warnings()),
               testing::HasSubstr("Filter inheritance resource limit exceeded"));
-  ASSERT_TRUE(document.querySelector("#first").has_value());
-  EXPECT_TRUE(document.querySelector("#first")->entityHandle().all_of<ComputedFilterComponent>());
-  ASSERT_TRUE(document.querySelector("#second").has_value());
-  EXPECT_FALSE(document.querySelector("#second")->entityHandle().all_of<ComputedFilterComponent>());
+  EXPECT_TRUE(first->entityHandle().all_of<ComputedFilterComponent>());
+  EXPECT_FALSE(second->entityHandle().all_of<ComputedFilterComponent>());
 }
 
 TEST_F(FilterSystemTest, ComputedFilterStructuralReservationsReleaseFamilyBytes) {
@@ -609,6 +619,13 @@ TEST_F(FilterSystemTest, SharedImageReservationFollowsSharedAllocationLifetime) 
   second.reset();
   EXPECT_EQ(budget.retainedBytes(), 0u);
   EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+
+  ComputedFilterResourceBudget adoptedBudget(
+      family, ComputedFilterResourceBudget::Limits{.maximumBytes = 3});
+  EXPECT_EQ(adoptedBudget.adoptImage(std::vector<uint8_t>(4, 0xff)), nullptr);
+  EXPECT_TRUE(adoptedBudget.rejected());
+  EXPECT_EQ(adoptedBudget.sharedImageMaterializations(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
 }
 
 TEST_F(FilterSystemTest, SharedImageBudgetRejectsBeforeMaterializingPixels) {
@@ -622,6 +639,105 @@ TEST_F(FilterSystemTest, SharedImageBudgetRejectsBeforeMaterializingPixels) {
   EXPECT_EQ(budget.shareImage(source, pixels), nullptr);
   EXPECT_TRUE(budget.rejected());
   EXPECT_EQ(budget.sharedImageMaterializations(), 0u);
+  EXPECT_EQ(budget.retainedBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, AdoptedImageKeepsFamilyReservationAfterBudgetDestruction) {
+  DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.computedFilterBytes = 64;
+  familyLimits.maximumTotalRetainedBytes = 64;
+  auto family = std::make_shared<DocumentResourceFamilyBudget>(familyLimits);
+  std::shared_ptr<const std::vector<uint8_t>> pixels;
+
+  {
+    ComputedFilterResourceBudget budget(family,
+                                        ComputedFilterResourceBudget::Limits{.maximumBytes = 64});
+    pixels = budget.adoptImage(std::vector<uint8_t>(24, 0x7f));
+    ASSERT_THAT(pixels, NotNull());
+    EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 24u);
+  }
+
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 24u);
+  pixels.reset();
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, InheritedComputedFiltersShareOneAccountedImageAllocation) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg"><defs>
+      <filter id="base"><feImage id="image" href="image.png"/></filter>
+      <filter id="derived-a" href="#base"/>
+      <filter id="derived-b" href="#base"/>
+    </defs></svg>
+  )");
+  auto& registry = document.registry();
+  auto imageElement = document.querySelector("#image");
+  ASSERT_TRUE(imageElement.has_value());
+  imageElement->entityHandle().emplace<LoadedImageComponent>(
+      ImageResource{{0xff, 0, 0, 0xff}, 1, 1});
+
+  DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.computedFilterBytes = 4096;
+  auto family = std::make_shared<DocumentResourceFamilyBudget>(familyLimits);
+  registry.ctx().emplace<ComputedFilterResourceBudget>(
+      family, ComputedFilterResourceBudget::Limits{.maximumBytes = 4096});
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  StyleSystem().computeAllStyles(registry, sink);
+  filterSystem.instantiateAllComputedComponents(registry, sink);
+
+  const std::vector<std::string_view> selectors = {"#base", "#derived-a", "#derived-b"};
+  const std::vector<uint8_t>* sharedPixels = nullptr;
+  for (const std::string_view selector : selectors) {
+    auto filter = document.querySelector(selector);
+    ASSERT_TRUE(filter.has_value());
+    const auto* computed = filter->entityHandle().try_get<ComputedFilterComponent>();
+    ASSERT_THAT(computed, NotNull());
+    ASSERT_THAT(computed->filterGraph.nodes, SizeIs(1));
+    const auto* image =
+        std::get_if<filter_primitive::Image>(&computed->filterGraph.nodes[0].primitive);
+    ASSERT_THAT(image, NotNull());
+    ASSERT_THAT(image->imageData, NotNull());
+    if (sharedPixels == nullptr) {
+      sharedPixels = image->imageData.get();
+    }
+    EXPECT_EQ(image->imageData.get(), sharedPixels);
+  }
+
+  auto& budget = registry.ctx().get<ComputedFilterResourceBudget>();
+  EXPECT_EQ(budget.sharedImageMaterializations(), 1u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter),
+            budget.retainedBytes());
+  for (const std::string_view selector : selectors) {
+    document.querySelector(selector)->entityHandle().remove<ComputedFilterComponent>();
+  }
+  EXPECT_EQ(budget.retainedBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, DestroyingComputedComponentReleasesStructuralFamilyReservation) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg"><defs>
+      <filter id="filter"><feFlood/></filter>
+    </defs></svg>
+  )");
+  auto& registry = document.registry();
+  auto family = std::make_shared<DocumentResourceFamilyBudget>();
+  registry.ctx().emplace<ComputedFilterResourceBudget>(family);
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  StyleSystem().computeAllStyles(registry, sink);
+  filterSystem.instantiateAllComputedComponents(registry, sink);
+  auto filter = document.querySelector("#filter");
+  ASSERT_TRUE(filter.has_value());
+  ASSERT_TRUE(filter->entityHandle().all_of<ComputedFilterComponent>());
+
+  auto& budget = registry.ctx().get<ComputedFilterResourceBudget>();
+  ASSERT_GT(budget.retainedBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter),
+            budget.retainedBytes());
+  filter->entityHandle().remove<ComputedFilterComponent>();
   EXPECT_EQ(budget.retainedBytes(), 0u);
   EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
 }
@@ -654,7 +770,7 @@ TEST_F(FilterSystemTest, FeImageUsesLoadedSvgSubDocument) {
   auto* imageNode = std::get_if<filter_primitive::Image>(&computed->filterGraph.nodes[0].primitive);
   ASSERT_THAT(imageNode, NotNull());
   EXPECT_TRUE(imageNode->svgSubDocument);
-  EXPECT_THAT(imageNode->imageData, IsEmpty());
+  EXPECT_FALSE(imageNode->hasImageData());
 }
 
 TEST_F(FilterSystemTest, FeImageCarriesImageRendering) {
@@ -708,7 +824,8 @@ TEST_F(FilterSystemTest, FeImageUsesLoadedRasterAndFragmentReference) {
     auto* imageNode =
         std::get_if<filter_primitive::Image>(&computed->filterGraph.nodes[0].primitive);
     ASSERT_THAT(imageNode, NotNull());
-    EXPECT_THAT(imageNode->imageData, testing::ElementsAre(0xFF, 0x00, 0x00, 0xFF));
+    ASSERT_THAT(imageNode->imageData, NotNull());
+    EXPECT_THAT(*imageNode->imageData, testing::ElementsAre(0xFF, 0x00, 0x00, 0xFF));
     EXPECT_EQ(imageNode->imageWidth, 1);
     EXPECT_EQ(imageNode->imageHeight, 1);
   }

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -738,6 +738,31 @@ TEST_F(FilterSystemTest, InheritedComputedFiltersShareOneAccountedImageAllocatio
   EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
 }
 
+TEST_F(FilterSystemTest, InheritedFilterFanoutDoesNotRescanSharedImagePixels) {
+  constexpr std::size_t kDerivedFilterCount = 256;
+  std::string source = R"(<svg xmlns="http://www.w3.org/2000/svg"><defs>
+    <filter id="base"><feImage id="image" href="image.png"/></filter>)";
+  for (std::size_t i = 0; i < kDerivedFilterCount; ++i) {
+    source += "<filter id='derived-" + std::to_string(i) + "' href='#base'/>";
+  }
+  source += "</defs></svg>";
+
+  auto document = ParseSVG(source);
+  auto imageElement = document.querySelector("#image");
+  ASSERT_TRUE(imageElement.has_value());
+  imageElement->entityHandle().emplace<LoadedImageComponent>(
+      ImageResource{std::vector<uint8_t>(4096, 0x7f), 1, 1024});
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  StyleSystem().computeAllStyles(document.registry(), sink);
+  filterSystem.instantiateAllComputedComponents(document.registry(), sink);
+
+  auto& budget = document.registry().ctx().get<ComputedFilterResourceBudget>();
+  EXPECT_EQ(budget.sharedImageMaterializations(), 1u);
+  EXPECT_EQ(budget.sharedImageComparedBytes(), 0u);
+  EXPECT_FALSE(budget.rejected());
+}
+
 TEST_F(FilterSystemTest, DestroyingComputedComponentReleasesStructuralFamilyReservation) {
   auto document = ParseSVG(R"(
     <svg xmlns="http://www.w3.org/2000/svg"><defs>

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -23,6 +23,7 @@
 #include "donner/svg/components/style/StyleSystem.h"
 #include "donner/svg/parser/SVGParser.h"
 
+using testing::ElementsAre;
 using testing::Gt;
 using testing::IsEmpty;
 using testing::Not;
@@ -626,6 +627,27 @@ TEST_F(FilterSystemTest, SharedImageReservationFollowsSharedAllocationLifetime) 
   EXPECT_TRUE(adoptedBudget.rejected());
   EXPECT_EQ(adoptedBudget.sharedImageMaterializations(), 0u);
   EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 0u);
+}
+
+TEST_F(FilterSystemTest, SharedImageIdentityTracksInPlacePixelChanges) {
+  auto family = std::make_shared<DocumentResourceFamilyBudget>();
+  ComputedFilterResourceBudget budget(family);
+  Registry registry;
+  const Entity source = registry.create();
+  std::vector<uint8_t> pixels = {0xff, 0, 0, 0xff};
+
+  auto first = budget.shareImage(source, pixels);
+  ASSERT_THAT(first, NotNull());
+  EXPECT_THAT(*first, ElementsAre(0xff, 0, 0, 0xff));
+
+  pixels[0] = 0;
+  pixels[1] = 0xff;
+  auto second = budget.shareImage(source, pixels);
+  ASSERT_THAT(second, NotNull());
+  EXPECT_NE(first.get(), second.get());
+  EXPECT_THAT(*first, ElementsAre(0xff, 0, 0, 0xff));
+  EXPECT_THAT(*second, ElementsAre(0, 0xff, 0, 0xff));
+  EXPECT_EQ(budget.sharedImageMaterializations(), 2u);
 }
 
 TEST_F(FilterSystemTest, SharedImageBudgetRejectsBeforeMaterializingPixels) {

--- a/donner/svg/components/resources/ImageComponent.h
+++ b/donner/svg/components/resources/ImageComponent.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <atomic>
+#include <cstdint>
 #include <optional>
 
 #include "donner/base/RcString.h"
@@ -23,10 +25,25 @@ struct ImageComponent {
  * raster image (PNG, JPEG, GIF).
  */
 struct LoadedImageComponent {
-  LoadedImageComponent() = default;
-  explicit LoadedImageComponent(ImageResource loadedImage) : image(std::move(loadedImage)) {}
+  LoadedImageComponent() : revision_(NextRevision()) {}
+  explicit LoadedImageComponent(ImageResource loadedImage)
+      : image(std::move(loadedImage)), revision_(NextRevision()) {}
+
+  /// Monotonic identity for the current decoded image payload.
+  std::uint64_t revision() const { return revision_; }
+
+  /// Mark a direct mutation of the decoded image payload.
+  void markImageModified() { revision_ = NextRevision(); }
 
   std::optional<ImageResource> image;  //!< Loaded image resource.
+
+private:
+  static std::uint64_t NextRevision() {
+    static std::atomic<std::uint64_t> nextRevision{1};
+    return nextRevision.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  std::uint64_t revision_ = 0;
 };
 
 /**

--- a/donner/svg/components/tests/DocumentResourceFamilyBudget_fuzzer.cc
+++ b/donner/svg/components/tests/DocumentResourceFamilyBudget_fuzzer.cc
@@ -22,6 +22,7 @@ DocumentResourceFamilyBudget::Limits MakeLimits(std::size_t perKindBytes, std::s
   return DocumentResourceFamilyBudget::Limits{
       .parsedPayloadBytes = perKindBytes,
       .geometryBytes = perKindBytes,
+      .computedFilterBytes = perKindBytes,
       .computedStyleBytes = perKindBytes,
       .maximumTotalRetainedBytes = totalBytes,
   };

--- a/donner/svg/components/tests/DocumentResourceFamilyBudget_tests.cc
+++ b/donner/svg/components/tests/DocumentResourceFamilyBudget_tests.cc
@@ -17,6 +17,7 @@ DocumentResourceFamilyBudget::Limits MakeLimits(std::size_t perKindBytes, std::s
   return DocumentResourceFamilyBudget::Limits{
       .parsedPayloadBytes = perKindBytes,
       .geometryBytes = perKindBytes,
+      .computedFilterBytes = perKindBytes,
       .computedStyleBytes = perKindBytes,
       .maximumTotalRetainedBytes = totalBytes,
   };
@@ -35,16 +36,17 @@ TEST(DocumentResourceFamilyBudgetTest, DefaultPreservesTwoFullCategoryReservatio
 }
 
 TEST(DocumentResourceFamilyBudgetTest, EnforcesAggregateBoundaryAcrossAllKinds) {
-  DocumentResourceFamilyBudget budget(MakeLimits(64, 57));
+  DocumentResourceFamilyBudget budget(MakeLimits(64, 76));
 
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ParsedPayload, 19), IsTrue());
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::Geometry, 19), IsTrue());
+  EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, 19), IsTrue());
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedStyle, 19), IsTrue());
-  EXPECT_EQ(budget.totalRetainedBytes(), 57u);
+  EXPECT_EQ(budget.totalRetainedBytes(), 76u);
 
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ParsedPayload, 1), IsFalse());
-  EXPECT_THAT(budget.securityStats().retainedBytes, ElementsAre(19, 19, 19));
-  EXPECT_EQ(budget.totalRetainedBytes(), 57u);
+  EXPECT_THAT(budget.securityStats().retainedBytes, ElementsAre(19, 19, 19, 19));
+  EXPECT_EQ(budget.totalRetainedBytes(), 76u);
   EXPECT_EQ(budget.securityStats().rejectedReservations, 1u);
   EXPECT_THAT(budget.securityStats().rejected, IsTrue());
 }
@@ -54,7 +56,7 @@ TEST(DocumentResourceFamilyBudgetTest, RejectionIsAtomicAndLatches) {
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ParsedPayload, 30), IsTrue());
 
   EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::Geometry, 21), IsFalse());
-  EXPECT_THAT(budget.securityStats().retainedBytes, ElementsAre(30, 0, 0));
+  EXPECT_THAT(budget.securityStats().retainedBytes, ElementsAre(30, 0, 0, 0));
   EXPECT_EQ(budget.totalRetainedBytes(), 30u);
 
   budget.release(DocumentResourceFamilyBudget::Kind::ParsedPayload, 30);
@@ -66,10 +68,10 @@ TEST(DocumentResourceFamilyBudgetTest, RejectionIsAtomicAndLatches) {
 
 TEST(DocumentResourceFamilyBudgetTest, RejectsPerKindBoundaryWithoutChargingTotal) {
   DocumentResourceFamilyBudget budget(MakeLimits(10, 100));
-  EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedStyle, 10), IsTrue());
+  EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, 10), IsTrue());
 
-  EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedStyle, 1), IsFalse());
-  EXPECT_EQ(budget.retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedStyle), 10u);
+  EXPECT_THAT(budget.reserve(DocumentResourceFamilyBudget::Kind::ComputedFilter, 1), IsFalse());
+  EXPECT_EQ(budget.retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedFilter), 10u);
   EXPECT_EQ(budget.totalRetainedBytes(), 10u);
 }
 

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <entt/entity/fwd.hpp>  // entt::type_list, entt::type_list_element
 #include <limits>
 #include <string>
@@ -73,6 +74,14 @@ std::optional<double> ParseNumberNoSuffix(std::string_view str) {
   } else {
     return std::nullopt;
   }
+}
+
+std::optional<int> CheckedInteger(double value, int minimum, int maximum) {
+  if (!std::isfinite(value) || value < static_cast<double>(minimum) ||
+      value > static_cast<double>(maximum)) {
+    return std::nullopt;
+  }
+  return static_cast<int>(value);
 }
 
 std::optional<Lengthd> ParseLengthAttribute(SVGParserContext& context, std::string_view value) {
@@ -1299,8 +1308,12 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFEConvolveMatrixElement>(
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
     const auto firstNumber = donner::parser::NumberParser::Parse(value);
     if (firstNumber.hasResult()) {
-      int orderX = static_cast<int>(firstNumber.result().number);
-      int orderY = orderX;
+      const std::optional<int> orderX =
+          CheckedInteger(firstNumber.result().number, 1, components::kMaximumFilterConvolveOrder);
+      if (!orderX.has_value()) {
+        return std::nullopt;
+      }
+      int orderY = *orderX;
       std::string_view remaining = value.substr(firstNumber.result().consumedChars);
       while (!remaining.empty() && (remaining.front() == ' ' || remaining.front() == ',')) {
         remaining.remove_prefix(1);
@@ -1308,10 +1321,12 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFEConvolveMatrixElement>(
       if (!remaining.empty()) {
         const auto secondNumber = donner::parser::NumberParser::Parse(remaining);
         if (secondNumber.hasResult()) {
-          orderY = static_cast<int>(secondNumber.result().number);
+          orderY = CheckedInteger(secondNumber.result().number, 1,
+                                  components::kMaximumFilterConvolveOrder)
+                       .value_or(orderY);
         }
       }
-      comp.orderX = orderX;
+      comp.orderX = *orderX;
       comp.orderY = orderY;
     }
   } else if (name == XMLQualifiedNameRef("kernelMatrix")) {
@@ -1351,13 +1366,15 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFEConvolveMatrixElement>(
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
     const auto maybeNumber = donner::parser::NumberParser::Parse(value);
     if (maybeNumber.hasResult()) {
-      comp.targetX = static_cast<int>(maybeNumber.result().number);
+      comp.targetX = CheckedInteger(maybeNumber.result().number, 0,
+                                    components::kMaximumFilterConvolveOrder - 1);
     }
   } else if (name == XMLQualifiedNameRef("targetY")) {
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
     const auto maybeNumber = donner::parser::NumberParser::Parse(value);
     if (maybeNumber.hasResult()) {
-      comp.targetY = static_cast<int>(maybeNumber.result().number);
+      comp.targetY = CheckedInteger(maybeNumber.result().number, 0,
+                                    components::kMaximumFilterConvolveOrder - 1);
     }
   } else if (name == XMLQualifiedNameRef("edgeMode")) {
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
@@ -1406,7 +1423,8 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFETurbulenceElement>(
   } else if (name == XMLQualifiedNameRef("numOctaves")) {
     auto& comp = element.entityHandle().get<components::FETurbulenceComponent>();
     if (auto maybeNumber = ParseNumberNoSuffix(value)) {
-      comp.numOctaves = static_cast<int>(*maybeNumber);
+      comp.numOctaves = CheckedInteger(*maybeNumber, 1, components::kMaximumFilterTurbulenceOctaves)
+                            .value_or(comp.numOctaves);
     }
   } else if (name == XMLQualifiedNameRef("seed")) {
     auto& comp = element.entityHandle().get<components::FETurbulenceComponent>();

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -1366,15 +1366,15 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFEConvolveMatrixElement>(
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
     const auto maybeNumber = donner::parser::NumberParser::Parse(value);
     if (maybeNumber.hasResult()) {
-      comp.targetX = CheckedInteger(maybeNumber.result().number, 0,
-                                    components::kMaximumFilterConvolveOrder - 1);
+      comp.targetX = CheckedInteger(maybeNumber.result().number, std::numeric_limits<int>::min(),
+                                    std::numeric_limits<int>::max());
     }
   } else if (name == XMLQualifiedNameRef("targetY")) {
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
     const auto maybeNumber = donner::parser::NumberParser::Parse(value);
     if (maybeNumber.hasResult()) {
-      comp.targetY = CheckedInteger(maybeNumber.result().number, 0,
-                                    components::kMaximumFilterConvolveOrder - 1);
+      comp.targetY = CheckedInteger(maybeNumber.result().number, std::numeric_limits<int>::min(),
+                                    std::numeric_limits<int>::max());
     }
   } else if (name == XMLQualifiedNameRef("edgeMode")) {
     auto& comp = element.entityHandle().get<components::FEConvolveMatrixComponent>();
@@ -1423,7 +1423,8 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGFETurbulenceElement>(
   } else if (name == XMLQualifiedNameRef("numOctaves")) {
     auto& comp = element.entityHandle().get<components::FETurbulenceComponent>();
     if (auto maybeNumber = ParseNumberNoSuffix(value)) {
-      comp.numOctaves = CheckedInteger(*maybeNumber, 1, components::kMaximumFilterTurbulenceOctaves)
+      comp.numOctaves = CheckedInteger(*maybeNumber, std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::max())
                             .value_or(comp.numOctaves);
     }
   } else if (name == XMLQualifiedNameRef("seed")) {

--- a/donner/svg/parser/tests/AttributeParser_tests.cc
+++ b/donner/svg/parser/tests/AttributeParser_tests.cc
@@ -1933,10 +1933,10 @@ TEST(AttributeParserTest, LengthTrailingDataWarnsAndKeepsDefault) {
   EXPECT_EQ(mask.width(), std::nullopt);
   EXPECT_EQ(mask.height(), std::nullopt);
 
-  EXPECT_THAT(warningSink.warnings(),
-              testing::Contains(
-                  testing::Field(&ParseDiagnostic::reason,
-                                 testing::HasSubstr("Unexpected data at end of attribute"))));
+  EXPECT_THAT(
+      warningSink.warnings(),
+      testing::Contains(testing::Field(&ParseDiagnostic::reason,
+                                       testing::HasSubstr("Unexpected data at end of attribute"))));
 }
 
 TEST(AttributeParserTest, MarkerOrientTrailingDataAndInvalidLengths) {
@@ -1964,10 +1964,10 @@ TEST(AttributeParserTest, MarkerOrientTrailingDataAndInvalidLengths) {
   EXPECT_THAT(marker.refX(), LengthIs(DoubleNear(0.0, 0.001), Lengthd::Unit::None));
   EXPECT_THAT(marker.refY(), LengthIs(DoubleNear(0.0, 0.001), Lengthd::Unit::None));
 
-  EXPECT_THAT(warningSink.warnings(),
-              testing::Contains(
-                  testing::Field(&ParseDiagnostic::reason,
-                                 testing::HasSubstr("Unexpected data after angle value"))));
+  EXPECT_THAT(
+      warningSink.warnings(),
+      testing::Contains(testing::Field(&ParseDiagnostic::reason,
+                                       testing::HasSubstr("Unexpected data after angle value"))));
 }
 
 TEST(AttributeParserTest, ImageInvalidPreserveAspectRatioKeepsDefault) {
@@ -1984,9 +1984,8 @@ TEST(AttributeParserTest, ImageInvalidPreserveAspectRatioKeepsDefault) {
   auto image = QueryElement<SVGImageElement>(document, "#img");
   EXPECT_EQ(image.preserveAspectRatio(), PreserveAspectRatio());
 
-  EXPECT_THAT(warningSink.warnings(),
-              testing::Contains(testing::Field(&ParseDiagnostic::reason,
-                                               testing::HasSubstr("align"))));
+  EXPECT_THAT(warningSink.warnings(), testing::Contains(testing::Field(
+                                          &ParseDiagnostic::reason, testing::HasSubstr("align"))));
 }
 
 // --- Filter enum and separator edge cases ---
@@ -2202,6 +2201,25 @@ TEST(AttributeParserTest, RotateListTrailingCommaWarnsAndKeepsParsedValues) {
               testing::Contains(testing::Field(&ParseDiagnostic::reason,
                                                testing::HasSubstr("Unexpected trailing comma")))
                   .Times(4));
+}
+
+TEST(AttributeParserTest, FilterIntegerAttributesRejectNonFiniteNumbers) {
+  auto document = ParseSVGExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <filter>
+        <feConvolveMatrix id="conv" order="1e20 -1e20"
+                          targetX="1e20" targetY="-1e20"/>
+        <feTurbulence id="turb" numOctaves="1e20"/>
+      </filter>
+    </svg>
+  )");
+
+  const auto& convolve = QueryComponent<components::FEConvolveMatrixComponent>(document, "#conv");
+  EXPECT_EQ(convolve.orderX, 3);
+  EXPECT_EQ(convolve.orderY, 3);
+  EXPECT_EQ(convolve.targetX, std::nullopt);
+  EXPECT_EQ(convolve.targetY, std::nullopt);
+  EXPECT_EQ(QueryComponent<components::FETurbulenceComponent>(document, "#turb").numOctaves, 1);
 }
 
 }  // namespace donner::svg::parser

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -196,6 +196,7 @@ donner_perf_sensitive_cc_library(
         "//donner/base",
         "//donner/svg",
         "//donner/svg/components:attached_id_lookup",
+        "//donner/svg/components/filter:computed_filter_resource_budget",
         "//donner/svg/renderer/common",
     ] + select({
         ":text_enabled": ["//donner/svg/text:text_engine"],

--- a/donner/svg/renderer/FilterGraphExecutor.cc
+++ b/donner/svg/renderer/FilterGraphExecutor.cc
@@ -17,6 +17,40 @@ namespace donner::svg {
 
 namespace {
 
+double BoundedPositiveFilterPixels(double value) {
+  if (!std::isfinite(value) || value <= 0.0) {
+    return 0.0;
+  }
+  return std::min(value, static_cast<double>(components::kMaximumFilterPixelRadius));
+}
+
+int BoundedRoundedFilterPixels(double value, int magnitudeLimit) {
+  if (!std::isfinite(value)) {
+    return 0;
+  }
+  const double bounded =
+      std::clamp(value, -static_cast<double>(magnitudeLimit), static_cast<double>(magnitudeLimit));
+  return static_cast<int>(std::round(bounded));
+}
+
+double BoundedPixelEdge(double value, double minimum, double maximum) {
+  if (std::isnan(value)) {
+    return minimum;
+  }
+  return std::clamp(value, minimum, maximum);
+}
+
+tiny_skia::filter::PixelRect BoundedPixelRect(const Box2d& box, int width, int height) {
+  const double minimum = -static_cast<double>(components::kMaximumFilterPixelOffset);
+  const double maximumX = static_cast<double>(width + components::kMaximumFilterPixelOffset);
+  const double maximumY = static_cast<double>(height + components::kMaximumFilterPixelOffset);
+  const double x0 = BoundedPixelEdge(box.topLeft.x, minimum, maximumX);
+  const double y0 = BoundedPixelEdge(box.topLeft.y, minimum, maximumY);
+  const double x1 = BoundedPixelEdge(box.bottomRight.x, minimum, maximumX);
+  const double y1 = BoundedPixelEdge(box.bottomRight.y, minimum, maximumY);
+  return tiny_skia::filter::PixelRect{x0, y0, std::max(0.0, x1 - x0), std::max(0.0, y1 - y0)};
+}
+
 namespace fp = components::filter_primitive;
 namespace gp = tiny_skia::filter::graph_primitive;
 
@@ -246,9 +280,13 @@ tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::GaussianBlur& primi
                                                    const PrimitiveConversionState& state) {
   gp::GaussianBlur blur;
   blur.sigmaX =
-      primitive.stdDeviationX >= 0 ? state.context.primitiveToPixelX(primitive.stdDeviationX) : 0.0;
+      primitive.stdDeviationX >= 0
+          ? BoundedPositiveFilterPixels(state.context.primitiveToPixelX(primitive.stdDeviationX))
+          : 0.0;
   blur.sigmaY =
-      primitive.stdDeviationY >= 0 ? state.context.primitiveToPixelY(primitive.stdDeviationY) : 0.0;
+      primitive.stdDeviationY >= 0
+          ? BoundedPositiveFilterPixels(state.context.primitiveToPixelY(primitive.stdDeviationY))
+          : 0.0;
   blur.edgeMode = static_cast<tiny_skia::filter::BlurEdgeMode>(primitive.edgeMode);
   return blur;
 }
@@ -262,8 +300,10 @@ tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::Flood& primitive,
 tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::Offset& primitive,
                                                    const PrimitiveConversionState& state) {
   const Vector2d offset = state.context.primitiveToPixelOffset(primitive.dx, primitive.dy);
-  return gp::Offset{static_cast<int>(std::lround(offset.x)),
-                    static_cast<int>(std::lround(offset.y))};
+  return gp::Offset{
+      BoundedRoundedFilterPixels(offset.x, components::kMaximumFilterPixelOffset),
+      BoundedRoundedFilterPixels(offset.y, components::kMaximumFilterPixelOffset),
+  };
 }
 
 tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::Composite& primitive,
@@ -345,12 +385,16 @@ tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::DropShadow& primiti
   dropShadow.g = color.g;
   dropShadow.b = color.b;
   dropShadow.a = color.a;
-  dropShadow.dx = static_cast<int>(std::lround(offset.x));
-  dropShadow.dy = static_cast<int>(std::lround(offset.y));
+  dropShadow.dx = BoundedRoundedFilterPixels(offset.x, components::kMaximumFilterPixelOffset);
+  dropShadow.dy = BoundedRoundedFilterPixels(offset.y, components::kMaximumFilterPixelOffset);
   dropShadow.sigmaX =
-      primitive.stdDeviationX >= 0 ? state.context.primitiveToPixelX(primitive.stdDeviationX) : 0.0;
+      primitive.stdDeviationX >= 0
+          ? BoundedPositiveFilterPixels(state.context.primitiveToPixelX(primitive.stdDeviationX))
+          : 0.0;
   dropShadow.sigmaY =
-      primitive.stdDeviationY >= 0 ? state.context.primitiveToPixelY(primitive.stdDeviationY) : 0.0;
+      primitive.stdDeviationY >= 0
+          ? BoundedPositiveFilterPixels(state.context.primitiveToPixelY(primitive.stdDeviationY))
+          : 0.0;
   return dropShadow;
 }
 
@@ -365,10 +409,10 @@ tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::Morphology& primiti
     morphology.op = primitive.op == fp::Morphology::Operator::Erode
                         ? tiny_skia::filter::MorphologyOp::Erode
                         : tiny_skia::filter::MorphologyOp::Dilate;
-    morphology.radiusX =
-        static_cast<int>(std::round(state.context.primitiveToPixelX(primitive.radiusX)));
-    morphology.radiusY =
-        static_cast<int>(std::round(state.context.primitiveToPixelY(primitive.radiusY)));
+    morphology.radiusX = BoundedRoundedFilterPixels(
+        state.context.primitiveToPixelX(primitive.radiusX), components::kMaximumFilterPixelRadius);
+    morphology.radiusY = BoundedRoundedFilterPixels(
+        state.context.primitiveToPixelY(primitive.radiusY), components::kMaximumFilterPixelRadius);
   }
   return morphology;
 }
@@ -567,11 +611,14 @@ tiny_skia::filter::GraphPrimitive ConvertPrimitive(const fp::Image& primitive,
                                                    const PrimitiveConversionState& state) {
   gp::Image image;
   image.sampling = ConvertImageSampling(primitive.imageRendering);
-  if (!HasExactRgbaPayload(primitive.imageData, primitive.imageWidth, primitive.imageHeight)) {
+  const std::span<const uint8_t> imageData = primitive.imageData
+                                                 ? std::span<const uint8_t>(*primitive.imageData)
+                                                 : std::span<const uint8_t>();
+  if (!HasExactRgbaPayload(imageData, primitive.imageWidth, primitive.imageHeight)) {
     return image;
   }
 
-  const std::vector<std::uint8_t> premultiplied = PremultiplyRgba(primitive.imageData);
+  const std::vector<std::uint8_t> premultiplied = PremultiplyRgba(imageData);
   if (primitive.isFragmentReference && state.graph.filterFromDevice.has_value()) {
     PopulateTransformedFragmentImage(image, primitive, state, premultiplied);
   } else if (primitive.isFragmentReference) {
@@ -640,10 +687,7 @@ tiny_skia::filter::FilterGraph CreateExecutableGraph(const FilterConversionConte
 
   if (context.filterRegion.has_value()) {
     const Box2d pixelRegion = context.deviceFromFilter.transformBox(*context.filterRegion);
-    graph.filterRegion =
-        tiny_skia::filter::PixelRect{pixelRegion.topLeft.x, pixelRegion.topLeft.y,
-                                     pixelRegion.bottomRight.x - pixelRegion.topLeft.x,
-                                     pixelRegion.bottomRight.y - pixelRegion.topLeft.y};
+    graph.filterRegion = BoundedPixelRect(pixelRegion, context.outputWidth, context.outputHeight);
   }
 
   const bool hasRotation = !NearZero(context.deviceFromFilter.data[1], 1e-6) ||
@@ -686,10 +730,7 @@ void PopulateSubregion(const components::FilterNode& node, const FilterConversio
 
   const Box2d pixelRegion =
       context.deviceFromFilter.transformBox(Box2d::FromXYWH(userX, userY, userWidth, userHeight));
-  graphNode.subregion =
-      tiny_skia::filter::PixelRect{pixelRegion.topLeft.x, pixelRegion.topLeft.y,
-                                   pixelRegion.bottomRight.x - pixelRegion.topLeft.x,
-                                   pixelRegion.bottomRight.y - pixelRegion.topLeft.y};
+  graphNode.subregion = BoundedPixelRect(pixelRegion, context.outputWidth, context.outputHeight);
   if (graph.filterFromDevice.has_value()) {
     graphNode.userSpaceSubregion =
         tiny_skia::filter::PixelRect{userX, userY, userWidth, userHeight};
@@ -727,7 +768,20 @@ void ApplyFilterGraphToPixmap(tiny_skia::Pixmap& pixmap, const components::Filte
                               const std::optional<Box2d>& filterRegion,
                               bool clipSourceToFilterRegion,
                               const tiny_skia::Pixmap* fillPaintInput,
-                              const tiny_skia::Pixmap* strokePaintInput) {
+                              const tiny_skia::Pixmap* strokePaintInput,
+                              components::FilterExecutionBudget* executionBudget) {
+  const std::uint64_t width = pixmap.width();
+  const std::uint64_t height = pixmap.height();
+  const std::uint64_t pixelCount = width * height;
+  const bool fitsBudget =
+      executionBudget != nullptr
+          ? executionBudget->consume(filterGraph, pixelCount,
+                                     components::FilterMemoryModel::CpuFloatNamedResults)
+          : components::FilterGraphFitsExecutionBudget(
+                filterGraph, pixelCount, components::FilterMemoryModel::CpuFloatNamedResults);
+  if (!fitsBudget) {
+    return;
+  }
   const FilterConversionContext context(filterGraph, deviceFromFilter, filterRegion,
                                         static_cast<int>(pixmap.width()),
                                         static_cast<int>(pixmap.height()));
@@ -785,13 +839,19 @@ void ClipFilterOutputToRegion(tiny_skia::Pixmap& pixmap, const std::optional<Box
   // This is the same rule used by the non-axis-aligned path above. Convert each continuous edge to
   // the first integer pixel index whose center is on or beyond that edge. Clamp both sides so a
   // fully offscreen region collapses to an empty kept rectangle without an out-of-bounds clear.
-  const auto firstPixelAtOrBeyond = [](double edge) {
+  const auto firstPixelAtOrBeyond = [](double edge, int limit) {
+    if (std::isnan(edge) || edge <= 0.5) {
+      return 0;
+    }
+    if (!std::isfinite(edge) || edge >= static_cast<double>(limit) + 0.5) {
+      return limit;
+    }
     return static_cast<int>(std::ceil(edge - 0.5));
   };
-  const int x0 = std::clamp(firstPixelAtOrBeyond(pixelRegion.topLeft.x), 0, width);
-  const int y0 = std::clamp(firstPixelAtOrBeyond(pixelRegion.topLeft.y), 0, height);
-  const int x1 = std::clamp(firstPixelAtOrBeyond(pixelRegion.bottomRight.x), 0, width);
-  const int y1 = std::clamp(firstPixelAtOrBeyond(pixelRegion.bottomRight.y), 0, height);
+  const int x0 = firstPixelAtOrBeyond(pixelRegion.topLeft.x, width);
+  const int y0 = firstPixelAtOrBeyond(pixelRegion.topLeft.y, height);
+  const int x1 = firstPixelAtOrBeyond(pixelRegion.bottomRight.x, width);
+  const int y1 = firstPixelAtOrBeyond(pixelRegion.bottomRight.y, height);
 
   auto data = pixmap.data();
   for (int y = 0; y < y0; ++y) {

--- a/donner/svg/renderer/FilterGraphExecutor.h
+++ b/donner/svg/renderer/FilterGraphExecutor.h
@@ -25,13 +25,16 @@ namespace donner::svg {
  *   running the filter graph.
  * @param fillPaintInput Optional `FillPaint` input pixmap, or nullptr if unused.
  * @param strokePaintInput Optional `StrokePaint` input pixmap, or nullptr if unused.
+ * @param executionBudget Optional shared per-frame budget. Direct callers may omit it to apply
+ *   only the graph-local limit.
  */
 void ApplyFilterGraphToPixmap(tiny_skia::Pixmap& pixmap, const components::FilterGraph& filterGraph,
                               const Transform2d& deviceFromFilter,
                               const std::optional<Box2d>& filterRegion,
                               bool clipSourceToFilterRegion = false,
                               const tiny_skia::Pixmap* fillPaintInput = nullptr,
-                              const tiny_skia::Pixmap* strokePaintInput = nullptr);
+                              const tiny_skia::Pixmap* strokePaintInput = nullptr,
+                              components::FilterExecutionBudget* executionBudget = nullptr);
 
 /**
  * Clears pixels outside the transformed filter region.

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -646,6 +646,10 @@ void Renderer::setOffscreenCreationHookForTesting(std::function<void()> hook) {
   impl_->setOffscreenCreationHookForTesting(std::move(hook));
 }
 
+std::uint64_t Renderer::filterBudgetChunksForTesting() const {
+  return impl_->filterBudgetChunksForTesting();
+}
+
 void Renderer::setDebugGeometryOverlay(bool enabled) {
   impl_->setDebugGeometryOverlay(enabled);
 }

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -339,6 +339,9 @@ public:
   /// Forwards the test-only in-constructor hook to the active backend.
   void setOffscreenCreationHookForTesting(std::function<void()> hook) override;
 
+  /// Forwards filter-budget chunk diagnostics from the active backend.
+  [[nodiscard]] std::uint64_t filterBudgetChunksForTesting() const override;
+
   /// Forwards \ref RendererInterface::setDebugGeometryOverlay to the
   /// active backend (no-op for backends without a debug overlay).
   void setDebugGeometryOverlay(bool enabled) override;

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -25,6 +25,7 @@
 #include "donner/svg/components/RenderingBehaviorComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/SVGDocumentContext.h"
+#include "donner/svg/components/filter/ComputedFilterResourceBudget.h"
 #include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/layout/SizedElementComponent.h"
@@ -36,6 +37,7 @@
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #include "donner/svg/components/shadow/ComputedShadowTreeComponent.h"
 #include "donner/svg/components/shadow/ShadowBranch.h"
+#include "donner/svg/components/shadow/ShadowTreeComponent.h"
 #include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/components/shape/ShapeSystem.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
@@ -579,14 +581,130 @@ std::optional<Vector2i> resolveFeImageRenderSize(const components::FilterGraph& 
 
   const double widthUser = resolveSize(node.width, Lengthd::Extent::X);
   const double heightUser = resolveSize(node.height, Lengthd::Extent::Y);
-  if (widthUser <= 0.0 || heightUser <= 0.0) {
+  if (!std::isfinite(widthUser) || !std::isfinite(heightUser) || widthUser <= 0.0 ||
+      heightUser <= 0.0) {
     return std::nullopt;
   }
 
   const double scaleX = filterGraph.userToPixelScale.x > 0.0 ? filterGraph.userToPixelScale.x : 1.0;
   const double scaleY = filterGraph.userToPixelScale.y > 0.0 ? filterGraph.userToPixelScale.y : 1.0;
-  return Vector2i(std::max(1, static_cast<int>(std::ceil(widthUser * scaleX))),
-                  std::max(1, static_cast<int>(std::ceil(heightUser * scaleY))));
+  const double pixelWidth = widthUser * scaleX;
+  const double pixelHeight = heightUser * scaleY;
+  if (!std::isfinite(pixelWidth) || !std::isfinite(pixelHeight) || pixelWidth <= 0.0 ||
+      pixelHeight <= 0.0 || pixelWidth > components::kMaximumFilterSurfaceDimension ||
+      pixelHeight > components::kMaximumFilterSurfaceDimension ||
+      pixelWidth * pixelHeight > components::kMaximumFilterSurfacePixels) {
+    return std::nullopt;
+  }
+  return Vector2i(std::max(1, static_cast<int>(std::ceil(pixelWidth))),
+                  std::max(1, static_cast<int>(std::ceil(pixelHeight))));
+}
+
+std::optional<std::uint64_t> BoundedRgbaBytes(Vector2i size) {
+  if (size.x <= 0 || size.y <= 0 || size.x > components::kMaximumFilterSurfaceDimension ||
+      size.y > components::kMaximumFilterSurfaceDimension) {
+    return std::nullopt;
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(size.x) * static_cast<std::uint64_t>(size.y);
+  if (pixels > components::kMaximumFilterSurfacePixels) {
+    return std::nullopt;
+  }
+  return pixels * 4u;
+}
+
+bool HasCompleteSnapshotRows(const RendererBitmap& snapshot) {
+  if (snapshot.empty()) {
+    return false;
+  }
+  const std::size_t tightRowBytes = static_cast<std::size_t>(snapshot.dimensions.x) * 4u;
+  const std::size_t height = static_cast<std::size_t>(snapshot.dimensions.y);
+  return snapshot.rowBytes >= tightRowBytes && height <= snapshot.pixels.size() / snapshot.rowBytes;
+}
+
+components::ComputedFilterResourceBudget& GetDriverComputedFilterResourceBudget(
+    Registry& registry) {
+  if (!registry.ctx().contains<components::ComputedFilterResourceBudget>()) {
+    std::shared_ptr<components::DocumentResourceFamilyBudget> family;
+    if (const auto* context = registry.ctx().find<components::DocumentResourceFamilyContext>()) {
+      family = context->budget;
+    }
+    registry.ctx().emplace<components::ComputedFilterResourceBudget>(std::move(family));
+  }
+  return registry.ctx().get<components::ComputedFilterResourceBudget>();
+}
+
+std::optional<std::uint64_t> ExistingFilterImageBytes(const components::FilterGraph& filterGraph) {
+  std::uint64_t bytes = 0;
+  for (const components::FilterNode& node : filterGraph.nodes) {
+    const auto* image = std::get_if<components::filter_primitive::Image>(&node.primitive);
+    if (!image) {
+      continue;
+    }
+    const std::uint64_t imageBytes = static_cast<std::uint64_t>(image->imageDataSize());
+    if (imageBytes > RendererDriver::kMaximumPreparedFilterImageBytes - bytes) {
+      return std::nullopt;
+    }
+    bytes += imageBytes;
+  }
+  return bytes;
+}
+
+std::optional<std::size_t> BoundedShadowTreeEntityCount(Registry& registry, Entity root,
+                                                        std::size_t maximumCount) {
+  struct WorkItem {
+    Entity entity = entt::null;
+    bool leaving = false;
+  };
+
+  std::vector<WorkItem> stack = {{root, false}};
+  std::unordered_set<Entity> activeReferences;
+  std::size_t scheduledEntities = 1;
+  std::size_t count = 0;
+  while (!stack.empty()) {
+    const WorkItem work = stack.back();
+    stack.pop_back();
+    if (work.entity == entt::null) {
+      continue;
+    }
+    if (work.leaving) {
+      activeReferences.erase(work.entity);
+      continue;
+    }
+    if (!activeReferences.insert(work.entity).second) {
+      continue;
+    }
+    if (count >= maximumCount) {
+      return std::nullopt;
+    }
+    ++count;
+    stack.push_back({work.entity, true});
+
+    if (const auto* shadow = registry.try_get<components::ShadowTreeComponent>(work.entity)) {
+      if (const std::optional<ResolvedReference> target = shadow->mainTargetEntity(registry)) {
+        if (scheduledEntities >= maximumCount) {
+          return std::nullopt;
+        }
+        ++scheduledEntities;
+        stack.push_back({target->handle, false});
+      }
+      continue;
+    }
+
+    const auto* tree = registry.try_get<donner::components::TreeComponent>(work.entity);
+    if (!tree) {
+      continue;
+    }
+    for (Entity child = tree->lastChild(); child != entt::null;
+         child = registry.get<donner::components::TreeComponent>(child).previousSibling()) {
+      if (scheduledEntities >= maximumCount) {
+        return std::nullopt;
+      }
+      ++scheduledEntities;
+      stack.push_back({child, false});
+    }
+  }
+  return count;
 }
 
 std::optional<components::FilterGraph> resolveFilterGraph(
@@ -596,6 +714,9 @@ std::optional<components::FilterGraph> resolveFilterGraph(
     // Convert CSS filter functions to a FilterGraph.
     // CSS Filter Effects Level 1 §8: shorthand filter functions use sRGB color space for
     // interpolation, unlike SVG filter elements which default to linearRGB.
+    if (effects->size() > components::kMaximumFilterGraphNodes) {
+      return std::nullopt;
+    }
     components::FilterGraph graph;
     graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
     for (const FilterEffect& effect : *effects) {
@@ -743,6 +864,9 @@ std::optional<components::FilterGraph> resolveFilterGraph(
             }
           },
           effect.value);
+      if (graph.nodes.size() > components::kMaximumFilterGraphNodes) {
+        return std::nullopt;
+      }
     }
     return graph;
   }
@@ -935,8 +1059,100 @@ std::optional<ImageParams> toImageParams(const components::RenderingInstanceComp
 
 }  // namespace
 
-RendererDriver::RendererDriver(RendererInterface& renderer, bool verbose)
-    : renderer_(renderer), verbose_(verbose) {}
+bool RendererDriver::FilterPreparationBudget::beginGraph(SecurityStats* stats) {
+  if (rejected || attempts >= kMaximumPreparedFilterGraphs) {
+    rejected = true;
+    if (stats) {
+      stats->filterPreparationRejected = true;
+    }
+    return false;
+  }
+  ++attempts;
+  if (stats) {
+    stats->filterPreparationAttempts = attempts;
+  }
+  return true;
+}
+
+bool RendererDriver::FilterPreparationBudget::reserveNodes(std::size_t nodeCount,
+                                                           SecurityStats* stats) {
+  if (rejected || nodeCount > kMaximumPreparedFilterNodes - nodes) {
+    rejected = true;
+    if (stats) {
+      stats->filterPreparationRejected = true;
+    }
+    return false;
+  }
+  ++graphs;
+  nodes += nodeCount;
+  if (stats) {
+    stats->preparedFilterGraphs = graphs;
+    stats->preparedFilterNodes = nodes;
+  }
+  return true;
+}
+
+bool RendererDriver::FilterPreparationBudget::reserveImageBytes(std::uint64_t byteCount,
+                                                                SecurityStats* stats) {
+  if (rejected || byteCount > kMaximumPreparedFilterImageBytes - imageBytes) {
+    rejected = true;
+    if (stats) {
+      stats->filterPreparationRejected = true;
+    }
+    return false;
+  }
+  imageBytes += byteCount;
+  if (stats) {
+    stats->preparedFilterImageBytes = imageBytes;
+  }
+  return true;
+}
+
+bool RendererDriver::FilterPreparationBudget::reservePayloadBytes(std::uint64_t byteCount,
+                                                                  SecurityStats* stats) {
+  if (rejected || byteCount > kMaximumPreparedFilterPayloadBytes - payloadBytes) {
+    rejected = true;
+    if (stats) {
+      stats->filterPreparationRejected = true;
+    }
+    return false;
+  }
+  payloadBytes += byteCount;
+  if (stats) {
+    stats->preparedFilterPayloadBytes = payloadBytes;
+  }
+  return true;
+}
+
+bool RendererDriver::FilterPreparationBudget::reserveShadowEntities(std::size_t entityCount,
+                                                                    SecurityStats* stats) {
+  if (rejected || entityCount > kMaximumPreparedFilterShadowEntities - shadowEntities) {
+    rejected = true;
+    if (stats) {
+      stats->filterPreparationRejected = true;
+    }
+    return false;
+  }
+  shadowEntities += entityCount;
+  if (stats) {
+    stats->preparedFilterShadowEntities = shadowEntities;
+  }
+  return true;
+}
+
+RendererDriver::RendererDriver(RendererInterface& renderer, bool verbose,
+                               SecurityStats* securityStats)
+    : renderer_(renderer), verbose_(verbose), securityStats_(securityStats) {}
+
+void RendererDriver::resetOwnedFilterPreparationBudget() {
+  if (filterPreparationBudget_ != &ownedFilterPreparationBudget_) {
+    return;
+  }
+  ownedFilterPreparationBudget_ = {};
+  if (securityStats_) {
+    *securityStats_ = {};
+  }
+}
 
 void RendererDriver::draw(SVGDocument& document) {
   if (document.threadingMode() == ThreadingMode::ConcurrentDom) {
@@ -1069,6 +1285,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document) {
 
 void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderViewport& viewport,
                                           const Transform2d& surfaceFromCanvas) {
+  resetOwnedFilterPreparationBudget();
   renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1115,6 +1332,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderVie
 void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Entity lastEntity,
                                      const RenderViewport& viewport,
                                      const Transform2d& surfaceFromCanvas) {
+  resetOwnedFilterPreparationBudget();
   renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1130,6 +1348,7 @@ bool RendererDriver::drawEntityRangeInterruptibly(Registry& registry, Entity fir
                                                   Entity lastEntity, const RenderViewport& viewport,
                                                   const Transform2d& surfaceFromCanvas,
                                                   const std::function<bool()>& shouldCancel) {
+  resetOwnedFilterPreparationBudget();
   renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1633,21 +1852,85 @@ std::optional<Box2d> RendererDriver::preparedFilterRegionFor(Entity entity) cons
   return std::nullopt;
 }
 
+bool RendererDriver::reservePreparedFilterGraph(const components::FilterGraph& filterGraph) {
+  std::uint64_t payloadBytes = 0;
+  for (const components::FilterNode& node : filterGraph.nodes) {
+    const std::uint64_t nodeBytes = components::FilterPrimitivePayloadBytes(node.primitive);
+    if (nodeBytes > kMaximumPreparedFilterPayloadBytes - payloadBytes) {
+      return filterPreparationBudget_->reservePayloadBytes(kMaximumPreparedFilterPayloadBytes + 1,
+                                                           securityStats_);
+    }
+    payloadBytes += nodeBytes;
+  }
+  if (!filterPreparationBudget_->reservePayloadBytes(payloadBytes, securityStats_)) {
+    return false;
+  }
+  const std::optional<std::uint64_t> decodedImageBytes = ExistingFilterImageBytes(filterGraph);
+  if (!decodedImageBytes.has_value() ||
+      !filterPreparationBudget_->reserveImageBytes(*decodedImageBytes, securityStats_)) {
+    return false;
+  }
+  return filterPreparationBudget_->reserveNodes(filterGraph.nodes.size(), securityStats_);
+}
+
+std::optional<std::uint64_t> RendererDriver::reservePreparedFilterImage(Vector2i size) {
+  const std::optional<std::uint64_t> bytes = BoundedRgbaBytes(size);
+  if (!bytes.has_value() || !filterPreparationBudget_->reserveImageBytes(*bytes, securityStats_)) {
+    return std::nullopt;
+  }
+  return bytes;
+}
+
+bool RendererDriver::reservePreparedFilterShadowTree(Registry& registry, Entity targetEntity) {
+  const std::optional<std::size_t> entityCount =
+      BoundedShadowTreeEntityCount(registry, targetEntity, kMaximumPreparedFilterShadowEntities);
+  return entityCount.has_value() &&
+         filterPreparationBudget_->reserveShadowEntities(*entityCount, securityStats_);
+}
+
+std::shared_ptr<const std::vector<std::uint8_t>> RendererDriver::adoptPreparedFilterSnapshot(
+    RendererBitmap snapshot, std::uint64_t reservedBytes, Registry& registry) {
+  const std::optional<std::uint64_t> actualBytes = BoundedRgbaBytes(snapshot.dimensions);
+  if (!HasCompleteSnapshotRows(snapshot) || !actualBytes.has_value() ||
+      *actualBytes > reservedBytes) {
+    return nullptr;
+  }
+  const std::size_t tightRowBytes = static_cast<std::size_t>(snapshot.dimensions.x) * 4u;
+  if (snapshot.rowBytes == tightRowBytes) {
+    return GetDriverComputedFilterResourceBudget(registry).adoptImage(std::move(snapshot.pixels));
+  }
+  std::vector<uint8_t> tightPixels(tightRowBytes * snapshot.dimensions.y);
+  for (int y = 0; y < snapshot.dimensions.y; ++y) {
+    std::memcpy(tightPixels.data() + y * tightRowBytes,
+                snapshot.pixels.data() + y * snapshot.rowBytes, tightRowBytes);
+  }
+  return GetDriverComputedFilterResourceBudget(registry).adoptImage(std::move(tightPixels));
+}
+
+const components::RenderingInstanceComponent* RendererDriver::beginPreparingFilterEntity(
+    Registry& registry, Entity entity) {
+  const auto* instance = registry.try_get<components::RenderingInstanceComponent>(entity);
+  if (!instance || !instance->resolvedFilter.has_value()) {
+    return nullptr;
+  }
+  if (!filterPreparationBudget_->beginGraph(securityStats_)) {
+    return nullptr;
+  }
+  const auto& style = instance->styleHandle(registry).get<components::ComputedStyleComponent>();
+  return style.properties.has_value() ? instance : nullptr;
+}
+
 void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Entity> entities) {
   // Iterate a caller-provided snapshot of entity IDs so that mid-loop storage mutation (from
   // `createFeImageShadowTree` inside `preRenderFeImageFragments`) cannot invalidate the iteration.
   // Each iteration re-reads the component from storage via `storage.get(entity)`, so references
   // are re-bound after any previous iteration's mutation.
-  auto& storage = registry.storage<components::RenderingInstanceComponent>();
   for (const Entity entity : entities) {
-    const auto* instance = storage.contains(entity) ? &storage.get(entity) : nullptr;
-    if (!instance || !instance->resolvedFilter.has_value()) {
+    const auto* instance = beginPreparingFilterEntity(registry, entity);
+    if (!instance) {
       continue;
     }
     const auto& style = instance->styleHandle(registry).get<components::ComputedStyleComponent>();
-    if (!style.properties.has_value()) {
-      continue;
-    }
 
     const Box2d filterViewBox =
         components::LayoutSystem().getViewBox(instance->dataHandle(registry));
@@ -1663,6 +1946,9 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
         computeFilterRegion(registry, instance->resolvedFilter.value(), *instance);
 
     if (filterGraph.has_value()) {
+      if (!reservePreparedFilterGraph(*filterGraph)) {
+        continue;
+      }
       filterGraph->filterRegion = filterRegion;
       if (filterGraph->primitiveUnits == PrimitiveUnits::ObjectBoundingBox) {
         filterGraph->elementBoundingBox =
@@ -1677,7 +1963,7 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
         // These calls may mutate `RenderingInstanceComponent` storage (shadow-tree creation +
         // global sort inside `createFeImageShadowTree`). We do NOT hold the `instance` reference
         // across them - the next iteration of this loop re-fetches via `storage.get(entity)`.
-        preRenderSvgFeImages(*filterGraph);
+        preRenderSvgFeImages(*filterGraph, registry);
         preRenderFeImageFragments(*filterGraph, registry, entity, filterRegion);
       }
     }
@@ -2898,16 +3184,22 @@ void RendererDriver::clearSubDocumentContextPaint(SVGDocument& subDocument) {
   }
 }
 
-void RendererDriver::preRenderSvgFeImages(components::FilterGraph& filterGraph) {
+void RendererDriver::preRenderSvgFeImages(components::FilterGraph& filterGraph,
+                                          Registry& registry) {
   for (auto& node : filterGraph.nodes) {
     auto* imageNode = std::get_if<components::filter_primitive::Image>(&node.primitive);
-    if (!imageNode || !imageNode->svgSubDocument || !imageNode->imageData.empty()) {
+    if (!imageNode || !imageNode->svgSubDocument || imageNode->hasImageData()) {
       continue;
     }
 
     SVGDocument subDoc = SVGDocument::CreateFromHandle(imageNode->svgSubDocument);
     const std::optional<Vector2i> renderSize = resolveFeImageRenderSize(filterGraph, node);
     const Vector2i targetSize = renderSize.value_or(subDoc.canvasSize());
+    const std::optional<std::uint64_t> imageBytes = reservePreparedFilterImage(targetSize);
+    if (!imageBytes.has_value()) {
+      imageNode->svgSubDocument.reset();
+      continue;
+    }
 
     // Create an independent offscreen renderer to render the sub-document.
     auto offscreen = renderer_.createOffscreenInstance();
@@ -2925,32 +3217,19 @@ void RendererDriver::preRenderSvgFeImages(components::FilterGraph& filterGraph) 
 
     RendererDriver subDriver(*offscreen, verbose_);
     subDriver.renderingSize_ = targetSize;
+    subDriver.filterPreparationBudget_ = filterPreparationBudget_;
+    subDriver.securityStats_ = securityStats_;
     subDriver.drawSubDocument(subDoc, Box2d::FromXYWH(0.0, 0.0, targetSize.x, targetSize.y),
                               imageNode->preserveAspectRatio, 1.0, Transform2d());
     offscreen->endFrame();
 
-    // Determine the rendered size from the sub-document's canvas size.
-    if (targetSize.x <= 0 || targetSize.y <= 0) {
-      continue;
-    }
-
     // Capture the rendered pixels.
     RendererBitmap snapshot = offscreen->takeSnapshot();
-    if (!snapshot.empty()) {
-      imageNode->imageWidth = snapshot.dimensions.x;
-      imageNode->imageHeight = snapshot.dimensions.y;
-
-      // The snapshot may have row padding. Convert to tightly packed RGBA.
-      const size_t tightRowBytes = static_cast<size_t>(snapshot.dimensions.x) * 4;
-      if (snapshot.rowBytes == tightRowBytes) {
-        imageNode->imageData = std::move(snapshot.pixels);
-      } else {
-        imageNode->imageData.resize(tightRowBytes * snapshot.dimensions.y);
-        for (int y = 0; y < snapshot.dimensions.y; ++y) {
-          std::memcpy(imageNode->imageData.data() + y * tightRowBytes,
-                      snapshot.pixels.data() + y * snapshot.rowBytes, tightRowBytes);
-        }
-      }
+    const Vector2i snapshotDimensions = snapshot.dimensions;
+    imageNode->imageData = adoptPreparedFilterSnapshot(std::move(snapshot), *imageBytes, registry);
+    if (imageNode->imageData) {
+      imageNode->imageWidth = snapshotDimensions.x;
+      imageNode->imageHeight = snapshotDimensions.y;
     }
 
     // Clear the sub-document pointer since we've now rendered to pixels.
@@ -2980,7 +3259,7 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     }
     for (auto& node : filterGraph.nodes) {
       if (auto* imageNode = std::get_if<components::filter_primitive::Image>(&node.primitive);
-          imageNode && !imageNode->fragmentId.empty() && imageNode->imageData.empty()) {
+          imageNode && !imageNode->fragmentId.empty() && !imageNode->hasImageData()) {
         imageNode->fragmentId = RcString();
       }
     }
@@ -2992,7 +3271,7 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
 
   for (auto& node : filterGraph.nodes) {
     auto* imageNode = std::get_if<components::filter_primitive::Image>(&node.primitive);
-    if (!imageNode || imageNode->fragmentId.empty() || !imageNode->imageData.empty()) {
+    if (!imageNode || imageNode->fragmentId.empty() || imageNode->hasImageData()) {
       continue;
     }
 
@@ -3018,6 +3297,12 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
       continue;
     }
 
+    const std::optional<std::uint64_t> imageBytes = reservePreparedFilterImage(renderingSize_);
+    if (!imageBytes.has_value()) {
+      imageNode->fragmentId = RcString();
+      continue;
+    }
+
     // Create an offscreen renderer at the same canvas size.
     auto offscreen = renderer_.createOffscreenInstance();
     if (!offscreen) {
@@ -3038,6 +3323,11 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     // to render the target subtree offscreen.
     std::optional<components::RenderingContext::FeImageSubtreeResult> shadowResult;
     if (targetInstance == nullptr) {
+      if (!reservePreparedFilterShadowTree(registry, targetEntity)) {
+        feImageFragmentGuard_->erase(entityId);
+        imageNode->fragmentId = RcString();
+        continue;
+      }
       if (!registry.ctx().contains<components::RenderingContext>()) {
         registry.ctx().emplace<components::RenderingContext>(registry);
       }
@@ -3074,6 +3364,8 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     subDriver.renderingSize_ = renderingSize_;
     subDriver.feImageFragmentGuard_ = feImageFragmentGuard_;
     subDriver.feImageFragmentDepth_ = feImageFragmentDepth_ + 1;
+    subDriver.filterPreparationBudget_ = filterPreparationBudget_;
+    subDriver.securityStats_ = securityStats_;
 
     // The fragment is rendered at its natural position in the document coordinate system
     // (no surfaceFromCanvasTransform_ offset). The filter pipeline applies a device-space
@@ -3114,21 +3406,11 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
 
     // Capture the rendered pixels.
     RendererBitmap snapshot = offscreen->takeSnapshot();
-    if (!snapshot.empty()) {
-      imageNode->imageWidth = snapshot.dimensions.x;
-      imageNode->imageHeight = snapshot.dimensions.y;
-
-      // Convert to tightly packed RGBA.
-      const size_t tightRowBytes = static_cast<size_t>(snapshot.dimensions.x) * 4;
-      if (snapshot.rowBytes == tightRowBytes) {
-        imageNode->imageData = std::move(snapshot.pixels);
-      } else {
-        imageNode->imageData.resize(tightRowBytes * snapshot.dimensions.y);
-        for (int y = 0; y < snapshot.dimensions.y; ++y) {
-          std::memcpy(imageNode->imageData.data() + y * tightRowBytes,
-                      snapshot.pixels.data() + y * snapshot.rowBytes, tightRowBytes);
-        }
-      }
+    const Vector2i snapshotDimensions = snapshot.dimensions;
+    imageNode->imageData = adoptPreparedFilterSnapshot(std::move(snapshot), *imageBytes, registry);
+    if (imageNode->imageData) {
+      imageNode->imageWidth = snapshotDimensions.x;
+      imageNode->imageHeight = snapshotDimensions.y;
     }
 
     // Remove from recursion guard after rendering.

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -1,11 +1,14 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <span>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/components/filter/FilterGraph.h"
@@ -25,11 +28,36 @@ namespace donner::svg {
  */
 class RendererDriver {
 public:
+  /// Aggregate limits for per-instance filter graph preparation and feImage snapshots.
+  static constexpr std::size_t kMaximumPreparedFilterGraphs =
+      components::FilterExecutionBudget::kMaximumExecutions;
+  static constexpr std::size_t kMaximumPreparedFilterNodes =
+      kMaximumPreparedFilterGraphs * components::kMaximumFilterGraphNodes;
+  static constexpr std::uint64_t kMaximumPreparedFilterImageBytes = 4ULL * 1024 * 1024;
+  static constexpr std::uint64_t kMaximumPreparedFilterPayloadBytes = 16ULL * 1024 * 1024;
+  static constexpr std::size_t kMaximumPreparedFilterShadowEntities = 4096;
+
+  /// Optional diagnostics for structured fuzzers and embedders auditing rejected preparation.
+  struct SecurityStats {
+    std::size_t filterPreparationAttempts = 0;
+    std::size_t preparedFilterGraphs = 0;
+    std::size_t preparedFilterNodes = 0;
+    std::uint64_t preparedFilterImageBytes = 0;
+    std::uint64_t preparedFilterPayloadBytes = 0;
+    std::size_t preparedFilterShadowEntities = 0;
+    bool filterPreparationRejected = false;
+  };
+
   /**
    * Create a renderer driver that will forward traversal output to the given
    * backend implementation.
+   *
+   * @param renderer Backend receiving prepared draw calls.
+   * @param verbose Whether to emit diagnostic warnings.
+   * @param securityStats Optional preparation diagnostics destination.
    */
-  explicit RendererDriver(RendererInterface& renderer, bool verbose = false);
+  explicit RendererDriver(RendererInterface& renderer, bool verbose = false,
+                          SecurityStats* securityStats = nullptr);
 
   /**
    * Render the given \ref SVGDocument using the configured backend.
@@ -190,6 +218,22 @@ public:
   [[nodiscard]] RendererBitmap takeSnapshot() const;
 
 private:
+  struct FilterPreparationBudget {
+    std::size_t attempts = 0;
+    std::size_t graphs = 0;
+    std::size_t nodes = 0;
+    std::uint64_t imageBytes = 0;
+    std::uint64_t payloadBytes = 0;
+    std::size_t shadowEntities = 0;
+    bool rejected = false;
+
+    bool beginGraph(SecurityStats* stats);
+    bool reserveNodes(std::size_t nodeCount, SecurityStats* stats);
+    bool reserveImageBytes(std::uint64_t byteCount, SecurityStats* stats);
+    bool reservePayloadBytes(std::uint64_t byteCount, SecurityStats* stats);
+    bool reserveShadowEntities(std::size_t entityCount, SecurityStats* stats);
+  };
+
   /**
    * Resolve and pre-render the filter graph for every entity with a resolved filter in `entities`,
    * caching each result in \ref preparedFilterGraphs_. Must be called BEFORE any `traverse` pass
@@ -202,6 +246,13 @@ private:
    * `RenderingInstanceComponent` pool).
    */
   void prepareFilterGraphs(Registry& registry, std::span<const Entity> entities);
+  const components::RenderingInstanceComponent* beginPreparingFilterEntity(Registry& registry,
+                                                                           Entity entity);
+  bool reservePreparedFilterGraph(const components::FilterGraph& filterGraph);
+  std::optional<std::uint64_t> reservePreparedFilterImage(Vector2i size);
+  bool reservePreparedFilterShadowTree(Registry& registry, Entity targetEntity);
+  std::shared_ptr<const std::vector<std::uint8_t>> adoptPreparedFilterSnapshot(
+      RendererBitmap snapshot, std::uint64_t reservedBytes, Registry& registry);
 
   /// Fetch a prepared filter graph for an entity, if any. Returns nullptr if the entity has no
   /// filter or if the pre-pass didn't record one for it.
@@ -213,6 +264,7 @@ private:
   void drawPreparedDocument(SVGDocument& document);
   void drawPreparedDocument(SVGDocument& document, const RenderViewport& viewport,
                             const Transform2d& surfaceFromCanvas);
+  void resetOwnedFilterPreparationBudget();
   [[nodiscard]] bool drawPreparedEntityRange(Registry& registry, Entity firstEntity,
                                              Entity lastEntity,
                                              const std::function<bool()>& shouldCancel);
@@ -278,7 +330,7 @@ private:
                        const Transform2d& parentAbsoluteTransform);
   void drawSubDocumentElement(SVGDocument& subDocument, std::string_view fragmentId,
                               const Transform2d& parentAbsoluteTransform, double opacity);
-  void preRenderSvgFeImages(components::FilterGraph& filterGraph);
+  void preRenderSvgFeImages(components::FilterGraph& filterGraph, Registry& registry);
   void preRenderFeImageFragments(components::FilterGraph& filterGraph, Registry& registry,
                                  Entity hostEntity, const std::optional<Box2d>& filterRegion);
   static void setSubDocumentContextPaint(SVGDocument& subDocument,
@@ -349,6 +401,10 @@ private:
   /// invariant. Shared across nested `RendererDriver` instances by copying the parent's value into
   /// the sub-driver (see `preRenderFeImageFragments`).
   int feImageFragmentDepth_ = 0;
+
+  FilterPreparationBudget ownedFilterPreparationBudget_;
+  FilterPreparationBudget* filterPreparationBudget_ = &ownedFilterPreparationBudget_;
+  SecurityStats* securityStats_ = nullptr;
 
   /// Filter graphs resolved and pre-rendered by \ref prepareFilterGraphs. Keyed by the entity
   /// whose filter produced the graph. Populated in a pre-pass before \ref traverse so the main

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1523,7 +1523,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (!device || !frameCommandEncoder || !target || !filterStack.empty() ||
         filterExecutionBudget->rejectionReason() !=
             components::FilterExecutionBudget::RejectionReason::MemoryLimit ||
-        filterExecutionBudget->activeGpuReservations() != 0) {
+        filterExecutionBudget->activeGpuReservations() != 0 ||
+        filterExecutionBudget->retainedGpuBytes() == 0) {
       return false;
     }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -6155,6 +6155,10 @@ void RendererGeode::setOffscreenCreationHookForTesting(std::function<void()> hoo
   impl_->offscreenCreationHookForTesting = std::move(hook);
 }
 
+std::uint64_t RendererGeode::filterBudgetChunksForTesting() const {
+  return 0;
+}
+
 std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapshot() {
   impl_->borrowedTargetSnapshot.reset();
   if (!impl_->device || !impl_->ownedTarget || impl_->hostTarget || impl_->pixelWidth <= 0 ||

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1519,6 +1519,38 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     framePendingReleases.clear();
   }
 
+  bool submitFilterBudgetChunk() {
+    if (!device || !frameCommandEncoder || !target) {
+      return false;
+    }
+
+    retireActiveEncoder();
+    geode::ScopedWgpuHandle<wgpu::CommandBuffer> commandBuffer(frameCommandEncoder.get().finish());
+    if (!commandBuffer) {
+      return false;
+    }
+    device->queue().submit(1, &commandBuffer.get());
+    device->countSubmit();
+
+    frameFinishedEncoders.clear();
+    framePendingTextureViewReleases.clear();
+    drainPendingReleases();
+
+    wgpu::CommandEncoderDescriptor descriptor = {};
+    descriptor.label = wgpuLabel("RendererGeodeFilterBudgetChunk");
+    frameCommandEncoder.reset(device->device().createCommandEncoder(descriptor));
+    if (!frameCommandEncoder) {
+      return false;
+    }
+    encoder = std::make_unique<geode::GeoEncoder>(
+        *device, *pipeline, *gradientPipeline, *imagePipeline, target, frameCommandEncoder.get());
+    configurePathEncoder(*encoder);
+    encoder->setLoadPreserve();
+    updateEncoderScissor();
+    filterExecutionBudget->beginChunkAfterSubmit();
+    return true;
+  }
+
   /// A saved encoder + target state for an in-progress isolated layer
   /// (`pushIsolatedLayer` / `popIsolatedLayer`). When the driver begins a
   /// group with non-identity opacity or a non-Normal blend mode, we
@@ -4705,9 +4737,15 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
     impl_->filterStack.push_back({});
     return;
   }
-  const std::optional<GeodeFilterAdmission> admission =
+  std::optional<GeodeFilterAdmission> admission =
       AdmitGeodeFilter(filterGraph, filterRegion, impl_->deviceFromLocalTransform,
                        impl_->pixelWidth, impl_->pixelHeight, *impl_->filterExecutionBudget);
+  if (!admission.has_value() && impl_->filterExecutionBudget->executions() != 0 &&
+      impl_->submitFilterBudgetChunk()) {
+    admission =
+        AdmitGeodeFilter(filterGraph, filterRegion, impl_->deviceFromLocalTransform,
+                         impl_->pixelWidth, impl_->pixelHeight, *impl_->filterExecutionBudget);
+  }
   if (!admission.has_value()) {
     impl_->pushRejectedFilterFrame();
     return;
@@ -6156,7 +6194,7 @@ void RendererGeode::setOffscreenCreationHookForTesting(std::function<void()> hoo
 }
 
 std::uint64_t RendererGeode::filterBudgetChunksForTesting() const {
-  return 0;
+  return impl_->filterExecutionBudget->chunks();
 }
 
 std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapshot() {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <deque>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -166,6 +167,27 @@ TextLayoutParams toTextLayoutParams(const TextParams& params) {
 /// with a one-shot warning; the follow-up is a texture-based stop lookup
 /// (a `GeodeGradientCacheComponent` holding a stop texture).
 constexpr size_t kMaxGradientStopsClient = 16;
+
+int boundedFloorToInt(double value, int minimum, int maximum) {
+  if (std::isnan(value)) {
+    return minimum;
+  }
+  if (value <= static_cast<double>(minimum)) {
+    return minimum;
+  }
+  if (value >= static_cast<double>(maximum)) {
+    return maximum;
+  }
+  return static_cast<int>(std::floor(value));
+}
+
+std::optional<uint32_t> checkedFilterRasterDimension(double value) {
+  if (!std::isfinite(value) || value <= 0.0 ||
+      value > static_cast<double>(components::kMaximumFilterSurfaceDimension)) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(std::max(1.0, std::ceil(value)));
+}
 
 /// Returns true when the filter graph contains spatial-shift primitives (feOffset) that can bring
 /// content from outside the viewport into view, requiring the filter layer buffer to be expanded.
@@ -1030,6 +1052,155 @@ std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevic
   return pool;
 }
 
+struct GeodeFilterAdmission {
+  Box2d region;
+  int bufferWidth = 0;
+  int bufferHeight = 0;
+  int bufferOffsetX = 0;
+  int bufferOffsetY = 0;
+  bool transformedCaptureReserved = false;
+  bool localRasterRequired = false;
+  components::FilterExecutionBudget::Reservation reservation;
+};
+
+struct GeodeFilterBuffer {
+  Box2d region;
+  int width = 0;
+  int height = 0;
+  int offsetX = 0;
+  int offsetY = 0;
+};
+
+std::optional<GeodeFilterBuffer> ComputeGeodeFilterBuffer(
+    const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+    const Transform2d& deviceFromFilter, int viewportWidth, int viewportHeight) {
+  GeodeFilterBuffer result{
+      filterRegion.value_or(Box2d(Vector2d::Zero(), Vector2d(viewportWidth, viewportHeight))),
+      viewportWidth, viewportHeight, 0, 0};
+  if (filterRegion.has_value()) {
+    constexpr int kMaxExpansion = 4096;
+    const Box2d deviceRegion = deviceFromFilter.transformBox(*filterRegion);
+    const int regionX0 = boundedFloorToInt(deviceRegion.topLeft.x, -kMaxExpansion, 0);
+    const int regionY0 = boundedFloorToInt(deviceRegion.topLeft.y, -kMaxExpansion, 0);
+    if ((regionX0 < 0 || regionY0 < 0) && graphHasSpatialShift(filterGraph)) {
+      result.offsetX = std::min(-regionX0, std::max(0, kMaxExpansion - viewportWidth));
+      result.offsetY = std::min(-regionY0, std::max(0, kMaxExpansion - viewportHeight));
+      result.width += result.offsetX;
+      result.height += result.offsetY;
+    }
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(result.width) * static_cast<std::uint64_t>(result.height);
+  if (pixels > components::kMaximumFilterSurfacePixels) {
+    result.width = viewportWidth;
+    result.height = viewportHeight;
+    result.offsetX = 0;
+    result.offsetY = 0;
+  }
+  if (result.width <= 0 || result.height <= 0) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+bool ShouldPlanGeodeLocalRaster(const components::FilterGraph& filterGraph,
+                                const std::optional<Box2d>& filterRegion,
+                                const Transform2d& deviceFromFilter,
+                                const GeodeFilterBuffer& buffer, bool fullExecutionFits) {
+  if (!filterRegion.has_value() || filterRegion->width() <= 0.0 || filterRegion->height() <= 0.0 ||
+      buffer.offsetX != 0 || buffer.offsetY != 0 ||
+      NearZero(deviceFromFilter.determinant(), 1e-12)) {
+    return false;
+  }
+  return isEligibleForTransformedBlurPath(filterGraph) &&
+         (shouldUseTransformedBlurPath(filterGraph, deviceFromFilter) || !fullExecutionFits);
+}
+
+struct GeodeLocalRasterGeometry {
+  double scaleX = 1.0;
+  double scaleY = 1.0;
+  double blurPadding = 0.0;
+  Box2d paddedRegion;
+  uint32_t width = 0;
+  uint32_t height = 0;
+};
+
+std::optional<GeodeLocalRasterGeometry> ComputeGeodeLocalRasterGeometry(
+    const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+    const Transform2d& deviceFromFilter, const GeodeFilterBuffer& buffer, bool fullExecutionFits) {
+  if (!ShouldPlanGeodeLocalRaster(filterGraph, filterRegion, deviceFromFilter, buffer,
+                                  fullExecutionFits)) {
+    return std::nullopt;
+  }
+  const double scaleX =
+      std::max(1.0, deviceFromFilter.transformVector(Vector2d(1.0, 0.0)).length());
+  const double scaleY =
+      std::max(1.0, deviceFromFilter.transformVector(Vector2d(0.0, 1.0)).length());
+  const double blurPadding = computeBlurPadding(filterGraph);
+  const Box2d paddedRegion(filterRegion->topLeft - Vector2d(blurPadding, blurPadding),
+                           filterRegion->bottomRight + Vector2d(blurPadding, blurPadding));
+  const std::optional<uint32_t> width = checkedFilterRasterDimension(paddedRegion.width() * scaleX);
+  const std::optional<uint32_t> height =
+      checkedFilterRasterDimension(paddedRegion.height() * scaleY);
+  if (!width || !height) {
+    return std::nullopt;
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(*width) * static_cast<std::uint64_t>(*height);
+  if (pixels > components::kMaximumFilterSurfacePixels) {
+    return std::nullopt;
+  }
+  return GeodeLocalRasterGeometry{scaleX, scaleY, blurPadding, paddedRegion, *width, *height};
+}
+
+std::optional<std::uint64_t> ComputeGeodeLocalFilterPixels(
+    const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+    const Transform2d& deviceFromFilter, const GeodeFilterBuffer& buffer, bool fullExecutionFits) {
+  const std::optional<GeodeLocalRasterGeometry> geometry = ComputeGeodeLocalRasterGeometry(
+      filterGraph, filterRegion, deviceFromFilter, buffer, fullExecutionFits);
+  if (!geometry.has_value()) {
+    return std::nullopt;
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(geometry->width) * static_cast<std::uint64_t>(geometry->height);
+  if (!components::FilterGraphFitsExecutionBudget(filterGraph, pixels,
+                                                  components::FilterMemoryModel::GpuAllNodes)) {
+    return std::nullopt;
+  }
+  return pixels;
+}
+
+std::optional<GeodeFilterAdmission> AdmitGeodeFilter(const components::FilterGraph& filterGraph,
+                                                     const std::optional<Box2d>& filterRegion,
+                                                     const Transform2d& deviceFromFilter,
+                                                     int viewportWidth, int viewportHeight,
+                                                     components::FilterExecutionBudget& budget) {
+  const std::optional<GeodeFilterBuffer> buffer = ComputeGeodeFilterBuffer(
+      filterGraph, filterRegion, deviceFromFilter, viewportWidth, viewportHeight);
+  if (!buffer.has_value()) {
+    budget.reject();
+    return std::nullopt;
+  }
+  const std::uint64_t bufferPixels =
+      static_cast<std::uint64_t>(buffer->width) * static_cast<std::uint64_t>(buffer->height);
+  const bool fullExecutionFits = components::FilterGraphFitsExecutionBudget(
+      filterGraph, bufferPixels, components::FilterMemoryModel::GpuAllNodes);
+  const std::optional<std::uint64_t> localPixels = ComputeGeodeLocalFilterPixels(
+      filterGraph, filterRegion, deviceFromFilter, *buffer, fullExecutionFits);
+  const std::uint64_t executionPixels = localPixels.has_value() && fullExecutionFits
+                                            ? std::max(bufferPixels, *localPixels)
+                                            : localPixels.value_or(bufferPixels);
+  const std::uint64_t captureBytes = bufferPixels * 4u + localPixels.value_or(0) * 4u;
+  auto reservation = budget.reserve(filterGraph, executionPixels,
+                                    components::FilterMemoryModel::GpuAllNodes, captureBytes);
+  if (!reservation.has_value()) {
+    return std::nullopt;
+  }
+  return GeodeFilterAdmission{buffer->region,     buffer->width,   buffer->height,
+                              buffer->offsetX,    buffer->offsetY, localPixels.has_value(),
+                              !fullExecutionFits, *reservation};
+}
+
 }  // namespace
 
 /// Gate for ordered cross-entity batching. Enabled: a batch's single draw can
@@ -1054,6 +1225,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   // Per-frame perf counters. Reset at `beginFrame`, read via
   // `lastFrameTimings()`; `GeodePerf_tests.cc` pins their ceilings.
   geode::GeodeCounters counters;
+  std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget =
+      std::make_shared<components::FilterExecutionBudget>();
+  bool ownsFilterExecutionBudget = true;
 
   // GPU resources. Created in the constructor; if device creation fails,
   // `device` is null and the renderer enters a no-op state.
@@ -1467,14 +1641,199 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     /// Descriptors captured at push for texture-pool release.
     wgpu::TextureDescriptor layerDesc = {};
     components::FilterGraph filterGraph;
+    components::FilterExecutionBudget::Reservation filterReservation;
     Box2d filterRegion;
     Transform2d deviceFromFilter;  // Full CTM at push time.
-    int filterBufferOffsetX = 0;   // Expansion into negative device X.
-    int filterBufferOffsetY = 0;   // Expansion into negative device Y.
+    bool transformedCaptureReserved = false;
+    bool localRasterRequiredForBudget = false;
+    int filterBufferOffsetX = 0;  // Expansion into negative device X.
+    int filterBufferOffsetY = 0;  // Expansion into negative device Y.
     std::vector<ClipStackEntry> savedClipStack;
+    bool allocationRejected = false;
   };
   std::vector<ClipStackEntry> clipStack;
   std::vector<FilterStackFrame> filterStack;
+  std::size_t rejectedFilterDepth = 0;
+
+  bool initializeClipEntry(const ResolvedClip& clip, ClipStackEntry& entry) {
+    if (rejectedFilterDepth != 0) {
+      clipStack.push_back(std::move(entry));
+      return false;
+    }
+    if (!clip.clipRect.has_value()) {
+      return true;
+    }
+    const Transform2d& deviceFromClip = deviceFromLocalTransform;
+    entry.pixelRect = deviceFromClip.transformBox(*clip.clipRect);
+    entry.valid = true;
+    const double a = deviceFromClip.data[0];
+    const double b = deviceFromClip.data[1];
+    const double c = deviceFromClip.data[2];
+    const double d = deviceFromClip.data[3];
+    constexpr double kAxisAlignedEps = 1e-9;
+    const bool axisAligned = (std::abs(b) < kAxisAlignedEps && std::abs(c) < kAxisAlignedEps) ||
+                             (std::abs(a) < kAxisAlignedEps && std::abs(d) < kAxisAlignedEps);
+    if (axisAligned) {
+      return true;
+    }
+    const Box2d& local = *clip.clipRect;
+    entry.polygonCorners[0] =
+        deviceFromClip.transformPosition(Vector2d(local.topLeft.x, local.topLeft.y));
+    entry.polygonCorners[1] =
+        deviceFromClip.transformPosition(Vector2d(local.bottomRight.x, local.topLeft.y));
+    entry.polygonCorners[2] =
+        deviceFromClip.transformPosition(Vector2d(local.bottomRight.x, local.bottomRight.y));
+    entry.polygonCorners[3] =
+        deviceFromClip.transformPosition(Vector2d(local.topLeft.x, local.bottomRight.y));
+    entry.hasPolygon = true;
+    return true;
+  }
+
+  bool readyForFilterCapture() const {
+    return device && pipeline && gradientPipeline && imagePipeline && encoder && filterEngine;
+  }
+
+  void pushRejectedFilterFrame() {
+    FilterStackFrame frame;
+    frame.savedEncoder = std::move(encoder);
+    frame.savedTarget = target;
+    frame.allocationRejected = true;
+    filterStack.push_back(std::move(frame));
+    ++rejectedFilterDepth;
+  }
+
+  bool beginFilterCapture(const components::FilterGraph& filterGraph,
+                          const GeodeFilterAdmission& admission,
+                          const Transform2d& deviceFromFilter) {
+    wgpu::TextureDescriptor textureDesc{};
+    textureDesc.label = wgpuLabel("RendererGeodeFilterLayer");
+    textureDesc.size = {static_cast<uint32_t>(admission.bufferWidth),
+                        static_cast<uint32_t>(admission.bufferHeight), 1u};
+    textureDesc.format = textureFormat;
+    textureDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
+                        wgpu::TextureUsage::CopySrc;
+    textureDesc.mipLevelCount = 1;
+    textureDesc.sampleCount = 1;
+    textureDesc.dimension = wgpu::TextureDimension::_2D;
+    wgpu::Texture layerTexture = acquireTexture(textureDesc);
+    if (!layerTexture) {
+      return false;
+    }
+
+    encoder->finish();
+    FilterStackFrame frame;
+    frame.savedEncoder = std::move(encoder);
+    frame.savedTarget = target;
+    frame.layerTexture = layerTexture;
+    frame.layerDesc = textureDesc;
+    frame.filterGraph = filterGraph;
+    frame.filterReservation = admission.reservation;
+    frame.filterRegion = admission.region;
+    frame.deviceFromFilter = deviceFromFilter;
+    frame.transformedCaptureReserved = admission.transformedCaptureReserved;
+    frame.localRasterRequiredForBudget = admission.localRasterRequired;
+    frame.filterBufferOffsetX = admission.bufferOffsetX;
+    frame.filterBufferOffsetY = admission.bufferOffsetY;
+    frame.savedClipStack = std::move(clipStack);
+    clipStack.clear();
+
+    target = layerTexture;
+    auto newEncoder =
+        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                            layerTexture, frameCommandEncoder.get());
+    configurePathEncoder(*newEncoder, /*collectGeometry=*/true, admission.bufferOffsetX,
+                         admission.bufferOffsetY);
+    newEncoder->clear(css::RGBA(0, 0, 0, 0));
+    encoder = std::move(newEncoder);
+    if (admission.bufferOffsetX != 0 || admission.bufferOffsetY != 0) {
+      deviceFromLocalTransform =
+          deviceFromLocalTransform *
+          Transform2d::Translate(admission.bufferOffsetX, admission.bufferOffsetY);
+    }
+    ClipStackEntry filterClipEntry;
+    filterClipEntry.pixelRect = deviceFromLocalTransform.transformBox(admission.region);
+    filterClipEntry.valid = true;
+    clipStack.push_back(std::move(filterClipEntry));
+    filterStack.push_back(std::move(frame));
+    updateEncoderScissor();
+    return true;
+  }
+
+  bool tryCompositeTransformedFilter(FilterStackFrame& frame) {
+    if (!frame.transformedCaptureReserved || !filterEngine || frame.filterGraph.empty()) {
+      return false;
+    }
+    const GeodeFilterBuffer buffer{frame.filterRegion, static_cast<int>(frame.layerDesc.size.width),
+                                   static_cast<int>(frame.layerDesc.size.height),
+                                   frame.filterBufferOffsetX, frame.filterBufferOffsetY};
+    const std::optional<GeodeLocalRasterGeometry> geometry = ComputeGeodeLocalRasterGeometry(
+        frame.filterGraph, frame.filterRegion, frame.deviceFromFilter, buffer,
+        !frame.localRasterRequiredForBudget);
+    if (!geometry.has_value()) {
+      return false;
+    }
+
+    wgpu::TextureDescriptor localDesc{};
+    localDesc.label = wgpuLabel("RendererGeodeBlurLocal");
+    localDesc.size = {geometry->width, geometry->height, 1u};
+    localDesc.format = textureFormat;
+    localDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
+                      wgpu::TextureUsage::CopySrc;
+    localDesc.mipLevelCount = 1;
+    localDesc.sampleCount = 1;
+    localDesc.dimension = wgpu::TextureDimension::_2D;
+    wgpu::Texture localTexture = acquireTexture(localDesc);
+    if (!localTexture) {
+      return false;
+    }
+
+    const Transform2d filterFromDevice = frame.deviceFromFilter.inverse();
+    const Transform2d localFromDevice = filterFromDevice *
+                                        Transform2d::Translate(-geometry->paddedRegion.topLeft.x,
+                                                               -geometry->paddedRegion.topLeft.y) *
+                                        Transform2d::Scale(geometry->scaleX, geometry->scaleY);
+    geode::GeoEncoder resampleEncoder(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                      localTexture, frameCommandEncoder.get());
+    configureEncoder(resampleEncoder);
+    resampleEncoder.setTransform(localFromDevice);
+    resampleEncoder.drawTexture(
+        frame.layerTexture,
+        Box2d::FromXYWH(0.0, 0.0, static_cast<double>(frame.layerDesc.size.width),
+                        static_cast<double>(frame.layerDesc.size.height)),
+        kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
+    resampleEncoder.finish();
+
+    const Transform2d localDeviceFromFilter =
+        Transform2d::Scale(geometry->scaleX, geometry->scaleY);
+    const Box2d localFilterRegion(Vector2d(geometry->blurPadding, geometry->blurPadding),
+                                  Vector2d(geometry->blurPadding + frame.filterRegion.width(),
+                                           geometry->blurPadding + frame.filterRegion.height()));
+    wgpu::Texture localFiltered =
+        filterEngine->execute(frame.filterGraph, localTexture, localFilterRegion,
+                              localDeviceFromFilter, *this, frameCommandEncoder);
+
+    const Transform2d deviceFromLocal =
+        Transform2d::Scale(1.0 / geometry->scaleX, 1.0 / geometry->scaleY) *
+        Transform2d::Translate(geometry->paddedRegion.topLeft.x, geometry->paddedRegion.topLeft.y) *
+        frame.deviceFromFilter;
+    target = frame.savedTarget;
+    auto compositeEncoder =
+        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                            frame.savedTarget, frameCommandEncoder.get());
+    configurePathEncoder(*compositeEncoder);
+    compositeEncoder->setLoadPreserve();
+    encoder = std::move(compositeEncoder);
+    updateEncoderScissor();
+    encoder->setTransform(deviceFromLocal);
+    encoder->drawTexture(localFiltered,
+                         Box2d::FromXYWH(0.0, 0.0, static_cast<double>(geometry->width),
+                                         static_cast<double>(geometry->height)),
+                         kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
+    encoder->setTransform(Transform2d());
+    releaseTextureAtFrameEnd(std::move(localTexture), localDesc);
+    frame.localRasterRequiredForBudget = false;
+    return true;
+  }
 
   /// Recompute the intersection of every rectangular clip entry on
   /// `clipStack` and apply it to the active encoder as a scissor,
@@ -3441,6 +3800,93 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     entries.clear();
   }
 
+  void resetForBeginFrame(const RenderViewport& nextViewport) {
+    borrowedTargetSnapshot.reset();
+    if (device) {
+      device->drainDeferredDestroys();
+    }
+    viewport = nextViewport;
+    pixelWidth = static_cast<int>(nextViewport.size.x * nextViewport.devicePixelRatio);
+    pixelHeight = static_cast<int>(nextViewport.size.y * nextViewport.devicePixelRatio);
+    deviceFromLocalTransform = Transform2d();
+    deviceFromLocalTransformStack.clear();
+    paint = PaintParams();
+    encoder.reset();
+    frameFinishedEncoders.clear();
+    geometryDebugEdges.clear();
+    rejectedFilterDepth = 0;
+    if (ownsFilterExecutionBudget) {
+      filterExecutionBudget->reset();
+    }
+    if (device) {
+      device->filterEngine().beginFrame();
+    }
+    if (texturePool) {
+      texturePool->beginFrame();
+    }
+    closeFrameGeneration();
+    if (device) {
+      currentFrameIndex = device->beginFrameGeneration();
+      frameGenerationOpen = true;
+    } else {
+      ++currentFrameIndex;
+    }
+    lastDrawSourceEntity = entt::null;
+    pendingBatch.reset();
+    counters.reset();
+  }
+
+  bool prepareFrameTarget() {
+    if (!device || !pipeline || !gradientPipeline || !imagePipeline || pixelWidth <= 0 ||
+        pixelHeight <= 0) {
+      retireOwnedTargetAtFrameBoundary();
+      return false;
+    }
+    device->setCounters(&counters);
+    if (hostTarget) {
+      retireOwnedTargetAtFrameBoundary();
+      pixelWidth = static_cast<int>(hostTarget.getWidth());
+      pixelHeight = static_cast<int>(hostTarget.getHeight());
+      target = hostTarget;
+      return true;
+    }
+
+    const bool canReuseTargets =
+        ownedTarget && targetWidth == pixelWidth && targetHeight == pixelHeight;
+    if (!canReuseTargets) {
+      retireOwnedTargetAtFrameBoundary();
+      wgpu::TextureDescriptor td = {};
+      td.label = wgpuLabel("RendererGeodeTarget");
+      td.size = {static_cast<uint32_t>(pixelWidth), static_cast<uint32_t>(pixelHeight), 1};
+      td.format = textureFormat;
+      td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::CopySrc |
+                 wgpu::TextureUsage::TextureBinding;
+      td.mipLevelCount = 1;
+      td.sampleCount = 1;
+      td.dimension = wgpu::TextureDimension::_2D;
+      ownedTarget.reset(device->device().createTexture(td));
+      device->countTexture();
+      targetWidth = pixelWidth;
+      targetHeight = pixelHeight;
+    }
+    target = ownedTarget.get();
+    return true;
+  }
+
+  void createFrameEncoder() {
+    wgpu::CommandEncoderDescriptor commandEncoderDesc = {};
+    commandEncoderDesc.label = wgpuLabel("RendererGeodeFrameCE");
+    frameCommandEncoder.reset(device->device().createCommandEncoder(commandEncoderDesc));
+    encoder = std::make_unique<geode::GeoEncoder>(
+        *device, *pipeline, *gradientPipeline, *imagePipeline, target, frameCommandEncoder.get());
+    configurePathEncoder(*encoder);
+    if (preserveTargetOnBeginFrame) {
+      encoder->setLoadPreserve();
+    } else {
+      encoder->clear(css::RGBA(0, 0, 0, 0));
+    }
+  }
+
   ~Impl() {
     encoder.reset();
     frameCommandEncoder.reset();
@@ -3793,134 +4239,9 @@ int RendererGeode::height() const {
 }
 
 void RendererGeode::beginFrame(const RenderViewport& viewport) {
-  impl_->borrowedTargetSnapshot.reset();
-
-  // Drain deferred-destroy resources from the previous frame before allocating
-  // new ones. By this point any GPU submission from the prior frame has had a
-  // chance to finish, and WebGPU's internal ref-counting keeps resources alive
-  // for any still-in-flight command buffers.
-  if (impl_->device) {
-    impl_->device->drainDeferredDestroys();
-  }
-
-  impl_->viewport = viewport;
-  impl_->pixelWidth = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
-  impl_->pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
-  impl_->deviceFromLocalTransform = Transform2d();
-  impl_->deviceFromLocalTransformStack.clear();
-  impl_->paint = PaintParams();
-  impl_->encoder.reset();
-  impl_->frameFinishedEncoders.clear();
-  impl_->geometryDebugEdges.clear();
-
-  // Reset the filter engine's per-frame state: the uniform scratch cursor
-  // (slots reuse stable buffer+offset pairs across frames) and the
-  // frame-scoped chunk pass counter (so the 64-pass command-buffer bound
-  // spans every filter graph in this frame). Pass bind groups are created
-  // per pass; the pooled textures they bind rotate across frames, so their
-  // identities are not stable cache keys. Runs BEFORE the texture pool's
-  // stale-bucket eviction below.
-  if (impl_->device) {
-    impl_->device->filterEngine().beginFrame();
-  }
-
-  if (impl_->texturePool) {
-    impl_->texturePool->beginFrame();
-  }
-  // A caller that abandons a frame (beginFrame without endFrame) must not leave
-  // its generation open forever, or every later eviction would be held back by
-  // it.
-  impl_->closeFrameGeneration();
-  if (impl_->device) {
-    impl_->currentFrameIndex = impl_->device->beginFrameGeneration();
-    impl_->frameGenerationOpen = true;
-  } else {
-    ++impl_->currentFrameIndex;
-  }
-
-  // `<use>`-batch detection: drop the previous-draw source-entity memo so
-  // cross-frame draws don't show up as "same-source runs".
-  impl_->lastDrawSourceEntity = entt::null;
-
-  // Drop any batch the previous frame left pending. `endFrame` normally flushes it, but an
-  // early-out that skips the flush must not carry a borrowed `ComputedPathComponent` pointer
-  // into a frame that may no longer have that component.
-  impl_->pendingBatch.reset();
-
-  // Reset counters regardless of device state.
-  impl_->counters.reset();
-
-  if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline || !impl_->imagePipeline ||
-      impl_->pixelWidth <= 0 || impl_->pixelHeight <= 0) {
-    impl_->retireOwnedTargetAtFrameBoundary();
-    return;
-  }
-
-  // Wire the counters onto the device for this frame. A shared GeodeDevice
-  // may have been handed to another renderer between frames - the last
-  // caller wins, which is exactly the serial per-frame access pattern we
-  // want. Must run AFTER the null-device guard above so headless systems
-  // don't null-ptr-crash in draw()→beginFrame().
-  impl_->device->setCounters(&impl_->counters);
-
-  if (impl_->hostTarget) {
-    // Embedded mode: render into the host-provided target texture.
-    // Override pixel dimensions from the texture itself.
-    impl_->retireOwnedTargetAtFrameBoundary();
-    impl_->pixelWidth = static_cast<int>(impl_->hostTarget.getWidth());
-    impl_->pixelHeight = static_cast<int>(impl_->hostTarget.getHeight());
-    impl_->target = impl_->hostTarget;
-
-  } else {
-    // Headless mode: reuse render targets across same-size frames.
-    // Content is cleared by the encoder's first
-    // render-pass `LoadOp::Clear`, so lingering pixels from the previous
-    // frame don't leak into this one.
-    const bool canReuseTargets = impl_->ownedTarget && impl_->targetWidth == impl_->pixelWidth &&
-                                 impl_->targetHeight == impl_->pixelHeight;
-
-    if (!canReuseTargets) {
-      impl_->retireOwnedTargetAtFrameBoundary();
-
-      // Direct render target. Snapshots copy it and layer/pattern blits sample it.
-      wgpu::TextureDescriptor td = {};
-      td.label = wgpuLabel("RendererGeodeTarget");
-      td.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                 static_cast<uint32_t>(impl_->pixelHeight), 1};
-      td.format = impl_->textureFormat;
-      td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::CopySrc |
-                 wgpu::TextureUsage::TextureBinding;
-      td.mipLevelCount = 1;
-      td.sampleCount = 1;
-      td.dimension = wgpu::TextureDimension::_2D;
-      impl_->ownedTarget.reset(impl_->device->device().createTexture(td));
-      impl_->target = impl_->ownedTarget.get();
-      impl_->device->countTexture();
-
-      impl_->targetWidth = impl_->pixelWidth;
-      impl_->targetHeight = impl_->pixelHeight;
-    } else {
-      impl_->target = impl_->ownedTarget.get();
-    }
-  }
-
-  // Single CommandEncoder for the entire frame - shared across the
-  // base encoder and every push/pop layer/filter/mask helper. One
-  // queue submit at `endFrame`.
-  wgpu::CommandEncoderDescriptor cedesc = {};
-  cedesc.label = wgpuLabel("RendererGeodeFrameCE");
-  impl_->frameCommandEncoder.reset(impl_->device->device().createCommandEncoder(cedesc));
-
-  impl_->encoder = std::make_unique<geode::GeoEncoder>(
-      *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      impl_->target, impl_->frameCommandEncoder.get());
-  impl_->configurePathEncoder(*impl_->encoder);
-  if (impl_->preserveTargetOnBeginFrame) {
-    impl_->encoder->setLoadPreserve();
-  } else {
-    // Default to a transparent clear so an empty frame matches the other
-    // backends' "no document content" appearance.
-    impl_->encoder->clear(css::RGBA(0, 0, 0, 0));
+  impl_->resetForBeginFrame(viewport);
+  if (impl_->prepareFrameTarget()) {
+    impl_->createFrameEncoder();
   }
 }
 
@@ -4035,39 +4356,8 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
   // transform to get pixel-space coordinates, then push onto the stack.
   // The active scissor is the INTERSECTION of everything on the stack.
   Impl::ClipStackEntry entry;
-  if (clip.clipRect.has_value()) {
-    const Transform2d& t = impl_->deviceFromLocalTransform;
-    entry.pixelRect = t.transformBox(*clip.clipRect);
-    entry.valid = true;
-
-    // Detect a non-axis-aligned ancestor transform - rotation or shear
-    // means the true clip shape is a parallelogram, not a rectangle,
-    // and a rectangular scissor can only describe its AABB. In that
-    // case we carry the 4 transformed corners through to the encoder
-    // as a polygon clip so the fragment shader can do a half-plane
-    // test per sample.
-    const double a = t.data[0];
-    const double b = t.data[1];
-    const double c = t.data[2];
-    const double d = t.data[3];
-    // Axis-aligned iff (no shear: b=c=0) OR (90°-rotation: a=d=0).
-    // Use a small tolerance to absorb floating-point noise in the
-    // composed transform chain.
-    constexpr double kAxisAlignedEps = 1e-9;
-    const bool axisAligned = (std::abs(b) < kAxisAlignedEps && std::abs(c) < kAxisAlignedEps) ||
-                             (std::abs(a) < kAxisAlignedEps && std::abs(d) < kAxisAlignedEps);
-    if (!axisAligned) {
-      const Box2d& local = *clip.clipRect;
-      const Vector2d tl(local.topLeft.x, local.topLeft.y);
-      const Vector2d tr(local.bottomRight.x, local.topLeft.y);
-      const Vector2d br(local.bottomRight.x, local.bottomRight.y);
-      const Vector2d bl(local.topLeft.x, local.bottomRight.y);
-      entry.polygonCorners[0] = t.transformPosition(tl);
-      entry.polygonCorners[1] = t.transformPosition(tr);
-      entry.polygonCorners[2] = t.transformPosition(br);
-      entry.polygonCorners[3] = t.transformPosition(bl);
-      entry.hasPolygon = true;
-    }
+  if (!impl_->initializeClipEntry(clip, entry)) {
+    return;
   }
 
   // Path-clip mask. When the clip has any `clipPaths`,
@@ -4407,116 +4697,28 @@ void RendererGeode::popIsolatedLayer() {
 void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
                                     const std::optional<Box2d>& filterRegion) {
   impl_->flushPendingBatch();  // Flush any pending `<use>` batch.
-  if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline || !impl_->imagePipeline ||
-      !impl_->encoder || !impl_->filterEngine) {
-    // Headless or degenerate state - push a placeholder frame so
-    // popFilterLayer stays balanced.
+  if (impl_->rejectedFilterDepth != 0) {
+    impl_->pushRejectedFilterFrame();
+    return;
+  }
+  if (!impl_->readyForFilterCapture()) {
     impl_->filterStack.push_back({});
     return;
   }
-
-  // Compute filter region in device-pixel coordinates. Fall back to the
-  // full target if none was specified.
-  Box2d region = filterRegion.value_or(
-      Box2d(Vector2d::Zero(), Vector2d(impl_->pixelWidth, impl_->pixelHeight)));
-
-  // Compute buffer expansion for spatial-shift primitives (feOffset). When the filter region's
-  // device-space AABB extends to negative coordinates (due to skew/rotation), expand the buffer
-  // so SourceGraphic captures all content that feOffset can shift into view.
-  int filterBufferOffsetX = 0;
-  int filterBufferOffsetY = 0;
-  const int viewportWidth = impl_->pixelWidth;
-  const int viewportHeight = impl_->pixelHeight;
-
-  if (filterRegion.has_value()) {
-    const Box2d deviceRegion = impl_->deviceFromLocalTransform.transformBox(*filterRegion);
-    const int regionX0 = static_cast<int>(std::floor(deviceRegion.topLeft.x));
-    const int regionY0 = static_cast<int>(std::floor(deviceRegion.topLeft.y));
-
-    if ((regionX0 < 0 || regionY0 < 0) && graphHasSpatialShift(filterGraph)) {
-      constexpr int kMaxExpansion = 4096;
-      if (regionX0 < 0) {
-        filterBufferOffsetX = std::min(-regionX0, std::max(0, kMaxExpansion - viewportWidth));
-      }
-      if (regionY0 < 0) {
-        filterBufferOffsetY = std::min(-regionY0, std::max(0, kMaxExpansion - viewportHeight));
-      }
-    }
-  }
-
-  const int bufferWidth = viewportWidth + filterBufferOffsetX;
-  const int bufferHeight = viewportHeight + filterBufferOffsetY;
-
-  // Allocate an offscreen filter layer capture. All draws between push/pop
-  // land here; pop runs the filter graph on it and composites back.
-  wgpu::TextureDescriptor td{};
-  td.label = wgpuLabel("RendererGeodeFilterLayer");
-  td.size = {static_cast<uint32_t>(bufferWidth), static_cast<uint32_t>(bufferHeight), 1u};
-  td.format = impl_->textureFormat;
-  td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-             wgpu::TextureUsage::CopySrc;
-  td.mipLevelCount = 1;
-  td.sampleCount = 1;
-  td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture layerTexture = impl_->acquireTexture(td);
-  if (!layerTexture) {
-    impl_->filterStack.push_back({});
+  const std::optional<GeodeFilterAdmission> admission =
+      AdmitGeodeFilter(filterGraph, filterRegion, impl_->deviceFromLocalTransform,
+                       impl_->pixelWidth, impl_->pixelHeight, *impl_->filterExecutionBudget);
+  if (!admission.has_value()) {
+    impl_->pushRejectedFilterFrame();
     return;
   }
 
-  // Finish the outer encoder so its queued draws land on the saved
-  // target before we redirect subsequent work into the filter layer.
-  impl_->encoder->finish();
-
-  Impl::FilterStackFrame frame;
-  frame.savedEncoder = std::move(impl_->encoder);
-  frame.savedTarget = impl_->target;
-  frame.layerTexture = layerTexture;
-  frame.layerDesc = td;
-  frame.filterGraph = filterGraph;
-  frame.filterRegion = region;
-  frame.deviceFromFilter = impl_->deviceFromLocalTransform;
-  frame.filterBufferOffsetX = filterBufferOffsetX;
-  frame.filterBufferOffsetY = filterBufferOffsetY;
-  frame.savedClipStack = std::move(impl_->clipStack);
-
-  // SVG 2 §15.5: the SourceGraphic that feeds the filter graph must be
-  // UNCLIPPED (paint → filter → clip → mask → opacity). Clear the outer
-  // clip stack so inner draws into the filter layer aren't gated by the
-  // outer clip-path. The outer mask textures and views stay alive in
-  // frame.savedClipStack, and popFilterLayer
-  // restores the stack and re-binds the mask before the composite blit.
-  impl_->clipStack.clear();
-
-  impl_->target = layerTexture;
-  auto newEncoder = std::make_unique<geode::GeoEncoder>(
-      *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      layerTexture, impl_->frameCommandEncoder.get());
-  impl_->configurePathEncoder(*newEncoder, /*collectGeometry=*/true, filterBufferOffsetX,
-                              filterBufferOffsetY);
-  newEncoder->clear(css::RGBA(0, 0, 0, 0));
-  impl_->encoder = std::move(newEncoder);
-
-  // Apply the buffer offset to the current transform so content at negative device coordinates
-  // renders into the expanded region. Subsequent setTransform calls will also pick up the offset.
-  if (filterBufferOffsetX != 0 || filterBufferOffsetY != 0) {
-    impl_->deviceFromLocalTransform =
-        impl_->deviceFromLocalTransform *
-        Transform2d::Translate(filterBufferOffsetX, filterBufferOffsetY);
+  if (!impl_->beginFilterCapture(filterGraph, *admission, impl_->deviceFromLocalTransform)) {
+    auto reservation = admission->reservation;
+    impl_->filterExecutionBudget->release(reservation);
+    impl_->filterExecutionBudget->reject();
+    impl_->pushRejectedFilterFrame();
   }
-
-  // Per SVG Filter Effects § filter region: pixels outside the filter region are
-  // transparent black for filter-primitive purposes. Scissor source draws to the
-  // filter region's device-space AABB so the SourceGraphic fed into filter
-  // primitives (e.g. feGaussianBlur) respects that boundary.
-  Impl::ClipStackEntry filterClipEntry;
-  filterClipEntry.pixelRect = impl_->deviceFromLocalTransform.transformBox(region);
-  filterClipEntry.valid = true;
-  impl_->clipStack.push_back(std::move(filterClipEntry));
-
-  impl_->filterStack.push_back(std::move(frame));
-  // Refresh scissor to the intersection of the outer clip stack and the filter region.
-  impl_->updateEncoderScissor();
 }
 
 void RendererGeode::popFilterLayer() {
@@ -4527,6 +4729,18 @@ void RendererGeode::popFilterLayer() {
   Impl::FilterStackFrame frame = std::move(impl_->filterStack.back());
   impl_->filterStack.pop_back();
   impl_->clipStack = std::move(frame.savedClipStack);
+
+  if (frame.allocationRejected) {
+    if (impl_->rejectedFilterDepth != 0) {
+      --impl_->rejectedFilterDepth;
+    }
+    if (frame.savedEncoder) {
+      impl_->target = frame.savedTarget;
+      impl_->encoder = std::move(frame.savedEncoder);
+      impl_->updateEncoderScissor();
+    }
+    return;
+  }
 
   if (!frame.layerTexture) {
     return;  // Placeholder frame from the headless/error path.
@@ -4546,132 +4760,20 @@ void RendererGeode::popFilterLayer() {
                 Transform2d::Translate(frame.filterBufferOffsetX, frame.filterBufferOffsetY)
           : frame.deviceFromFilter;
 
-  // ── Transformed-blur path ────────────────────────────────────────────────
-  // An anisotropic blur under a rotated CTM (or any blur under skew) cannot be
-  // reproduced by Geode's device-axis separable blur - the blur would land in
-  // device axes instead of the element's local axes. Mirror tiny-skia: rasterize
-  // the captured device content into an axis-aligned filter-local raster, run the
-  // (now axis-aligned) blur there, then composite the result back through the CTM
-  // so the blur is oriented correctly. Eligible only for the simple blur/offset
-  // chain (see isEligibleForTransformedBlurPath) and only when no buffer offset
-  // is active (the local raster supplies its own blur padding). tiny-skia is the
-  // parity reference.
-  bool transformedBlurComposited = false;
-  if (impl_->filterEngine && !frame.filterGraph.empty() && frame.filterRegion.width() > 0 &&
-      frame.filterRegion.height() > 0 && frame.filterBufferOffsetX == 0 &&
-      frame.filterBufferOffsetY == 0 && !NearZero(frame.deviceFromFilter.determinant(), 1e-12) &&
-      isEligibleForTransformedBlurPath(frame.filterGraph) &&
-      shouldUseTransformedBlurPath(frame.filterGraph, frame.deviceFromFilter)) {
-    const Transform2d& deviceFromFilter = frame.deviceFromFilter;
-    const Box2d& filterRegion = frame.filterRegion;
-
-    // Local raster density from the CTM basis vectors (min 1× to avoid collapse),
-    // matching tiny-skia's transformed-blur raster sizing.
-    const double scaleX =
-        std::max(1.0, deviceFromFilter.transformVector(Vector2d(1.0, 0.0)).length());
-    const double scaleY =
-        std::max(1.0, deviceFromFilter.transformVector(Vector2d(0.0, 1.0)).length());
-
-    const double blurPadding = computeBlurPadding(frame.filterGraph);
-    const Box2d paddedRegion(filterRegion.topLeft - Vector2d(blurPadding, blurPadding),
-                             filterRegion.bottomRight + Vector2d(blurPadding, blurPadding));
-
-    const uint32_t localWidth = static_cast<uint32_t>(
-        std::max(1, static_cast<int>(std::ceil(paddedRegion.width() * scaleX))));
-    const uint32_t localHeight = static_cast<uint32_t>(
-        std::max(1, static_cast<int>(std::ceil(paddedRegion.height() * scaleY))));
-
-    // Cap the local raster to avoid pathological allocations under extreme CTMs.
-    constexpr uint32_t kMaxLocalDim = 8192u;
-    if (localWidth <= kMaxLocalDim && localHeight <= kMaxLocalDim) {
-      // Allocate the local-raster offscreen texture.
-      wgpu::TextureDescriptor localDesc{};
-      localDesc.label = wgpuLabel("RendererGeodeBlurLocal");
-      localDesc.size = {localWidth, localHeight, 1u};
-      localDesc.format = impl_->textureFormat;
-      localDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-                        wgpu::TextureUsage::CopySrc;
-      localDesc.mipLevelCount = 1;
-      localDesc.sampleCount = 1;
-      localDesc.dimension = wgpu::TextureDimension::_2D;
-      wgpu::Texture localTexture = impl_->acquireTexture(localDesc);
-
-      if (localTexture) {
-        // Transform chains mirror tiny-skia (operator* applies the left factor
-        // first): device pixel → filter user space → padded-raster origin → local
-        // raster pixels.
-        const Transform2d filterFromDevice = deviceFromFilter.inverse();
-        const Transform2d localFromDevice =
-            filterFromDevice *
-            Transform2d::Translate(-paddedRegion.topLeft.x, -paddedRegion.topLeft.y) *
-            Transform2d::Scale(scaleX, scaleY);
-
-        // Resample the captured device content into the local raster in the
-        // shared frame command stream.
-        {
-          geode::GeoEncoder resampleEncoder(*impl_->device, *impl_->pipeline,
-                                            *impl_->gradientPipeline, *impl_->imagePipeline,
-                                            localTexture, impl_->frameCommandEncoder.get());
-          impl_->configureEncoder(resampleEncoder);
-          resampleEncoder.setTransform(localFromDevice);
-          resampleEncoder.drawTexture(
-              frame.layerTexture,
-              Box2d::FromXYWH(0.0, 0.0, static_cast<double>(frame.layerDesc.size.width),
-                              static_cast<double>(frame.layerDesc.size.height)),
-              kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
-          resampleEncoder.finish();
-        }
-
-        // Run the filter graph axis-aligned in local-raster space: deviceFromFilter
-        // is a pure Scale, and the filter region is in unscaled local units.
-        const Transform2d localDeviceFromFilter = Transform2d::Scale(scaleX, scaleY);
-        const Box2d localFilterRegion(
-            Vector2d(blurPadding, blurPadding),
-            Vector2d(blurPadding + filterRegion.width(), blurPadding + filterRegion.height()));
-        wgpu::Texture localFiltered =
-            impl_->filterEngine->execute(frame.filterGraph, localTexture, localFilterRegion,
-                                         localDeviceFromFilter, *impl_, impl_->frameCommandEncoder);
-
-        // Restore the outer target + encoder, then composite the local result back
-        // through the CTM. Transform chain (left factor first): local raster pixels
-        // → filter user space → device pixels.
-        const Transform2d deviceFromLocal =
-            Transform2d::Scale(1.0 / scaleX, 1.0 / scaleY) *
-            Transform2d::Translate(paddedRegion.topLeft.x, paddedRegion.topLeft.y) *
-            deviceFromFilter;
-
-        impl_->target = frame.savedTarget;
-        auto compositeEncoder = std::make_unique<geode::GeoEncoder>(
-            *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-            frame.savedTarget, impl_->frameCommandEncoder.get());
-        impl_->configurePathEncoder(*compositeEncoder);
-        compositeEncoder->setLoadPreserve();
-        impl_->encoder = std::move(compositeEncoder);
-        impl_->updateEncoderScissor();
-        impl_->encoder->setTransform(deviceFromLocal);
-        impl_->encoder->drawTexture(localFiltered,
-                                    Box2d::FromXYWH(0.0, 0.0, static_cast<double>(localWidth),
-                                                    static_cast<double>(localHeight)),
-                                    kWholeTextureUv, 1.0, /*pixelated=*/false,
-                                    /*sourceIsPremultiplied=*/true);
-        impl_->encoder->setTransform(Transform2d());
-
-        impl_->releaseTextureAtFrameEnd(std::move(localTexture), localDesc);
-        transformedBlurComposited = true;
-      } else {
-        impl_->releaseTexture(std::move(localTexture), localDesc);
-      }
-    }
-  }
-
-  if (transformedBlurComposited) {
+  if (impl_->tryCompositeTransformedFilter(frame)) {
+    impl_->filterExecutionBudget->release(frame.filterReservation);
     impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
     return;
   }
 
   // Run the filter graph on the captured layer texture.
   wgpu::Texture filteredTexture = frame.layerTexture;
-  if (impl_->filterEngine && !frame.filterGraph.empty()) {
+  const bool discardCapturedLayer = frame.localRasterRequiredForBudget;
+  if (frame.localRasterRequiredForBudget) {
+    impl_->filterExecutionBudget->reject();
+  } else if (impl_->filterEngine && !frame.filterGraph.empty() &&
+             static_cast<std::uint64_t>(frame.layerDesc.size.width) * frame.layerDesc.size.height <=
+                 components::kMaximumFilterSurfacePixels) {
     filteredTexture =
         impl_->filterEngine->execute(frame.filterGraph, frame.layerTexture, frame.filterRegion,
                                      bufferDeviceFromFilter, *impl_, impl_->frameCommandEncoder);
@@ -4688,6 +4790,11 @@ void RendererGeode::popFilterLayer() {
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
+  if (discardCapturedLayer) {
+    impl_->filterExecutionBudget->release(frame.filterReservation);
+    impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
+    return;
+  }
   if (frame.filterBufferOffsetX != 0 || frame.filterBufferOffsetY != 0) {
     // The filter result is in an expanded texture. Extract the viewport-sized region at the
     // buffer offset using a GPU texture copy, then blit the viewport-sized result.
@@ -4868,7 +4975,7 @@ void RendererGeode::popMask() {
 }
 
 bool RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) {
-  if (!impl_->device || !impl_->pipeline) {
+  if (impl_->rejectedFilterDepth != 0 || !impl_->device || !impl_->pipeline) {
     return false;
   }
 
@@ -6037,8 +6144,11 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
   if (!impl_->device) {
     return nullptr;
   }
-  return std::unique_ptr<RendererInterface>(
+  auto renderer = std::unique_ptr<RendererGeode>(
       new RendererGeode(impl_->device, impl_->verbose, impl_->offscreenCreationHookForTesting));
+  renderer->impl_->filterExecutionBudget = impl_->filterExecutionBudget;
+  renderer->impl_->ownsFilterExecutionBudget = false;
+  return renderer;
 }
 
 void RendererGeode::setOffscreenCreationHookForTesting(std::function<void()> hook) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1520,7 +1520,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   }
 
   bool submitFilterBudgetChunk() {
-    if (!device || !frameCommandEncoder || !target) {
+    if (!device || !frameCommandEncoder || !target || !filterStack.empty() ||
+        filterExecutionBudget->rejectionReason() !=
+            components::FilterExecutionBudget::RejectionReason::MemoryLimit ||
+        filterExecutionBudget->activeGpuReservations() != 0) {
       return false;
     }
 
@@ -1547,8 +1550,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     configurePathEncoder(*encoder);
     encoder->setLoadPreserve();
     updateEncoderScissor();
-    filterExecutionBudget->beginChunkAfterSubmit();
-    return true;
+    return filterExecutionBudget->beginChunkAfterSubmit();
   }
 
   /// A saved encoder + target state for an in-progress isolated layer
@@ -4876,6 +4878,7 @@ void RendererGeode::popFilterLayer() {
   // intermediates have already been queued for frame-end pool release
   // through `FilterTextureAllocator`; recycle the layer capture here.
   impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
+  impl_->filterExecutionBudget->release(frame.filterReservation);
 }
 
 void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds, MaskType maskType) {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -325,6 +325,9 @@ public:
   /// Install a zero-default hook entered after the new renderer owns its device.
   void setOffscreenCreationHookForTesting(std::function<void()> hook) override;
 
+  /// Number of filter-budget command-buffer chunks submitted in the current frame.
+  [[nodiscard]] std::uint64_t filterBudgetChunksForTesting() const override;
+
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
   [[nodiscard]] RendererBitmap takeSnapshotInterruptibly(
       const std::function<bool()>& shouldCancel) const override;

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -325,7 +325,7 @@ public:
   /// Install a zero-default hook entered after the new renderer owns its device.
   void setOffscreenCreationHookForTesting(std::function<void()> hook) override;
 
-  /// Number of filter-budget command-buffer chunks submitted in the current frame.
+  /// Number of filter-budget command-buffer chunks submitted by this renderer family.
   [[nodiscard]] std::uint64_t filterBudgetChunksForTesting() const override;
 
   [[nodiscard]] RendererBitmap takeSnapshot() const override;

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -703,6 +703,9 @@ public:
   /// Install a zero-default hook entered from inside offscreen backend construction.
   virtual void setOffscreenCreationHookForTesting(std::function<void()> /*hook*/) {}
 
+  /// Number of filter-budget command-buffer chunks submitted in the current frame.
+  [[nodiscard]] virtual std::uint64_t filterBudgetChunksForTesting() const { return 0; }
+
   /**
    * Enable or disable the backend's geometry debug overlay.
    *

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -703,7 +703,7 @@ public:
   /// Install a zero-default hook entered from inside offscreen backend construction.
   virtual void setOffscreenCreationHookForTesting(std::function<void()> /*hook*/) {}
 
-  /// Number of filter-budget command-buffer chunks submitted in the current frame.
+  /// Number of filter-budget command-buffer chunks submitted by this renderer family.
   [[nodiscard]] virtual std::uint64_t filterBudgetChunksForTesting() const { return 0; }
 
   /**

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <span>
 #include <utility>
@@ -744,6 +745,133 @@ std::vector<std::uint8_t> PremultiplyRgba(std::span<const std::uint8_t> rgbaPixe
 #ifdef DONNER_FILTERS_ENABLED
 // Blur implementation moved to tiny_skia::filter::gaussianBlur (GaussianBlur.h).
 
+int BoundedFloorToInt(double value, int minimum, int maximum) {
+  if (std::isnan(value)) {
+    return 0;
+  }
+  if (value <= static_cast<double>(minimum)) {
+    return minimum;
+  }
+  if (value >= static_cast<double>(maximum)) {
+    return maximum;
+  }
+  return static_cast<int>(std::floor(value));
+}
+
+std::optional<int> CheckedFilterRasterDimension(double value) {
+  if (!std::isfinite(value) || value <= 0.0 ||
+      value > static_cast<double>(components::kMaximumFilterSurfaceDimension)) {
+    return std::nullopt;
+  }
+  return std::max(1, static_cast<int>(std::ceil(value)));
+}
+
+bool graphHasSpatialShift(const components::FilterGraph& filterGraph);
+bool isEligibleForTransformedBlurPath(const components::FilterGraph& filterGraph);
+bool shouldUseTransformedBlurPath(const components::FilterGraph& filterGraph,
+                                  const Transform2d& deviceFromFilter);
+double computeBlurPadding(const components::FilterGraph& filterGraph);
+
+struct FilterBufferMetrics {
+  int width = 0;
+  int height = 0;
+  int offsetX = 0;
+  int offsetY = 0;
+};
+
+FilterBufferMetrics ComputeFilterBufferMetrics(const components::FilterGraph& filterGraph,
+                                               const std::optional<Box2d>& filterRegion,
+                                               const Transform2d& deviceFromFilter,
+                                               int viewportWidth, int viewportHeight) {
+  constexpr int kMaxExpansion = 4096;
+  int bufferX0 = 0;
+  int bufferY0 = 0;
+  if (filterRegion.has_value()) {
+    const Box2d deviceRegion = deviceFromFilter.transformBox(*filterRegion);
+    bufferX0 = std::min(0, BoundedFloorToInt(deviceRegion.topLeft.x, -kMaxExpansion, 0));
+    bufferY0 = std::min(0, BoundedFloorToInt(deviceRegion.topLeft.y, -kMaxExpansion, 0));
+  }
+
+  FilterBufferMetrics result{viewportWidth, viewportHeight, 0, 0};
+  if ((bufferX0 >= 0 && bufferY0 >= 0) || !graphHasSpatialShift(filterGraph)) {
+    return result;
+  }
+  result.offsetX = std::min(-bufferX0, std::max(0, kMaxExpansion - viewportWidth));
+  result.offsetY = std::min(-bufferY0, std::max(0, kMaxExpansion - viewportHeight));
+  result.width = viewportWidth + result.offsetX;
+  result.height = viewportHeight + result.offsetY;
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(result.width) * static_cast<std::uint64_t>(result.height);
+  if (pixels > components::kMaximumFilterSurfacePixels) {
+    return {viewportWidth, viewportHeight, 0, 0};
+  }
+  return result;
+}
+
+bool CanUseLocalFilterRaster(const components::FilterGraph& filterGraph,
+                             const std::optional<Box2d>& filterRegion,
+                             const Transform2d& deviceFromFilter, bool fullExecutionFits) {
+  if (!filterRegion.has_value() || filterRegion->width() <= 0.0 || filterRegion->height() <= 0.0 ||
+      NearZero(deviceFromFilter.determinant())) {
+    return false;
+  }
+  return isEligibleForTransformedBlurPath(filterGraph) &&
+         (shouldUseTransformedBlurPath(filterGraph, deviceFromFilter) || !fullExecutionFits);
+}
+
+struct LocalFilterRasterGeometry {
+  double scaleX = 1.0;
+  double scaleY = 1.0;
+  double blurPadding = 0.0;
+  Box2d paddedRegion;
+  int width = 0;
+  int height = 0;
+};
+
+std::optional<LocalFilterRasterGeometry> ComputeLocalFilterRasterGeometry(
+    const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+    const Transform2d& deviceFromFilter, bool fullExecutionFits) {
+  if (!CanUseLocalFilterRaster(filterGraph, filterRegion, deviceFromFilter, fullExecutionFits)) {
+    return std::nullopt;
+  }
+  const double scaleX =
+      std::max(1.0, deviceFromFilter.transformVector(Vector2d(1.0, 0.0)).length());
+  const double scaleY =
+      std::max(1.0, deviceFromFilter.transformVector(Vector2d(0.0, 1.0)).length());
+  const double blurPadding = computeBlurPadding(filterGraph);
+  const Box2d paddedRegion(filterRegion->topLeft - Vector2d(blurPadding, blurPadding),
+                           filterRegion->bottomRight + Vector2d(blurPadding, blurPadding));
+  const std::optional<int> width = CheckedFilterRasterDimension(paddedRegion.width() * scaleX);
+  const std::optional<int> height = CheckedFilterRasterDimension(paddedRegion.height() * scaleY);
+  if (!width || !height) {
+    return std::nullopt;
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(*width) * static_cast<std::uint64_t>(*height);
+  if (pixels > components::kMaximumFilterSurfacePixels) {
+    return std::nullopt;
+  }
+  return LocalFilterRasterGeometry{scaleX, scaleY, blurPadding, paddedRegion, *width, *height};
+}
+
+std::optional<std::uint64_t> ComputeLocalFilterPixels(const components::FilterGraph& filterGraph,
+                                                      const std::optional<Box2d>& filterRegion,
+                                                      const Transform2d& deviceFromFilter,
+                                                      bool fullExecutionFits) {
+  const std::optional<LocalFilterRasterGeometry> geometry = ComputeLocalFilterRasterGeometry(
+      filterGraph, filterRegion, deviceFromFilter, fullExecutionFits);
+  if (!geometry.has_value()) {
+    return std::nullopt;
+  }
+  const std::uint64_t pixels =
+      static_cast<std::uint64_t>(geometry->width) * static_cast<std::uint64_t>(geometry->height);
+  if (!components::FilterGraphFitsExecutionBudget(
+          filterGraph, pixels, components::FilterMemoryModel::CpuFloatNamedResults)) {
+    return std::nullopt;
+  }
+  return pixels;
+}
+
 /**
  * Returns true if the filter graph is a linear chain of single-input blur-family primitives
  * eligible for the transformed local-raster path.
@@ -955,6 +1083,11 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   currentClipMask_.reset();
   clipStack_.clear();
   surfaceStack_.clear();
+  filterLayerStack_.clear();
+  rejectedFilterDepth_ = 0;
+  if (ownsFilterExecutionBudget_) {
+    filterExecutionBudget_->reset();
+  }
   patternFillPaint_.reset();
   patternStrokePaint_.reset();
   frameCounters_ = RendererTinySkiaFrameCounters();
@@ -982,6 +1115,8 @@ void RendererTinySkia::endFrame() {
   }
 
   surfaceStack_.clear();
+  filterLayerStack_.clear();
+  rejectedFilterDepth_ = 0;
   deviceFromLocalTransform_ = Transform2d();
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
@@ -1026,6 +1161,10 @@ void RendererTinySkia::popTransform() {
 void RendererTinySkia::pushClip(const ResolvedClip& clip) {
   clipStack_.push_back(currentClipMask_);
   clipEpochStack_.push_back(clipEpoch_);
+
+  if (rejectedFilterDepth_ != 0) {
+    return;
+  }
 
   std::optional<tiny_skia::Mask> clipMask = buildClipMask(clip);
   if (!clipMask.has_value()) {
@@ -1143,6 +1282,11 @@ void RendererTinySkia::pushIsolatedLayer(double opacity, MixBlendMode blendMode)
   frame.kind = SurfaceKind::IsolatedLayer;
   frame.opacity = opacity;
   frame.blendMode = blendMode;
+  if (rejectedFilterDepth_ != 0) {
+    frame.allocationRejected = true;
+    surfaceStack_.push_back(std::move(frame));
+    return;
+  }
   const int width = static_cast<int>(currentPixmap().width());
   const int height = static_cast<int>(currentPixmap().height());
   frame.pixmap = createTransparentPixmap(width, height);
@@ -1165,6 +1309,9 @@ void RendererTinySkia::popIsolatedLayer() {
 
   SurfaceFrame frame = std::move(surfaceStack_.back());
   surfaceStack_.pop_back();
+  if (frame.allocationRejected) {
+    return;
+  }
   compositePixmap(frame.pixmap, frame.opacity, frame.blendMode);
   if (!surfaceStack_.empty()) {
     SurfaceFrame& parent = surfaceStack_.back();
@@ -1177,9 +1324,86 @@ void RendererTinySkia::popIsolatedLayer() {
   }
 }
 
+#ifdef DONNER_FILTERS_ENABLED
+std::optional<RendererTinySkia::FilterAdmission> RendererTinySkia::admitFilterLayer(
+    const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+    const Transform2d& deviceFromFilter, int viewportWidth, int viewportHeight) {
+  const FilterBufferMetrics buffer = ComputeFilterBufferMetrics(
+      filterGraph, filterRegion, deviceFromFilter, viewportWidth, viewportHeight);
+  const bool usesFillPaint =
+      graphUsesStandardInput(filterGraph, components::FilterStandardInput::FillPaint);
+  const bool usesStrokePaint =
+      graphUsesStandardInput(filterGraph, components::FilterStandardInput::StrokePaint);
+  const std::uint64_t surfaceCount =
+      1u + static_cast<std::uint64_t>(usesFillPaint) + static_cast<std::uint64_t>(usesStrokePaint);
+  if (buffer.width <= 0 || buffer.height <= 0) {
+    filterExecutionBudget_->reject();
+    return std::nullopt;
+  }
+
+  const std::uint64_t pixelCount =
+      static_cast<std::uint64_t>(buffer.width) * static_cast<std::uint64_t>(buffer.height);
+  if (pixelCount > components::kMaximumFilterSurfacePixels ||
+      pixelCount > std::numeric_limits<std::uint64_t>::max() / 4u / surfaceCount) {
+    filterExecutionBudget_->reject();
+    return std::nullopt;
+  }
+  const bool fullExecutionFits = components::FilterGraphFitsExecutionBudget(
+      filterGraph, pixelCount, components::FilterMemoryModel::CpuFloatNamedResults);
+  const std::optional<std::uint64_t> localPixelCount =
+      ComputeLocalFilterPixels(filterGraph, filterRegion, deviceFromFilter, fullExecutionFits);
+  if (!fullExecutionFits && !localPixelCount.has_value()) {
+    filterExecutionBudget_->reject();
+    return std::nullopt;
+  }
+
+  std::uint64_t executionPixelCount = pixelCount;
+  std::uint64_t captureBytes = pixelCount * 4u * surfaceCount;
+  if (localPixelCount.has_value()) {
+    executionPixelCount =
+        fullExecutionFits ? std::max(pixelCount, *localPixelCount) : *localPixelCount;
+    captureBytes += *localPixelCount * 4u;
+  }
+  auto reservation = filterExecutionBudget_->reserve(
+      filterGraph, executionPixelCount, components::FilterMemoryModel::CpuFloatNamedResults,
+      captureBytes);
+  if (!reservation.has_value()) {
+    return std::nullopt;
+  }
+  return FilterAdmission{buffer.width,  buffer.height,   buffer.offsetX,     buffer.offsetY,
+                         usesFillPaint, usesStrokePaint, !fullExecutionFits, *reservation};
+}
+
+bool RendererTinySkia::initializeFilterSurface(SurfaceFrame& frame,
+                                               const FilterAdmission& admission) {
+  frame.pixmap = createTransparentPixmap(admission.width, admission.height);
+  if (admission.usesFillPaint) {
+    frame.fillPaintPixmap = createTransparentPixmap(admission.width, admission.height);
+  }
+  if (admission.usesStrokePaint) {
+    frame.strokePaintPixmap = createTransparentPixmap(admission.width, admission.height);
+  }
+  const bool allocationFailed = frame.pixmap.width() == 0 || frame.pixmap.height() == 0 ||
+                                (admission.usesFillPaint && !frame.fillPaintPixmap.has_value()) ||
+                                (admission.usesStrokePaint && !frame.strokePaintPixmap.has_value());
+  if (!allocationFailed) {
+    return true;
+  }
+  filterExecutionBudget_->release(frame.filterReservation);
+  filterExecutionBudget_->reject();
+  return false;
+}
+#endif  // DONNER_FILTERS_ENABLED
+
 void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGraph,
                                        const std::optional<Box2d>& filterRegion) {
 #ifdef DONNER_FILTERS_ENABLED
+  if (rejectedFilterDepth_ != 0) {
+    filterLayerStack_.push_back(false);
+    ++rejectedFilterDepth_;
+    return;
+  }
+
   SurfaceFrame frame;
   frame.kind = SurfaceKind::FilterLayer;
   frame.filterGraph = filterGraph;
@@ -1188,58 +1412,22 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
 
   const int viewportWidth = static_cast<int>(currentPixmap().width());
   const int viewportHeight = static_cast<int>(currentPixmap().height());
-
-  // Compute the filter buffer dimensions. When the filter region's AABB in device space extends
-  // beyond the viewport (e.g., due to skew or rotation placing content at negative coordinates),
-  // expand the buffer so the SourceGraphic captures all content. This is needed because feOffset
-  // or other spatial primitives may shift content into the viewport later.
-  int bufferX0 = 0;
-  int bufferY0 = 0;
-  int width = viewportWidth;
-  int height = viewportHeight;
-
-  if (filterRegion.has_value()) {
-    const Box2d deviceRegion = deviceFromLocalTransform_.transformBox(*filterRegion);
-    const int regionX0 = static_cast<int>(std::floor(deviceRegion.topLeft.x));
-    const int regionY0 = static_cast<int>(std::floor(deviceRegion.topLeft.y));
-    const int regionX1 = static_cast<int>(std::ceil(deviceRegion.bottomRight.x));
-    const int regionY1 = static_cast<int>(std::ceil(deviceRegion.bottomRight.y));
-
-    // Expand buffer to cover the union of viewport and filter region AABB.
-    bufferX0 = std::min(0, regionX0);
-    bufferY0 = std::min(0, regionY0);
-    const int bufferX1 = std::max(viewportWidth, regionX1);
-    const int bufferY1 = std::max(viewportHeight, regionY1);
-    width = bufferX1 - bufferX0;
-    height = bufferY1 - bufferY0;
-
-    // Cap to a reasonable maximum to avoid huge allocations.
-    constexpr int kMaxBufferDim = 4096;
-    width = std::min(width, kMaxBufferDim);
-    height = std::min(height, kMaxBufferDim);
+  const std::optional<FilterAdmission> admission = admitFilterLayer(
+      filterGraph, filterRegion, frame.deviceFromFilter, viewportWidth, viewportHeight);
+  if (!admission.has_value()) {
+    filterLayerStack_.push_back(false);
+    ++rejectedFilterDepth_;
+    return;
   }
-
-  // Expand the buffer into negative device coordinates only when the filter graph contains
-  // spatial primitives (feOffset, feDisplacementMap) that can shift content into the viewport
-  // from outside. Without such primitives, content at negative coordinates would never be
-  // visible, so expansion is unnecessary.
-  if ((bufferX0 < 0 || bufferY0 < 0) && graphHasSpatialShift(filterGraph)) {
-    constexpr int kMaxExpansion = 4096;
-    frame.filterBufferOffsetX = std::min(-bufferX0, std::max(0, kMaxExpansion - viewportWidth));
-    frame.filterBufferOffsetY = std::min(-bufferY0, std::max(0, kMaxExpansion - viewportHeight));
-    width = viewportWidth + frame.filterBufferOffsetX;
-    height = viewportHeight + frame.filterBufferOffsetY;
-  } else {
-    // No expansion needed - use viewport dimensions.
-    width = viewportWidth;
-    height = viewportHeight;
-  }
-  frame.pixmap = createTransparentPixmap(width, height);
-  if (graphUsesStandardInput(filterGraph, components::FilterStandardInput::FillPaint)) {
-    frame.fillPaintPixmap = createTransparentPixmap(width, height);
-  }
-  if (graphUsesStandardInput(filterGraph, components::FilterStandardInput::StrokePaint)) {
-    frame.strokePaintPixmap = createTransparentPixmap(width, height);
+  frame.filterReservation = admission->reservation;
+  frame.localRasterRequiredForBudget = admission->localRasterRequired;
+  frame.filterBufferOffsetX = admission->bufferOffsetX;
+  frame.filterBufferOffsetY = admission->bufferOffsetY;
+  filterLayerStack_.push_back(true);
+  if (!initializeFilterSurface(frame, *admission)) {
+    filterLayerStack_.back() = false;
+    ++rejectedFilterDepth_;
+    return;
   }
 
   // Per SVG spec, the rendering order is: paint → filter → clip-path → mask → opacity.
@@ -1273,8 +1461,124 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
 #endif
 }
 
+#ifdef DONNER_FILTERS_ENABLED
+bool RendererTinySkia::compositeTransformedFilter(SurfaceFrame& frame) {
+  const std::optional<LocalFilterRasterGeometry> geometry =
+      ComputeLocalFilterRasterGeometry(frame.filterGraph, frame.filterRegion,
+                                       frame.deviceFromFilter, !frame.localRasterRequiredForBudget);
+  if (!geometry.has_value()) {
+    return false;
+  }
+
+  tiny_skia::Pixmap localPixmap = createTransparentPixmap(geometry->width, geometry->height);
+  if (localPixmap.width() == 0 || localPixmap.height() == 0) {
+    return false;
+  }
+  const Transform2d filterFromDevice = frame.deviceFromFilter.inverse();
+  const Transform2d localFromDevice =
+      filterFromDevice *
+      Transform2d::Translate(-geometry->paddedRegion.topLeft.x, -geometry->paddedRegion.topLeft.y) *
+      Transform2d::Scale(geometry->scaleX, geometry->scaleY);
+  tiny_skia::PixmapPaint resamplePaint =
+      makePixmapPaint(localPixmap, tiny_skia::FilterQuality::Bilinear);
+  resamplePaint.opacity = 1.0f;
+  resamplePaint.blendMode = tiny_skia::BlendMode::Source;
+  auto localView = localPixmap.mutableView();
+  tiny_skia::Painter::drawPixmap(localView, 0, 0, frame.pixmap.view(), resamplePaint,
+                                 toTinyTransform(localFromDevice));
+
+  const Transform2d localFromFilter = Transform2d::Scale(geometry->scaleX, geometry->scaleY);
+  const Box2d localFilterRegion(Vector2d(geometry->blurPadding, geometry->blurPadding),
+                                Vector2d(geometry->blurPadding + frame.filterRegion->width(),
+                                         geometry->blurPadding + frame.filterRegion->height()));
+  ApplyFilterGraphToPixmap(localPixmap, frame.filterGraph, localFromFilter, localFilterRegion,
+                           false);
+  ClipFilterOutputToRegion(localPixmap, localFilterRegion, localFromFilter);
+
+  const Transform2d deviceFromLocal =
+      Transform2d::Scale(1.0 / geometry->scaleX, 1.0 / geometry->scaleY) *
+      Transform2d::Translate(geometry->paddedRegion.topLeft.x, geometry->paddedRegion.topLeft.y) *
+      frame.deviceFromFilter;
+  tiny_skia::PixmapPaint compositePaint =
+      makePixmapPaint(currentPixmap(), tiny_skia::FilterQuality::Bilinear);
+  compositePaint.opacity = 1.0f;
+  compositePaint.blendMode = tiny_skia::BlendMode::SourceOver;
+  const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
+  auto pixmapView = currentPixmapView();
+  tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, localPixmap.view(), compositePaint,
+                                 toTinyTransform(deviceFromLocal), mask);
+  return true;
+}
+
+tiny_skia::Pixmap RendererTinySkia::extractFilterViewport(const SurfaceFrame& frame, int width,
+                                                          int height) {
+  tiny_skia::Pixmap viewport = createTransparentPixmap(width, height);
+  const auto source = frame.pixmap.data();
+  auto destination = viewport.data();
+  const int sourceWidth = static_cast<int>(frame.pixmap.width());
+  const int sourceHeight = static_cast<int>(frame.pixmap.height());
+  for (int y = 0; y < height; ++y) {
+    const int sourceY = y + frame.filterBufferOffsetY;
+    if (sourceY < 0 || sourceY >= sourceHeight) {
+      continue;
+    }
+    const int sourceXStart = std::max(0, frame.filterBufferOffsetX);
+    const int sourceXEnd = std::min(sourceWidth, frame.filterBufferOffsetX + width);
+    if (sourceXStart >= sourceXEnd) {
+      continue;
+    }
+    const int destinationX = sourceXStart - frame.filterBufferOffsetX;
+    const auto sourceOffset = static_cast<std::size_t>((sourceY * sourceWidth + sourceXStart) * 4);
+    const auto destinationOffset = static_cast<std::size_t>((y * width + destinationX) * 4);
+    const auto count = static_cast<std::size_t>((sourceXEnd - sourceXStart) * 4);
+    std::memcpy(&destination[destinationOffset], &source[sourceOffset], count);
+  }
+  return viewport;
+}
+
+void RendererTinySkia::compositeDeviceFilter(SurfaceFrame& frame) {
+  const bool hasOffset = frame.filterBufferOffsetX != 0 || frame.filterBufferOffsetY != 0;
+  const Transform2d bufferDeviceFromFilter =
+      hasOffset ? frame.deviceFromFilter *
+                      Transform2d::Translate(frame.filterBufferOffsetX, frame.filterBufferOffsetY)
+                : frame.deviceFromFilter;
+  ApplyFilterGraphToPixmap(
+      frame.pixmap, frame.filterGraph, bufferDeviceFromFilter, frame.filterRegion, true,
+      frame.fillPaintPixmap.has_value() ? &*frame.fillPaintPixmap : nullptr,
+      frame.strokePaintPixmap.has_value() ? &*frame.strokePaintPixmap : nullptr);
+  ClipFilterOutputToRegion(frame.pixmap, frame.filterRegion, bufferDeviceFromFilter);
+
+  tiny_skia::PixmapPaint paint =
+      makePixmapPaint(currentPixmap(), tiny_skia::FilterQuality::Nearest);
+  paint.opacity = 1.0f;
+  paint.blendMode = tiny_skia::BlendMode::SourceOver;
+  const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
+  auto pixmapView = currentPixmapView();
+  if (hasOffset) {
+    tiny_skia::Pixmap viewport = extractFilterViewport(frame, static_cast<int>(pixmapView.width()),
+                                                       static_cast<int>(pixmapView.height()));
+    tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, viewport.view(), paint,
+                                   tiny_skia::Transform::identity(), mask);
+    return;
+  }
+  tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, frame.pixmap.view(), paint,
+                                 tiny_skia::Transform::identity(), mask);
+}
+#endif  // DONNER_FILTERS_ENABLED
+
 void RendererTinySkia::popFilterLayer() {
 #ifdef DONNER_FILTERS_ENABLED
+  if (filterLayerStack_.empty()) {
+    return;
+  }
+  const bool layerAccepted = filterLayerStack_.back();
+  filterLayerStack_.pop_back();
+  if (!layerAccepted) {
+    if (rejectedFilterDepth_ != 0) {
+      --rejectedFilterDepth_;
+    }
+    return;
+  }
   if (surfaceStack_.empty() || surfaceStack_.back().kind != SurfaceKind::FilterLayer) {
     return;
   }
@@ -1290,163 +1594,17 @@ void RendererTinySkia::popFilterLayer() {
   clipEpoch_ = frame.savedClipEpoch;
   clipEpochStack_ = std::move(frame.savedClipEpochStack);
 
-  // Transform is maintained by RendererDriver via setTransform. The filter buffer offset
-  // (if any) was applied in setTransform and is automatically removed when the surface is
-  // popped, since setTransform checks surfaceStack_.back().
-
-  // Use the transformed local-raster path for eligible simple blur chains with
-  // rotation or skew transforms. This resamples device content into an axis-aligned local
-  // raster, applies the blur in filter-local coordinates, and composites back. This produces
-  // correct blur orientation for rotated/skewed elements.
-  // Only activate when the transform has rotation/skew (off-diagonal elements non-zero).
-  // For pure scale+translate, the device-space blur is already correct.
-  const bool useTransformedBlurPath =
-      frame.filterRegion.has_value() && frame.filterRegion->width() > 0 &&
-      frame.filterRegion->height() > 0 && !NearZero(frame.deviceFromFilter.determinant()) &&
-      isEligibleForTransformedBlurPath(frame.filterGraph) &&
-      shouldUseTransformedBlurPath(frame.filterGraph, frame.deviceFromFilter);
-
-  if (useTransformedBlurPath) {
-    const Transform2d& deviceFromFilter = frame.deviceFromFilter;
-    const Box2d& filterRegion = *frame.filterRegion;
-
-    // Compute local raster density from the filter transform basis vectors.
-    const double scaleX =
-        std::max(1.0, deviceFromFilter.transformVector(Vector2d(1.0, 0.0)).length());
-    const double scaleY =
-        std::max(1.0, deviceFromFilter.transformVector(Vector2d(0.0, 1.0)).length());
-
-    const double blurPadding = computeBlurPadding(frame.filterGraph);
-    const Box2d paddedRegion(filterRegion.topLeft - Vector2d(blurPadding, blurPadding),
-                             filterRegion.bottomRight + Vector2d(blurPadding, blurPadding));
-
-    const int localWidth = std::max(1, static_cast<int>(std::ceil(paddedRegion.width() * scaleX)));
-    const int localHeight =
-        std::max(1, static_cast<int>(std::ceil(paddedRegion.height() * scaleY)));
-
-    // Allocate local-raster pixmap.
-    tiny_skia::Pixmap localPixmap = createTransparentPixmap(localWidth, localHeight);
-    if (localPixmap.width() == 0 || localPixmap.height() == 0) {
-      goto device_space_fallback;
-    }
-
-    {
-      // Resample device pixels into local filter coordinates.
-      // Transform chain: device → filter (inverse of deviceFromFilter) → padded origin
-      // (translate) → local raster pixels (scale).
-      // Operator* convention: (A * B)(p) = B(A(p)), so A is applied first.
-      const Transform2d filterFromDevice = deviceFromFilter.inverse();
-      const Transform2d localFromDevice =
-          filterFromDevice *
-          Transform2d::Translate(-paddedRegion.topLeft.x, -paddedRegion.topLeft.y) *
-          Transform2d::Scale(scaleX, scaleY);
-
-      {
-        tiny_skia::PixmapPaint resamplePaint =
-            makePixmapPaint(localPixmap, tiny_skia::FilterQuality::Bilinear);
-        resamplePaint.opacity = 1.0f;
-        resamplePaint.blendMode = tiny_skia::BlendMode::Source;
-
-        auto localView = localPixmap.mutableView();
-        tiny_skia::Painter::drawPixmap(localView, 0, 0, frame.pixmap.view(), resamplePaint,
-                                       toTinyTransform(localFromDevice));
-      }
-
-      // Execute the filter graph in local raster space.
-      const Transform2d localTransform = Transform2d::Scale(scaleX, scaleY);
-      const Box2d localFilterRegion(
-          Vector2d(blurPadding, blurPadding),
-          Vector2d(blurPadding + filterRegion.width(), blurPadding + filterRegion.height()));
-
-      ApplyFilterGraphToPixmap(localPixmap, frame.filterGraph, localTransform, localFilterRegion,
-                               false);
-
-      // Clip to the original filter region within the padded raster.
-      ClipFilterOutputToRegion(localPixmap, localFilterRegion, localTransform);
-
-      // Composite the filtered local raster back to the parent device pixmap.
-      // Transform chain: local raster → filter coords (inverse scale + translate back) → device.
-      // Operator* convention: (A * B)(p) = B(A(p)), so A is applied first.
-      const Transform2d deviceFromLocal =
-          Transform2d::Scale(1.0 / scaleX, 1.0 / scaleY) *
-          Transform2d::Translate(paddedRegion.topLeft.x, paddedRegion.topLeft.y) * deviceFromFilter;
-
-      tiny_skia::PixmapPaint compositePaint =
-          makePixmapPaint(currentPixmap(), tiny_skia::FilterQuality::Bilinear);
-      compositePaint.opacity = 1.0f;
-      compositePaint.blendMode = tiny_skia::BlendMode::SourceOver;
-
-      const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
-      auto pixmapView = currentPixmapView();
-      tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, localPixmap.view(), compositePaint,
-                                     toTinyTransform(deviceFromLocal), mask);
-    }
-  } else {
-  device_space_fallback: {
-    // When the filter buffer is offset (expanded to capture content at negative device
-    // coordinates), adjust the deviceFromFilter transform to include the offset.
-    const Transform2d bufferDeviceFromFilter =
-        (frame.filterBufferOffsetX != 0 || frame.filterBufferOffsetY != 0)
-            ? frame.deviceFromFilter *
-                  Transform2d::Translate(frame.filterBufferOffsetX, frame.filterBufferOffsetY)
-            : frame.deviceFromFilter;
-
-    ApplyFilterGraphToPixmap(
-        frame.pixmap, frame.filterGraph, bufferDeviceFromFilter, frame.filterRegion, true,
-        frame.fillPaintPixmap.has_value() ? &*frame.fillPaintPixmap : nullptr,
-        frame.strokePaintPixmap.has_value() ? &*frame.strokePaintPixmap : nullptr);
-    ClipFilterOutputToRegion(frame.pixmap, frame.filterRegion, bufferDeviceFromFilter);
-
-    {
-      // Composite the filter result with the restored clip mask applied, so the clip-path
-      // clips the filter output rather than the input.
-      tiny_skia::PixmapPaint paint =
-          makePixmapPaint(currentPixmap(), tiny_skia::FilterQuality::Nearest);
-      paint.opacity = 1.0f;
-      paint.blendMode = tiny_skia::BlendMode::SourceOver;
-
-      const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
-      auto pixmapView = currentPixmapView();
-
-      if (frame.filterBufferOffsetX != 0 || frame.filterBufferOffsetY != 0) {
-        // The filter buffer is expanded beyond the viewport. Extract the viewport-sized region
-        // at the buffer offset and composite that. drawPixmap doesn't support negative dest
-        // coordinates, so we copy the relevant region into a viewport-sized pixmap first.
-        const int vpW = static_cast<int>(pixmapView.width());
-        const int vpH = static_cast<int>(pixmapView.height());
-        tiny_skia::Pixmap viewportRegion = createTransparentPixmap(vpW, vpH);
-        const auto srcData = frame.pixmap.data();
-        auto dstData = viewportRegion.data();
-        const int bufW = static_cast<int>(frame.pixmap.width());
-        const int bufH = static_cast<int>(frame.pixmap.height());
-        const int ox = frame.filterBufferOffsetX;
-        const int oy = frame.filterBufferOffsetY;
-        for (int y = 0; y < vpH; ++y) {
-          const int srcY = y + oy;
-          if (srcY < 0 || srcY >= bufH) {
-            continue;
-          }
-          // Copy the overlapping row segment.
-          const int srcXStart = std::max(0, ox);
-          const int srcXEnd = std::min(bufW, ox + vpW);
-          if (srcXStart >= srcXEnd) {
-            continue;
-          }
-          const int dstX = srcXStart - ox;
-          const auto srcOff = static_cast<std::size_t>((srcY * bufW + srcXStart) * 4);
-          const auto dstOff = static_cast<std::size_t>((y * vpW + dstX) * 4);
-          const auto count = static_cast<std::size_t>((srcXEnd - srcXStart) * 4);
-          std::memcpy(&dstData[dstOff], &srcData[srcOff], count);
-        }
-        tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, viewportRegion.view(), paint,
-                                       tiny_skia::Transform::identity(), mask);
-      } else {
-        tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, frame.pixmap.view(), paint,
-                                       tiny_skia::Transform::identity(), mask);
-      }
-    }
+  if (compositeTransformedFilter(frame)) {
+    filterExecutionBudget_->release(frame.filterReservation);
+    return;
   }
+  if (frame.localRasterRequiredForBudget) {
+    filterExecutionBudget_->reject();
+    filterExecutionBudget_->release(frame.filterReservation);
+    return;
   }
+  compositeDeviceFilter(frame);
+  filterExecutionBudget_->release(frame.filterReservation);
 #endif  // DONNER_FILTERS_ENABLED
 }
 
@@ -1456,6 +1614,11 @@ void RendererTinySkia::pushMask(const std::optional<Box2d>& maskBounds, MaskType
   frame.maskBounds = maskBounds;
   frame.maskBoundsTransform = deviceFromLocalTransform_;
   frame.maskType = maskType;
+  if (rejectedFilterDepth_ != 0) {
+    frame.allocationRejected = true;
+    surfaceStack_.push_back(std::move(frame));
+    return;
+  }
   frame.pixmap = createTransparentPixmap(static_cast<int>(currentPixmap().width()),
                                          static_cast<int>(currentPixmap().height()));
   surfaceStack_.push_back(std::move(frame));
@@ -1467,6 +1630,10 @@ void RendererTinySkia::transitionMaskToContent() {
   }
 
   SurfaceFrame& frame = surfaceStack_.back();
+  if (frame.allocationRejected) {
+    frame.kind = SurfaceKind::MaskContent;
+    return;
+  }
   const tiny_skia::MaskType tinyMaskType = frame.maskType == MaskType::Alpha
                                                ? tiny_skia::MaskType::Alpha
                                                : tiny_skia::MaskType::Luminance;
@@ -1531,6 +1698,10 @@ void RendererTinySkia::popMask() {
 
 bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
                                         const Transform2d& targetFromPattern) {
+  if (rejectedFilterDepth_ != 0) {
+    return false;
+  }
+
   SurfaceFrame frame;
   frame.kind = SurfaceKind::PatternTile;
   frame.savedTransform = deviceFromLocalTransform_;
@@ -1974,6 +2145,9 @@ void RendererTinySkia::drawImagePixmap(const tiny_skia::PixmapView& source, int 
 }
 
 void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& params) {
+  if (rejectedFilterDepth_ != 0) {
+    return;
+  }
   if (!HasExactRgbaPayload(image.data, image.width, image.height)) {
     return;
   }
@@ -1996,6 +2170,9 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
 }
 
 void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) {
+  if (rejectedFilterDepth_ != 0) {
+    return;
+  }
   if (bitmap.empty()) {
     return;
   }
@@ -2628,7 +2805,10 @@ bool RendererTinySkia::save(const char* filename) {
 }
 
 std::unique_ptr<RendererInterface> RendererTinySkia::createOffscreenInstance() const {
-  return std::make_unique<RendererTinySkia>(verbose_);
+  auto renderer = std::make_unique<RendererTinySkia>(verbose_);
+  renderer->filterExecutionBudget_ = filterExecutionBudget_;
+  renderer->ownsFilterExecutionBudget_ = false;
+  return renderer;
 }
 
 int RendererTinySkia::width() const {
@@ -2640,10 +2820,16 @@ int RendererTinySkia::height() const {
 }
 
 tiny_skia::Pixmap& RendererTinySkia::currentPixmap() {
+  if (rejectedFilterDepth_ != 0) {
+    return rejectedPixmap_;
+  }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
 }
 
 const tiny_skia::Pixmap& RendererTinySkia::currentPixmap() const {
+  if (rejectedFilterDepth_ != 0) {
+    return rejectedPixmap_;
+  }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
 }
 

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -316,13 +316,16 @@ private:
   struct SurfaceFrame {
     SurfaceKind kind;
     tiny_skia::Pixmap pixmap;
+    bool allocationRejected = false;
     std::optional<tiny_skia::Pixmap> fillPaintPixmap;
     std::optional<tiny_skia::Pixmap> strokePaintPixmap;
     double opacity = 1.0;
     MixBlendMode blendMode = MixBlendMode::Normal;
     components::FilterGraph filterGraph;
+    components::FilterExecutionBudget::Reservation filterReservation;
     std::optional<Box2d> filterRegion;
     Transform2d deviceFromFilter;
+    bool localRasterRequiredForBudget = false;
     int filterBufferOffsetX = 0;
     int filterBufferOffsetY = 0;
     std::optional<Box2d> maskBounds;
@@ -346,6 +349,17 @@ private:
     std::uint64_t savedClipEpoch = 0;
     /// @see savedClipEpoch
     std::vector<std::uint64_t> savedClipEpochStack;
+  };
+
+  struct FilterAdmission {
+    int width = 0;
+    int height = 0;
+    int bufferOffsetX = 0;
+    int bufferOffsetY = 0;
+    bool usesFillPaint = false;
+    bool usesStrokePaint = false;
+    bool localRasterRequired = false;
+    components::FilterExecutionBudget::Reservation reservation;
   };
 
   /// Last clip mask seen at one clip-stack depth, and the identity assigned to it.
@@ -385,6 +399,13 @@ private:
   [[nodiscard]] const tiny_skia::Pixmap& currentPixmap() const;
   [[nodiscard]] tiny_skia::MutablePixmapView currentPixmapView();
   [[nodiscard]] std::optional<tiny_skia::Mask> buildClipMask(const ResolvedClip& clip) const;
+  [[nodiscard]] std::optional<FilterAdmission> admitFilterLayer(
+      const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
+      const Transform2d& deviceFromFilter, int viewportWidth, int viewportHeight);
+  bool initializeFilterSurface(SurfaceFrame& frame, const FilterAdmission& admission);
+  bool compositeTransformedFilter(SurfaceFrame& frame);
+  void compositeDeviceFilter(SurfaceFrame& frame);
+  tiny_skia::Pixmap extractFilterViewport(const SurfaceFrame& frame, int width, int height);
   [[nodiscard]] std::optional<tiny_skia::Paint> makeFillPaint(const Box2d& bounds);
   [[nodiscard]] std::optional<tiny_skia::Paint> makeStrokePaint(const Box2d& bounds,
                                                                 const StrokeParams& stroke);
@@ -448,7 +469,13 @@ private:
   std::vector<Transform2d> deviceFromLocalTransformStack_;
   std::optional<tiny_skia::Mask> currentClipMask_;
   std::vector<std::optional<tiny_skia::Mask>> clipStack_;
+  tiny_skia::Pixmap rejectedPixmap_;
   std::vector<SurfaceFrame> surfaceStack_;
+  std::vector<bool> filterLayerStack_;
+  std::size_t rejectedFilterDepth_ = 0;
+  std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget_ =
+      std::make_shared<components::FilterExecutionBudget>();
+  bool ownsFilterExecutionBudget_ = true;
   std::optional<PatternPaintState> patternFillPaint_;
   std::optional<PatternPaintState> patternStrokePaint_;
 

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -207,6 +207,60 @@ namespace {
 
 constexpr wgpu::TextureFormat kFormat = wgpu::TextureFormat::RGBA8Unorm;
 
+double boundedPositiveFilterPixels(double value) {
+  if (!std::isfinite(value) || value <= 0.0) {
+    return 0.0;
+  }
+  return std::min(value, static_cast<double>(svg::components::kMaximumFilterPixelRadius));
+}
+
+double boundedSignedFilterPixels(double value) {
+  if (!std::isfinite(value)) {
+    return 0.0;
+  }
+  return std::clamp(value, -static_cast<double>(svg::components::kMaximumFilterPixelOffset),
+                    static_cast<double>(svg::components::kMaximumFilterPixelOffset));
+}
+
+int32_t boundedRoundedInt32(double value, int32_t minimum, int32_t maximum) {
+  if (std::isnan(value)) {
+    return 0;
+  }
+  if (value <= static_cast<double>(minimum)) {
+    return minimum;
+  }
+  if (value >= static_cast<double>(maximum)) {
+    return maximum;
+  }
+  return static_cast<int32_t>(std::round(value));
+}
+
+int32_t boundedFloorInt32(double value, int32_t minimum, int32_t maximum) {
+  if (std::isnan(value)) {
+    return minimum;
+  }
+  if (value <= static_cast<double>(minimum)) {
+    return minimum;
+  }
+  if (value >= static_cast<double>(maximum)) {
+    return maximum;
+  }
+  return static_cast<int32_t>(std::floor(value));
+}
+
+int32_t boundedCeilInt32(double value, int32_t minimum, int32_t maximum) {
+  if (std::isnan(value)) {
+    return minimum;
+  }
+  if (value <= static_cast<double>(minimum)) {
+    return minimum;
+  }
+  if (value >= static_cast<double>(maximum)) {
+    return maximum;
+  }
+  return static_cast<int32_t>(std::ceil(value));
+}
+
 /// Uniform buffer layout matching the WGSL `BlurParams` struct.
 struct BlurParams {
   float stdDeviation;
@@ -778,7 +832,6 @@ void dispatchTwoInputUniform(FilterResourceArena& arena, GeodeDevice& device,
                              const wgpu::Texture& in2, const wgpu::Texture& output,
                              const wgpu::Buffer& uniformBuffer, uint64_t uniformOffset,
                              size_t uniformSize, const char* label) {
-  const wgpu::Device& dev = device.device();
   const uint32_t width = output.getWidth();
   const uint32_t height = output.getHeight();
 
@@ -1507,13 +1560,357 @@ void GeodeFilterEngine::beginFrame() {
   }
 }
 
+struct FilterExecutionCoordinates {
+  using FilterGraph = svg::components::FilterGraph;
+  using FilterInput = svg::components::FilterInput;
+  using FilterNode = svg::components::FilterNode;
+
+  FilterExecutionCoordinates(const FilterGraph& graph, const wgpu::Texture& sourceGraphic,
+                             const Box2d& filterRegion, const Transform2d& deviceFromFilter)
+      : graph(graph),
+        filterRegion(filterRegion),
+        deviceFromFilter(deviceFromFilter),
+        scaleX(std::max(deviceFromFilter.transformVector(Vector2d(1.0, 0.0)).length(), 1e-12)),
+        scaleY(NearZero(scaleX, 1e-12)
+                   ? std::abs(deviceFromFilter.data[3])
+                   : std::max(std::abs(deviceFromFilter.determinant()) / scaleX, 1e-12)),
+        isObjectBoundingBox(graph.primitiveUnits == svg::PrimitiveUnits::ObjectBoundingBox),
+        boundingBoxWidth(graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->width()
+                                                              : 1.0),
+        boundingBoxHeight(graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->height()
+                                                               : 1.0),
+        boundingBoxX(graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->topLeft.x
+                                                          : 0.0),
+        boundingBoxY(graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->topLeft.y
+                                                          : 0.0),
+        filterFromDevice(deviceFromFilter.inverse()),
+        primitiveUnitsBounds(computePrimitiveUnitsBounds(sourceGraphic)),
+        previousOutputSubregion(filterRegion) {}
+
+  double toPixelX(double value) const {
+    return std::abs(isObjectBoundingBox ? value * boundingBoxWidth : value) * scaleX;
+  }
+
+  double toPixelY(double value) const {
+    return std::abs(isObjectBoundingBox ? value * boundingBoxHeight : value) * scaleY;
+  }
+
+  Vector2d toPixelOffset(double dx, double dy) const {
+    const Vector2d userOffset = isObjectBoundingBox
+                                    ? Vector2d(dx * boundingBoxWidth, dy * boundingBoxHeight)
+                                    : Vector2d(dx, dy);
+    return deviceFromFilter.transformVector(userOffset);
+  }
+
+  Box2d resolveInputSubregion(const FilterInput& input) const {
+    if (const auto* named = std::get_if<FilterInput::Named>(&input.value)) {
+      auto it = namedSubregions.find(named->name.str());
+      return it != namedSubregions.end() ? it->second : previousOutputSubregion;
+    }
+    return std::holds_alternative<FilterInput::Previous>(input.value) ? previousOutputSubregion
+                                                                      : filterRegion;
+  }
+
+  Box2d computeNodeSubregion(const FilterNode& node) const {
+    using namespace svg::components;
+    const bool sourceGenerator =
+        std::holds_alternative<filter_primitive::Flood>(node.primitive) ||
+        std::holds_alternative<filter_primitive::Turbulence>(node.primitive) ||
+        std::holds_alternative<filter_primitive::Image>(node.primitive) ||
+        std::holds_alternative<filter_primitive::Tile>(node.primitive);
+    const bool explicitSubregion = node.x.has_value() || node.y.has_value() ||
+                                   node.width.has_value() || node.height.has_value();
+    if (explicitSubregion) {
+      return explicitNodeSubregion(node);
+    }
+    const size_t slots = filterInputSlotCount(node);
+    if (sourceGenerator || slots == 0) {
+      return filterRegion;
+    }
+    Box2d inputBounds = resolveInputSubregion(filterInputOrDefault(node, 0));
+    for (size_t index = 1; index < slots; ++index) {
+      inputBounds =
+          Box2d::Union(inputBounds, resolveInputSubregion(filterInputOrDefault(node, index)));
+    }
+    expandPrimitiveBounds(node, inputBounds);
+    return intersect(inputBounds, filterRegion);
+  }
+
+  double resolvePrimitivePosition(const Lengthd& length, Lengthd::Extent extent, double origin,
+                                  double boundingBoxDimension) const {
+    return resolvePosition(length, extent, origin, boundingBoxDimension);
+  }
+
+  double resolvePrimitiveSize(const Lengthd& length, Lengthd::Extent extent,
+                              double boundingBoxDimension) const {
+    return resolveSize(length, extent, boundingBoxDimension);
+  }
+
+  const FilterGraph& graph;
+  Box2d filterRegion;
+  const Transform2d& deviceFromFilter;
+  double scaleX = 1.0;
+  double scaleY = 1.0;
+  bool isObjectBoundingBox = false;
+  double boundingBoxWidth = 1.0;
+  double boundingBoxHeight = 1.0;
+  double boundingBoxX = 0.0;
+  double boundingBoxY = 0.0;
+  Transform2d filterFromDevice;
+  Box2d primitiveUnitsBounds;
+  Box2d previousOutputSubregion;
+  std::unordered_map<std::string, Box2d> namedSubregions;
+
+private:
+  Box2d computePrimitiveUnitsBounds(const wgpu::Texture& sourceGraphic) const {
+    if (isObjectBoundingBox) {
+      return graph.elementBoundingBox.value_or(Box2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0)));
+    }
+    const double userWidth = NearZero(scaleX, 1e-12)
+                                 ? static_cast<double>(sourceGraphic.getWidth())
+                                 : static_cast<double>(sourceGraphic.getWidth()) / scaleX;
+    const double userHeight = NearZero(scaleY, 1e-12)
+                                  ? static_cast<double>(sourceGraphic.getHeight())
+                                  : static_cast<double>(sourceGraphic.getHeight()) / scaleY;
+    return Box2d::FromXYWH(0.0, 0.0, userWidth, userHeight);
+  }
+
+  double resolvePosition(const Lengthd& length, Lengthd::Extent extent, double origin,
+                         double boundingBoxDimension) const {
+    if (isObjectBoundingBox && length.unit == Lengthd::Unit::None) {
+      return origin + length.value * boundingBoxDimension;
+    }
+    if (length.unit == Lengthd::Unit::Percent) {
+      const double referenceOrigin =
+          isObjectBoundingBox ? (extent == Lengthd::Extent::X ? boundingBoxX : boundingBoxY) : 0.0;
+      const double referenceSize =
+          isObjectBoundingBox ? boundingBoxDimension
+                              : (extent == Lengthd::Extent::X ? primitiveUnitsBounds.width()
+                                                              : primitiveUnitsBounds.height());
+      return referenceOrigin + referenceSize * length.value / 100.0;
+    }
+    return length.toPixels(primitiveUnitsBounds, FontMetrics(), extent);
+  }
+
+  double resolveSize(const Lengthd& length, Lengthd::Extent extent,
+                     double boundingBoxDimension) const {
+    if (isObjectBoundingBox && length.unit == Lengthd::Unit::None) {
+      return length.value * boundingBoxDimension;
+    }
+    if (length.unit == Lengthd::Unit::Percent) {
+      const double referenceSize =
+          isObjectBoundingBox ? boundingBoxDimension
+                              : (extent == Lengthd::Extent::X ? primitiveUnitsBounds.width()
+                                                              : primitiveUnitsBounds.height());
+      return referenceSize * length.value / 100.0;
+    }
+    return length.toPixels(primitiveUnitsBounds, FontMetrics(), extent);
+  }
+
+  static Box2d intersect(const Box2d& first, const Box2d& second) {
+    return Box2d(Vector2d(std::max(first.topLeft.x, second.topLeft.x),
+                          std::max(first.topLeft.y, second.topLeft.y)),
+                 Vector2d(std::min(first.bottomRight.x, second.bottomRight.x),
+                          std::min(first.bottomRight.y, second.bottomRight.y)));
+  }
+
+  Box2d explicitNodeSubregion(const FilterNode& node) const {
+    const double x = node.x.has_value() ? resolvePosition(*node.x, Lengthd::Extent::X,
+                                                          isObjectBoundingBox ? boundingBoxX : 0.0,
+                                                          boundingBoxWidth)
+                                        : filterRegion.topLeft.x;
+    const double y = node.y.has_value() ? resolvePosition(*node.y, Lengthd::Extent::Y,
+                                                          isObjectBoundingBox ? boundingBoxY : 0.0,
+                                                          boundingBoxHeight)
+                                        : filterRegion.topLeft.y;
+    const double width = node.width.has_value()
+                             ? resolveSize(*node.width, Lengthd::Extent::X, boundingBoxWidth)
+                             : filterRegion.width();
+    const double height = node.height.has_value()
+                              ? resolveSize(*node.height, Lengthd::Extent::Y, boundingBoxHeight)
+                              : filterRegion.height();
+    return intersect(Box2d(Vector2d(x, y), Vector2d(x + width, y + height)), filterRegion);
+  }
+
+  void expandPrimitiveBounds(const FilterNode& node, Box2d& inputBounds) const {
+    using namespace svg::components;
+    if (const auto* blur = std::get_if<filter_primitive::GaussianBlur>(&node.primitive)) {
+      const double x = std::ceil((blur->stdDeviationX >= 0
+                                      ? boundedPositiveFilterPixels(toPixelX(blur->stdDeviationX))
+                                      : 0.0) *
+                                 3.0);
+      const double y = std::ceil((blur->stdDeviationY >= 0
+                                      ? boundedPositiveFilterPixels(toPixelY(blur->stdDeviationY))
+                                      : 0.0) *
+                                 3.0);
+      inputBounds = Box2d(Vector2d(inputBounds.topLeft.x - x, inputBounds.topLeft.y - y),
+                          Vector2d(inputBounds.bottomRight.x + x, inputBounds.bottomRight.y + y));
+      return;
+    }
+    if (const auto* drop = std::get_if<filter_primitive::DropShadow>(&node.primitive)) {
+      expandDropShadow(*drop, inputBounds);
+      return;
+    }
+    if (const auto* morphology = std::get_if<filter_primitive::Morphology>(&node.primitive);
+        morphology && morphology->op == filter_primitive::Morphology::Operator::Dilate) {
+      const double x = boundedPositiveFilterPixels(toPixelX(morphology->radiusX));
+      const double y = boundedPositiveFilterPixels(toPixelY(morphology->radiusY));
+      inputBounds = Box2d(Vector2d(inputBounds.topLeft.x - x, inputBounds.topLeft.y - y),
+                          Vector2d(inputBounds.bottomRight.x + x, inputBounds.bottomRight.y + y));
+    }
+  }
+
+  void expandDropShadow(const svg::components::filter_primitive::DropShadow& drop,
+                        Box2d& inputBounds) const {
+    const double x = std::ceil((drop.stdDeviationX >= 0
+                                    ? boundedPositiveFilterPixels(toPixelX(drop.stdDeviationX))
+                                    : 0.0) *
+                               3.0);
+    const double y = std::ceil((drop.stdDeviationY >= 0
+                                    ? boundedPositiveFilterPixels(toPixelY(drop.stdDeviationY))
+                                    : 0.0) *
+                               3.0);
+    const Vector2d offset = toPixelOffset(drop.dx, drop.dy);
+    const Vector2d boundedOffset(boundedSignedFilterPixels(offset.x),
+                                 boundedSignedFilterPixels(offset.y));
+    const Box2d shadow(Vector2d(inputBounds.topLeft.x + boundedOffset.x - x,
+                                inputBounds.topLeft.y + boundedOffset.y - y),
+                       Vector2d(inputBounds.bottomRight.x + boundedOffset.x + x,
+                                inputBounds.bottomRight.y + boundedOffset.y + y));
+    inputBounds = Box2d::Union(inputBounds, shadow);
+  }
+};
+
+struct FilterGraphExecution {
+  FilterGraphExecution(GeodeFilterEngine& engine, const svg::components::FilterGraph& graph,
+                       const wgpu::Texture& sourceGraphic, const Box2d& filterRegion,
+                       const Transform2d& deviceFromFilter,
+                       FilterTextureAllocator& textureAllocator,
+                       ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
+                       svg::components::FilterExecutionBudget* executionBudget)
+      : engine(engine),
+        graph(graph),
+        sourceGraphic(sourceGraphic),
+        filterRegion(filterRegion),
+        deviceFromFilter(deviceFromFilter),
+        textureAllocator(textureAllocator),
+        commandEncoder(commandEncoder),
+        executionBudget(executionBudget),
+        device_(engine.device_),
+        framePassesInCommandBuffer_(engine.framePassesInCommandBuffer_),
+        verbose_(engine.verbose_),
+        warnedUnsupported_(engine.warnedUnsupported_) {}
+
+  wgpu::Texture run();
+
+#define DONNER_FORWARD_FILTER_OPERATION(name)        \
+  template <typename... Args>                        \
+  decltype(auto) name(Args&&... args) {              \
+    return engine.name(std::forward<Args>(args)...); \
+  }
+  DONNER_FORWARD_FILTER_OPERATION(applySourceAlpha)
+  DONNER_FORWARD_FILTER_OPERATION(applyGaussianBlur)
+  DONNER_FORWARD_FILTER_OPERATION(applyColorSpaceConversion)
+  DONNER_FORWARD_FILTER_OPERATION(applySubregionClip)
+  DONNER_FORWARD_FILTER_OPERATION(applyOffset)
+  DONNER_FORWARD_FILTER_OPERATION(applyColorMatrix)
+  DONNER_FORWARD_FILTER_OPERATION(applyFlood)
+  DONNER_FORWARD_FILTER_OPERATION(applyMerge)
+  DONNER_FORWARD_FILTER_OPERATION(applyComposite)
+  DONNER_FORWARD_FILTER_OPERATION(applyBlend)
+  DONNER_FORWARD_FILTER_OPERATION(applyMorphology)
+  DONNER_FORWARD_FILTER_OPERATION(applyComponentTransfer)
+  DONNER_FORWARD_FILTER_OPERATION(applyConvolveMatrix)
+  DONNER_FORWARD_FILTER_OPERATION(applyTurbulence)
+  DONNER_FORWARD_FILTER_OPERATION(applyDisplacementMap)
+  DONNER_FORWARD_FILTER_OPERATION(applyDiffuseLighting)
+  DONNER_FORWARD_FILTER_OPERATION(applySpecularLighting)
+  DONNER_FORWARD_FILTER_OPERATION(applyDropShadow)
+  DONNER_FORWARD_FILTER_OPERATION(applyImage)
+  DONNER_FORWARD_FILTER_OPERATION(applyTile)
+#undef DONNER_FORWARD_FILTER_OPERATION
+
+  GeodeFilterEngine& engine;
+  const svg::components::FilterGraph& graph;
+  const wgpu::Texture& sourceGraphic;
+  const Box2d& filterRegion;
+  const Transform2d& deviceFromFilter;
+  FilterTextureAllocator& textureAllocator;
+  ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder;
+  svg::components::FilterExecutionBudget* executionBudget;
+  GeodeDevice& device_;
+  size_t& framePassesInCommandBuffer_;
+  bool& verbose_;
+  bool& warnedUnsupported_;
+};
+
+wgpu::Texture RunFilterGraphExecution(FilterGraphExecution& execution);
+
 wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& graph,
                                          const wgpu::Texture& sourceGraphic,
                                          const Box2d& filterRegion,
                                          const Transform2d& deviceFromFilter,
                                          FilterTextureAllocator& textureAllocator,
-                                         ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder) {
+                                         ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
+                                         svg::components::FilterExecutionBudget* executionBudget) {
+  return FilterGraphExecution(*this, graph, sourceGraphic, filterRegion, deviceFromFilter,
+                              textureAllocator, commandEncoder, executionBudget)
+      .run();
+}
+
+wgpu::Texture FilterGraphExecution::run() {
+  return RunFilterGraphExecution(*this);
+}
+
+wgpu::Texture RunFilterGraphExecution(FilterGraphExecution& execution) {
+  const auto& graph = execution.graph;
+  const auto& sourceGraphic = execution.sourceGraphic;
+  const auto& filterRegion = execution.filterRegion;
+  const auto& deviceFromFilter = execution.deviceFromFilter;
+  auto& textureAllocator = execution.textureAllocator;
+  auto& commandEncoder = execution.commandEncoder;
+  auto* executionBudget = execution.executionBudget;
+  auto& device_ = execution.device_;
+  auto& framePassesInCommandBuffer_ = execution.framePassesInCommandBuffer_;
+  auto& verbose_ = execution.verbose_;
+  auto& warnedUnsupported_ = execution.warnedUnsupported_;
+#define DONNER_BIND_FILTER_OPERATION(name)                        \
+  const auto name = [&](auto&&... args) -> decltype(auto) {       \
+    return execution.name(std::forward<decltype(args)>(args)...); \
+  }
+  DONNER_BIND_FILTER_OPERATION(applySourceAlpha);
+  DONNER_BIND_FILTER_OPERATION(applyGaussianBlur);
+  DONNER_BIND_FILTER_OPERATION(applyColorSpaceConversion);
+  DONNER_BIND_FILTER_OPERATION(applySubregionClip);
+  DONNER_BIND_FILTER_OPERATION(applyOffset);
+  DONNER_BIND_FILTER_OPERATION(applyColorMatrix);
+  DONNER_BIND_FILTER_OPERATION(applyFlood);
+  DONNER_BIND_FILTER_OPERATION(applyMerge);
+  DONNER_BIND_FILTER_OPERATION(applyComposite);
+  DONNER_BIND_FILTER_OPERATION(applyBlend);
+  DONNER_BIND_FILTER_OPERATION(applyMorphology);
+  DONNER_BIND_FILTER_OPERATION(applyComponentTransfer);
+  DONNER_BIND_FILTER_OPERATION(applyConvolveMatrix);
+  DONNER_BIND_FILTER_OPERATION(applyTurbulence);
+  DONNER_BIND_FILTER_OPERATION(applyDisplacementMap);
+  DONNER_BIND_FILTER_OPERATION(applyDiffuseLighting);
+  DONNER_BIND_FILTER_OPERATION(applySpecularLighting);
+  DONNER_BIND_FILTER_OPERATION(applyDropShadow);
+  DONNER_BIND_FILTER_OPERATION(applyImage);
+  DONNER_BIND_FILTER_OPERATION(applyTile);
+#undef DONNER_BIND_FILTER_OPERATION
+
   using namespace svg::components;
+
+  const std::uint64_t pixelCount =
+      static_cast<std::uint64_t>(sourceGraphic.getWidth()) * sourceGraphic.getHeight();
+  const bool fitsBudget =
+      executionBudget != nullptr
+          ? executionBudget->consume(graph, pixelCount, FilterMemoryModel::GpuAllNodes)
+          : FilterGraphFitsExecutionBudget(graph, pixelCount, FilterMemoryModel::GpuAllNodes);
+  if (!fitsBudget) {
+    return sourceGraphic;
+  }
 
   FilterResourceArena arena(device_, textureAllocator, commandEncoder, framePassesInCommandBuffer_);
   std::unordered_map<std::string, wgpu::Texture> namedBuffers;
@@ -1523,201 +1920,33 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     sourceAlpha = applySourceAlpha(arena, sourceGraphic);
   }
 
-  // Derive per-axis scale factors from the full CTM's basis vectors so
-  // that rotation/skew in the ancestor transform is accounted for.
-  // This matches the CPU FilterGraphExecutor's decomposition.
-  const Vector2d transformedXAxis = deviceFromFilter.transformVector(Vector2d(1.0, 0.0));
-  const double scaleX = std::max(transformedXAxis.length(), 1e-12);
-  const double determinant = deviceFromFilter.determinant();
-  const double scaleY = NearZero(scaleX, 1e-12) ? std::abs(deviceFromFilter.data[3])
-                                                : std::max(std::abs(determinant) / scaleX, 1e-12);
-
-  // For objectBoundingBox primitiveUnits, values are relative to the element
-  // bounding box.  Scale through the bbox dimensions first, then to pixels.
-  const bool isOBB = graph.primitiveUnits == svg::PrimitiveUnits::ObjectBoundingBox;
-  const double bboxW =
-      graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->width() : 1.0;
-  const double bboxH =
-      graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->height() : 1.0;
-  auto toPixelX = [&](double val) -> double {
-    return std::abs(isOBB ? val * bboxW : val) * scaleX;
+  FilterExecutionCoordinates coordinates(graph, sourceGraphic, filterRegion, deviceFromFilter);
+  const double scaleX = coordinates.scaleX;
+  const double scaleY = coordinates.scaleY;
+  const bool isOBB = coordinates.isObjectBoundingBox;
+  const double bboxW = coordinates.boundingBoxWidth;
+  const double bboxH = coordinates.boundingBoxHeight;
+  const double bboxX = coordinates.boundingBoxX;
+  const double bboxY = coordinates.boundingBoxY;
+  const Box2d& filterRegionSubregion = coordinates.filterRegion;
+  const Transform2d& filterFromDevice = coordinates.filterFromDevice;
+  auto& previousOutputSubregion = coordinates.previousOutputSubregion;
+  auto& namedSubregions = coordinates.namedSubregions;
+  const auto toPixelX = [&](double value) { return coordinates.toPixelX(value); };
+  const auto toPixelY = [&](double value) { return coordinates.toPixelY(value); };
+  const auto toPixelOffset = [&](double dx, double dy) {
+    return coordinates.toPixelOffset(dx, dy);
   };
-  auto toPixelY = [&](double val) -> double {
-    return std::abs(isOBB ? val * bboxH : val) * scaleY;
+  const auto resolveInputSubregion = [&](const FilterInput& input) {
+    return coordinates.resolveInputSubregion(input);
   };
-
-  // Transform a user-space offset vector through the full CTM so that
-  // rotation/skew is preserved (used by feOffset, feDropShadow).
-  auto toPixelOffset = [&](double dx, double dy) -> Vector2d {
-    const Vector2d userOffset = isOBB ? Vector2d(dx * bboxW, dy * bboxH) : Vector2d(dx, dy);
-    return deviceFromFilter.transformVector(userOffset);
+  const auto resolvePrimitivePosition = [&](const Lengthd& length, Lengthd::Extent extent,
+                                            double origin, double boundingBoxDimension) {
+    return coordinates.resolvePrimitivePosition(length, extent, origin, boundingBoxDimension);
   };
-
-  // Bounding-box origin for OBB position resolution.
-  const double bboxX =
-      graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->topLeft.x : 0.0;
-  const double bboxY =
-      graph.elementBoundingBox.has_value() ? graph.elementBoundingBox->topLeft.y : 0.0;
-
-  // Inverse CTM for rotation-aware subregion clipping.
-  const Transform2d filterFromDevice = deviceFromFilter.inverse();
-
-  // Reference bounds for Length::toPixels in the non-OBB case.
-  const Box2d primitiveUnitsBounds = [&]() -> Box2d {
-    if (isOBB) {
-      return graph.elementBoundingBox.value_or(Box2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0)));
-    }
-    const double userW = NearZero(scaleX, 1e-12)
-                             ? static_cast<double>(sourceGraphic.getWidth())
-                             : static_cast<double>(sourceGraphic.getWidth()) / scaleX;
-    const double userH = NearZero(scaleY, 1e-12)
-                             ? static_cast<double>(sourceGraphic.getHeight())
-                             : static_cast<double>(sourceGraphic.getHeight()) / scaleY;
-    return Box2d::FromXYWH(0.0, 0.0, userW, userH);
-  }();
-
-  // Resolve a primitive subregion length to user-space position.
-  auto resolvePrimitivePosition = [&](const Lengthd& len, Lengthd::Extent extent, double origin,
-                                      double bboxDim) -> double {
-    if (isOBB && len.unit == Lengthd::Unit::None) {
-      return origin + len.value * bboxDim;
-    }
-    if (len.unit == Lengthd::Unit::Percent) {
-      const double refOrigin = isOBB ? (extent == Lengthd::Extent::X ? bboxX : bboxY) : 0.0;
-      const double refSize = isOBB ? bboxDim
-                                   : (extent == Lengthd::Extent::X ? primitiveUnitsBounds.width()
-                                                                   : primitiveUnitsBounds.height());
-      return refOrigin + refSize * len.value / 100.0;
-    }
-    return len.toPixels(primitiveUnitsBounds, FontMetrics(), extent);
-  };
-
-  // Resolve a primitive subregion length to user-space size.
-  auto resolvePrimitiveSize = [&](const Lengthd& len, Lengthd::Extent extent,
-                                  double bboxDim) -> double {
-    if (isOBB && len.unit == Lengthd::Unit::None) {
-      return len.value * bboxDim;
-    }
-    if (len.unit == Lengthd::Unit::Percent) {
-      const double refSize = isOBB ? bboxDim
-                                   : (extent == Lengthd::Extent::X ? primitiveUnitsBounds.width()
-                                                                   : primitiveUnitsBounds.height());
-      return refSize * len.value / 100.0;
-    }
-    return len.toPixels(primitiveUnitsBounds, FontMetrics(), extent);
-  };
-
-  // Per-node subregion tracking in user space, mirroring tiny-skia's
-  // defaultNodeSubregion / resolveInputSubregion / previousOutputSubregion.
-  // Used to propagate subregion bounds through the filter graph so that
-  // non-source-generator nodes (feOffset, feComposite, etc.) clip to their
-  // input bounds rather than the full filter region.
-  const Box2d filterRegionSubregion = filterRegion;
-  Box2d previousOutputSubregion = filterRegionSubregion;
-  std::unordered_map<std::string, Box2d> namedSubregions;
-
-  // Resolve the user-space subregion for a filter input reference.
-  auto resolveInputSubregion = [&](const FilterInput& input) -> Box2d {
-    if (const auto* named = std::get_if<FilterInput::Named>(&input.value)) {
-      auto it = namedSubregions.find(named->name.str());
-      if (it != namedSubregions.end()) {
-        return it->second;
-      }
-      return previousOutputSubregion;
-    }
-    if (std::holds_alternative<FilterInput::Previous>(input.value)) {
-      return previousOutputSubregion;
-    }
-    // StandardInput (SourceGraphic, SourceAlpha, etc.) → full filter region.
-    return filterRegionSubregion;
-  };
-
-  // Intersect two user-space boxes.
-  auto boxIntersect = [](const Box2d& a, const Box2d& b) -> Box2d {
-    return Box2d(Vector2d(std::max(a.topLeft.x, b.topLeft.x), std::max(a.topLeft.y, b.topLeft.y)),
-                 Vector2d(std::min(a.bottomRight.x, b.bottomRight.x),
-                          std::min(a.bottomRight.y, b.bottomRight.y)));
-  };
-
-  // User-space subregion for a node, mirroring tiny-skia's
-  // defaultNodeSubregion: source generators and nodes with no inputs
-  // default to the filter region; other nodes inherit the union of their
-  // input subregions with primitive-specific expansion (blur, drop-shadow,
-  // dilate). Explicit x/y/width/height attributes override and are
-  // intersected with the filter region. Computed once per node up front so
-  // the blur path can fold the per-primitive clip into its final pass.
-  auto computeNodeSubregion = [&](const FilterNode& node) -> Box2d {
-    const bool isSourceGenerator =
-        std::holds_alternative<filter_primitive::Flood>(node.primitive) ||
-        std::holds_alternative<filter_primitive::Turbulence>(node.primitive) ||
-        std::holds_alternative<filter_primitive::Image>(node.primitive) ||
-        std::holds_alternative<filter_primitive::Tile>(node.primitive);
-
-    const bool hasExplicitSubregion = node.x.has_value() || node.y.has_value() ||
-                                      node.width.has_value() || node.height.has_value();
-
-    // The slot count and not the populated list: a two-input primitive with nothing filled in
-    // still reads two defaulted inputs, so its bounds come from those defaults rather than from
-    // the whole filter region.
-    const size_t slots = filterInputSlotCount(node);
-
-    Box2d nodeSubregion = filterRegionSubregion;
-    if (hasExplicitSubregion) {
-      const double ux =
-          node.x.has_value() ? resolvePrimitivePosition(*node.x, Lengthd::Extent::X,
-                                                        isOBB ? bboxX : 0.0, bboxW)
-                             : filterRegion.topLeft.x;
-      const double uy =
-          node.y.has_value() ? resolvePrimitivePosition(*node.y, Lengthd::Extent::Y,
-                                                        isOBB ? bboxY : 0.0, bboxH)
-                             : filterRegion.topLeft.y;
-      const double uw =
-          node.width.has_value() ? resolvePrimitiveSize(*node.width, Lengthd::Extent::X, bboxW)
-                                 : filterRegion.width();
-      const double uh =
-          node.height.has_value() ? resolvePrimitiveSize(*node.height, Lengthd::Extent::Y, bboxH)
-                                  : filterRegion.height();
-      nodeSubregion = boxIntersect(Box2d(Vector2d(ux, uy), Vector2d(ux + uw, uy + uh)),
-                                   filterRegionSubregion);
-    } else if (!isSourceGenerator && slots > 0) {
-      // Walk every slot the primitive reads, so a defaulted `in2` contributes its subregion
-      // the same way an explicit one would.
-      Box2d inputBounds = resolveInputSubregion(filterInputOrDefault(node, 0));
-      for (size_t i = 1; i < slots; ++i) {
-        inputBounds =
-            Box2d::Union(inputBounds, resolveInputSubregion(filterInputOrDefault(node, i)));
-      }
-      if (const auto* blur = std::get_if<filter_primitive::GaussianBlur>(&node.primitive)) {
-        const double expandX =
-            std::ceil((blur->stdDeviationX >= 0 ? toPixelX(blur->stdDeviationX) : 0.0) * 3.0);
-        const double expandY =
-            std::ceil((blur->stdDeviationY >= 0 ? toPixelY(blur->stdDeviationY) : 0.0) * 3.0);
-        inputBounds = Box2d(
-            Vector2d(inputBounds.topLeft.x - expandX, inputBounds.topLeft.y - expandY),
-            Vector2d(inputBounds.bottomRight.x + expandX, inputBounds.bottomRight.y + expandY));
-      } else if (const auto* drop = std::get_if<filter_primitive::DropShadow>(&node.primitive)) {
-        const double expandX =
-            std::ceil((drop->stdDeviationX >= 0 ? toPixelX(drop->stdDeviationX) : 0.0) * 3.0);
-        const double expandY =
-            std::ceil((drop->stdDeviationY >= 0 ? toPixelY(drop->stdDeviationY) : 0.0) * 3.0);
-        const Vector2d pixOff = toPixelOffset(drop->dx, drop->dy);
-        Box2d shadowBounds = Box2d(Vector2d(inputBounds.topLeft.x + pixOff.x - expandX,
-                                            inputBounds.topLeft.y + pixOff.y - expandY),
-                                   Vector2d(inputBounds.bottomRight.x + pixOff.x + expandX,
-                                            inputBounds.bottomRight.y + pixOff.y + expandY));
-        inputBounds = Box2d::Union(inputBounds, shadowBounds);
-      } else if (const auto* morph = std::get_if<filter_primitive::Morphology>(&node.primitive)) {
-        if (morph->op == filter_primitive::Morphology::Operator::Dilate) {
-          const double rx = toPixelX(morph->radiusX);
-          const double ry = toPixelY(morph->radiusY);
-          inputBounds =
-              Box2d(Vector2d(inputBounds.topLeft.x - rx, inputBounds.topLeft.y - ry),
-                    Vector2d(inputBounds.bottomRight.x + rx, inputBounds.bottomRight.y + ry));
-        }
-      }
-      nodeSubregion = boxIntersect(inputBounds, filterRegionSubregion);
-    }
-    return nodeSubregion;
+  const auto resolvePrimitiveSize = [&](const Lengthd& length, Lengthd::Extent extent,
+                                        double boundingBoxDimension) {
+    return coordinates.resolvePrimitiveSize(length, extent, boundingBoxDimension);
   };
 
   for (const FilterNode& node : graph.nodes) {
@@ -1725,7 +1954,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     // blur path can fold the per-primitive clip into its final pass.
     const bool hasExplicitSubregion = node.x.has_value() || node.y.has_value() ||
                                       node.width.has_value() || node.height.has_value();
-    const Box2d nodeSubregion = computeNodeSubregion(node);
+    const Box2d nodeSubregion = coordinates.computeNodeSubregion(node);
     const bool ctmAxisAligned =
         NearZero(deviceFromFilter.data[1], 1e-6) && NearZero(deviceFromFilter.data[2], 1e-6);
     bool clipMergedIntoBlur = false;
@@ -1738,8 +1967,12 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     // Dispatch based on primitive type.
     wgpu::Texture outputTex;
     if (const auto* blur = std::get_if<filter_primitive::GaussianBlur>(&node.primitive)) {
-      const double sx = blur->stdDeviationX >= 0 ? toPixelX(blur->stdDeviationX) : 0.0;
-      const double sy = blur->stdDeviationY >= 0 ? toPixelY(blur->stdDeviationY) : 0.0;
+      const double sx = blur->stdDeviationX >= 0
+                            ? boundedPositiveFilterPixels(toPixelX(blur->stdDeviationX))
+                            : 0.0;
+      const double sy = blur->stdDeviationY >= 0
+                            ? boundedPositiveFilterPixels(toPixelY(blur->stdDeviationY))
+                            : 0.0;
       const uint32_t em = toShaderEdgeMode(blur->edgeMode);
       const bool nodeLinearRGB =
           node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
@@ -1789,8 +2022,8 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       // maps correctly to device pixels.
       const Vector2d pixelOffset = toPixelOffset(offset->dx, offset->dy);
       filter_primitive::Offset scaled = *offset;
-      scaled.dx = pixelOffset.x;
-      scaled.dy = pixelOffset.y;
+      scaled.dx = boundedSignedFilterPixels(pixelOffset.x);
+      scaled.dy = boundedSignedFilterPixels(pixelOffset.y);
       outputTex = applyOffset(arena, inputTex, scaled);
     } else if (const auto* cm = std::get_if<filter_primitive::ColorMatrix>(&node.primitive)) {
       // Per SVG spec, feColorMatrix operates in linearRGB by default (the
@@ -1873,8 +2106,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       if (morphDisabled) {
         outputTex = inputTex;
       } else {
-        const int rx = static_cast<int>(std::round(toPixelX(morph->radiusX)));
-        const int ry = static_cast<int>(std::round(toPixelY(morph->radiusY)));
+        const int rx = boundedRoundedInt32(toPixelX(morph->radiusX), 0,
+                                           svg::components::kMaximumFilterPixelRadius);
+        const int ry = boundedRoundedInt32(toPixelY(morph->radiusY), 0,
+                                           svg::components::kMaximumFilterPixelRadius);
         // feMorphology operates in the filter's color-interpolation-filters
         // space (linearRGB by default). Erode/dilate are component-wise min/max
         // on PREMULTIPLIED channels, and the un-premultiply → linearize →
@@ -1994,10 +2229,16 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     } else if (const auto* drop = std::get_if<filter_primitive::DropShadow>(&node.primitive)) {
       // stdDeviation is magnitude only; dx/dy are directional and need
       // the full CTM projection (matching feOffset).
-      double sx = drop->stdDeviationX >= 0 ? toPixelX(drop->stdDeviationX) : 0.0;
-      double sy = drop->stdDeviationY >= 0 ? toPixelY(drop->stdDeviationY) : 0.0;
+      double sx = drop->stdDeviationX >= 0
+                      ? boundedPositiveFilterPixels(toPixelX(drop->stdDeviationX))
+                      : 0.0;
+      double sy = drop->stdDeviationY >= 0
+                      ? boundedPositiveFilterPixels(toPixelY(drop->stdDeviationY))
+                      : 0.0;
       const Vector2d pixelOffset = toPixelOffset(drop->dx, drop->dy);
-      outputTex = applyDropShadow(arena, inputTex, *drop, sx, sy, pixelOffset.x, pixelOffset.y);
+      outputTex =
+          applyDropShadow(arena, inputTex, *drop, sx, sy, boundedSignedFilterPixels(pixelOffset.x),
+                          boundedSignedFilterPixels(pixelOffset.y));
     } else if (const auto* image = std::get_if<filter_primitive::Image>(&node.primitive)) {
       // Resolve the feImage placement rect in user space, honoring percent/OBB
       // units (via the same helpers used for subregion clipping) and defaulting
@@ -2036,12 +2277,15 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         outputTex = applyTile(arena, inputTex, 0, 0, 0, 0);
       } else {
         const Box2d sourcePixels = deviceFromFilter.transformBox(tileSourceSubregion);
-        int32_t srcX = static_cast<int32_t>(std::floor(sourcePixels.topLeft.x));
-        int32_t srcY = static_cast<int32_t>(std::floor(sourcePixels.topLeft.y));
-        int32_t srcW =
-            static_cast<int32_t>(std::ceil(sourcePixels.bottomRight.x - sourcePixels.topLeft.x));
-        int32_t srcH =
-            static_cast<int32_t>(std::ceil(sourcePixels.bottomRight.y - sourcePixels.topLeft.y));
+        constexpr int32_t kMaximumTileExtent = svg::components::kMaximumFilterPixelOffset;
+        int32_t srcX =
+            boundedFloorInt32(sourcePixels.topLeft.x, -kMaximumTileExtent, kMaximumTileExtent);
+        int32_t srcY =
+            boundedFloorInt32(sourcePixels.topLeft.y, -kMaximumTileExtent, kMaximumTileExtent);
+        int32_t srcW = boundedCeilInt32(sourcePixels.bottomRight.x - sourcePixels.topLeft.x, 0,
+                                        kMaximumTileExtent);
+        int32_t srcH = boundedCeilInt32(sourcePixels.bottomRight.y - sourcePixels.topLeft.y, 0,
+                                        kMaximumTileExtent);
         outputTex = applyTile(arena, inputTex, srcX, srcY, srcW, srcH);
       }
     } else {
@@ -2138,7 +2382,7 @@ struct BoxBlurPlan {
 
 BoxBlurPlan computeBoxPasses(double sigma) {
   // Same window-size formula as tiny-skia: window = round(sigma * 3*sqrt(2π)/4).
-  constexpr double kMaxSigma = 10000.0;
+  constexpr double kMaxSigma = svg::components::kMaximumFilterPixelRadius;
   if (!std::isfinite(sigma) || sigma > kMaxSigma) {
     sigma = kMaxSigma;
   }
@@ -2262,8 +2506,6 @@ wgpu::Texture GeodeFilterEngine::runBlurPass(FilterResourceArena& arena, const w
                                              const wgpu::Texture& output, uint32_t width,
                                              uint32_t height, float stdDeviation, uint32_t axis,
                                              uint32_t edgeMode, const Box2d* clip) {
-  const wgpu::Device& dev = device_.device();
-
   BlurParams params{};
   params.stdDeviation = stdDeviation;
   params.axis = axis;
@@ -2295,8 +2537,6 @@ wgpu::Texture GeodeFilterEngine::runBoxBlurPass(FilterResourceArena& arena,
                                                 uint32_t height, int32_t boxLeft, int32_t boxRight,
                                                 uint32_t axis, uint32_t edgeMode,
                                                 const Box2d* clip) {
-  const wgpu::Device& dev = device_.device();
-
   BlurParams params{};
   params.stdDeviation = 0.0f;
   params.axis = axis;
@@ -2878,7 +3118,8 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
   params.baseFreqX = static_cast<float>(primitive.baseFrequencyX);
   params.baseFreqY = static_cast<float>(primitive.baseFrequencyY);
   params.numOctaves = primitive.numOctaves;
-  params.seed = static_cast<int32_t>(primitive.seed);
+  params.seed = boundedRoundedInt32(primitive.seed, std::numeric_limits<int32_t>::min(),
+                                    std::numeric_limits<int32_t>::max());
   params.stitchTiles = primitive.stitchTiles ? 1u : 0u;
   params.typeFlag =
       primitive.type == svg::components::filter_primitive::Turbulence::Type::Turbulence ? 1u : 0u;
@@ -3145,14 +3386,13 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
                   &params.pixelToUser4, &params.pixelToUser5, &params.hasShear);
 
   const Box2d samplePixels = deviceFromFilter.transformBox(sampleSubregion);
-  params.sampleMinX = std::clamp(static_cast<int32_t>(std::floor(samplePixels.topLeft.x)),
-                                 int32_t(0), static_cast<int32_t>(width) - 1);
-  params.sampleMinY = std::clamp(static_cast<int32_t>(std::floor(samplePixels.topLeft.y)),
-                                 int32_t(0), static_cast<int32_t>(height) - 1);
-  params.sampleMaxX = std::clamp(static_cast<int32_t>(std::ceil(samplePixels.bottomRight.x)) - 1,
-                                 int32_t(0), static_cast<int32_t>(width) - 1);
-  params.sampleMaxY = std::clamp(static_cast<int32_t>(std::ceil(samplePixels.bottomRight.y)) - 1,
-                                 int32_t(0), static_cast<int32_t>(height) - 1);
+  params.sampleMinX = boundedFloorInt32(samplePixels.topLeft.x, 0, static_cast<int32_t>(width) - 1);
+  params.sampleMinY =
+      boundedFloorInt32(samplePixels.topLeft.y, 0, static_cast<int32_t>(height) - 1);
+  params.sampleMaxX =
+      boundedCeilInt32(samplePixels.bottomRight.x, 1, static_cast<int32_t>(width)) - 1;
+  params.sampleMaxY =
+      boundedCeilInt32(samplePixels.bottomRight.y, 1, static_cast<int32_t>(height)) - 1;
 
   // Upload as storage buffer.
   wgpu::BufferDescriptor bufDesc{};
@@ -3259,14 +3499,13 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
   }
 
   const Box2d samplePixels = deviceFromFilter.transformBox(sampleSubregion);
-  params.sampleMinX = std::clamp(static_cast<int32_t>(std::floor(samplePixels.topLeft.x)),
-                                 int32_t(0), static_cast<int32_t>(width) - 1);
-  params.sampleMinY = std::clamp(static_cast<int32_t>(std::floor(samplePixels.topLeft.y)),
-                                 int32_t(0), static_cast<int32_t>(height) - 1);
-  params.sampleMaxX = std::clamp(static_cast<int32_t>(std::ceil(samplePixels.bottomRight.x)) - 1,
-                                 int32_t(0), static_cast<int32_t>(width) - 1);
-  params.sampleMaxY = std::clamp(static_cast<int32_t>(std::ceil(samplePixels.bottomRight.y)) - 1,
-                                 int32_t(0), static_cast<int32_t>(height) - 1);
+  params.sampleMinX = boundedFloorInt32(samplePixels.topLeft.x, 0, static_cast<int32_t>(width) - 1);
+  params.sampleMinY =
+      boundedFloorInt32(samplePixels.topLeft.y, 0, static_cast<int32_t>(height) - 1);
+  params.sampleMaxX =
+      boundedCeilInt32(samplePixels.bottomRight.x, 1, static_cast<int32_t>(width)) - 1;
+  params.sampleMaxY =
+      boundedCeilInt32(samplePixels.bottomRight.y, 1, static_cast<int32_t>(height)) - 1;
 
   // Upload as storage buffer.
   wgpu::BufferDescriptor bufDesc{};
@@ -3361,6 +3600,57 @@ wgpu::Texture GeodeFilterEngine::applyDropShadow(
   return output;
 }
 
+bool HasSafeFilterImageSource(const svg::components::filter_primitive::Image& primitive,
+                              std::span<const uint8_t> imageData,
+                              uint32_t maximumTextureDimension) {
+  return svg::HasExactRgbaPayload(imageData, primitive.imageWidth, primitive.imageHeight) &&
+         static_cast<uint32_t>(primitive.imageWidth) <= maximumTextureDimension &&
+         static_cast<uint32_t>(primitive.imageHeight) <= maximumTextureDimension &&
+         static_cast<uint32_t>(primitive.imageWidth) <= std::numeric_limits<uint32_t>::max() / 4u;
+}
+
+std::optional<ImageParams> CreateFragmentImageParams(
+    const svg::components::filter_primitive::Image& primitive,
+    const svg::components::FilterGraph& graph, const Transform2d& deviceFromFilter) {
+  if (!primitive.isFragmentReference) {
+    return std::nullopt;
+  }
+  ImageParams params{};
+  const bool hasRotation =
+      !NearZero(deviceFromFilter.data[1], 1e-6) || !NearZero(deviceFromFilter.data[2], 1e-6);
+  if (hasRotation && !NearZero(deviceFromFilter.determinant(), 1e-12)) {
+    const double scaleX = graph.userToPixelScale.x;
+    const double scaleY = graph.userToPixelScale.y;
+    const Transform2d viewBoxScaleInv = Transform2d::Scale(
+        NearZero(scaleX, 1e-12) ? 1.0 : 1.0 / scaleX, NearZero(scaleY, 1e-12) ? 1.0 : 1.0 / scaleY);
+    const Transform2d regionOffset = Transform2d::Translate(primitive.fragmentRegionTopLeft.x,
+                                                            primitive.fragmentRegionTopLeft.y);
+    const Transform2d deviceFromFragment = viewBoxScaleInv * regionOffset * deviceFromFilter;
+    const Transform2d fragmentFromDevice = deviceFromFragment.inverse();
+    params.m00 = static_cast<float>(fragmentFromDevice.data[0]);
+    params.m01 = static_cast<float>(fragmentFromDevice.data[2]);
+    params.m02 = static_cast<float>(fragmentFromDevice.data[4]);
+    params.m10 = static_cast<float>(fragmentFromDevice.data[1]);
+    params.m11 = static_cast<float>(fragmentFromDevice.data[3]);
+    params.m12 = static_cast<float>(fragmentFromDevice.data[5]);
+    params.pixelatedScaleX =
+        static_cast<float>(deviceFromFragment.transformVector(Vector2d(1.0, 0.0)).length());
+    params.pixelatedScaleY =
+        static_cast<float>(deviceFromFragment.transformVector(Vector2d(0.0, 1.0)).length());
+  } else {
+    const double scaleX = graph.userToPixelScale.x > 0.0 ? graph.userToPixelScale.x : 1.0;
+    const double scaleY = graph.userToPixelScale.y > 0.0 ? graph.userToPixelScale.y : 1.0;
+    params.m00 = 1.0f;
+    params.m02 = static_cast<float>(-primitive.fragmentRegionTopLeft.x * scaleX);
+    params.m11 = 1.0f;
+    params.m12 = static_cast<float>(-primitive.fragmentRegionTopLeft.y * scaleY);
+    params.pixelatedScaleX = 1.0f;
+    params.pixelatedScaleY = 1.0f;
+  }
+  params.samplingMode = ImageSamplingMode(primitive.imageRendering);
+  return params;
+}
+
 wgpu::Texture GeodeFilterEngine::applyImage(
     FilterResourceArena& arena, const svg::components::filter_primitive::Image& primitive,
     uint32_t width, uint32_t height, const svg::components::FilterGraph& graph,
@@ -3368,13 +3658,11 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     const Box2d& placementRegionUser) {
   const wgpu::Device& dev = device_.device();
 
-  const bool hasExactPayload =
-      svg::HasExactRgbaPayload(primitive.imageData, primitive.imageWidth, primitive.imageHeight);
+  const std::span<const uint8_t> imageData = primitive.imageData
+                                                 ? std::span<const uint8_t>(*primitive.imageData)
+                                                 : std::span<const uint8_t>();
   const bool hasSafeTextureExtent =
-      hasExactPayload &&
-      static_cast<uint32_t>(primitive.imageWidth) <= device_.maxTextureDimension2D() &&
-      static_cast<uint32_t>(primitive.imageHeight) <= device_.maxTextureDimension2D() &&
-      static_cast<uint32_t>(primitive.imageWidth) <= std::numeric_limits<uint32_t>::max() / 4u;
+      HasSafeFilterImageSource(primitive, imageData, device_.maxTextureDimension2D());
   wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterImageOutput");
 
   const auto renderTransparentOutput = [&]() {
@@ -3417,7 +3705,7 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   // (consistent with feFlood / feMerge).
   const uint32_t imgW = static_cast<uint32_t>(primitive.imageWidth);
   const uint32_t imgH = static_cast<uint32_t>(primitive.imageHeight);
-  const std::vector<uint8_t> premul = svg::PremultiplyRgba(primitive.imageData);
+  const std::vector<uint8_t> premul = svg::PremultiplyRgba(imageData);
 
   wgpu::TextureDescriptor imgDesc{};
   imgDesc.label = wgpuLabel("FilterImageSource");
@@ -3441,69 +3729,10 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   device_.queue().writeTexture(dstInfo, premul.data(), premul.size(), layout, extent);
   device_.countTextureWrite(premul.size());
 
-  // Fragment references with a non-axis-aligned ancestor transform: project the fragment image
-  // through the full CTM (rotation/skew) so placement matches the CPU path. The transform
-  // chain is:
-  //   fragment pixel → (÷ viewBoxScale) → document user space
-  //   → (+ filterRegion.topLeft) → host user space
-  //   → (× deviceFromFilter) → device pixels
-  // The shader receives the inverse: device pixel → fragment pixel.
-  const bool hasRotation =
-      !NearZero(deviceFromFilter.data[1], 1e-6) || !NearZero(deviceFromFilter.data[2], 1e-6);
-  if (primitive.isFragmentReference && hasRotation &&
-      !NearZero(deviceFromFilter.determinant(), 1e-12)) {
-    const double uScaleX = graph.userToPixelScale.x;
-    const double uScaleY = graph.userToPixelScale.y;
-    const Transform2d viewBoxScaleInv =
-        Transform2d::Scale(NearZero(uScaleX, 1e-12) ? 1.0 : 1.0 / uScaleX,
-                           NearZero(uScaleY, 1e-12) ? 1.0 : 1.0 / uScaleY);
-    const Transform2d regionOffset = Transform2d::Translate(primitive.fragmentRegionTopLeft.x,
-                                                            primitive.fragmentRegionTopLeft.y);
-    const Transform2d deviceFromFragment = viewBoxScaleInv * regionOffset * deviceFromFilter;
-    const Transform2d fragmentFromDevice = deviceFromFragment.inverse();
-
-    ImageParams params{};
-    params.m00 = static_cast<float>(fragmentFromDevice.data[0]);
-    params.m01 = static_cast<float>(fragmentFromDevice.data[2]);
-    params.m02 = static_cast<float>(fragmentFromDevice.data[4]);
-    params.m10 = static_cast<float>(fragmentFromDevice.data[1]);
-    params.m11 = static_cast<float>(fragmentFromDevice.data[3]);
-    params.m12 = static_cast<float>(fragmentFromDevice.data[5]);
-    params.samplingMode = ImageSamplingMode(primitive.imageRendering);
-    params.pixelatedScaleX =
-        static_cast<float>(deviceFromFragment.transformVector(Vector2d(1.0, 0.0)).length());
-    params.pixelatedScaleY =
-        static_cast<float>(deviceFromFragment.transformVector(Vector2d(0.0, 1.0)).length());
-    params.pad1 = 0;
-
-    auto uniformBuffer = writeUniformSlot(*resourceCache_, device_, &params, sizeof(params));
-    dispatchInputOutputUniform(arena, device_, imageBindGroupLayout_.get(), imagePipeline_.get(),
-                               imgTex, output, uniformBuffer.buffer, uniformBuffer.offset,
-                               sizeof(ImageParams), "FilterImageFragRefPass");
-    return output;
-  }
-
-  // Fragment references without rotation: simple device-space post-translation to position
-  // content at the filter region origin, matching the CPU path's non-rotated fragment case.
-  if (primitive.isFragmentReference) {
-    const double uScaleX = graph.userToPixelScale.x > 0.0 ? graph.userToPixelScale.x : 1.0;
-    const double uScaleY = graph.userToPixelScale.y > 0.0 ? graph.userToPixelScale.y : 1.0;
-    const double deviceOffsetX = primitive.fragmentRegionTopLeft.x * uScaleX;
-    const double deviceOffsetY = primitive.fragmentRegionTopLeft.y * uScaleY;
-
-    ImageParams params{};
-    params.m00 = 1.0f;
-    params.m01 = 0.0f;
-    params.m02 = static_cast<float>(-deviceOffsetX);
-    params.m10 = 0.0f;
-    params.m11 = 1.0f;
-    params.m12 = static_cast<float>(-deviceOffsetY);
-    params.samplingMode = ImageSamplingMode(primitive.imageRendering);
-    params.pixelatedScaleX = 1.0f;
-    params.pixelatedScaleY = 1.0f;
-    params.pad1 = 0;
-
-    auto uniformBuffer = writeUniformSlot(*resourceCache_, device_, &params, sizeof(params));
+  if (std::optional<ImageParams> fragmentParams =
+          CreateFragmentImageParams(primitive, graph, deviceFromFilter)) {
+    auto uniformBuffer =
+        writeUniformSlot(*resourceCache_, device_, &*fragmentParams, sizeof(*fragmentParams));
     dispatchInputOutputUniform(arena, device_, imageBindGroupLayout_.get(), imagePipeline_.get(),
                                imgTex, output, uniformBuffer.buffer, uniformBuffer.offset,
                                sizeof(ImageParams), "FilterImageFragRefPass");

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -222,6 +222,22 @@ double boundedSignedFilterPixels(double value) {
                     static_cast<double>(svg::components::kMaximumFilterPixelOffset));
 }
 
+double boundedTurbulenceFrequency(double value) {
+  if (!std::isfinite(value)) {
+    return 0.0;
+  }
+  return std::clamp(value, -svg::components::kMaximumFilterTurbulenceFrequency,
+                    svg::components::kMaximumFilterTurbulenceFrequency);
+}
+
+double boundedTurbulenceSeed(double value) {
+  if (!std::isfinite(value)) {
+    return 0.0;
+  }
+  return std::clamp(value, -svg::components::kMaximumFilterTurbulenceSeed,
+                    svg::components::kMaximumFilterTurbulenceSeed);
+}
+
 int32_t boundedRoundedInt32(double value, int32_t minimum, int32_t maximum) {
   if (std::isnan(value)) {
     return 0;
@@ -406,6 +422,7 @@ float srgbToLinearChannel(float c) {
 /// Generate permutation + gradient tables from seed, matching tiny-skia exactly.
 void generateTurbulenceTables(double seedVal, TurbulenceTables& tables) {
   // Seed clamping matching resvg.
+  seedVal = boundedTurbulenceSeed(seedVal);
   long seed;  // NOLINT
   if (seedVal <= 0) {
     seed = -(static_cast<long>(seedVal)) % (kRandM - 1) + 1;  // NOLINT
@@ -3103,10 +3120,13 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
     const svg::components::filter_primitive::Turbulence& primitive,
     const Transform2d& deviceFromFilter) {
   const wgpu::Device& dev = device_.device();
+  const double baseFrequencyX = boundedTurbulenceFrequency(primitive.baseFrequencyX);
+  const double baseFrequencyY = boundedTurbulenceFrequency(primitive.baseFrequencyY);
+  const double seed = boundedTurbulenceSeed(primitive.seed);
 
   // Negative baseFrequency is invalid per SVG Filter Effects §15.20.3; produce transparent black
   // (matching resvg/tiny-skia behavior).
-  if (primitive.baseFrequencyX < 0.0 || primitive.baseFrequencyY < 0.0) {
+  if (baseFrequencyX < 0.0 || baseFrequencyY < 0.0) {
     return createTransparentIntermediateTexture(arena, width, height,
                                                 "FilterTurbulenceTransparent");
   }
@@ -3115,10 +3135,10 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
       createIntermediateTexture(arena, dev, width, height, "FilterTurbulenceOutput");
 
   TurbulenceParams params{};
-  params.baseFreqX = static_cast<float>(primitive.baseFrequencyX);
-  params.baseFreqY = static_cast<float>(primitive.baseFrequencyY);
+  params.baseFreqX = static_cast<float>(baseFrequencyX);
+  params.baseFreqY = static_cast<float>(baseFrequencyY);
   params.numOctaves = primitive.numOctaves;
-  params.seed = boundedRoundedInt32(primitive.seed, std::numeric_limits<int32_t>::min(),
+  params.seed = boundedRoundedInt32(seed, std::numeric_limits<int32_t>::min(),
                                     std::numeric_limits<int32_t>::max());
   params.stitchTiles = primitive.stitchTiles ? 1u : 0u;
   params.typeFlag =
@@ -3143,7 +3163,7 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
 
   // Generate permutation + gradient tables from the seed.
   TurbulenceTables tables{};
-  generateTurbulenceTables(primitive.seed, tables);
+  generateTurbulenceTables(seed, tables);
 
   // Upload params as storage buffer.
   wgpu::BufferDescriptor bufDesc{};

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -22,6 +22,7 @@
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::svg::components {
+class FilterExecutionBudget;
 struct FilterGraph;
 struct FilterNode;
 
@@ -133,13 +134,16 @@ public:
    *   this slot: the current command buffer is submitted and a fresh encoder is installed in the
    *   slot every 64 passes, so no single command buffer grows without bound while small filters
    *   keep the two-submissions-per-frame shape.
+   * @param executionBudget Optional shared per-frame budget. Direct callers may omit it to apply
+   *   only the graph-local limit.
    * @return The filtered output texture (RGBA8Unorm, TextureBinding | CopySrc).
    */
   wgpu::Texture execute(const svg::components::FilterGraph& graph,
                         const wgpu::Texture& sourceGraphic, const Box2d& filterRegion,
                         const Transform2d& deviceFromFilter,
                         FilterTextureAllocator& textureAllocator,
-                        ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder);
+                        ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
+                        svg::components::FilterExecutionBudget* executionBudget = nullptr);
 
   /**
    * Begin a new frame for this engine: reset the frame-scoped chunk pass
@@ -160,6 +164,7 @@ public:
   void beginFrame();
 
 private:
+  friend struct FilterGraphExecution;
   /// Two-pass separable Gaussian blur via compute shader.
   /// @param input The input texture.
   /// @param stdDeviationX Standard deviation in X (pixels).
@@ -195,8 +200,8 @@ private:
   /// @return Output texture for this pass.
   wgpu::Texture runBoxBlurPass(FilterResourceArena& arena, const wgpu::Texture& input,
                                const wgpu::Texture& output, uint32_t width, uint32_t height,
-                               int32_t boxLeft, int32_t boxRight, uint32_t axis,
-                               uint32_t edgeMode, const Box2d* clip = nullptr);
+                               int32_t boxLeft, int32_t boxRight, uint32_t axis, uint32_t edgeMode,
+                               const Box2d* clip = nullptr);
 
   /// Shift pixels by (dx, dy) via compute shader.
   /// @param input The input texture.

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -288,6 +288,16 @@ constexpr std::string_view kHugeRadiusMorphologySvg = R"SVG(
 </svg>
 )SVG";
 
+constexpr std::string_view kChunkedMorphologySvg = R"SVG(
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <filter id="filter1">
+    <feMorphology radius="256"/><feMorphology radius="256"/>
+    <feMorphology radius="256"/><feMorphology radius="256"/>
+  </filter>
+  <rect x="20" y="20" width="160" height="160" fill="red" filter="url(#filter1)"/>
+</svg>
+)SVG";
+
 // ---------------------------------------------------------------------------
 // Fixture: image blits - drawImage uniform pooling.
 // ---------------------------------------------------------------------------
@@ -346,6 +356,14 @@ TEST_F(GeodePerfTest, MorphologyHugeRadiusIsBoundedBeforeEncoding) {
   // only the frame and readback submissions instead of scaling work with the raw radius.
   EXPECT_GE(c.submits, 1u);
   EXPECT_LE(c.submits, 3u);
+}
+
+TEST_F(GeodePerfTest, MultipleBoundedMorphologyNodesStillChunkCommandBuffers) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device);
+  const geode::GeodeCounters counters = renderAndGetCounters(kChunkedMorphologySvg, device);
+  EXPECT_GE(counters.submits, 3u);
+  EXPECT_LE(counters.submits, 6u);
 }
 
 TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -332,7 +332,7 @@ TEST_F(GeodePerfTest, MultiImageBlit_PoolsCompositeUniforms) {
          "blit.";
 }
 
-TEST_F(GeodePerfTest, MorphologyHugeRadius_ChunksFilterCommandBuffers) {
+TEST_F(GeodePerfTest, MorphologyHugeRadiusIsBoundedBeforeEncoding) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
@@ -341,23 +341,11 @@ TEST_F(GeodePerfTest, MorphologyHugeRadius_ChunksFilterCommandBuffers) {
   RecordProperty("submits", std::to_string(c.submits));
   printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
 
-  // The shared-encoder design keeps a small blur at two submissions (frame
-  // + readback). A pathological morphology (323 X + 323 Y passes here) must
-  // not regress that design into one unbounded command buffer: every 64
-  // passes the filter arena submits its chunk and starts a fresh encoder,
-  // so 646 passes produce 10 chunk submits plus the final frame submit and
-  // the readback submit, 12 in total. Assert a bounded range rather than
-  // the exact count so incidental extra submits (device warm-up, snapshot
-  // plumbing) don't turn this into a change-detector. The pass count
-  // scales with the DEVICE-pixel radius, so this ceiling is only valid at
-  // this fixture's fixed 200x200 canvas at devicePixelRatio 1; rescaling
-  // the fixture requires retuning both bounds.
-  EXPECT_GE(c.submits, 6u)
-      << "Huge-radius morphology should force chunked filter submissions beyond the shared "
-         "frame + readback pair.";
-  EXPECT_LE(c.submits, 20u)
-      << "Chunked filter submissions should bound the command buffer to 64 passes each: "
-         "646 passes chunk into 10 mid-frame submits plus frame and readback submits.";
+  // Untrusted radii are admitted at the shared filter pixel-radius ceiling before command
+  // encoding. The bounded morphology therefore stays below the 64-pass chunk threshold and uses
+  // only the frame and readback submissions instead of scaling work with the raw radius.
+  EXPECT_GE(c.submits, 1u);
+  EXPECT_LE(c.submits, 3u);
 }
 
 TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {
@@ -375,7 +363,6 @@ TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {
       << "The filter layer, all Gaussian passes, composite, and readback should require only the "
          "shared frame submission plus the snapshot submission.";
 }
-
 
 // ---------------------------------------------------------------------------
 // Fixture: lion.svg - the workhorse SVG used across Donner test suites.

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -176,6 +176,352 @@ TEST(FilterGraphExecutorTest, ClipsCompletelyOffscreenFilterRegion) {
   }
 }
 
+TEST(FilterGraphExecutorTest, ExtremeFilterValuesStayWithinNumericAndWorkBounds) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(8, 8);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  SetPixel(pixmap, 1, 1, Pixel{255, 0, 0, 255});
+
+  components::FilterGraph graph;
+  components::FilterNode offset;
+  offset.inputs.push_back(components::FilterInput{});
+  offset.primitive = components::filter_primitive::Offset{.dx = 1e300, .dy = -1e300};
+  graph.nodes.push_back(std::move(offset));
+
+  components::FilterNode morphology;
+  morphology.inputs.push_back(components::FilterInput{});
+  morphology.primitive = components::filter_primitive::Morphology{
+      .op = components::filter_primitive::Morphology::Operator::Dilate,
+      .radiusX = 1e300,
+      .radiusY = 1e300,
+  };
+  graph.nodes.push_back(std::move(morphology));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d::Scale(1e300),
+                           Box2d::FromXYWH(-1e300, -1e300, 2e300, 2e300));
+  ClipFilterOutputToRegion(pixmap, Box2d::FromXYWH(1e300, 1e300, 1e300, 1e300),
+                           Transform2d::Scale(1e300));
+
+  EXPECT_EQ(pixmap.width(), 8u);
+  EXPECT_EQ(pixmap.height(), 8u);
+}
+
+TEST(FilterGraphExecutorTest, RejectsAggregateConvolveWorkAndNamedBufferMemory) {
+  components::FilterGraph graph;
+  components::FilterNode convolve;
+  convolve.primitive = components::filter_primitive::ConvolveMatrix{
+      .orderX = 32,
+      .orderY = 32,
+      .kernelMatrix = std::vector<double>(32 * 32, 1.0),
+  };
+  convolve.result = RcString("convolve");
+  graph.nodes.push_back(std::move(convolve));
+  for (size_t i = 1; i < components::kMaximumFilterGraphNodes; ++i) {
+    components::FilterNode flood;
+    flood.primitive = components::filter_primitive::Flood{};
+    flood.result = RcString("retained-" + std::to_string(i));
+    graph.nodes.push_back(std::move(flood));
+  }
+
+  constexpr std::uint64_t kPixels = 1024ULL * 1024;
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kPixels, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForCpuBaselineFilterBuffers) {
+  components::FilterGraph graph;
+  components::FilterNode flood;
+  flood.primitive = components::filter_primitive::Flood{};
+  graph.nodes.push_back(std::move(flood));
+
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels,
+      components::FilterMemoryModel::CpuFloatNamedResults));
+
+  components::FilterNode secondFlood;
+  secondFlood.primitive = components::filter_primitive::Flood{};
+  graph.nodes.push_back(std::move(secondFlood));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels,
+      components::FilterMemoryModel::CpuFloatNamedResults));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForTurbulenceOctaveWork) {
+  components::FilterGraph graph;
+  components::FilterNode turbulence;
+  turbulence.primitive = components::filter_primitive::Turbulence{.numOctaves = 16};
+  graph.nodes.push_back(std::move(turbulence));
+
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 1024ULL * 1024, components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, 1024ULL * 1024, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForBlurPassWorkAndScratchMemory) {
+  components::FilterGraph graph;
+  for (int i = 0; i < 21; ++i) {
+    components::FilterNode blur;
+    blur.primitive = components::filter_primitive::GaussianBlur{
+        .stdDeviationX = 3.0,
+        .stdDeviationY = 3.0,
+    };
+    graph.nodes.push_back(std::move(blur));
+  }
+
+  constexpr std::uint64_t kExactWorkBudgetPixels = 1024ULL * 1024;
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, kExactWorkBudgetPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+  graph.nodes.push_back(graph.nodes.front());
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kExactWorkBudgetPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+
+  graph.nodes.resize(1);
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels,
+      components::FilterMemoryModel::CpuFloatNamedResults));
+  graph.nodes.push_back(graph.nodes.front());
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels,
+      components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels, components::FilterMemoryModel::GpuAllNodes));
+
+  constexpr std::uint64_t kLinearRgbGpuBoundaryPixels = 3'800'000;
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kLinearRgbGpuBoundaryPixels, components::FilterMemoryModel::GpuAllNodes));
+  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, kLinearRgbGpuBoundaryPixels, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForGpuPerNodeSubregionTextures) {
+  components::FilterGraph graph;
+  for (int i = 0; i < 3; ++i) {
+    components::FilterNode blend;
+    blend.primitive = components::filter_primitive::Blend{};
+    graph.nodes.push_back(std::move(blend));
+  }
+
+  constexpr std::uint64_t kGpuNodeClipBoundaryPixels = 4'200'000;
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kGpuNodeClipBoundaryPixels, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForGenericPrimitivePassWork) {
+  components::FilterGraph graph;
+  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+  for (int i = 0; i < 12; ++i) {
+    components::FilterNode blend;
+    blend.primitive = components::filter_primitive::Blend{};
+    graph.nodes.push_back(std::move(blend));
+  }
+
+  constexpr std::uint64_t kGenericWorkBoundaryPixels = 4'800'000;
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, kGenericWorkBoundaryPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForZeroDeviationBlurAndShadowWork) {
+  components::FilterGraph zeroBlurGraph;
+  for (int i = 0; i < 32; ++i) {
+    components::FilterNode blur;
+    blur.primitive = components::filter_primitive::GaussianBlur{};
+    zeroBlurGraph.nodes.push_back(std::move(blur));
+  }
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      zeroBlurGraph, 2'000'000, components::FilterMemoryModel::CpuFloatNamedResults));
+
+  components::FilterGraph zeroShadowGraph;
+  for (int i = 0; i < 16; ++i) {
+    components::FilterNode shadow;
+    shadow.primitive = components::filter_primitive::DropShadow{};
+    zeroShadowGraph.nodes.push_back(std::move(shadow));
+  }
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      zeroShadowGraph, 1'500'000, components::FilterMemoryModel::CpuFloatNamedResults));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForBicubicImageSamplingWork) {
+  components::FilterGraph graph;
+  components::FilterNode imageNode;
+  imageNode.primitive = components::filter_primitive::Image{};
+  graph.nodes.push_back(std::move(imageNode));
+
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 4'000'000, components::FilterMemoryModel::CpuFloatNamedResults));
+  auto& image = std::get<components::filter_primitive::Image>(graph.nodes[0].primitive);
+  image.imageRendering = ImageRendering::Pixelated;
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, 4'000'000, components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, 4'000'000, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, AccountsForDropShadowBlurWorkAndMemory) {
+  components::FilterGraph graph;
+  for (int i = 0; i < 13; ++i) {
+    components::FilterNode shadow;
+    shadow.primitive = components::filter_primitive::DropShadow{
+        .stdDeviationX = 3.0,
+        .stdDeviationY = 3.0,
+    };
+    graph.nodes.push_back(std::move(shadow));
+  }
+
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 1024ULL * 1024, components::FilterMemoryModel::CpuFloatNamedResults));
+
+  graph.nodes.resize(1);
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, components::kMaximumFilterSurfacePixels,
+      components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 7'000'000, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, RejectsAggregateWorkAcrossSeparateFilterExecutions) {
+  components::FilterGraph graph;
+  components::FilterNode blur;
+  blur.primitive = components::filter_primitive::GaussianBlur{
+      .stdDeviationX = 3.0,
+      .stdDeviationY = 3.0,
+  };
+  graph.nodes.push_back(std::move(blur));
+
+  components::FilterExecutionBudget budget;
+  constexpr std::uint64_t kPixels = 1024ULL * 1024;
+  for (int i = 0; i < 42; ++i) {
+    EXPECT_TRUE(
+        budget.consume(graph, kPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+  }
+  EXPECT_FALSE(budget.consume(graph, kPixels, components::FilterMemoryModel::CpuFloatNamedResults));
+
+  budget.reset();
+  std::size_t maximumSurfaceExecutions = 0;
+  while (budget.consume(graph, components::kMaximumFilterSurfacePixels,
+                        components::FilterMemoryModel::CpuFloatNamedResults)) {
+    ++maximumSurfaceExecutions;
+  }
+  EXPECT_GT(maximumSurfaceExecutions, 0u);
+  EXPECT_LT(maximumSurfaceExecutions, components::FilterExecutionBudget::kMaximumExecutions);
+  EXPECT_TRUE(budget.rejected());
+  EXPECT_LE(budget.workUnits(), components::kMaximumFilterFrameWorkUnits);
+}
+
+TEST(FilterGraphExecutorTest, ReservesCaptureMemoryBeforeAllocationAndLatchesRejection) {
+  components::FilterGraph graph;
+  components::FilterNode blur;
+  blur.primitive = components::filter_primitive::GaussianBlur{
+      .stdDeviationX = 3.0,
+      .stdDeviationY = 3.0,
+  };
+  graph.nodes.push_back(std::move(blur));
+
+  constexpr std::uint64_t kCaptureBytes = components::kMaximumFilterSurfacePixels * 4;
+  components::FilterExecutionBudget cpuBudget;
+  auto outer =
+      cpuBudget.reserve(graph, components::kMaximumFilterSurfacePixels,
+                        components::FilterMemoryModel::CpuFloatNamedResults, kCaptureBytes);
+  ASSERT_TRUE(outer.has_value());
+  EXPECT_FALSE(cpuBudget
+                   .reserve(graph, components::kMaximumFilterSurfacePixels,
+                            components::FilterMemoryModel::CpuFloatNamedResults, kCaptureBytes)
+                   .has_value());
+  EXPECT_TRUE(cpuBudget.rejected());
+  EXPECT_FALSE(cpuBudget.reserve(graph, 1, components::FilterMemoryModel::CpuFloatNamedResults, 4)
+                   .has_value());
+
+  components::FilterExecutionBudget gpuBudget;
+  EXPECT_FALSE(gpuBudget
+                   .reserve(graph, components::kMaximumFilterSurfacePixels,
+                            components::FilterMemoryModel::GpuAllNodes, kCaptureBytes)
+                   .has_value());
+}
+
+TEST(FilterGraphExecutorTest, RejectsNestedCaptureMemoryBeforeAllocation) {
+  components::FilterGraph graph;
+  components::FilterNode dropShadow;
+  dropShadow.primitive = components::filter_primitive::DropShadow{
+      .stdDeviationX = 0.1,
+      .stdDeviationY = 0.1,
+  };
+  graph.nodes.push_back(std::move(dropShadow));
+
+  constexpr std::uint64_t kPixels = 1024ULL * 1024;
+  constexpr std::uint64_t kCaptureBytes = kPixels * 4;
+
+  components::FilterExecutionBudget cpuBudget;
+  std::vector<components::FilterExecutionBudget::Reservation> cpuReservations;
+  while (true) {
+    auto reservation = cpuBudget.reserve(
+        graph, kPixels, components::FilterMemoryModel::CpuFloatNamedResults, kCaptureBytes);
+    if (!reservation.has_value()) {
+      break;
+    }
+    cpuReservations.push_back(*reservation);
+  }
+  EXPECT_FALSE(cpuReservations.empty());
+  EXPECT_TRUE(cpuBudget.rejected());
+  EXPECT_EQ(cpuBudget.captureBytesReserved(), cpuReservations.size() * kCaptureBytes);
+  EXPECT_EQ(cpuBudget.retainedBytes(), cpuReservations.size() * kCaptureBytes);
+  EXPECT_LE(cpuBudget.retainedBytes(), components::kMaximumFilterFrameBytes);
+  for (auto& reservation : cpuReservations) {
+    cpuBudget.release(reservation);
+  }
+  EXPECT_EQ(cpuBudget.retainedBytes(), 0);
+
+  components::FilterExecutionBudget gpuBudget;
+  std::size_t gpuReservations = 0;
+  while (gpuBudget.reserve(graph, kPixels, components::FilterMemoryModel::GpuAllNodes,
+                           kCaptureBytes)) {
+    ++gpuReservations;
+  }
+  EXPECT_GT(gpuReservations, 0u);
+  EXPECT_TRUE(gpuBudget.rejected());
+  EXPECT_EQ(gpuBudget.captureBytesReserved(), gpuReservations * kCaptureBytes);
+  EXPECT_LE(gpuBudget.retainedBytes(), components::kMaximumFilterFrameBytes);
+}
+
+TEST(FilterGraphExecutorTest, AccountsForMergeFanInWorkAndMemory) {
+  components::FilterGraph graph;
+  components::FilterNode merge;
+  merge.primitive = components::filter_primitive::Merge{};
+  merge.inputs.resize(components::kMaximumFilterMergeInputs,
+                      components::FilterInput{components::FilterInput::Previous{}});
+  graph.nodes.push_back(std::move(merge));
+
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 2049ULL * 1024, components::FilterMemoryModel::CpuFloatNamedResults));
+
+  graph.nodes[0].inputs.push_back(components::FilterInput{components::FilterInput::Previous{}});
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 1, components::FilterMemoryModel::CpuFloatNamedResults));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, 1, components::FilterMemoryModel::GpuAllNodes));
+}
+
+TEST(FilterGraphExecutorTest, InvalidConvolveDivisorFailsClosed) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(2, 2);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  components::FilterGraph graph;
+  components::FilterNode node;
+  node.primitive = components::filter_primitive::ConvolveMatrix{
+      .orderX = 1,
+      .orderY = 1,
+      .kernelMatrix = {1.0},
+      .divisor = 0.0,
+  };
+  graph.nodes.push_back(std::move(node));
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+  EXPECT_EQ(pixmap.width(), 2u);
+  EXPECT_EQ(pixmap.height(), 2u);
+}
+
 // Regression: a filter region whose origin x maps past the pixmap width writes out of bounds.
 // In the axis-aligned clip, x0 = max(0, floor(originX)) was clamped at the low end but NOT the high
 // end, while x1 = clamp(ceil(right), 0, width) was clamped to width. With originX = 15 on a 10-wide
@@ -1461,7 +1807,8 @@ tiny_skia::Pixmap RenderTwoColumnFeImage(bool pixelated, int width = 8, int heig
 
   components::filter_primitive::Image image;
   // Straight-alpha RGBA, two columns: red then blue, duplicated across both rows.
-  image.imageData = {255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255, 0, 0, 255, 255};
+  image.imageData = std::make_shared<const std::vector<uint8_t>>(std::initializer_list<uint8_t>{
+      255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255, 0, 0, 255, 255});
   image.imageWidth = 2;
   image.imageHeight = 2;
   image.imageRendering = pixelated ? ImageRendering::Pixelated : ImageRendering::Auto;
@@ -1509,7 +1856,8 @@ TEST(FilterGraphExecutorTest, FeImageRejectsTrailingPayloadBytes) {
   tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
 
   components::filter_primitive::Image image;
-  image.imageData = {255, 0, 0, 255, 17};
+  image.imageData = std::make_shared<const std::vector<uint8_t>>(
+      std::initializer_list<uint8_t>{255, 0, 0, 255, 17});
   image.imageWidth = 1;
   image.imageHeight = 1;
 

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -506,6 +506,39 @@ TEST(FilterGraphExecutorTest, ActiveGpuReservationBlocksMemoryChunk) {
   EXPECT_EQ(budget.chunks(), 0u);
 }
 
+TEST(FilterGraphExecutorTest, EmptyChunkCannotRetryIntrinsicallyOversizedGraph) {
+  components::FilterGraph graph;
+  components::FilterNode blur;
+  blur.primitive = components::filter_primitive::GaussianBlur{
+      .stdDeviationX = 3.0,
+      .stdDeviationY = 3.0,
+  };
+  graph.nodes.push_back(std::move(blur));
+
+  components::FilterExecutionBudget budget;
+  auto small = budget.reserve(graph, 1024, components::FilterMemoryModel::GpuAllNodes, 4096);
+  ASSERT_TRUE(small.has_value());
+  budget.release(*small);
+
+  constexpr std::uint64_t kOversizedPixels = 5'800'000;
+  constexpr std::uint64_t kCaptureBytes = kOversizedPixels * 4;
+  EXPECT_FALSE(budget
+                   .reserve(graph, kOversizedPixels, components::FilterMemoryModel::GpuAllNodes,
+                            kCaptureBytes)
+                   .has_value());
+  EXPECT_GT(budget.retainedGpuBytes(), 0u);
+  ASSERT_TRUE(budget.beginChunkAfterSubmit());
+  EXPECT_EQ(budget.chunks(), 1u);
+
+  EXPECT_FALSE(budget
+                   .reserve(graph, kOversizedPixels, components::FilterMemoryModel::GpuAllNodes,
+                            kCaptureBytes)
+                   .has_value());
+  EXPECT_EQ(budget.retainedGpuBytes(), 0u);
+  EXPECT_FALSE(budget.beginChunkAfterSubmit());
+  EXPECT_EQ(budget.chunks(), 1u);
+}
+
 TEST(FilterGraphExecutorTest, RejectsNestedCaptureMemoryBeforeAllocation) {
   components::FilterGraph graph;
   components::FilterNode dropShadow;

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -469,6 +469,43 @@ TEST(FilterGraphExecutorTest, ReservesCaptureMemoryBeforeAllocationAndLatchesRej
                    .has_value());
 }
 
+TEST(FilterGraphExecutorTest, PermanentRejectionCannotStartMemoryChunk) {
+  components::FilterGraph invalidGraph;
+  invalidGraph.nodes.resize(components::kMaximumFilterGraphNodes + 1u);
+  components::FilterExecutionBudget budget;
+
+  EXPECT_FALSE(
+      budget.reserve(invalidGraph, 1, components::FilterMemoryModel::GpuAllNodes, 4).has_value());
+  EXPECT_EQ(budget.rejectionReason(),
+            components::FilterExecutionBudget::RejectionReason::InvalidGraph);
+  EXPECT_FALSE(budget.beginChunkAfterSubmit());
+  EXPECT_EQ(budget.chunks(), 0u);
+}
+
+TEST(FilterGraphExecutorTest, ActiveGpuReservationBlocksMemoryChunk) {
+  components::FilterGraph graph;
+  components::FilterNode blur;
+  blur.primitive = components::filter_primitive::GaussianBlur{
+      .stdDeviationX = 3.0,
+      .stdDeviationY = 3.0,
+  };
+  graph.nodes.push_back(std::move(blur));
+
+  constexpr std::uint64_t kPixels = 1024ULL * 1024;
+  constexpr std::uint64_t kCaptureBytes = kPixels * 4;
+  components::FilterExecutionBudget budget;
+  ASSERT_TRUE(
+      budget.reserve(graph, kPixels, components::FilterMemoryModel::GpuAllNodes, kCaptureBytes));
+  while (
+      budget.reserve(graph, kPixels, components::FilterMemoryModel::GpuAllNodes, kCaptureBytes)) {}
+
+  EXPECT_EQ(budget.rejectionReason(),
+            components::FilterExecutionBudget::RejectionReason::MemoryLimit);
+  EXPECT_GT(budget.activeGpuReservations(), 0u);
+  EXPECT_FALSE(budget.beginChunkAfterSubmit());
+  EXPECT_EQ(budget.chunks(), 0u);
+}
+
 TEST(FilterGraphExecutorTest, RejectsNestedCaptureMemoryBeforeAllocation) {
   components::FilterGraph graph;
   components::FilterNode dropShadow;

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -206,6 +206,34 @@ TEST(FilterGraphExecutorTest, ExtremeFilterValuesStayWithinNumericAndWorkBounds)
   EXPECT_EQ(pixmap.height(), 8u);
 }
 
+TEST(FilterGraphExecutorTest, MorphologyAdmissionChargesPassSamplesAndRetainedTextures) {
+  components::FilterGraph graph;
+  for (int index = 0; index < 4; ++index) {
+    components::FilterNode node;
+    node.primitive = components::filter_primitive::Morphology{
+        .op = components::filter_primitive::Morphology::Operator::Dilate,
+        .radiusX = components::kMaximumFilterMorphologyRadius,
+        .radiusY = components::kMaximumFilterMorphologyRadius,
+    };
+    graph.nodes.push_back(std::move(node));
+  }
+
+  constexpr std::uint64_t kExpectedWorkMultiplier = 1047;
+  const std::uint64_t boundaryPixels =
+      components::kMaximumFilterWorkUnits / (4 * kExpectedWorkMultiplier);
+  EXPECT_TRUE(components::FilterGraphFitsExecutionBudget(
+      graph, boundaryPixels, components::FilterMemoryModel::GpuAllNodes));
+  EXPECT_FALSE(components::FilterGraphFitsExecutionBudget(
+      graph, boundaryPixels + 1, components::FilterMemoryModel::GpuAllNodes));
+
+  std::uint64_t workUnits = 0;
+  std::uint64_t retainedBytes = 0;
+  ASSERT_TRUE(components::FilterGraphExecutionCost(
+      graph, 100, components::FilterMemoryModel::GpuAllNodes, workUnits, retainedBytes));
+  EXPECT_EQ(workUnits, 4u * 100u * kExpectedWorkMultiplier);
+  EXPECT_EQ(retainedBytes, 100u * 4u * (2u + 4u * 21u));
+}
+
 TEST(FilterGraphExecutorTest, RejectsAggregateConvolveWorkAndNamedBufferMemory) {
   components::FilterGraph graph;
   components::FilterNode convolve;

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -13,8 +13,10 @@
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/css/Specificity.h"
 #include "donner/svg/components/ComputedClipPathsComponent.h"
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
 #include "donner/svg/components/IdComponent.h"
 #include "donner/svg/components/PreserveAspectRatioComponent.h"
+#include "donner/svg/components/filter/ComputedFilterResourceBudget.h"
 #include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/components/layout/SizedElementComponent.h"
@@ -941,6 +943,67 @@ TEST_F(RendererDriverTest, InterruptibleDocumentRedrawIgnoresFeImageShadowSentin
   EXPECT_TRUE(driver.drawInterruptibly(document, viewport, Transform2d(), neverCancel));
   EXPECT_EQ(drawPathCount, firstDrawPathCount)
       << "a lingering OffscreenFeImage shadow must not become the interruptible range sentinel";
+}
+
+TEST_F(RendererDriverTest, FilterPreparationStopsAtAggregateGraphLimit) {
+  std::string svg = R"svg(<defs><filter id="f"><feFlood/></filter></defs>)svg";
+  for (std::size_t i = 0; i < RendererDriver::kMaximumPreparedFilterGraphs + 1; ++i) {
+    svg += R"svg(<rect width="1" height="1" filter="url(#f)"/>)svg";
+  }
+  SVGDocument document = makeDocument(svg, Vector2i(1, 1));
+  RendererDriver::SecurityStats stats;
+  RendererDriver boundedDriver(renderer, /*verbose=*/false, &stats);
+
+  EXPECT_CALL(renderer, pushFilterLayer(_, _))
+      .Times(static_cast<int>(RendererDriver::kMaximumPreparedFilterGraphs));
+  boundedDriver.draw(document);
+
+  EXPECT_TRUE(stats.filterPreparationRejected);
+  EXPECT_EQ(stats.filterPreparationAttempts, RendererDriver::kMaximumPreparedFilterGraphs);
+  EXPECT_EQ(stats.preparedFilterGraphs, RendererDriver::kMaximumPreparedFilterGraphs);
+  EXPECT_EQ(stats.preparedFilterNodes, RendererDriver::kMaximumPreparedFilterGraphs);
+}
+
+TEST_F(RendererDriverTest, PreparedFragmentImageKeepsFamilyReservationWithSharedPixels) {
+  SVGDocument document = makeDocument(R"svg(
+    <defs>
+      <filter id="filter"><feImage href="#source"/></filter>
+      <rect id="source" width="1" height="1" fill="red"/>
+    </defs>
+    <rect width="1" height="1" filter="url(#filter)"/>
+  )svg",
+                                      Vector2i(1, 1));
+  auto family = std::make_shared<components::DocumentResourceFamilyBudget>();
+  document.registry().ctx().emplace<components::ComputedFilterResourceBudget>(family);
+
+  ON_CALL(renderer, createOffscreenInstance()).WillByDefault([]() {
+    auto offscreen = std::make_unique<::testing::NiceMock<MockRendererInterface>>();
+    ON_CALL(*offscreen, takeSnapshot())
+        .WillByDefault(::testing::Return(MockRendererInterface::makeDummyBitmap()));
+    return offscreen;
+  });
+
+  std::shared_ptr<const std::vector<uint8_t>> retainedPixels;
+  EXPECT_CALL(renderer, pushFilterLayer(_, _))
+      .WillOnce([&](const components::FilterGraph& graph, const std::optional<Box2d>&) {
+        ASSERT_THAT(graph.nodes, SizeIs(1));
+        const auto* image =
+            std::get_if<components::filter_primitive::Image>(&graph.nodes[0].primitive);
+        ASSERT_NE(image, nullptr);
+        ASSERT_THAT(image->imageData, testing::NotNull());
+        retainedPixels = image->imageData;
+      });
+
+  driver.draw(document);
+
+  ASSERT_THAT(retainedPixels, testing::NotNull());
+  const std::size_t pixelBytes = retainedPixels->size();
+  const std::size_t retainedWithPixels =
+      family->retainedBytes(components::DocumentResourceFamilyBudget::Kind::ComputedFilter);
+  retainedPixels.reset();
+  const std::size_t retainedWithoutPixels =
+      family->retainedBytes(components::DocumentResourceFamilyBudget::Kind::ComputedFilter);
+  EXPECT_EQ(retainedWithPixels, retainedWithoutPixels + pixelBytes);
 }
 
 TEST_F(RendererDriverTest, DrawEntityRangeConvertsCssFilterFunctionsToFilterGraph) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -2992,6 +2992,27 @@ TEST_F(RendererGeodeTest, FilterComponentTransferGammaInverts) {
       << "Gamma component transfer should square the red channel";
 }
 
+TEST_F(RendererGeodeTest, FilterTurbulenceBoundsNonFiniteSeedAndFrequency) {
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+
+  components::FilterGraph graph;
+  components::FilterNode node;
+  components::filter_primitive::Turbulence turbulence;
+  turbulence.baseFrequencyX = std::numeric_limits<double>::infinity();
+  turbulence.baseFrequencyY = std::numeric_limits<double>::quiet_NaN();
+  turbulence.numOctaves = 1;
+  turbulence.seed = -std::numeric_limits<double>::infinity();
+  node.primitive = turbulence;
+  graph.nodes.push_back(node);
+
+  renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+  renderer.popFilterLayer();
+  renderer.endFrame();
+
+  EXPECT_FALSE(renderer.takeSnapshot().empty());
+}
+
 /// feConvolveMatrix box blur: 3×3 kernel of all 1s / divisor=9.
 TEST_F(RendererGeodeTest, FilterConvolveMatrixBoxBlur) {
   RendererGeode renderer = createRenderer();

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -2347,9 +2347,8 @@ TEST_F(RendererGeodeTest, FilterImagePixelatedSmoothsFromNearestIntegerScale) {
   beginFrame(renderer);
 
   components::filter_primitive::Image image;
-  image.imageData = {
-      255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255, 0, 0, 255, 255,
-  };
+  image.imageData = std::make_shared<const std::vector<uint8_t>>(std::initializer_list<uint8_t>{
+      255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255, 0, 0, 255, 255});
   image.imageWidth = 2;
   image.imageHeight = 2;
   image.imageRendering = ImageRendering::Pixelated;
@@ -2374,7 +2373,8 @@ TEST_F(RendererGeodeTest, FilterImageWithTrailingPayloadIsTransparent) {
   beginFrame(renderer);
 
   components::filter_primitive::Image image;
-  image.imageData = {255, 0, 0, 255, 17};
+  image.imageData = std::make_shared<const std::vector<uint8_t>>(
+      std::initializer_list<uint8_t>{255, 0, 0, 255, 17});
   image.imageWidth = 1;
   image.imageHeight = 1;
 
@@ -2400,7 +2400,8 @@ TEST_F(RendererGeodeTest, FilterImageOverTextureAxisLimitIsTransparent) {
             static_cast<uint32_t>(std::numeric_limits<int>::max()));
   const int overLimitWidth = static_cast<int>(sharedDevice()->maxTextureDimension2D()) + 1;
   components::filter_primitive::Image image;
-  image.imageData.resize(static_cast<std::size_t>(overLimitWidth) * 4u, 255);
+  image.imageData = std::make_shared<const std::vector<uint8_t>>(
+      static_cast<std::size_t>(overLimitWidth) * 4u, 255);
   image.imageWidth = overLimitWidth;
   image.imageHeight = 1;
 

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -509,6 +509,38 @@ TEST(RendererPublicApiTest, FacadeForwardsFrameStateAndPrimitiveCalls) {
   EXPECT_GE(renderer.height(), 0);
 }
 
+TEST(RendererPublicApiTest, RejectedFilterSuppressesItsSubtreeAndRestoresParent) {
+  if (!ActiveRendererSupportsFeature(RendererBackendFeature::FilterEffects)) {
+    GTEST_SKIP() << "Filter rendering disabled in this variant (" << ActiveRendererBackendName()
+                 << ")";
+  }
+
+  std::unique_ptr<RendererInterface> renderer = CreateActiveRendererInstance();
+  renderer->beginFrame(RenderViewport{.size = Vector2d(16.0, 8.0), .devicePixelRatio = 1.0});
+  renderer->setTransform(Transform2d());
+
+  components::FilterGraph rejectedGraph;
+  rejectedGraph.nodes.resize(components::kMaximumFilterGraphNodes + 1);
+  renderer->pushFilterLayer(rejectedGraph, Box2d::FromXYWH(0.0, 0.0, 16.0, 8.0));
+
+  PaintParams green;
+  green.fill = PaintServer::Solid{css::Color(css::RGBA(0, 255, 0, 255))};
+  renderer->setPaint(green);
+  renderer->drawRect(Box2d::FromXYWH(0.0, 0.0, 16.0, 8.0), StrokeParams{});
+  renderer->popFilterLayer();
+
+  PaintParams blue;
+  blue.fill = PaintServer::Solid{css::Color(css::RGBA(0, 0, 255, 255))};
+  renderer->setPaint(blue);
+  renderer->drawRect(Box2d::FromXYWH(8.0, 0.0, 8.0, 8.0), StrokeParams{});
+  renderer->endFrame();
+
+  const RendererBitmap snapshot = NormalizeSnapshot(renderer->takeSnapshot());
+  ASSERT_FALSE(snapshot.empty());
+  EXPECT_THAT(PixelAt(snapshot, 2, 4), IsTransparent());
+  EXPECT_THAT(PixelAt(snapshot, 12, 4), IsBlueish());
+}
+
 TEST(RendererPublicApiTest, PatternTileRejectsUnsafeDimensionsWithoutChangingFrameState) {
   Renderer renderer;
   renderer.beginFrame(RenderViewport{

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <utility>
 
 #include "tiny_skia/filter/Blend.h"
 #include "tiny_skia/filter/ColorMatrix.h"
@@ -27,6 +28,11 @@
 namespace tiny_skia::filter {
 
 namespace {
+
+template <typename Visitor, typename Variant>
+decltype(auto) VisitPrimitive(Visitor&& visitor, Variant&& variant) {
+  return std::visit(std::forward<Visitor>(visitor), std::forward<Variant>(variant));
+}
 
 /// Internal bounding box for subregion tracking (x0/y0 = top-left, x1/y1 = bottom-right).
 struct Box {
@@ -541,13 +547,15 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
 
     std::optional<NodeOutput> output;
 
-    std::visit(
+    VisitPrimitive(
         [&](const auto& primitive) {
           using T = std::decay_t<decltype(primitive)>;
           using namespace graph_primitive;
 
           if constexpr (std::is_same_v<T, GaussianBlur>) {
-            auto fp = FloatPixmap(input->in(nodeLinearRGB));
+            const bool canConsumeSource = graph.nodes.size() == 1 && input == source;
+            auto fp = canConsumeSource ? input->release(nodeLinearRGB)
+                                       : FloatPixmap(input->in(nodeLinearRGB));
             gaussianBlur(fp, primitive.sigmaX, primitive.sigmaY, primitive.edgeMode);
             output = NodeOutput{std::move(fp), nodeLinearRGB};
 
@@ -645,7 +653,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
           } else if constexpr (std::is_same_v<T, graph_primitive::Morphology>) {
             // SVG Filter Effects §15.4: a negative radius, or a zero radius on both axes
             // (which is also the lacuna value 0 used for an absent/empty/invalid `radius`),
-            // disables the effect — the result is the filter input image (pass-through), not
+            // disables the effect - the result is the filter input image (pass-through), not
             // transparent black. A zero radius on only one axis is a no-op along that axis,
             // so the effect still applies (e.g. radius="10 0" erodes horizontally only).
             const bool disabled = primitive.radiusX < 0 || primitive.radiusY < 0 ||
@@ -913,8 +921,8 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
                     out[ch] = std::clamp(static_cast<float>(acc), 0.0f, 1.0f);
                   }
                   // Mitchell's negative lobes can drive a premultiplied input's R/G/B above
-                  // its A on edges; clamp R/G/B to A so downstream filter primitives — which
-                  // consume `FloatPixmap` as premultiplied — don't see ghost-bright halos
+                  // its A on edges; clamp R/G/B to A so downstream filter primitives - which
+                  // consume `FloatPixmap` as premultiplied - don't see ghost-bright halos
                   // (PR #610 Codex P1). For straight-alpha inputs this is a no-op since the
                   // earlier bilinear path stored unclamped values that already satisfied
                   // R/G/B ≤ A on the suite's tests.

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
@@ -8,6 +8,7 @@
 /// conversion is done in uint8 space.
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -37,7 +38,7 @@ class FloatPixmap {
     // primitives' caps so a `FloatPixmap` can hold the float conversion of
     // any `Pixmap` the allocator already accepted. The prior 64 MiB capped
     // float pixmaps at ~2048×2048, which contributed to filters silently
-    // failing at high editor zoom — see `GaussianBlur.cpp` and
+    // failing at high editor zoom - see `GaussianBlur.cpp` and
     // `ZoomFilterRepro_tests.cc`.
     constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
     if (count * sizeof(float) > kMaxAllocationBytes) {
@@ -236,8 +237,9 @@ class FloatPixmap {
     }
 #endif
     for (; i < count; ++i) {
-      bytes[i] = static_cast<std::uint8_t>(
-          std::clamp(data_[i] * 255.0f + 0.5f, 0.0f, 255.0f));
+      const float scaled = data_[i] * 255.0f + 0.5f;
+      bytes[i] =
+          std::isfinite(scaled) ? static_cast<std::uint8_t>(std::clamp(scaled, 0.0f, 255.0f)) : 0;
     }
     return *Pixmap::fromVec(std::move(bytes), IntSize::fromWH(width_, height_).value());
   }
@@ -251,9 +253,7 @@ class FloatPixmap {
   }
 
   /// Mutable float data.
-  [[nodiscard]] std::span<float> data() {
-    return std::span<float>(data_.data(), data_.size());
-  }
+  [[nodiscard]] std::span<float> data() { return std::span<float>(data_.data(), data_.size()); }
 
   /// Fill with a color (values already in [0,1] premultiplied).
   void fill(float r, float g, float b, float a) {

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/GaussianBlur.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/GaussianBlur.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <numbers>
+#include <span>
 #include <vector>
 
 #include "tiny_skia/filter/SimdVec.h"
@@ -127,15 +128,18 @@ int resolveEdge(int coord, int size, BlurEdgeMode edgeMode) {
     return coord;
   }
   switch (edgeMode) {
-    case BlurEdgeMode::Duplicate: return std::clamp(coord, 0, size - 1);
-    case BlurEdgeMode::Wrap: return ((coord % size) + size) % size;
-    case BlurEdgeMode::None: return -1;
+    case BlurEdgeMode::Duplicate:
+      return std::clamp(coord, 0, size - 1);
+    case BlurEdgeMode::Wrap:
+      return ((coord % size) + size) % size;
+    case BlurEdgeMode::None:
+      return -1;
   }
   return -1;
 }
 
 // ---------------------------------------------------------------------------
-// Weighted convolution (σ < 2.0) — uint8 path.
+// Weighted convolution (sigma < 2.0) - uint8 path.
 // ---------------------------------------------------------------------------
 
 void convolveHorizontalWeighted(const std::uint8_t* src, std::uint8_t* dst, int width, int height,
@@ -168,7 +172,7 @@ void convolveHorizontalWeighted(const std::uint8_t* src, std::uint8_t* dst, int 
 // ---------------------------------------------------------------------------
 // Running-sum box blur (σ ≥ 2.0): O(1) per pixel per pass.
 // Uses Vec4u32 SIMD + ScaledDivider (Phases 1+2).
-// Phase 7: Loop splitting for EdgeMode::None — eliminates edge checks in bulk middle.
+// Phase 7: Loop splitting for EdgeMode::None - eliminates edge checks in bulk middle.
 // ---------------------------------------------------------------------------
 
 void boxBlurHorizontal(const std::uint8_t* src, std::uint8_t* dst, int width, int height,
@@ -191,7 +195,7 @@ void boxBlurHorizontal(const std::uint8_t* src, std::uint8_t* dst, int width, in
       }
       sum.scaledDivide(divider).storeToU8(dstRow);
 
-      // Section 1: Left edge — leaving pixel is out of bounds (x < pass.left + 1).
+      // Section 1: Left edge - leaving pixel is out of bounds (x < pass.left + 1).
       const int leftEdgeEnd = std::min(pass.left + 1, width);
       for (int x = 1; x < leftEdgeEnd; ++x) {
         const int enterX = x + pass.right;
@@ -202,7 +206,7 @@ void boxBlurHorizontal(const std::uint8_t* src, std::uint8_t* dst, int width, in
         sum.scaledDivide(divider).storeToU8(dstRow + static_cast<std::size_t>(x) * 4);
       }
 
-      // Section 2: Bulk middle — both entering and leaving pixels are in bounds.
+      // Section 2: Bulk middle - both entering and leaving pixels are in bounds.
       const int bulkEnd = std::min(width - pass.right, width);
       for (int x = leftEdgeEnd; x < bulkEnd; ++x) {
         sum += Vec4u32::loadFromU8(srcRow + static_cast<std::size_t>(x + pass.right) * 4);
@@ -210,7 +214,7 @@ void boxBlurHorizontal(const std::uint8_t* src, std::uint8_t* dst, int width, in
         sum.scaledDivide(divider).storeToU8(dstRow + static_cast<std::size_t>(x) * 4);
       }
 
-      // Section 3: Right edge — entering pixel is out of bounds.
+      // Section 3: Right edge - entering pixel is out of bounds.
       for (int x = std::max(leftEdgeEnd, bulkEnd); x < width; ++x) {
         // enterX = x + pass.right >= width, no addition needed.
         const int leaveX = x - pass.left - 1;
@@ -246,7 +250,7 @@ void boxBlurHorizontal(const std::uint8_t* src, std::uint8_t* dst, int width, in
 }
 
 // ---------------------------------------------------------------------------
-// Float box blur — uses Vec4f32 SIMD for all paths (Phases 2+6).
+// Float box blur - uses Vec4f32 SIMD for all paths (Phases 2+6).
 // Phase 7: Loop splitting for EdgeMode::None.
 // ---------------------------------------------------------------------------
 
@@ -295,7 +299,7 @@ void boxBlurHorizontalFloat(const float* src, float* dst, int width, int height,
         (sum * invWidth).store(dstRow + static_cast<std::size_t>(x) * 4);
       }
 
-      // Bulk middle — no edge checks.
+      // Bulk middle - no edge checks.
       const int bulkEnd = std::min(width - pass.right, width);
       for (int x = leftEdgeEnd; x < bulkEnd; ++x) {
         sum += Vec4f32::load(srcRow + static_cast<std::size_t>(x + pass.right) * 4);
@@ -336,7 +340,6 @@ void boxBlurHorizontalFloat(const float* src, float* dst, int width, int height,
   }
 }
 
-
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -367,12 +370,12 @@ void gaussianBlur(Pixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMode edg
     if (sigmaX < 2.0) {
       const WeightedKernel kernel = makeGaussianKernel(sigmaX);
       convolveHorizontalWeighted(buffer.data(), scratch.data(), width, height, kernel, edgeMode);
-      buffer.swap(scratch);
+      std::swap(buffer, scratch);
     } else {
       const BoxBlurPlan plan = computeBoxPasses(sigmaX);
       for (int i = 0; i < plan.numPasses; ++i) {
         boxBlurHorizontal(buffer.data(), scratch.data(), width, height, plan.passes[i], edgeMode);
-        buffer.swap(scratch);
+        std::swap(buffer, scratch);
       }
     }
   }
@@ -380,23 +383,23 @@ void gaussianBlur(Pixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMode edg
   if (sigmaY > 0.0) {
     // Transpose for cache-friendly vertical blur.
     transposeRGBA(buffer.data(), scratch.data(), width, height);
-    buffer.swap(scratch);
+    std::swap(buffer, scratch);
 
     if (sigmaY < 2.0) {
       const WeightedKernel kernel = makeGaussianKernel(sigmaY);
       convolveHorizontalWeighted(buffer.data(), scratch.data(), height, width, kernel, edgeMode);
-      buffer.swap(scratch);
+      std::swap(buffer, scratch);
     } else {
       const BoxBlurPlan plan = computeBoxPasses(sigmaY);
       for (int i = 0; i < plan.numPasses; ++i) {
         boxBlurHorizontal(buffer.data(), scratch.data(), height, width, plan.passes[i], edgeMode);
-        buffer.swap(scratch);
+        std::swap(buffer, scratch);
       }
     }
 
     // Transpose back.
     transposeRGBA(buffer.data(), scratch.data(), height, width);
-    buffer.swap(scratch);
+    std::swap(buffer, scratch);
   }
 
   std::copy(buffer.begin(), buffer.end(), pixmap.data().begin());
@@ -414,12 +417,12 @@ void gaussianBlur(FloatPixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMod
   }
 
   // Guard against OOM: each buffer is width*height*4 floats. The cap
-  // matches `Pixmap::fromSize`'s 1 GiB defensive ceiling — large enough
+  // matches `Pixmap::fromSize`'s 1 GiB defensive ceiling - large enough
   // to handle a viewport-sized SourceGraphic (e.g. the editor's worst
   // case at the `kMaxCanvasDim=8192` clamp boundary requires ~616 MiB
   // of float buffer per blur scratch), small enough to reject inputs
   // claiming pathological sizes. The prior 64 MiB cap silently no-op'd
-  // the blur whenever the SourceGraphic exceeded ~2048×2048 floats —
+  // the blur whenever the SourceGraphic exceeded ~2048x2048 floats -
   // which is the path the editor hits at high zoom, surfacing as
   // "filters disappear when I zoom in." See `ZoomFilterRepro_tests.cc`.
   constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
@@ -428,49 +431,59 @@ void gaussianBlur(FloatPixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMod
     return;
   }
 
-  auto srcSpan = pixmap.data();
-  std::vector<float> buffer(srcSpan.begin(), srcSpan.end());
-  std::vector<float> scratch(buffer.size());
-
-  if (sigmaX > 0.0) {
-    if (sigmaX < 2.0) {
-      const WeightedKernel kernel = makeGaussianKernel(sigmaX);
-      convolveHorizontalWeightedFloat(buffer.data(), scratch.data(), width, height, kernel,
-                                      edgeMode);
-      buffer.swap(scratch);
+  // Process one scanline at a time. This bounds blur scratch to two rows or columns instead of one
+  // full float surface, so a large but admitted SourceGraphic does not transiently triple its
+  // retained memory. Every pass reads a complete line before copying its result back.
+  const auto blurLine = [&](std::span<float> line, std::span<float> scratch, double sigma) {
+    if (!(sigma > 0.0)) {
+      return;
+    }
+    std::span<float> input = line;
+    std::span<float> output = scratch;
+    const int linePixels = static_cast<int>(line.size() / 4);
+    if (sigma < 2.0) {
+      const WeightedKernel kernel = makeGaussianKernel(sigma);
+      convolveHorizontalWeightedFloat(input.data(), output.data(), linePixels, 1, kernel, edgeMode);
+      std::swap(input, output);
     } else {
-      const BoxBlurPlan plan = computeBoxPasses(sigmaX);
+      const BoxBlurPlan plan = computeBoxPasses(sigma);
       for (int i = 0; i < plan.numPasses; ++i) {
-        boxBlurHorizontalFloat(buffer.data(), scratch.data(), width, height, plan.passes[i],
+        boxBlurHorizontalFloat(input.data(), output.data(), linePixels, 1, plan.passes[i],
                                edgeMode);
-        buffer.swap(scratch);
+        std::swap(input, output);
       }
+    }
+    if (input.data() != line.data()) {
+      std::copy(input.begin(), input.end(), line.begin());
+    }
+  };
+
+  std::span<float> pixels = pixmap.data();
+  if (sigmaX > 0.0) {
+    const std::size_t rowFloats = static_cast<std::size_t>(width) * 4;
+    std::vector<float> rowScratch(rowFloats);
+    for (int y = 0; y < height; ++y) {
+      blurLine(pixels.subspan(static_cast<std::size_t>(y) * rowFloats, rowFloats), rowScratch,
+               sigmaX);
     }
   }
 
   if (sigmaY > 0.0) {
-    transposeRGBA(buffer.data(), scratch.data(), width, height);
-    buffer.swap(scratch);
-
-    if (sigmaY < 2.0) {
-      const WeightedKernel kernel = makeGaussianKernel(sigmaY);
-      convolveHorizontalWeightedFloat(buffer.data(), scratch.data(), height, width, kernel,
-                                      edgeMode);
-      buffer.swap(scratch);
-    } else {
-      const BoxBlurPlan plan = computeBoxPasses(sigmaY);
-      for (int i = 0; i < plan.numPasses; ++i) {
-        boxBlurHorizontalFloat(buffer.data(), scratch.data(), height, width, plan.passes[i],
-                               edgeMode);
-        buffer.swap(scratch);
+    std::vector<float> column(static_cast<std::size_t>(height) * 4);
+    std::vector<float> columnScratch(column.size());
+    for (int x = 0; x < width; ++x) {
+      for (int y = 0; y < height; ++y) {
+        const std::size_t source = (static_cast<std::size_t>(y) * width + x) * 4;
+        std::copy_n(pixels.data() + source, 4, column.data() + static_cast<std::size_t>(y) * 4);
+      }
+      blurLine(column, columnScratch, sigmaY);
+      for (int y = 0; y < height; ++y) {
+        const std::size_t destination = (static_cast<std::size_t>(y) * width + x) * 4;
+        std::copy_n(column.data() + static_cast<std::size_t>(y) * 4, 4,
+                    pixels.data() + destination);
       }
     }
-
-    transposeRGBA(buffer.data(), scratch.data(), height, width);
-    buffer.swap(scratch);
   }
-
-  std::copy(buffer.begin(), buffer.end(), pixmap.data().begin());
 }
 
 }  // namespace tiny_skia::filter

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/Turbulence.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/Turbulence.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <utility>
 
 #include "tiny_skia/filter/TurbulenceKernel.h"
@@ -22,9 +23,55 @@ constexpr int kPerlinN = 0x1000;       // 4096: offset added to coordinates to k
 
 // Park-Miller LCG constants (Schrage's method to avoid overflow).
 constexpr long kRandM = 2147483647;  // 2^31 - 1  // NOLINT
-constexpr long kRandA = 16807;                     // NOLINT
-constexpr long kRandQ = 127773;  // kRandM / kRandA  // NOLINT
-constexpr long kRandR = 2836;    // kRandM % kRandA  // NOLINT
+constexpr long kRandA = 16807;       // NOLINT
+constexpr long kRandQ = 127773;      // kRandM / kRandA  // NOLINT
+constexpr long kRandR = 2836;        // kRandM % kRandA  // NOLINT
+constexpr double kMaximumBaseFrequency = 1024.0;
+constexpr double kMaximumTransformCoefficient = 1.0e6;
+
+template <typename T>
+struct SplitNoiseCoordinate {
+  int base = 0;
+  T fraction = 0;
+};
+
+template <typename T>
+SplitNoiseCoordinate<T> splitNoiseCoordinate(T value) {
+  if (!std::isfinite(value)) {
+    value = 0;
+  }
+  const T floored = std::floor(value);
+  int base = 0;
+  if (floored >= static_cast<T>(std::numeric_limits<int>::min()) &&
+      floored <= static_cast<T>(std::numeric_limits<int>::max() - 1)) {
+    base = static_cast<int>(floored);
+  } else {
+    // Only the low eight bits select the permutation-table entry. Reduce huge coordinates before
+    // converting instead of invoking undefined behavior in a floating-point-to-integer cast.
+    base = static_cast<int>(std::fmod(floored, static_cast<T>(kBLen)));
+  }
+  return SplitNoiseCoordinate<T>{base, value - floored};
+}
+
+template <typename T>
+T boundedFinite(T value, T magnitude) {
+  if (std::isnan(value)) {
+    return 0;
+  }
+  return std::clamp(value, -magnitude, magnitude);
+}
+
+template <typename T>
+int boundedStitchExtent(T value) {
+  constexpr int kMaximumExtent = std::numeric_limits<int>::max() - kPerlinN;
+  if (!std::isfinite(value) || value >= static_cast<T>(kMaximumExtent)) {
+    return kMaximumExtent;
+  }
+  if (value <= 1) {
+    return 1;
+  }
+  return static_cast<int>(value);
+}
 
 struct StitchInfo {
   int width = 0;
@@ -34,21 +81,21 @@ struct StitchInfo {
 };
 
 class TurbulenceGenerator {
-public:
+ public:
   explicit TurbulenceGenerator(double seedVal) { init(seedVal); }
 
   // Compute noise at (x, y) for a given color channel (0=R, 1=G, 2=B, 3=A).
   double noise2(int channel, double x, double y, const StitchInfo* stitch) const {
-    double t = x + static_cast<double>(kPerlinN);
-    int bx0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitX = splitNoiseCoordinate(x + static_cast<double>(kPerlinN));
+    int bx0 = splitX.base;
     int bx1 = bx0 + 1;
-    double rx0 = t - static_cast<double>(static_cast<int64_t>(t));
+    double rx0 = splitX.fraction;
     double rx1 = rx0 - 1.0;
 
-    t = y + static_cast<double>(kPerlinN);
-    int by0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitY = splitNoiseCoordinate(y + static_cast<double>(kPerlinN));
+    int by0 = splitY.base;
     int by1 = by0 + 1;
-    double ry0 = t - static_cast<double>(static_cast<int64_t>(t));
+    double ry0 = splitY.fraction;
     double ry1 = ry0 - 1.0;
 
     // Apply stitching before masking.
@@ -99,16 +146,16 @@ public:
   // Compute noise at (x, y) for all 4 channels simultaneously.
   // Shares lattice lookups and s-curve computation across channels.
   void noise2_4ch(double x, double y, const StitchInfo* stitch, double out[4]) const {
-    double t = x + static_cast<double>(kPerlinN);
-    int bx0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitX = splitNoiseCoordinate(x + static_cast<double>(kPerlinN));
+    int bx0 = splitX.base;
     int bx1 = bx0 + 1;
-    double rx0 = t - static_cast<double>(static_cast<int64_t>(t));
+    double rx0 = splitX.fraction;
     double rx1 = rx0 - 1.0;
 
-    t = y + static_cast<double>(kPerlinN);
-    int by0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitY = splitNoiseCoordinate(y + static_cast<double>(kPerlinN));
+    int by0 = splitY.base;
     int by1 = by0 + 1;
-    double ry0 = t - static_cast<double>(static_cast<int64_t>(t));
+    double ry0 = splitY.fraction;
     double ry1 = ry0 - 1.0;
 
     // Apply stitching before masking.
@@ -154,16 +201,16 @@ public:
   // Float-precision 4-channel noise, vectorized by `turbulenceBlend4`.
   // Uses SOA gradient tables for cache-friendly 4-channel SIMD loads.
   void noise2_4ch_f(float x, float y, const StitchInfo* stitch, float out[4]) const {
-    float t = x + static_cast<float>(kPerlinN);
-    int bx0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitX = splitNoiseCoordinate(x + static_cast<float>(kPerlinN));
+    int bx0 = splitX.base;
     int bx1 = bx0 + 1;
-    float rx0 = t - static_cast<float>(static_cast<int64_t>(t));
+    float rx0 = splitX.fraction;
     float rx1 = rx0 - 1.0f;
 
-    t = y + static_cast<float>(kPerlinN);
-    int by0 = static_cast<int>(static_cast<int64_t>(t));
+    const auto splitY = splitNoiseCoordinate(y + static_cast<float>(kPerlinN));
+    int by0 = splitY.base;
     int by1 = by0 + 1;
-    float ry0 = t - static_cast<float>(static_cast<int64_t>(t));
+    float ry0 = splitY.fraction;
     float ry1 = ry0 - 1.0f;
 
     if (stitch) {
@@ -195,14 +242,13 @@ public:
     turbulenceBlend4(corners, weights, out);
   }
 
-private:
+ private:
   void init(double seedVal) {
     // Seed clamping matching resvg.
+    seedVal = boundedFinite(seedVal, static_cast<double>(kRandM - 1));
     long seed;  // NOLINT
     if (seedVal <= 0) {
-      seed = -(static_cast<long>(seedVal)) % (kRandM - 1) + 1;  // NOLINT
-    } else if (seedVal > kRandM - 1) {
-      seed = kRandM - 1;
+      seed = static_cast<long>(-seedVal) % (kRandM - 1) + 1;  // NOLINT
     } else {
       seed = static_cast<long>(seedVal);  // NOLINT
     }
@@ -218,11 +264,9 @@ private:
 
         // Two random calls per gradient vector.
         seed = random(seed);
-        gradient_[ch][k][0] =
-            static_cast<double>((seed % (kBLen + kBLen)) - kBLen) / kBLen;
+        gradient_[ch][k][0] = static_cast<double>((seed % (kBLen + kBLen)) - kBLen) / kBLen;
         seed = random(seed);
-        gradient_[ch][k][1] =
-            static_cast<double>((seed % (kBLen + kBLen)) - kBLen) / kBLen;
+        gradient_[ch][k][1] = static_cast<double>((seed % (kBLen + kBLen)) - kBLen) / kBLen;
 
         // Normalize to unit length.
         const double mag = std::sqrt(gradient_[ch][k][0] * gradient_[ch][k][0] +
@@ -334,11 +378,13 @@ void turbulence(Pixmap& dst, const TurbulenceParams& params) {
       // inverse transform (handles skew/rotation, not just scale).
       const double px = static_cast<double>(x);
       const double py = static_cast<double>(y);
-      const double ux = params.filterFromDeviceA * px + params.filterFromDeviceB * py;
-      const double uy = params.filterFromDeviceC * px + params.filterFromDeviceD * py;
+      const double ux = boundedFinite(params.filterFromDeviceA, kMaximumTransformCoefficient) * px +
+                        boundedFinite(params.filterFromDeviceB, kMaximumTransformCoefficient) * py;
+      const double uy = boundedFinite(params.filterFromDeviceC, kMaximumTransformCoefficient) * px +
+                        boundedFinite(params.filterFromDeviceD, kMaximumTransformCoefficient) * py;
 
-      double freqX = params.baseFrequencyX;
-      double freqY = params.baseFrequencyY;
+      double freqX = boundedFinite(params.baseFrequencyX, kMaximumBaseFrequency);
+      double freqY = boundedFinite(params.baseFrequencyY, kMaximumBaseFrequency);
       double ratio = 1.0;
 
       for (int octave = 0; octave < numOctaves; octave++) {
@@ -348,10 +394,8 @@ void turbulence(Pixmap& dst, const TurbulenceParams& params) {
         StitchInfo stitch;
         StitchInfo* stitchPtr = nullptr;
         if (params.stitchTiles) {
-          stitch.width = static_cast<int>(static_cast<double>(params.tileWidth) * freqX);
-          stitch.height = static_cast<int>(static_cast<double>(params.tileHeight) * freqY);
-          if (stitch.width < 1) stitch.width = 1;
-          if (stitch.height < 1) stitch.height = 1;
+          stitch.width = boundedStitchExtent(static_cast<double>(params.tileWidth) * freqX);
+          stitch.height = boundedStitchExtent(static_cast<double>(params.tileHeight) * freqY);
           stitch.wrapX = stitch.width + kPerlinN;
           stitch.wrapY = stitch.height + kPerlinN;
           stitchPtr = &stitch;
@@ -446,12 +490,18 @@ void turbulence(FloatPixmap& dst, const TurbulenceParams& params) {
   const bool isFractal = (params.type == TurbulenceType::FractalNoise);
 
   // Pre-convert transform coefficients to float.
-  const float fA = static_cast<float>(params.filterFromDeviceA);
-  const float fB = static_cast<float>(params.filterFromDeviceB);
-  const float fC = static_cast<float>(params.filterFromDeviceC);
-  const float fD = static_cast<float>(params.filterFromDeviceD);
-  const float baseFreqXf = static_cast<float>(params.baseFrequencyX);
-  const float baseFreqYf = static_cast<float>(params.baseFrequencyY);
+  const float fA =
+      static_cast<float>(boundedFinite(params.filterFromDeviceA, kMaximumTransformCoefficient));
+  const float fB =
+      static_cast<float>(boundedFinite(params.filterFromDeviceB, kMaximumTransformCoefficient));
+  const float fC =
+      static_cast<float>(boundedFinite(params.filterFromDeviceC, kMaximumTransformCoefficient));
+  const float fD =
+      static_cast<float>(boundedFinite(params.filterFromDeviceD, kMaximumTransformCoefficient));
+  const float baseFreqXf =
+      static_cast<float>(boundedFinite(params.baseFrequencyX, kMaximumBaseFrequency));
+  const float baseFreqYf =
+      static_cast<float>(boundedFinite(params.baseFrequencyY, kMaximumBaseFrequency));
 
   auto data = dst.data();
 
@@ -475,10 +525,8 @@ void turbulence(FloatPixmap& dst, const TurbulenceParams& params) {
         StitchInfo stitch;
         StitchInfo* stitchPtr = nullptr;
         if (params.stitchTiles) {
-          stitch.width = static_cast<int>(static_cast<float>(params.tileWidth) * freqX);
-          stitch.height = static_cast<int>(static_cast<float>(params.tileHeight) * freqY);
-          if (stitch.width < 1) stitch.width = 1;
-          if (stitch.height < 1) stitch.height = 1;
+          stitch.width = boundedStitchExtent(static_cast<float>(params.tileWidth) * freqX);
+          stitch.height = boundedStitchExtent(static_cast<float>(params.tileHeight) * freqY);
           stitch.wrapX = stitch.width + kPerlinN;
           stitch.wrapY = stitch.height + kPerlinN;
           stitchPtr = &stitch;


### PR DESCRIPTION
Bounds filter graph preparation, retained state, and backend execution before attacker-controlled SVG filters can amplify memory, traversal, or sample work.

- limits filter href resolution, aggregate graph structure, input edges, scalar vectors, shared image payloads, and computed-filter retention with lifecycle-aware release
- preflights CSS URL expansion, feImage rasterization, numeric conversions, and converted image copies before allocation or graph mutation
- accounts TinySkia and Geode retained and transient surfaces, morphology passes, blur and drop-shadow samples, convolution kernels, turbulence work, and subtree suppression
- rejects a filter subtree atomically when its graph or execution budget is exhausted while allowing later independent content to render
- adds causal cap, cap-plus-one, replacement, lifecycle, backend, and sanitizer regressions

## Validation

- default, TinySkia, full-text, and Geode filter and renderer matrices: passed
- ASan structured corpus and UBSan filter/renderer coverage: passed
- Wasm renderer build: passed
- full lint and complexity checks: passed
- CMake validation, formatting, diff, privacy, and no-lockfile checks: clean

This layer is stacked on #1044 and is limited to filter preparation and execution resource accounting.
