### PR TITLE
Stabilize Firefox thumbnail renderer handoff

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -468,8 +468,18 @@ void AsyncRenderer::requestRender(const RenderRequest& request) {
     }
     if (sampleThumbnailActive_) {
       // Main-document presentation always preempts background preview work. The thumbnail
-      // traversal polls its independent token between rendered entities.
-      cancelSampleThumbnail_.cancel();
+      // traversal polls its independent token between rendered entities. Worker-local offscreen
+      // renderer construction cannot poll, so let that one first-use operation return before
+      // applying the cancellation signal.
+      if (sampleThumbnailRendererCreationActive_) {
+        cancelSampleThumbnailAfterRendererCreation_ = true;
+        if (!foregroundHandoffCountedForRendererCreation_) {
+          foregroundHandoffCountedForRendererCreation_ = true;
+          ++sampleThumbnailCounters_.foregroundHandoffWaits;
+        }
+      } else {
+        cancelSampleThumbnail_.cancel();
+      }
     }
   }
   cv_.notify_one();
@@ -600,7 +610,11 @@ void AsyncRenderer::cancelSampleThumbnailWork() {
   sampleThumbnailResult_.reset();
   if (sampleThumbnailActive_) {
     discardActiveSampleThumbnailResult_ = true;
-    cancelSampleThumbnail_.cancel();
+    if (sampleThumbnailRendererCreationActive_) {
+      cancelSampleThumbnailAfterRendererCreation_ = true;
+    } else {
+      cancelSampleThumbnail_.cancel();
+    }
   }
 }
 
@@ -686,6 +700,16 @@ void AsyncRenderer::workerLoop() {
           cancelSampleThumbnail_.reset();
           sampleThumbnailActive_ = true;
           discardActiveSampleThumbnailResult_ = false;
+          cancelSampleThumbnailAfterRendererCreation_ = false;
+          foregroundHandoffCountedForRendererCreation_ = false;
+#if   defined(__EMSCRIPTEN__)
+          sampleThumbnailRendererCreationActive_ =
+              sampleThumbnailRenderer == nullptr || sampleThumbnailRendererRoot != &workerRenderer;
+#else
+          sampleThumbnailRendererCreationActive_ =
+              sampleThumbnailRenderer == nullptr ||
+              sampleThumbnailRendererRoot != sampleThumbnailStorage->nativeRenderer;
+#endif
           ++sampleThumbnailCounters_.started;
         }
       }
@@ -748,6 +772,21 @@ void AsyncRenderer::workerLoop() {
       }
       offscreenRenderer = requestedRoot != nullptr ? sampleThumbnailRenderer.get() : nullptr;
 #endif
+
+      bool cancelAfterRendererCreation = false;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (sampleThumbnailRendererCreationActive_) {
+          sampleThumbnailRendererCreationActive_ = false;
+          sampleThumbnailCounters_.firstAttemptCompleted = true;
+          cancelAfterRendererCreation = cancelSampleThumbnailAfterRendererCreation_;
+          cancelSampleThumbnailAfterRendererCreation_ = false;
+          foregroundHandoffCountedForRendererCreation_ = false;
+        }
+      }
+      if (cancelAfterRendererCreation) {
+        cancelSampleThumbnail_.cancel();
+      }
 
       SampleThumbnailRenderResult result;
       if (offscreenRenderer == nullptr) {

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -667,7 +667,8 @@ bool AsyncRenderer::prepareSampleThumbnailRendererForRequest(
   return forceRecreate;
 }
 
-void AsyncRenderer::delaySampleThumbnailRendererCreationForTesting(bool shouldDelay) const {
+void AsyncRenderer::delaySampleThumbnailRendererCreationForTesting(bool shouldDelay,
+                                                                   int constructionStart) const {
   if (!shouldDelay) {
     return;
   }
@@ -677,11 +678,19 @@ void AsyncRenderer::delaySampleThumbnailRendererCreationForTesting(bool shouldDe
     return;
   }
 #ifdef __EMSCRIPTEN__
-  MAIN_THREAD_ASYNC_EM_ASM({ window['__donnerSampleThumbnailRendererCreationBlocked'] = true; });
+  MAIN_THREAD_EM_ASM(
+      {
+        window['__donnerSampleThumbnailRendererCreationBlocked'] = ({
+          'blocked' : true,
+          'constructionStarts' : $0,
+        });
+      },
+      constructionStart);
 #endif
   std::this_thread::sleep_for(delay);
 #ifdef __EMSCRIPTEN__
-  MAIN_THREAD_ASYNC_EM_ASM({ window['__donnerSampleThumbnailRendererCreationBlocked'] = false; });
+  MAIN_THREAD_EM_ASM(
+      { window['__donnerSampleThumbnailRendererCreationBlocked']['blocked'] = false; });
 #endif
 }
 
@@ -715,7 +724,7 @@ void AsyncRenderer::workerLoop() {
     std::optional<RenderRequest> requestStorage;
     std::optional<SampleThumbnailRenderRequest> sampleThumbnailStorage;
     bool runCompositorWarmup = false;
-    bool delaySampleThumbnailRendererCreation = false;
+    [[maybe_unused]] bool delaySampleThumbnailRendererCreation = false;
     {
       std::unique_lock<std::mutex> lock(mutex_);
       cv_.wait(lock, [this] {
@@ -811,11 +820,28 @@ void AsyncRenderer::workerLoop() {
     }
 
     if (sampleThumbnailStorage.has_value()) {
-      delaySampleThumbnailRendererCreationForTesting(delaySampleThumbnailRendererCreation);
       svg::RendererInterface* offscreenRenderer = nullptr;
 #if defined(__EMSCRIPTEN__)
       if (sampleThumbnailRenderer == nullptr || sampleThumbnailRendererRoot != &workerRenderer) {
+        workerRenderer.setOffscreenCreationHookForTesting([this,
+                                                           delaySampleThumbnailRendererCreation] {
+          int constructionStart = 0;
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            constructionStart =
+                static_cast<int>(++sampleThumbnailCounters_.offscreenRendererConstructionStarts);
+            sampleThumbnailCounters_.offscreenRendererConstructionBlocked =
+                delaySampleThumbnailRendererCreation;
+          }
+          delaySampleThumbnailRendererCreationForTesting(delaySampleThumbnailRendererCreation,
+                                                         constructionStart);
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            sampleThumbnailCounters_.offscreenRendererConstructionBlocked = false;
+          }
+        });
         sampleThumbnailRenderer = workerRenderer.createOffscreenInstance();
+        workerRenderer.setOffscreenCreationHookForTesting({});
         sampleThumbnailRendererRoot = &workerRenderer;
         if (sampleThumbnailRenderer != nullptr) {
           std::lock_guard<std::mutex> lock(mutex_);

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -7,6 +7,10 @@
 #include <thread>
 #include <utility>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/threading.h>
+#endif
+
 #include "donner/base/MemoryAttribution.h"
 #include "donner/base/Utils.h"
 #include "donner/editor/OverlayRenderer.h"
@@ -260,7 +264,6 @@ SampleThumbnailRenderResult RenderSampleThumbnail(
 
 }  // namespace
 
-
 PresentationSnapshotPlan ChoosePresentationSnapshotPlan(bool hasCompositedPreview,
                                                         bool requiresTextureSnapshotPresentation,
                                                         bool captureCpuSnapshot) {
@@ -386,8 +389,7 @@ void AsyncRenderer::notePublishedCompositedPreview(
 
 bool AsyncRenderer::workerStateBusy(const WorkerState& state) {
   return std::holds_alternative<RenderingState>(state) ||
-         std::holds_alternative<CancellingState>(state) ||
-         std::holds_alternative<DoneState>(state);
+         std::holds_alternative<CancellingState>(state) || std::holds_alternative<DoneState>(state);
 }
 
 bool AsyncRenderer::workerStateRenderInFlight(const WorkerState& state) {
@@ -517,9 +519,8 @@ void AsyncRenderer::cancelInFlight() {
     // input still needs a retry frame. Active render/cancellation states provide their own later
     // completion wake; an active compositor warmup uses the durable waiter above.
     const bool cancellationSettled =
-        !compositorWarmupActive_ &&
-        (std::holds_alternative<IdleState>(workerState_) ||
-         std::holds_alternative<DoneState>(workerState_));
+        !compositorWarmupActive_ && (std::holds_alternative<IdleState>(workerState_) ||
+                                     std::holds_alternative<DoneState>(workerState_));
     if (cancellationSettled) {
       wakeAfterSettledCancellation = wakeCallback_;
     }
@@ -640,8 +641,69 @@ void AsyncRenderer::setWakeCallback(std::function<void()> callback) {
   wakeCallback_ = std::move(callback);
 }
 
+void AsyncRenderer::setSampleThumbnailRendererCreationPlanForTesting(
+    int requestNumber, std::chrono::milliseconds delay) {
+  constexpr int kMaximumRequestNumber = 64;
+  constexpr std::chrono::milliseconds kMaximumDelay(5000);
+  sampleThumbnailRendererCreationRequestForTesting_.store(
+      std::clamp(requestNumber, 0, kMaximumRequestNumber), std::memory_order_release);
+  sampleThumbnailRendererCreationDelayMsForTesting_.store(
+      std::clamp(delay, std::chrono::milliseconds(0), kMaximumDelay).count(),
+      std::memory_order_release);
+}
+
+bool AsyncRenderer::prepareSampleThumbnailRendererForRequest(
+    std::unique_ptr<svg::RendererInterface>& renderer, svg::RendererInterface*& rendererRoot,
+    svg::RendererInterface* requestedRoot) {
+  const int nextRequest = static_cast<int>(sampleThumbnailCounters_.started + 1);
+  const int recreateRequest =
+      sampleThumbnailRendererCreationRequestForTesting_.load(std::memory_order_acquire);
+  const bool forceRecreate = recreateRequest > 0 && nextRequest == recreateRequest;
+  if (forceRecreate) {
+    renderer.reset();
+    rendererRoot = nullptr;
+  }
+  sampleThumbnailRendererCreationActive_ = renderer == nullptr || rendererRoot != requestedRoot;
+  return forceRecreate;
+}
+
+void AsyncRenderer::delaySampleThumbnailRendererCreationForTesting(bool shouldDelay) const {
+  if (!shouldDelay) {
+    return;
+  }
+  const auto delay = std::chrono::milliseconds(
+      sampleThumbnailRendererCreationDelayMsForTesting_.load(std::memory_order_acquire));
+  if (delay.count() <= 0) {
+    return;
+  }
+#ifdef __EMSCRIPTEN__
+  MAIN_THREAD_ASYNC_EM_ASM({ window['__donnerSampleThumbnailRendererCreationBlocked'] = true; });
+#endif
+  std::this_thread::sleep_for(delay);
+#ifdef __EMSCRIPTEN__
+  MAIN_THREAD_ASYNC_EM_ASM({ window['__donnerSampleThumbnailRendererCreationBlocked'] = false; });
+#endif
+}
+
+void AsyncRenderer::finishSampleThumbnailRendererCreation() {
+  bool cancelAfterRendererCreation = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (sampleThumbnailRendererCreationActive_) {
+      sampleThumbnailRendererCreationActive_ = false;
+      sampleThumbnailCounters_.firstAttemptCompleted = true;
+      cancelAfterRendererCreation = cancelSampleThumbnailAfterRendererCreation_;
+      cancelSampleThumbnailAfterRendererCreation_ = false;
+      foregroundHandoffCountedForRendererCreation_ = false;
+    }
+  }
+  if (cancelAfterRendererCreation) {
+    cancelSampleThumbnail_.cancel();
+  }
+}
+
 void AsyncRenderer::workerLoop() {
-#if   defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__)
   // Emscripten's WebGPU object table is per-worker. Construct and use the
   // renderer on this pthread so wgpu handles never cross JS worker boundaries.
   svg::Renderer workerRenderer;
@@ -653,6 +715,7 @@ void AsyncRenderer::workerLoop() {
     std::optional<RenderRequest> requestStorage;
     std::optional<SampleThumbnailRenderRequest> sampleThumbnailStorage;
     bool runCompositorWarmup = false;
+    bool delaySampleThumbnailRendererCreation = false;
     {
       std::unique_lock<std::mutex> lock(mutex_);
       cv_.wait(lock, [this] {
@@ -702,13 +765,13 @@ void AsyncRenderer::workerLoop() {
           discardActiveSampleThumbnailResult_ = false;
           cancelSampleThumbnailAfterRendererCreation_ = false;
           foregroundHandoffCountedForRendererCreation_ = false;
-#if   defined(__EMSCRIPTEN__)
-          sampleThumbnailRendererCreationActive_ =
-              sampleThumbnailRenderer == nullptr || sampleThumbnailRendererRoot != &workerRenderer;
+#if defined(__EMSCRIPTEN__)
+          delaySampleThumbnailRendererCreation = prepareSampleThumbnailRendererForRequest(
+              sampleThumbnailRenderer, sampleThumbnailRendererRoot, &workerRenderer);
 #else
-          sampleThumbnailRendererCreationActive_ =
-              sampleThumbnailRenderer == nullptr ||
-              sampleThumbnailRendererRoot != sampleThumbnailStorage->nativeRenderer;
+          delaySampleThumbnailRendererCreation = prepareSampleThumbnailRendererForRequest(
+              sampleThumbnailRenderer, sampleThumbnailRendererRoot,
+              sampleThumbnailStorage->nativeRenderer);
 #endif
           ++sampleThumbnailCounters_.started;
         }
@@ -748,8 +811,9 @@ void AsyncRenderer::workerLoop() {
     }
 
     if (sampleThumbnailStorage.has_value()) {
+      delaySampleThumbnailRendererCreationForTesting(delaySampleThumbnailRendererCreation);
       svg::RendererInterface* offscreenRenderer = nullptr;
-#if   defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__)
       if (sampleThumbnailRenderer == nullptr || sampleThumbnailRendererRoot != &workerRenderer) {
         sampleThumbnailRenderer = workerRenderer.createOffscreenInstance();
         sampleThumbnailRendererRoot = &workerRenderer;
@@ -773,20 +837,7 @@ void AsyncRenderer::workerLoop() {
       offscreenRenderer = requestedRoot != nullptr ? sampleThumbnailRenderer.get() : nullptr;
 #endif
 
-      bool cancelAfterRendererCreation = false;
-      {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (sampleThumbnailRendererCreationActive_) {
-          sampleThumbnailRendererCreationActive_ = false;
-          sampleThumbnailCounters_.firstAttemptCompleted = true;
-          cancelAfterRendererCreation = cancelSampleThumbnailAfterRendererCreation_;
-          cancelSampleThumbnailAfterRendererCreation_ = false;
-          foregroundHandoffCountedForRendererCreation_ = false;
-        }
-      }
-      if (cancelAfterRendererCreation) {
-        cancelSampleThumbnail_.cancel();
-      }
+      finishSampleThumbnailRendererCreation();
 
       SampleThumbnailRenderResult result;
       if (offscreenRenderer == nullptr) {
@@ -839,7 +890,7 @@ void AsyncRenderer::workerLoop() {
             ? 0.0
             : std::chrono::duration<double, std::milli>(workerDequeuedAt - request.queuedAt)
                   .count();
-#if   defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__)
     svg::Renderer& requestRenderer = workerRenderer;
 #else
     // Geode editor builds intentionally use the request renderer so worker texture snapshots are
@@ -1428,9 +1479,9 @@ void AsyncRenderer::workerLoop() {
           // `verifyPixelIdentity` reference render uses, so pixels match the
           // composited modes by construction.
           svg::RendererDriver directDriver(requestRenderer);
-          renderCompleted = directDriver.drawInterruptibly(
-              requestDocument, viewport, surfaceFromCanvas,
-              [this]() { return cancelRender_.isCancelled(); });
+          renderCompleted =
+              directDriver.drawInterruptibly(requestDocument, viewport, surfaceFromCanvas,
+                                             [this]() { return cancelRender_.isCancelled(); });
         }
       }
       workerTiming.renderFrameMs = elapsedSince(renderFrameStart);
@@ -1632,9 +1683,9 @@ void AsyncRenderer::workerLoop() {
           done.result.version = request.version;
           done.result.documentGeneration = request.documentGeneration;
           done.presentationHoldPollsRemaining = replayResultHoldFramesForTesting_;
-          lastFastPathCounters_ =
-              compositor_ != nullptr ? compositor_->fastPathCountersForTesting()
-                                     : svg::compositor::CompositorController::FastPathCounters{};
+          lastFastPathCounters_ = compositor_ != nullptr
+                                      ? compositor_->fastPathCountersForTesting()
+                                      : svg::compositor::CompositorController::FastPathCounters{};
           lastCompositorRenderFrameStats_ =
               compositor_ != nullptr ? compositor_->lastRenderFrameStats()
                                      : svg::compositor::CompositorController::RenderFrameStats{};
@@ -1667,12 +1718,12 @@ void AsyncRenderer::workerLoop() {
           done.result.workerMs = workerMs;
           done.result.workerTiming = workerTiming;
           done.result.workerCompletedAt = workerEnd;
-            workerState_ = std::move(done);
-            // Snapshot the callback under the lock so a concurrent
-            // `setWakeCallback` swap can't tear the invocation. Fire it
-            // outside the lock to keep the hook cheap and avoid any
-            // chance of deadlock if the caller re-enters AsyncRenderer.
-            wake = wakeCallback_;
+          workerState_ = std::move(done);
+          // Snapshot the callback under the lock so a concurrent
+          // `setWakeCallback` swap can't tear the invocation. Fire it
+          // outside the lock to keep the hook cheap and avoid any
+          // chance of deadlock if the caller re-enters AsyncRenderer.
+          wake = wakeCallback_;
           notifyStateChange = true;
         }
       } else if (std::holds_alternative<CancellingState>(workerState_)) {

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -47,7 +47,6 @@
 #include <variant>
 #include <vector>
 
-
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
@@ -73,7 +72,6 @@ class GeodeDevice;
 }
 
 namespace donner::editor {
-
 
 /// Non-null renderer/document handoff for a render request.
 struct RenderLease {
@@ -425,6 +423,10 @@ struct SampleThumbnailRenderStats {
   std::uint64_t rendered = 0;
   std::uint64_t cancelled = 0;
   std::uint64_t offscreenRendererCreations = 0;
+  /// Foreground renders queued while the first worker-local offscreen attempt was still active.
+  std::uint64_t foregroundHandoffWaits = 0;
+  /// True once the first worker-local offscreen thumbnail attempt has released its renderer.
+  bool firstAttemptCompleted = false;
   bool pending = false;
   bool active = false;
   bool resultReady = false;

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -425,7 +425,7 @@ struct SampleThumbnailRenderStats {
   std::uint64_t offscreenRendererCreations = 0;
   /// Foreground renders queued while the first worker-local offscreen attempt was still active.
   std::uint64_t foregroundHandoffWaits = 0;
-  /// True once the first worker-local offscreen thumbnail attempt has released its renderer.
+  /// True once the first worker-local offscreen renderer initialization has completed.
   bool firstAttemptCompleted = false;
   bool pending = false;
   bool active = false;
@@ -844,6 +844,12 @@ private:
   std::optional<SampleThumbnailRenderResult> sampleThumbnailResult_;
   bool sampleThumbnailActive_ = false;
   bool discardActiveSampleThumbnailResult_ = false;
+  /// Renderer construction itself cannot poll the thumbnail cancellation token. Foreground work
+  /// arriving in this window defers that signal until construction returns, avoiding a browser
+  /// WebGPU cancellation handoff while preserving priority before thumbnail rendering starts.
+  bool sampleThumbnailRendererCreationActive_ = false;
+  bool cancelSampleThumbnailAfterRendererCreation_ = false;
+  bool foregroundHandoffCountedForRendererCreation_ = false;
   SampleThumbnailRenderStats sampleThumbnailCounters_;
   svg::compositor::CancellationToken cancelSampleThumbnail_;
   std::atomic<std::chrono::milliseconds::rep> sampleThumbnailRenderDelayMsForTesting_{0};

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -592,6 +592,10 @@ public:
   /// Inject a cancellation-aware delay before thumbnail parsing for deterministic priority tests.
   void setSampleThumbnailRenderDelayForTesting(std::chrono::milliseconds delay);
 
+  /// Recreate and pause one numbered offscreen renderer construction for browser handoff tests.
+  void setSampleThumbnailRendererCreationPlanForTesting(int requestNumber,
+                                                        std::chrono::milliseconds delay);
+
   /// Install a callback that the worker thread invokes when a render
   /// result or cancellation completes. Used by the editor's on-demand
   /// render loop to wake the UI thread (e.g. via `glfwPostEmptyEvent`)
@@ -810,6 +814,11 @@ public:
 
 private:
   void workerLoop();
+  bool prepareSampleThumbnailRendererForRequest(std::unique_ptr<svg::RendererInterface>& renderer,
+                                                svg::RendererInterface*& rendererRoot,
+                                                svg::RendererInterface* requestedRoot);
+  void delaySampleThumbnailRendererCreationForTesting(bool shouldDelay) const;
+  void finishSampleThumbnailRendererCreation();
 
   std::thread thread_;
   mutable std::mutex mutex_;
@@ -853,6 +862,8 @@ private:
   SampleThumbnailRenderStats sampleThumbnailCounters_;
   svg::compositor::CancellationToken cancelSampleThumbnail_;
   std::atomic<std::chrono::milliseconds::rep> sampleThumbnailRenderDelayMsForTesting_{0};
+  std::atomic<int> sampleThumbnailRendererCreationRequestForTesting_{0};
+  std::atomic<std::chrono::milliseconds::rep> sampleThumbnailRendererCreationDelayMsForTesting_{0};
   /// Offscreen-only cache preparation left over after publishing a correct first document frame.
   /// It shares the worker but not `WorkerState`, so input can post a foreground render immediately;
   /// that request cancels this work at the compositor's existing safe points.

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -425,6 +425,8 @@ struct SampleThumbnailRenderStats {
   std::uint64_t offscreenRendererCreations = 0;
   /// Offscreen constructors entered before any test-only construction block.
   std::uint64_t offscreenRendererConstructionStarts = 0;
+  /// True only while the test-controlled block is active inside construction.
+  bool offscreenRendererConstructionBlocked = false;
   /// Foreground renders queued while the first worker-local offscreen attempt was still active.
   std::uint64_t foregroundHandoffWaits = 0;
   /// True once the first worker-local offscreen renderer initialization has completed.
@@ -819,7 +821,8 @@ private:
   bool prepareSampleThumbnailRendererForRequest(std::unique_ptr<svg::RendererInterface>& renderer,
                                                 svg::RendererInterface*& rendererRoot,
                                                 svg::RendererInterface* requestedRoot);
-  void delaySampleThumbnailRendererCreationForTesting(bool shouldDelay) const;
+  void delaySampleThumbnailRendererCreationForTesting(bool shouldDelay,
+                                                      int constructionStart) const;
   void finishSampleThumbnailRendererCreation();
 
   std::thread thread_;

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -423,6 +423,8 @@ struct SampleThumbnailRenderStats {
   std::uint64_t rendered = 0;
   std::uint64_t cancelled = 0;
   std::uint64_t offscreenRendererCreations = 0;
+  /// Offscreen constructors entered before any test-only construction block.
+  std::uint64_t offscreenRendererConstructionStarts = 0;
   /// Foreground renders queued while the first worker-local offscreen attempt was still active.
   std::uint64_t foregroundHandoffWaits = 0;
   /// True once the first worker-local offscreen renderer initialization has completed.

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3094,6 +3094,24 @@ Box2d EditorShell::canvasZoomControlScreenRect() const {
   return Box2d::FromXYWH(x, y, width, height);
 }
 
+std::optional<Entity> EditorShell::toolbarPaintSelectionIdentity(
+    bool rendererBusy, const svg::SVGDocumentHandle& currentPaintDocument) {
+  if (app_.selectedElements().empty()) {
+    return std::nullopt;
+  }
+
+  if (rendererBusy) {
+    // The render worker may be traversing or rebuilding the shared registry. Reuse the stable
+    // identity captured before handoff instead of resolving an ElementAnchor against that registry
+    // from the UI thread.
+    return toolbarPaintSnapshotDocument_ == currentPaintDocument ? toolbarPaintSnapshotSelection_
+                                                                 : std::nullopt;
+  }
+
+  ++toolbarLiveSelectionIdentityReadsForTesting_;
+  return app_.selectedElements().front().unsafeEntityHandle().entity();
+}
+
 void EditorShell::renderFillStrokeToolbarWidget() {
   const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
   const bool canvasInteractionActive = selectTool_.isDragging() || selectTool_.isMarqueeing() ||
@@ -3103,10 +3121,7 @@ void EditorShell::renderFillStrokeToolbarWidget() {
   std::optional<Entity> currentPaintSelection;
   if (app_.hasDocument()) {
     currentPaintDocument = app_.document().document().handle();
-    if (!app_.selectedElements().empty()) {
-      ++toolbarLiveSelectionIdentityReadsForTesting_;
-      currentPaintSelection = app_.selectedElements().front().unsafeEntityHandle().entity();
-    }
+    currentPaintSelection = toolbarPaintSelectionIdentity(rendererBusy, currentPaintDocument);
   }
   const bool paintSnapshotMatchesSelection =
       toolbarPaintSnapshot_ != nullptr && toolbarPaintSnapshotDocument_ == currentPaintDocument &&

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -129,7 +129,8 @@ void PublishActiveSampleId(const char* sampleId) {
 void PublishSampleThumbnailStats(int requested, int started, int completed, int rendered, int ready,
                                  int pending, int active, int resultReady,
                                  int foregroundHandoffWaits, int firstAttemptCompleted,
-                                 int offscreenRendererConstructionStarts) {
+                                 int offscreenRendererConstructionStarts,
+                                 int offscreenRendererConstructionBlocked) {
   MAIN_THREAD_ASYNC_EM_ASM(
       {
         const frame = Number(window['__donnerMainLoopRenderedFrames'] || 0) + 1;
@@ -162,10 +163,12 @@ void PublishSampleThumbnailStats(int requested, int started, int completed, int 
           'foregroundHandoffWaits' : $8,
           'firstAttemptCompleted' : Boolean($9),
           'offscreenRendererConstructionStarts' : $10,
+          'offscreenRendererConstructionBlocked' : Boolean($11),
         });
       },
       requested, started, completed, rendered, ready, pending, active, resultReady,
-      foregroundHandoffWaits, firstAttemptCompleted, offscreenRendererConstructionStarts);
+      foregroundHandoffWaits, firstAttemptCompleted, offscreenRendererConstructionStarts,
+      offscreenRendererConstructionBlocked);
 }
 
 void PublishInteractionStats(int selectedCount, int pendingClick, int workerBusy, int dragging,
@@ -4436,7 +4439,8 @@ void EditorShell::publishSampleThumbnailStats() const {
       static_cast<int>(stats.completed), static_cast<int>(stats.rendered), static_cast<int>(ready),
       stats.pending ? 1 : 0, stats.active ? 1 : 0, stats.resultReady ? 1 : 0,
       static_cast<int>(stats.foregroundHandoffWaits), stats.firstAttemptCompleted ? 1 : 0,
-      static_cast<int>(stats.offscreenRendererConstructionStarts));
+      static_cast<int>(stats.offscreenRendererConstructionStarts),
+      stats.offscreenRendererConstructionBlocked ? 1 : 0);
 #endif
 }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -109,7 +109,8 @@ void PublishActiveSampleId(const char* sampleId) {
 }
 
 void PublishSampleThumbnailStats(int requested, int started, int completed, int rendered, int ready,
-                                 int pending, int active, int resultReady) {
+                                 int pending, int active, int resultReady,
+                                 int foregroundHandoffWaits, int firstAttemptCompleted) {
   MAIN_THREAD_ASYNC_EM_ASM(
       {
         const frame = Number(window['__donnerMainLoopRenderedFrames'] || 0) + 1;
@@ -139,9 +140,12 @@ void PublishSampleThumbnailStats(int requested, int started, int completed, int 
           'pending' : Boolean($5),
           'active' : Boolean($6),
           'resultReady' : Boolean($7),
+          'foregroundHandoffWaits' : $8,
+          'firstAttemptCompleted' : Boolean($9),
         });
       },
-      requested, started, completed, rendered, ready, pending, active, resultReady);
+      requested, started, completed, rendered, ready, pending, active, resultReady,
+      foregroundHandoffWaits, firstAttemptCompleted);
 }
 
 void PublishInteractionStats(int selectedCount, int pendingClick, int workerBusy, int dragging,
@@ -4402,10 +4406,11 @@ void EditorShell::publishSampleThumbnailStats() const {
   }
   const SampleThumbnailRenderStats stats =
       renderCoordinator_.asyncRenderer().sampleThumbnailRenderStats();
-  PublishSampleThumbnailStats(static_cast<int>(stats.requested), static_cast<int>(stats.started),
-                              static_cast<int>(stats.completed), static_cast<int>(stats.rendered),
-                              static_cast<int>(ready), stats.pending ? 1 : 0, stats.active ? 1 : 0,
-                              stats.resultReady ? 1 : 0);
+  PublishSampleThumbnailStats(
+      static_cast<int>(stats.requested), static_cast<int>(stats.started),
+      static_cast<int>(stats.completed), static_cast<int>(stats.rendered), static_cast<int>(ready),
+      stats.pending ? 1 : 0, stats.active ? 1 : 0, stats.resultReady ? 1 : 0,
+      static_cast<int>(stats.foregroundHandoffWaits), stats.firstAttemptCompleted ? 1 : 0);
 #endif
 }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -89,6 +89,24 @@
 namespace donner::editor {
 
 #ifdef __EMSCRIPTEN__
+int SampleThumbnailRendererCreationRequestForTesting() {
+  return MAIN_THREAD_EM_ASM_INT({
+    const raw =
+        new URLSearchParams(window.location.search).get('sampleThumbnailRendererCreationRequest');
+    const value = Number(raw || 0);
+    return Number.isFinite(value) ? Math.max(0, Math.min(64, Math.floor(value))) : 0;
+  });
+}
+
+int SampleThumbnailRendererCreationDelayMsForTesting() {
+  return MAIN_THREAD_EM_ASM_INT({
+    const raw =
+        new URLSearchParams(window.location.search).get('sampleThumbnailRendererCreationDelayMs');
+    const value = Number(raw || 0);
+    return Number.isFinite(value) ? Math.max(0, Math.min(5000, Math.floor(value))) : 0;
+  });
+}
+
 // The app runs on a pthread in the browser build, where `window` and
 // `document` do not exist; every publish below proxies to the browser main
 // thread. Fire-and-forget: none of these are read back by the app.
@@ -1168,6 +1186,11 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
     installFramebufferUnderlayPlan(std::move(plan));
   });
   renderCoordinator_.asyncRenderer().setCompositorDiagnosticsEnabled(false);
+#ifdef __EMSCRIPTEN__
+  renderCoordinator_.asyncRenderer().setSampleThumbnailRendererCreationPlanForTesting(
+      SampleThumbnailRendererCreationRequestForTesting(),
+      std::chrono::milliseconds(SampleThumbnailRendererCreationDelayMsForTesting()));
+#endif
   // Install the embedded + system font catalog as the process-wide default provider, so every
   // document FontManager created by the render paths resolves font-family names against embedded
   // Google Fonts and macOS system fonts before falling back to Public Sans (Design 0013 W3).

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -128,7 +128,8 @@ void PublishActiveSampleId(const char* sampleId) {
 
 void PublishSampleThumbnailStats(int requested, int started, int completed, int rendered, int ready,
                                  int pending, int active, int resultReady,
-                                 int foregroundHandoffWaits, int firstAttemptCompleted) {
+                                 int foregroundHandoffWaits, int firstAttemptCompleted,
+                                 int offscreenRendererConstructionStarts) {
   MAIN_THREAD_ASYNC_EM_ASM(
       {
         const frame = Number(window['__donnerMainLoopRenderedFrames'] || 0) + 1;
@@ -160,10 +161,11 @@ void PublishSampleThumbnailStats(int requested, int started, int completed, int 
           'resultReady' : Boolean($7),
           'foregroundHandoffWaits' : $8,
           'firstAttemptCompleted' : Boolean($9),
+          'offscreenRendererConstructionStarts' : $10,
         });
       },
       requested, started, completed, rendered, ready, pending, active, resultReady,
-      foregroundHandoffWaits, firstAttemptCompleted);
+      foregroundHandoffWaits, firstAttemptCompleted, offscreenRendererConstructionStarts);
 }
 
 void PublishInteractionStats(int selectedCount, int pendingClick, int workerBusy, int dragging,
@@ -4433,7 +4435,8 @@ void EditorShell::publishSampleThumbnailStats() const {
       static_cast<int>(stats.requested), static_cast<int>(stats.started),
       static_cast<int>(stats.completed), static_cast<int>(stats.rendered), static_cast<int>(ready),
       stats.pending ? 1 : 0, stats.active ? 1 : 0, stats.resultReady ? 1 : 0,
-      static_cast<int>(stats.foregroundHandoffWaits), stats.firstAttemptCompleted ? 1 : 0);
+      static_cast<int>(stats.foregroundHandoffWaits), stats.firstAttemptCompleted ? 1 : 0,
+      static_cast<int>(stats.offscreenRendererConstructionStarts));
 #endif
 }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3104,6 +3104,7 @@ void EditorShell::renderFillStrokeToolbarWidget() {
   if (app_.hasDocument()) {
     currentPaintDocument = app_.document().document().handle();
     if (!app_.selectedElements().empty()) {
+      ++toolbarLiveSelectionIdentityReadsForTesting_;
       currentPaintSelection = app_.selectedElements().front().unsafeEntityHandle().entity();
     }
   }

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -656,6 +656,9 @@ private:
   std::unique_ptr<internal::ToolbarPaintState> toolbarPaintSnapshot_;
   svg::SVGDocumentHandle toolbarPaintSnapshotDocument_;
   std::optional<Entity> toolbarPaintSnapshotSelection_;
+  /// Number of live selection-identity reads performed by the paint toolbar. Test-only
+  /// observability for the document-handoff boundary.
+  std::uint64_t toolbarLiveSelectionIdentityReadsForTesting_ = 0;
   /// Document-derived menu/shortcut state from the last idle UI epoch. Busy frames must replay
   /// these values instead of traversing the live registry behind the worker's write guard.
   bool cachedCanvasHasSelectableElements_ = false;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -452,6 +452,8 @@ private:
   void renderToolPalette(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderEditingScopeBreadcrumb();
   void renderCanvasZoomControl();
+  [[nodiscard]] std::optional<Entity> toolbarPaintSelectionIdentity(
+      bool rendererBusy, const svg::SVGDocumentHandle& currentPaintDocument);
   void renderFillStrokeToolbarWidget();
   void renderCompactTopBar();
   void renderSidebars();

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -1226,6 +1226,10 @@ public:
     shell.renderFillStrokeToolbarWidget();
   }
 
+  static std::uint64_t ToolbarLiveSelectionIdentityReads(const EditorShell& shell) {
+    return shell.toolbarLiveSelectionIdentityReadsForTesting_;
+  }
+
   static void RenderToolPalette(EditorShell& shell, const ImVec2& paneOrigin,
                                 const ImVec2& contentRegion) {
     shell.renderToolPalette(paneOrigin, contentRegion);
@@ -3509,11 +3513,17 @@ TEST(EditorShellTest, FillStrokeToolbarKeepsChosenPaintVisibleWhileRendererIsBus
   EditorShellTestAccess::App(shell).setActiveFill(kDifferentAuthoringFill);
   constexpr ImVec2 kCursor(20.0f, 40.0f);
   RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  const std::uint64_t liveSelectionReadsBeforeHandoff =
+      EditorShellTestAccess::ToolbarLiveSelectionIdentityReads(shell);
   AsyncRenderer& renderer =
       EditorShellTestAccess::BeginDelayedRender(shell, std::chrono::milliseconds(500));
   ASSERT_TRUE(renderer.isBusy());
 
   RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  EXPECT_EQ(EditorShellTestAccess::ToolbarLiveSelectionIdentityReads(shell),
+            liveSelectionReadsBeforeHandoff)
+      << "A busy toolbar frame must reuse the pre-handoff selection identity without resolving "
+         "the worker-owned registry";
   EXPECT_TRUE(DrawDataContainsColor(IM_COL32(0x33, 0x66, 0xcc, 0xff)))
       << "The selected element's fill swatch must not change while its render is in flight";
   EXPECT_FALSE(DrawDataContainsColor(IM_COL32(0xff, 0x00, 0xaa, 0xff)))

--- a/donner/editor/tests/SampleThumbnailAsync_tests.cc
+++ b/donner/editor/tests/SampleThumbnailAsync_tests.cc
@@ -31,6 +31,7 @@ namespace {
 using namespace std::chrono_literals;
 using svg::test::RgbaEq;
 using testing::ByMove;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 
@@ -212,6 +213,59 @@ TEST(SampleThumbnailAsyncTest, MainDocumentPreemptsThumbnailDuringSnapshotReadba
   ASSERT_TRUE(cancelled.has_value());
   EXPECT_EQ(cancelled->key, 51u);
   EXPECT_EQ(cancelled->outcome, SampleThumbnailRenderOutcome::Cancelled);
+}
+
+TEST(SampleThumbnailAsyncTest, FirstOffscreenCreationCompletesBeforeForegroundHandoff) {
+  struct CreationGate {
+    std::atomic<bool> entered{false};
+    std::atomic<bool> release{false};
+  };
+  const auto gate = std::make_shared<CreationGate>();
+  NiceMock<svg::tests::MockRendererInterface> thumbnailRoot;
+  EXPECT_CALL(thumbnailRoot, createOffscreenInstance())
+      .WillOnce(Invoke([gate]() -> std::unique_ptr<svg::RendererInterface> {
+        gate->entered.store(true, std::memory_order_release);
+        while (!gate->release.load(std::memory_order_acquire)) {
+          std::this_thread::sleep_for(1ms);
+        }
+        return std::make_unique<svg::Renderer>();
+      }));
+
+  AsyncRenderer renderer;
+  ASSERT_TRUE(renderer.requestSampleThumbnail(ThumbnailRequest(52u, kRedSvg, thumbnailRoot)));
+  ASSERT_TRUE(WaitUntil([&] { return gate->entered.load(std::memory_order_acquire); }));
+
+  ParseWarningSink warnings = ParseWarningSink::Disabled();
+  auto parsed = svg::parser::SVGParser::ParseSVG(kBlueSvg, warnings);
+  ASSERT_FALSE(parsed.hasError());
+  svg::SVGDocument document = std::move(parsed.result());
+  document.setCanvasSize(64, 48);
+  svg::Renderer documentRenderer;
+  RenderRequest mainRequest(documentRenderer, document);
+  mainRequest.version = 3u;
+  mainRequest.documentGeneration = 3u;
+  mainRequest.rasterViewport = EditorRasterViewport{
+      .documentRect = Box2d::FromXYWH(0.0, 0.0, 64.0, 48.0),
+      .outputSizePx = Vector2i(64, 48),
+      .semanticCanvasSizePx = Vector2i(64, 48),
+      .outputFromDocument = Transform2d(),
+  };
+
+  renderer.cancelSampleThumbnailWork();
+  renderer.requestRender(mainRequest);
+  gate->release.store(true, std::memory_order_release);
+  ASSERT_TRUE(WaitUntil([&] { return renderer.sampleThumbnailRenderStats().completed == 1u; }));
+
+  const SampleThumbnailRenderStats stats = renderer.sampleThumbnailRenderStats();
+  EXPECT_EQ(stats.foregroundHandoffWaits, 1u);
+  EXPECT_TRUE(stats.firstAttemptCompleted);
+
+  std::optional<RenderResult> mainResult;
+  ASSERT_TRUE(WaitUntil([&] {
+    mainResult = renderer.pollResult();
+    return mainResult.has_value();
+  }));
+  EXPECT_EQ(mainResult->version, 3u);
 }
 
 TEST(SampleThumbnailAsyncTest, ShutdownRejectsBothPriorityLanesWithoutResurrectingWorker) {

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -643,6 +643,26 @@ async function openBasicShapes(page: Page): Promise<{
     throw new Error("editor canvas is missing");
   }
 
+  // These callers measure overlays and presentation pixels, not the thumbnail-to-foreground
+  // scheduler transition. The dedicated Firefox handoff regression below forces that collision
+  // deterministically. Let first-use offscreen WebGPU work settle here so a visual oracle cannot
+  // spend its entire deadline on an unrelated thumbnail cancellation.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const stats = window.__donnerSampleThumbnailStats;
+          if (!stats) return false;
+          const completed = stats.completed ?? 0;
+          return completed > 0 && (stats.ready ?? 0) > 0 && !stats.active && !stats.pending;
+        }),
+      {
+        message: "the first offscreen thumbnail must settle before a visual sample replaces it",
+        timeout: scaledMs(20_000),
+        intervals: [16, 25, 50, 100],
+      },
+    )
+    .toBe(true);
   const beforeSampleResults = await page.evaluate(
     () => window.__donnerWorkerStats?.completedResults || 0,
   );

--- a/donner/editor/wasm/tests/playwright.compatibility.config.js
+++ b/donner/editor/wasm/tests/playwright.compatibility.config.js
@@ -14,7 +14,7 @@ module.exports = defineConfig({
         /Firefox keeps the dragged shape and its selection outline in every drag frame/,
         /Firefox never exposes the checkerboard while dragging a Splash letter/,
         /Firefox renders every visible Splash layer thumbnail/,
-        /Firefox hands the first active thumbnail to a foreground sample load/,
+        /Firefox hands a blocked thumbnail renderer to a foreground sample load/,
       ],
       use: {
         ...devices["Desktop Firefox"],

--- a/donner/editor/wasm/tests/playwright.compatibility.config.js
+++ b/donner/editor/wasm/tests/playwright.compatibility.config.js
@@ -14,6 +14,7 @@ module.exports = defineConfig({
         /Firefox keeps the dragged shape and its selection outline in every drag frame/,
         /Firefox never exposes the checkerboard while dragging a Splash letter/,
         /Firefox renders every visible Splash layer thumbnail/,
+        /Firefox hands the first active thumbnail to a foreground sample load/,
       ],
       use: {
         ...devices["Desktop Firefox"],

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -128,6 +128,7 @@ declare global {
       resultReady: boolean;
       foregroundHandoffWaits: number;
       firstAttemptCompleted: boolean;
+      offscreenRendererConstructionStarts: number;
     };
     __donnerSampleThumbnailRendererCreationBlocked?: boolean;
     __donnerLayerThumbnailStats?: {
@@ -858,10 +859,7 @@ test("WGPU diagnostics do not block the first carousel interaction", async ({ pa
   expect(fatalMessages).toEqual([]);
 });
 
-test("Firefox hands a blocked thumbnail renderer to a foreground sample load", async ({
-  browserName,
-  page,
-}) => {
+test("Firefox hands a blocked thumbnail renderer to a foreground sample load", async ({ browserName, page }) => {
   test.skip(browserName !== "firefox", "Firefox worker-owned WebGPU handoff regression");
   page.on("console", (message) => {
     if (message.type() === "error" || message.type() === "warning") {
@@ -886,14 +884,18 @@ test("Firefox hands a blocked thumbnail renderer to a foreground sample load", a
   await expect
     .poll(
       () =>
-        page.evaluate(() => window.__donnerSampleThumbnailRendererCreationBlocked === true),
+        page.evaluate(() => ({
+          blocked: window.__donnerSampleThumbnailRendererCreationBlocked === true,
+          constructionStarts:
+            window.__donnerSampleThumbnailStats?.offscreenRendererConstructionStarts ?? 0,
+        })),
       {
         message: "the second worker-owned offscreen renderer must be blocked before replacement",
         timeout: scaledMs(10_000),
         intervals: [8, 16, 25, 50],
       },
     )
-    .toBe(true);
+    .toEqual({ blocked: true, constructionStarts: 2 });
 
   const completedBefore = await page.evaluate(
     () => window.__donnerWorkerStats?.completedResults ?? 0,
@@ -910,8 +912,7 @@ test("Firefox hands a blocked thumbnail renderer to a foreground sample load", a
           return {
             firstAttemptCompleted: thumbnails?.firstAttemptCompleted ?? false,
             foregroundHandoffWaits: thumbnails?.foregroundHandoffWaits ?? 0,
-            foregroundResultCompleted:
-              (window.__donnerWorkerStats?.completedResults ?? 0) > before,
+            foregroundResultCompleted: (window.__donnerWorkerStats?.completedResults ?? 0) > before,
           };
         }, completedBefore),
       {

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -129,6 +129,7 @@ declare global {
       foregroundHandoffWaits: number;
       firstAttemptCompleted: boolean;
     };
+    __donnerSampleThumbnailRendererCreationBlocked?: boolean;
     __donnerLayerThumbnailStats?: {
       rowCount: number;
       renderedCount: number;
@@ -168,6 +169,8 @@ interface WgpuCarouselThumbnailStats extends WgpuReadbackColorStats {
 interface OpenEditorOptions {
   wgpuReadbackStats?: boolean;
   postInitializationDwellMs?: number;
+  sampleThumbnailRendererCreationRequest?: number;
+  sampleThumbnailRendererCreationDelayMs?: number;
 }
 
 const kFatalRuntimePattern =
@@ -292,6 +295,16 @@ async function openEditor(page: Page, options: OpenEditorOptions = {}): Promise<
   // not include that debug-only work unless they are explicitly guarding it.
   if (options.wgpuReadbackStats === true) {
     url.searchParams.set("wgpuReadbackStats", "1");
+  }
+  if ((options.sampleThumbnailRendererCreationRequest ?? 0) > 0) {
+    url.searchParams.set(
+      "sampleThumbnailRendererCreationRequest",
+      String(options.sampleThumbnailRendererCreationRequest),
+    );
+    url.searchParams.set(
+      "sampleThumbnailRendererCreationDelayMs",
+      String(options.sampleThumbnailRendererCreationDelayMs ?? 0),
+    );
   }
   const fatalMessages: string[] = [];
   const recordFatalMessage = (message: string) => {
@@ -845,7 +858,7 @@ test("WGPU diagnostics do not block the first carousel interaction", async ({ pa
   expect(fatalMessages).toEqual([]);
 });
 
-test("Firefox hands the first active thumbnail to a foreground sample load", async ({
+test("Firefox hands a blocked thumbnail renderer to a foreground sample load", async ({
   browserName,
   page,
 }) => {
@@ -858,7 +871,11 @@ test("Firefox hands the first active thumbnail to a foreground sample load", asy
   page.on("pageerror", (error) => {
     console.log(`firefox-handoff-pageerror: ${error.stack || error.message}`);
   });
-  const fatalMessages = await openEditor(page, { postInitializationDwellMs: 0 });
+  const fatalMessages = await openEditor(page, {
+    postInitializationDwellMs: 0,
+    sampleThumbnailRendererCreationRequest: 2,
+    sampleThumbnailRendererCreationDelayMs: 5000,
+  });
   const canvas = page.locator("canvas#canvas");
   const bounds = await canvas.boundingBox();
   expect(bounds).not.toBeNull();
@@ -869,12 +886,9 @@ test("Firefox hands the first active thumbnail to a foreground sample load", asy
   await expect
     .poll(
       () =>
-        page.evaluate(() => {
-          const stats = window.__donnerSampleThumbnailStats;
-          return Boolean(stats && stats.started > 0 && stats.completed === 0 && stats.active);
-        }),
+        page.evaluate(() => window.__donnerSampleThumbnailRendererCreationBlocked === true),
       {
-        message: "the first worker-owned offscreen thumbnail must be active before replacement",
+        message: "the second worker-owned offscreen renderer must be blocked before replacement",
         timeout: scaledMs(10_000),
         intervals: [8, 16, 25, 50],
       },

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -850,6 +850,14 @@ test("Firefox hands the first active thumbnail to a foreground sample load", asy
   page,
 }) => {
   test.skip(browserName !== "firefox", "Firefox worker-owned WebGPU handoff regression");
+  page.on("console", (message) => {
+    if (message.type() === "error" || message.type() === "warning") {
+      console.log(`firefox-handoff-console[${message.type()}]: ${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    console.log(`firefox-handoff-pageerror: ${error.stack || error.message}`);
+  });
   const fatalMessages = await openEditor(page, { postInitializationDwellMs: 0 });
   const canvas = page.locator("canvas#canvas");
   const bounds = await canvas.boundingBox();

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -126,6 +126,8 @@ declare global {
       pending: boolean;
       active: boolean;
       resultReady: boolean;
+      foregroundHandoffWaits: number;
+      firstAttemptCompleted: boolean;
     };
     __donnerLayerThumbnailStats?: {
       rowCount: number;
@@ -840,6 +842,67 @@ test("WGPU diagnostics do not block the first carousel interaction", async ({ pa
   // an unblocked main thread.
   expect(carouselHeartbeatGapMs).toBeLessThan(scaledMs(100));
   expect(heartbeat?.maxGapMs).toBeLessThan(scaledMs(100));
+  expect(fatalMessages).toEqual([]);
+});
+
+test("Firefox hands the first active thumbnail to a foreground sample load", async ({
+  browserName,
+  page,
+}) => {
+  test.skip(browserName !== "firefox", "Firefox worker-owned WebGPU handoff regression");
+  const fatalMessages = await openEditor(page, { postInitializationDwellMs: 0 });
+  const canvas = page.locator("canvas#canvas");
+  const bounds = await canvas.boundingBox();
+  expect(bounds).not.toBeNull();
+  if (bounds === null) {
+    return;
+  }
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const stats = window.__donnerSampleThumbnailStats;
+          return Boolean(stats && stats.started > 0 && stats.completed === 0 && stats.active);
+        }),
+      {
+        message: "the first worker-owned offscreen thumbnail must be active before replacement",
+        timeout: scaledMs(10_000),
+        intervals: [8, 16, 25, 50],
+      },
+    )
+    .toBe(true);
+
+  const completedBefore = await page.evaluate(
+    () => window.__donnerWorkerStats?.completedResults ?? 0,
+  );
+  await page.mouse.click(bounds.x + bounds.width * 0.24, bounds.y + 282);
+  await expect(canvas).toHaveAttribute("data-active-sample-id", "donner-splash", {
+    timeout: scaledMs(1000),
+  });
+  await expect
+    .poll(
+      () =>
+        page.evaluate((before) => {
+          const thumbnails = window.__donnerSampleThumbnailStats;
+          return {
+            firstAttemptCompleted: thumbnails?.firstAttemptCompleted ?? false,
+            foregroundHandoffWaits: thumbnails?.foregroundHandoffWaits ?? 0,
+            foregroundResultCompleted:
+              (window.__donnerWorkerStats?.completedResults ?? 0) > before,
+          };
+        }, completedBefore),
+      {
+        message: "the first offscreen attempt must release before the foreground document result",
+        timeout: scaledMs(20_000),
+        intervals: [16, 25, 50, 100],
+      },
+    )
+    .toEqual({
+      firstAttemptCompleted: true,
+      foregroundHandoffWaits: 1,
+      foregroundResultCompleted: true,
+    });
   expect(fatalMessages).toEqual([]);
 });
 

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -129,8 +129,12 @@ declare global {
       foregroundHandoffWaits: number;
       firstAttemptCompleted: boolean;
       offscreenRendererConstructionStarts: number;
+      offscreenRendererConstructionBlocked: boolean;
     };
-    __donnerSampleThumbnailRendererCreationBlocked?: boolean;
+    __donnerSampleThumbnailRendererCreationBlocked?: {
+      blocked: boolean;
+      constructionStarts: number;
+    };
     __donnerLayerThumbnailStats?: {
       rowCount: number;
       renderedCount: number;
@@ -884,11 +888,13 @@ test("Firefox hands a blocked thumbnail renderer to a foreground sample load", a
   await expect
     .poll(
       () =>
-        page.evaluate(() => ({
-          blocked: window.__donnerSampleThumbnailRendererCreationBlocked === true,
-          constructionStarts:
-            window.__donnerSampleThumbnailStats?.offscreenRendererConstructionStarts ?? 0,
-        })),
+        page.evaluate(
+          () =>
+            window.__donnerSampleThumbnailRendererCreationBlocked ?? {
+              blocked: false,
+              constructionStarts: 0,
+            },
+        ),
       {
         message: "the second worker-owned offscreen renderer must be blocked before replacement",
         timeout: scaledMs(10_000),

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -324,6 +324,28 @@ test("the composited drag gate does not cancel first-use offscreen WebGPU work",
   assert.match(helper.slice(0, sampleClick), /timeout:\s*scaledMs\(20_000\)/);
 });
 
+test("shared Basic Shapes visual gates settle first-use thumbnails before replacement", () => {
+  const helperStart = presentationRegressionSource.indexOf("async function openBasicShapes(");
+  const helperEnd = presentationRegressionSource.indexOf(
+    "async function toggleViewMenuItem(",
+    helperStart,
+  );
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "expected the Basic Shapes open helper");
+  const helper = presentationRegressionSource.slice(helperStart, helperEnd);
+
+  const thumbnailPrecondition = helper.indexOf("__donnerSampleThumbnailStats");
+  const sampleClick = helper.indexOf("page.mouse.click");
+  assert.ok(
+    thumbnailPrecondition >= 0 && thumbnailPrecondition < sampleClick,
+    "visual-only gates must not replace a first-use thumbnail render before it settles",
+  );
+  assert.match(helper, /completed\s*>\s*0/);
+  assert.match(helper, /\(stats\.ready\s*\?\?\s*0\)\s*>\s*0/);
+  assert.match(helper, /!stats\.active/);
+  assert.match(helper, /!stats\.pending/);
+  assert.match(helper.slice(0, sampleClick), /timeout:\s*scaledMs\(20_000\)/);
+});
+
 test("worker WebGPU startup keeps its browser Promise bridge private and single-purpose", () => {
   assert.doesNotMatch(geodeDeviceHeader, /CreateHeadlessAsync/);
   assert.doesNotMatch(geodeDeviceHeader, /donnerGeodeCompleteHeadlessImport/);

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -642,6 +642,10 @@ std::unique_ptr<RendererInterface> Renderer::createOffscreenInstance() const {
   return impl_->createOffscreenInstance();
 }
 
+void Renderer::setOffscreenCreationHookForTesting(std::function<void()> hook) {
+  impl_->setOffscreenCreationHookForTesting(std::move(hook));
+}
+
 void Renderer::setDebugGeometryOverlay(bool enabled) {
   impl_->setDebugGeometryOverlay(enabled);
 }

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -336,6 +336,9 @@ public:
   /// Creates an offscreen renderer of the active backend type.
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
+  /// Forwards the test-only in-constructor hook to the active backend.
+  void setOffscreenCreationHookForTesting(std::function<void()> hook) override;
+
   /// Forwards \ref RendererInterface::setDebugGeometryOverlay to the
   /// active backend (no-op for backends without a debug overlay).
   void setDebugGeometryOverlay(bool enabled) override;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1049,6 +1049,7 @@ constexpr bool kEnableSceneBatching = true;
 struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::FilterTextureAllocator {
   bool verbose = false;
   bool antialias = true;
+  std::function<void()> offscreenCreationHookForTesting;
 
   // Per-frame perf counters. Reset at `beginFrame`, read via
   // `lastFrameTimings()`; `GeodePerf_tests.cc` pins their ceilings.
@@ -3621,6 +3622,10 @@ RendererGeode::RendererGeode(bool verbose) : impl_(std::make_unique<Impl>()) {
 }
 
 RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool verbose)
+    : RendererGeode(std::move(device), verbose, {}) {}
+
+RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool verbose,
+                             std::function<void()> constructionHook)
     : impl_(std::make_unique<Impl>()) {
   impl_->verbose = verbose;
   impl_->device = std::move(device);
@@ -3629,6 +3634,9 @@ RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool ve
       std::cerr << "RendererGeode: null GeodeDevice passed - entering no-op mode\n";
     }
     return;
+  }
+  if (constructionHook) {
+    constructionHook();
   }
   impl_->initPipelines(verbose);
 }
@@ -6029,8 +6037,12 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
   if (!impl_->device) {
     return nullptr;
   }
-  auto renderer = std::make_unique<RendererGeode>(impl_->device, impl_->verbose);
-  return renderer;
+  return std::unique_ptr<RendererInterface>(
+      new RendererGeode(impl_->device, impl_->verbose, impl_->offscreenCreationHookForTesting));
+}
+
+void RendererGeode::setOffscreenCreationHookForTesting(std::function<void()> hook) {
+  impl_->offscreenCreationHookForTesting = std::move(hook);
 }
 
 std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapshot() {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -322,6 +322,9 @@ public:
 
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
+  /// Install a zero-default hook entered after the new renderer owns its device.
+  void setOffscreenCreationHookForTesting(std::function<void()> hook) override;
+
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
   [[nodiscard]] RendererBitmap takeSnapshotInterruptibly(
       const std::function<bool()>& shouldCancel) const override;
@@ -446,6 +449,9 @@ public:
   }
 
 private:
+  RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool verbose,
+                std::function<void()> constructionHook);
+
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -700,6 +700,9 @@ public:
     return nullptr;
   }
 
+  /// Install a zero-default hook entered from inside offscreen backend construction.
+  virtual void setOffscreenCreationHookForTesting(std::function<void()> /*hook*/) {}
+
   /**
    * Enable or disable the backend's geometry debug overlay.
    *


### PR DESCRIPTION
Repairs the browser-worker handoff when foreground document rendering interrupts construction of the first offscreen sample-thumbnail renderer.

- Defers cancellation only while the worker-owned offscreen renderer is in its unpollable construction window, then publishes the pending cancellation immediately afterward.
- Preserves foreground render priority and keeps the production path unchanged when no thumbnail cancellation is pending.
- Keeps the fill/stroke toolbar from resolving a selected element against the worker-owned registry during a busy handoff, while preserving the pre-handoff paint snapshot until the next idle refresh.
- Adds zero-default, bounded test controls plus native and headed-Firefox regressions that force the second-renderer collision deterministically.

Validation:

- `bazel test //...` (354 passed, 122 configuration skips)
- `bazel test //donner/editor/... --test_tag_filters=-manual,-perf` (80 passed, 8 expected fuzzer skips)
- CI-parity toolbar handoff regression burn-in (400 runs)
- `bazel test //donner/editor/tests:sample_thumbnail_async_tests`
- Headed Firefox thumbnail collision smoke test
- `bazel test //donner/editor/wasm:editor_wasm_size_test`
- `tools/lint.sh`
- `python3 tools/cmake/gen_cmakelists.py --check`
- Independent exact-range code and privacy review
