### PR TITLE
Bound renderer geometry and text materialization

### DIFF
--- a/donner/base/BezierUtils.cc
+++ b/donner/base/BezierUtils.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "donner/base/MathUtils.h"
 
@@ -18,9 +19,10 @@ Vector2d Lerp2d(const Vector2d& a, const Vector2d& b, double t) {
 constexpr int kMaxApproximationDepth = 10;
 
 /// Recursive helper for ApproximateCubicWithQuadratics.
-void approximateCubicWithQuadraticsImpl(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
+bool approximateCubicWithQuadraticsImpl(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
                                         const Vector2d& p3, double tolerance,
-                                        std::vector<Vector2d>& out, int depth) {
+                                        std::size_t maximumOutputPoints, std::vector<Vector2d>& out,
+                                        int depth) {
   // Compute the best-fit quadratic control point: Q1 = (3*(p1+p2) - p0 - p3) / 4
   const Vector2d q1 = (3.0 * (p1 + p2) - p0 - p3) * 0.25;
 
@@ -55,16 +57,22 @@ void approximateCubicWithQuadraticsImpl(const Vector2d& p0, const Vector2d& p1, 
 
   if (error <= tolerance || depth >= kMaxApproximationDepth) {
     // Emit the quadratic: (control point, end point)
+    if (out.size() > maximumOutputPoints || maximumOutputPoints - out.size() < 2u) {
+      return false;
+    }
     out.push_back(q1);
     out.push_back(p3);
-    return;
+    return true;
   }
 
   // Split at t=0.5 and recurse.
   auto [left, right] = SplitCubic(p0, p1, p2, p3, 0.5);
-  approximateCubicWithQuadraticsImpl(left[0], left[1], left[2], left[3], tolerance, out, depth + 1);
-  approximateCubicWithQuadraticsImpl(right[0], right[1], right[2], right[3], tolerance, out,
-                                     depth + 1);
+  if (!approximateCubicWithQuadraticsImpl(left[0], left[1], left[2], left[3], tolerance,
+                                          maximumOutputPoints, out, depth + 1)) {
+    return false;
+  }
+  return approximateCubicWithQuadraticsImpl(right[0], right[1], right[2], right[3], tolerance,
+                                            maximumOutputPoints, out, depth + 1);
 }
 
 }  // namespace
@@ -185,7 +193,17 @@ std::pair<std::array<Vector2d, 4>, std::array<Vector2d, 4>> SplitCubic(
 void ApproximateCubicWithQuadratics(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
                                     const Vector2d& p3, double tolerance,
                                     std::vector<Vector2d>& out) {
-  approximateCubicWithQuadraticsImpl(p0, p1, p2, p3, tolerance, out, 0);
+  (void)approximateCubicWithQuadraticsImpl(p0, p1, p2, p3, tolerance,
+                                           std::numeric_limits<std::size_t>::max(), out, 0);
+}
+
+bool ApproximateCubicWithQuadratics(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
+                                    const Vector2d& p3, double tolerance,
+                                    std::size_t maximumOutputPoints, std::vector<Vector2d>& out) {
+  if (out.size() > maximumOutputPoints) {
+    return false;
+  }
+  return approximateCubicWithQuadraticsImpl(p0, p1, p2, p3, tolerance, maximumOutputPoints, out, 0);
 }
 
 SmallVector<double, 1> QuadraticYExtrema(const Vector2d& p0, const Vector2d& p1,

--- a/donner/base/BezierUtils.h
+++ b/donner/base/BezierUtils.h
@@ -2,6 +2,7 @@
 /// @file
 
 #include <array>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -99,6 +100,16 @@ std::pair<std::array<Vector2d, 4>, std::array<Vector2d, 4>> SplitCubic(
 void ApproximateCubicWithQuadratics(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
                                     const Vector2d& p3, double tolerance,
                                     std::vector<Vector2d>& out);
+
+/**
+ * Bounded variant of \ref ApproximateCubicWithQuadratics.
+ *
+ * @return False without exceeding \p maximumOutputPoints when the approximation needs more
+ * points than the caller can retain.
+ */
+bool ApproximateCubicWithQuadratics(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2,
+                                    const Vector2d& p3, double tolerance,
+                                    std::size_t maximumOutputPoints, std::vector<Vector2d>& out);
 
 /**
  * Find parameter values where the Y-derivative is zero for a quadratic Bezier curve.

--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -520,6 +520,10 @@ Path::MeasuredPath Path::measure() const {
   return result;
 }
 
+Path::MeasuredPath Path::measure(std::size_t /*maximumWorkUnits*/) const {
+  return measure();
+}
+
 Path::PointOnPath Path::pointAtArcLength(double distance) const {
   return measure().pointAtArcLength(distance);
 }

--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -144,8 +144,11 @@ constexpr double kPathLengthTolerance = 0.001;
 
 class GeometryQueryWorkBudget {
 public:
+  explicit GeometryQueryWorkBudget(std::size_t maximumWork = Path::kMaximumGeometryQueryWork)
+      : maximumWork_(std::min(maximumWork, Path::kMaximumGeometryQueryWork)) {}
+
   bool consume() {
-    if (consumed_ >= Path::kMaximumGeometryQueryWork) {
+    if (consumed_ >= maximumWork_) {
       return false;
     }
     ++consumed_;
@@ -155,6 +158,7 @@ public:
   std::size_t consumed() const { return consumed_; }
 
 private:
+  std::size_t maximumWork_ = 0;
   std::size_t consumed_ = 0;
 };
 
@@ -484,8 +488,12 @@ double Path::pathLength() const {
 }
 
 Path::MeasuredPath Path::measure() const {
+  return measure(kMaximumGeometryQueryWork);
+}
+
+Path::MeasuredPath Path::measure(std::size_t maximumWorkUnits) const {
   MeasuredPath result;
-  GeometryQueryWorkBudget workBudget;
+  GeometryQueryWorkBudget workBudget(maximumWorkUnits);
 
   if (!measurementBaseRetainedBytes().has_value()) {
     InvalidateMeasurement(result.valid_, result.totalLength_, result.segments_, result.arcSamples_);
@@ -518,10 +526,6 @@ Path::MeasuredPath Path::measure() const {
   }
 
   return result;
-}
-
-Path::MeasuredPath Path::measure(std::size_t /*maximumWorkUnits*/) const {
-  return measure();
 }
 
 Path::PointOnPath Path::pointAtArcLength(double distance) const {

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -292,6 +292,18 @@ public:
   [[nodiscard]] MeasuredPath measure() const;
 
   /**
+   * Builds an arc-length index without consuming more than p maximumWorkUnits command visits
+   * and recursive subdivisions.
+   *
+   * Values above ef kMaximumGeometryQueryWork are clamped to that existing per-query ceiling.
+   * If the supplied allowance is exhausted, the returned measurement is invalid and reports the
+   * work it consumed.
+   *
+   * @param maximumWorkUnits Caller-provided work allowance for this query.
+   */
+  [[nodiscard]] MeasuredPath measure(std::size_t maximumWorkUnits) const;
+
+  /**
    * Bytes needed to reserve the maximum possible segment array before measurement starts.
    *
    * Callers retaining a MeasuredPath can preflight this base allocation before calling measure().

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -292,10 +292,10 @@ public:
   [[nodiscard]] MeasuredPath measure() const;
 
   /**
-   * Builds an arc-length index without consuming more than p maximumWorkUnits command visits
+   * Builds an arc-length index without consuming more than @p maximumWorkUnits command visits
    * and recursive subdivisions.
    *
-   * Values above ef kMaximumGeometryQueryWork are clamped to that existing per-query ceiling.
+   * Values above @ref kMaximumGeometryQueryWork are clamped to that existing per-query ceiling.
    * If the supplied allowance is exhausted, the returned measurement is invalid and reports the
    * work it consumed.
    *

--- a/donner/base/fonts/BUILD.bazel
+++ b/donner/base/fonts/BUILD.bazel
@@ -4,8 +4,14 @@ load("//build_defs:visibility.bzl", "donner_internal_visibility")
 
 donner_cc_library(
     name = "sfnt_utils",
-    srcs = ["SfntUtils.cc"],
-    hdrs = ["SfntUtils.h"],
+    srcs = [
+        "CffOutlineComplexity.cc",
+        "SfntUtils.cc",
+    ],
+    hdrs = [
+        "CffOutlineComplexity.h",
+        "SfntUtils.h",
+    ],
     visibility = ["//donner:__subpackages__"],
 )
 

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -19,18 +19,22 @@ constexpr std::size_t kMaximumStemHints = 96;
 constexpr std::size_t kMaximumCharStringLength = 65535;
 constexpr std::size_t kMaximumVertices = 1024 * 1024;
 constexpr std::size_t kMaximumGlyphWork = 16 * 1024 * 1024;
-constexpr std::size_t kMaximumFontValidationWork = 64 * 1024 * 1024;
-
 struct ValidationBudget {
+  explicit ValidationBudget(std::size_t maximumWork) : maximumWork(maximumWork) {}
+
   bool charge(std::size_t count) {
-    if (work > kMaximumFontValidationWork || count > kMaximumFontValidationWork - work) {
+    if (work > maximumWork || count > maximumWork - work) {
+      work = maximumWork;
+      exhausted = true;
       return false;
     }
     work += count;
     return true;
   }
 
+  std::size_t maximumWork = 0;
   std::size_t work = 0;
+  bool exhausted = false;
 };
 
 bool HasBytes(std::span<const uint8_t> data, std::size_t offset, std::size_t length) {
@@ -532,7 +536,10 @@ public:
       return {.status = CffOutlineValidationStatus::Invalid};
     }
     return {.status = CffOutlineValidationStatus::Complete,
-            .glyphs = {{static_cast<uint32_t>(vertices_), static_cast<uint32_t>(work_)}}};
+            .work = work_,
+            .glyphs = {{.maximumVertices = static_cast<uint32_t>(vertices_),
+                        .work = static_cast<uint32_t>(work_),
+                        .renderable = renderable_}}};
   }
 
 private:
@@ -770,7 +777,22 @@ private:
   }
 
   Flow finishCff1() {
-    if (!consumeOptionalWidth(0) || stackSize_ != 0 || !closeContour()) return Flow::Error;
+    if (stackSize_ == 0 || (!widthSeen_ && stackSize_ == 1)) {
+      if (!consumeOptionalWidth(0) || stackSize_ != 0 || !closeContour()) return Flow::Error;
+      return Flow::EndGlyph;
+    }
+    if (!consumeOptionalWidth(4) || stackSize_ != 4) return Flow::Error;
+    for (const std::size_t index : {std::size_t{2}, std::size_t{3}}) {
+      const Number& character = stack_[index];
+      if (!character.known || !std::isfinite(character.value) ||
+          std::floor(character.value) != character.value || character.value < 0.0 ||
+          character.value > 255.0) {
+        return Flow::Error;
+      }
+    }
+    stackSize_ = 0;
+    renderable_ = false;
+    if (!closeContour()) return Flow::Error;
     return Flow::EndGlyph;
   }
 
@@ -831,6 +853,7 @@ private:
   std::size_t work_ = 0;
   bool widthSeen_ = false;
   bool contourOpen_ = false;
+  bool renderable_ = true;
 };
 
 }  // namespace
@@ -838,33 +861,41 @@ private:
 CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> table, bool cff2,
                                                           std::size_t expectedGlyphs,
                                                           std::size_t maximumWork) {
-  static_cast<void>(maximumWork);
   if (expectedGlyphs == 0 || expectedGlyphs > kMaximumGlyphs) {
     return {};
   }
-  ValidationBudget validationBudget;
+  ValidationBudget validationBudget(maximumWork);
   const std::optional<ParsedCff> parsed = cff2
                                               ? ParseCff2(table, expectedGlyphs, &validationBudget)
                                               : ParseCff1(table, expectedGlyphs, &validationBudget);
   if (!parsed.has_value()) {
-    return {};
+    return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
+                                                 : CffOutlineValidationStatus::Invalid,
+            .work = validationBudget.work};
   }
   if (parsed->unsupportedVariation) {
-    return {.status = CffOutlineValidationStatus::UnsupportedVariation};
+    return {.status = CffOutlineValidationStatus::UnsupportedVariation,
+            .work = validationBudget.work};
   }
 
-  CffOutlineValidationResult result{.status = CffOutlineValidationStatus::Complete};
+  CffOutlineValidationResult result{.status = CffOutlineValidationStatus::Complete,
+                                    .work = validationBudget.work};
   result.glyphs.reserve(expectedGlyphs);
   for (std::size_t glyph = 0; glyph < expectedGlyphs; ++glyph) {
     const auto bytes = IndexItem(parsed->charStrings, glyph);
-    if (!bytes.has_value() || parsed->glyphFd[glyph] >= parsed->localSubrs.size()) return {};
+    if (!bytes.has_value() || parsed->glyphFd[glyph] >= parsed->localSubrs.size()) {
+      return {.status = CffOutlineValidationStatus::Invalid, .work = validationBudget.work};
+    }
     CharStringValidator validator(*parsed, cff2, parsed->glyphFd[glyph], &validationBudget);
     CffOutlineValidationResult glyphResult = validator.validate(*bytes);
     if (glyphResult.status != CffOutlineValidationStatus::Complete) {
-      return {.status = glyphResult.status};
+      return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
+                                                   : glyphResult.status,
+              .work = validationBudget.work};
     }
     result.glyphs.push_back(glyphResult.glyphs.front());
   }
+  result.work = validationBudget.work;
   return result;
 }
 

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -836,7 +836,9 @@ private:
 }  // namespace
 
 CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> table, bool cff2,
-                                                          std::size_t expectedGlyphs) {
+                                                          std::size_t expectedGlyphs,
+                                                          std::size_t maximumWork) {
+  static_cast<void>(maximumWork);
   if (expectedGlyphs == 0 || expectedGlyphs > kMaximumGlyphs) {
     return {};
   }

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -1,11 +1,869 @@
 #include "donner/base/fonts/CffOutlineComplexity.h"
 
-namespace donner::fonts {
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cmath>
+#include <limits>
+#include <optional>
 
-CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> /*table*/,
-                                                          bool /*cff2*/,
-                                                          std::size_t /*expectedGlyphs*/) {
-  return {};
+namespace donner::fonts {
+namespace {
+
+constexpr std::size_t kMaximumGlyphs = 65535;
+constexpr std::size_t kMaximumSubroutines = 65536;
+constexpr std::size_t kMaximumSubroutineDepth = 10;
+constexpr std::size_t kMaximumCff1Stack = 48;
+constexpr std::size_t kMaximumCff2Stack = 513;
+constexpr std::size_t kMaximumStemHints = 96;
+constexpr std::size_t kMaximumCharStringLength = 65535;
+constexpr std::size_t kMaximumVertices = 1024 * 1024;
+constexpr std::size_t kMaximumGlyphWork = 16 * 1024 * 1024;
+constexpr std::size_t kMaximumFontValidationWork = 64 * 1024 * 1024;
+
+struct ValidationBudget {
+  bool charge(std::size_t count) {
+    if (work > kMaximumFontValidationWork || count > kMaximumFontValidationWork - work) {
+      return false;
+    }
+    work += count;
+    return true;
+  }
+
+  std::size_t work = 0;
+};
+
+bool HasBytes(std::span<const uint8_t> data, std::size_t offset, std::size_t length) {
+  return offset <= data.size() && length <= data.size() - offset;
+}
+
+uint16_t ReadBe16(const uint8_t* data) {
+  return static_cast<uint16_t>((static_cast<uint16_t>(data[0]) << 8) | data[1]);
+}
+
+uint32_t ReadBe32(const uint8_t* data) {
+  return (static_cast<uint32_t>(data[0]) << 24) | (static_cast<uint32_t>(data[1]) << 16) |
+         (static_cast<uint32_t>(data[2]) << 8) | data[3];
+}
+
+struct CffIndexView {
+  std::span<const uint8_t> table;
+  std::size_t count = 0;
+  std::size_t offsetsOffset = 0;
+  std::size_t dataOffset = 0;
+  std::size_t endOffset = 0;
+  uint8_t offSize = 0;
+};
+
+std::optional<std::size_t> ReadOffset(const CffIndexView& index, std::size_t position) {
+  if (position > index.count ||
+      !HasBytes(index.table, index.offsetsOffset + position * index.offSize, index.offSize)) {
+    return std::nullopt;
+  }
+  std::size_t result = 0;
+  const std::size_t start = index.offsetsOffset + position * index.offSize;
+  for (uint8_t byte = 0; byte < index.offSize; ++byte) {
+    result = (result << 8) | index.table[start + byte];
+  }
+  return result;
+}
+
+std::optional<CffIndexView> ParseIndex(std::span<const uint8_t> table, std::size_t offset,
+                                       bool cff2, ValidationBudget* budget) {
+  const std::size_t countBytes = cff2 ? 4 : 2;
+  if (!HasBytes(table, offset, countBytes)) {
+    return std::nullopt;
+  }
+  const std::size_t count =
+      cff2 ? ReadBe32(table.data() + offset) : ReadBe16(table.data() + offset);
+  if (count > kMaximumSubroutines || !budget->charge(count + 1)) {
+    return std::nullopt;
+  }
+  if (count == 0) {
+    return CffIndexView{.table = table, .count = 0, .endOffset = offset + countBytes};
+  }
+  if (!HasBytes(table, offset + countBytes, 1)) {
+    return std::nullopt;
+  }
+  const uint8_t offSize = table[offset + countBytes];
+  if (offSize == 0 || offSize > 4 ||
+      count + 1 > (std::numeric_limits<std::size_t>::max() - offset - countBytes - 1) / offSize) {
+    return std::nullopt;
+  }
+  CffIndexView result{
+      .table = table, .count = count, .offsetsOffset = offset + countBytes + 1, .offSize = offSize};
+  const std::size_t offsetsBytes = (count + 1) * offSize;
+  if (!HasBytes(table, result.offsetsOffset, offsetsBytes)) {
+    return std::nullopt;
+  }
+  result.dataOffset = result.offsetsOffset + offsetsBytes;
+  const std::optional<std::size_t> first = ReadOffset(result, 0);
+  const std::optional<std::size_t> last = ReadOffset(result, count);
+  if (!first.has_value() || !last.has_value() || *first != 1 || *last == 0 ||
+      *last - 1 > table.size() - result.dataOffset) {
+    return std::nullopt;
+  }
+  std::size_t previous = *first;
+  for (std::size_t item = 1; item <= count; ++item) {
+    const std::optional<std::size_t> current = ReadOffset(result, item);
+    if (!current.has_value() || *current < previous) {
+      return std::nullopt;
+    }
+    previous = *current;
+  }
+  result.endOffset = result.dataOffset + *last - 1;
+  return result;
+}
+
+std::optional<std::span<const uint8_t>> IndexItem(const CffIndexView& index, std::size_t item) {
+  if (item >= index.count) {
+    return std::nullopt;
+  }
+  const std::optional<std::size_t> begin = ReadOffset(index, item);
+  const std::optional<std::size_t> end = ReadOffset(index, item + 1);
+  if (!begin.has_value() || !end.has_value() || *begin == 0 || *end < *begin) {
+    return std::nullopt;
+  }
+  const std::size_t itemOffset = index.dataOffset + *begin - 1;
+  const std::size_t itemLength = *end - *begin;
+  return HasBytes(index.table, itemOffset, itemLength)
+             ? std::optional(index.table.subspan(itemOffset, itemLength))
+             : std::nullopt;
+}
+
+struct Number {
+  double value = 0.0;
+  bool known = true;
+  bool integerEncoded = true;
+};
+
+std::optional<std::size_t> KnownOffset(const Number& number, std::size_t tableSize) {
+  if (!number.known || !number.integerEncoded || !std::isfinite(number.value) ||
+      number.value < 0.0 || std::floor(number.value) != number.value ||
+      number.value > static_cast<double>(tableSize)) {
+    return std::nullopt;
+  }
+  return static_cast<std::size_t>(number.value);
+}
+
+std::optional<Number> ParseBcdNumber(std::span<const uint8_t> bytes, std::size_t* cursor) {
+  double value = 0.0;
+  bool negative = false;
+  bool fraction = false;
+  double place = 0.1;
+  int exponent = 0;
+  bool exponentNegative = false;
+  bool inExponent = false;
+  bool integerDigit = false;
+  bool integerLeadingZero = false;
+  bool exponentDigit = false;
+  while (*cursor < bytes.size()) {
+    const uint8_t encoded = bytes[(*cursor)++];
+    const std::array<uint8_t, 2> nibbles{static_cast<uint8_t>(encoded >> 4),
+                                         static_cast<uint8_t>(encoded & 0x0F)};
+    for (std::size_t nibbleIndex = 0; nibbleIndex < nibbles.size(); ++nibbleIndex) {
+      const uint8_t nibble = nibbles[nibbleIndex];
+      if (nibble <= 9) {
+        if (inExponent) {
+          if (!exponentDigit && nibble == 0) return std::nullopt;
+          exponentDigit = true;
+          exponent = std::min(1000, exponent * 10 + nibble);
+        } else if (fraction) {
+          value += nibble * place;
+          place *= 0.1;
+        } else {
+          if (integerDigit && integerLeadingZero) return std::nullopt;
+          integerLeadingZero = !integerDigit && nibble == 0;
+          integerDigit = true;
+          value = value * 10.0 + nibble;
+        }
+      } else if (nibble == 0xA) {
+        if (fraction || inExponent) return std::nullopt;
+        fraction = true;
+      } else if (nibble == 0xB || nibble == 0xC) {
+        if (inExponent || (!integerDigit && !fraction)) return std::nullopt;
+        inExponent = true;
+        exponentNegative = nibble == 0xC;
+      } else if (nibble == 0xE) {
+        if (negative || integerDigit || fraction || inExponent) return std::nullopt;
+        negative = true;
+      } else if (nibble == 0xF) {
+        if ((nibbleIndex == 0 && nibbles[1] != 0xF) || (inExponent && !exponentDigit)) {
+          return std::nullopt;
+        }
+        const double signedValue = negative ? -value : value;
+        const int signedExponent = exponentNegative ? -exponent : exponent;
+        const double result = signedValue * std::pow(10.0, signedExponent);
+        return std::isfinite(result) ? std::optional(Number{result, true, false}) : std::nullopt;
+      } else {
+        return std::nullopt;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<Number> ParseDictNumber(std::span<const uint8_t> bytes, std::size_t* cursor,
+                                      uint8_t first) {
+  if (first >= 32 && first <= 246) {
+    return Number{static_cast<double>(static_cast<int>(first) - 139), true};
+  }
+  if (first >= 247 && first <= 250 && *cursor < bytes.size()) {
+    return Number{static_cast<double>((first - 247) * 256 + bytes[(*cursor)++] + 108), true};
+  }
+  if (first >= 251 && first <= 254 && *cursor < bytes.size()) {
+    return Number{
+        static_cast<double>(-(static_cast<int>(first) - 251) * 256 - bytes[(*cursor)++] - 108),
+        true};
+  }
+  if (first == 28 && HasBytes(bytes, *cursor, 2)) {
+    const int16_t value = std::bit_cast<int16_t>(ReadBe16(bytes.data() + *cursor));
+    *cursor += 2;
+    return Number{static_cast<double>(value), true};
+  }
+  if (first == 29 && HasBytes(bytes, *cursor, 4)) {
+    const int32_t value = std::bit_cast<int32_t>(ReadBe32(bytes.data() + *cursor));
+    *cursor += 4;
+    return Number{static_cast<double>(value), true};
+  }
+  return first == 30 ? ParseBcdNumber(bytes, cursor) : std::nullopt;
+}
+
+struct DictFields {
+  std::optional<std::size_t> charStrings;
+  std::optional<std::size_t> privateSize;
+  std::optional<std::size_t> privateOffset;
+  std::optional<std::size_t> subrs;
+  std::optional<std::size_t> fdArray;
+  std::optional<std::size_t> fdSelect;
+  bool cid = false;
+  bool unsupportedVariation = false;
+};
+
+bool AssignOffset(std::span<const Number> stack, std::size_t tableSize,
+                  std::optional<std::size_t>* destination) {
+  const std::optional<std::size_t> value =
+      stack.size() == 1 ? KnownOffset(stack.front(), tableSize) : std::nullopt;
+  if (!value.has_value() || destination->has_value()) {
+    return false;
+  }
+  *destination = *value;
+  return true;
+}
+
+bool ApplyDictOperator(uint16_t op, std::span<const Number> stack, std::size_t tableSize, bool cff2,
+                       DictFields* fields) {
+  if (op == 17) return AssignOffset(stack, tableSize, &fields->charStrings);
+  if (op == 18) {
+    const std::optional<std::size_t> size =
+        stack.size() == 2 ? KnownOffset(stack[0], tableSize) : std::nullopt;
+    const std::optional<std::size_t> offset =
+        stack.size() == 2 ? KnownOffset(stack[1], tableSize) : std::nullopt;
+    if (!size.has_value() || !offset.has_value() || fields->privateOffset.has_value()) return false;
+    fields->privateSize = *size;
+    fields->privateOffset = *offset;
+    return true;
+  }
+  if (op == 19) return AssignOffset(stack, tableSize, &fields->subrs);
+  if (op == 24 && cff2) {
+    fields->unsupportedVariation = true;
+    return stack.size() == 1;
+  }
+  if (op == 0x0C1E && !cff2) {
+    fields->cid = true;
+    return stack.size() == 3;
+  }
+  if (op == 0x0C06 && !cff2) {
+    return stack.size() == 1 && stack.front().known && stack.front().value == 2.0;
+  }
+  if (op == 0x0C24) return AssignOffset(stack, tableSize, &fields->fdArray);
+  if (op == 0x0C25) return AssignOffset(stack, tableSize, &fields->fdSelect);
+  if ((op == 22 || op == 23) && cff2) {
+    fields->unsupportedVariation = true;
+  }
+  return true;
+}
+
+std::optional<DictFields> ParseDict(std::span<const uint8_t> bytes, std::size_t tableSize,
+                                    bool cff2, ValidationBudget* budget) {
+  if (!budget->charge(bytes.size())) {
+    return std::nullopt;
+  }
+  std::array<Number, kMaximumCff2Stack> operands{};
+  std::size_t operandCount = 0;
+  std::size_t cursor = 0;
+  DictFields fields;
+  const std::size_t stackLimit = cff2 ? kMaximumCff2Stack : kMaximumCff1Stack;
+  while (cursor < bytes.size()) {
+    const uint8_t first = bytes[cursor++];
+    if (first >= 28 || first == 30) {
+      const std::optional<Number> number = ParseDictNumber(bytes, &cursor, first);
+      if (!number.has_value() || operandCount >= stackLimit) return std::nullopt;
+      operands[operandCount++] = *number;
+      continue;
+    }
+    uint16_t op = first;
+    if (first == 12) {
+      if (cursor >= bytes.size()) return std::nullopt;
+      op = static_cast<uint16_t>(0x0C00u | bytes[cursor++]);
+    }
+    if (!ApplyDictOperator(op, std::span(operands).first(operandCount), tableSize, cff2, &fields)) {
+      return std::nullopt;
+    }
+    operandCount = 0;
+  }
+  return operandCount == 0 ? std::optional(fields) : std::nullopt;
+}
+
+std::optional<CffIndexView> ParsePrivateSubrs(std::span<const uint8_t> table,
+                                              const DictFields& fields, bool cff2,
+                                              ValidationBudget* budget) {
+  if (!fields.privateOffset.has_value() || !fields.privateSize.has_value()) {
+    return CffIndexView{.table = table};
+  }
+  if (!HasBytes(table, *fields.privateOffset, *fields.privateSize)) {
+    return std::nullopt;
+  }
+  const std::span<const uint8_t> privateDict =
+      table.subspan(*fields.privateOffset, *fields.privateSize);
+  const std::optional<DictFields> privateFields =
+      ParseDict(privateDict, table.size(), cff2, budget);
+  if (!privateFields.has_value() || privateFields->unsupportedVariation) {
+    return std::nullopt;
+  }
+  if (!privateFields->subrs.has_value()) {
+    return CffIndexView{.table = table};
+  }
+  if (*privateFields->subrs > table.size() - *fields.privateOffset) {
+    return std::nullopt;
+  }
+  return ParseIndex(table, *fields.privateOffset + *privateFields->subrs, cff2, budget);
+}
+
+std::optional<std::vector<uint16_t>> ParseFdSelect(std::span<const uint8_t> table,
+                                                   std::size_t offset, std::size_t glyphCount,
+                                                   std::size_t fdCount, bool cff2,
+                                                   ValidationBudget* budget) {
+  if (!budget->charge(glyphCount + 1)) return std::nullopt;
+  if (!HasBytes(table, offset, 1)) return std::nullopt;
+  std::vector<uint16_t> result(glyphCount);
+  const uint8_t format = table[offset++];
+  if (format == 0) {
+    if (!HasBytes(table, offset, glyphCount)) return std::nullopt;
+    for (std::size_t glyph = 0; glyph < glyphCount; ++glyph) {
+      if (table[offset + glyph] >= fdCount) return std::nullopt;
+      result[glyph] = table[offset + glyph];
+    }
+    return result;
+  }
+  const bool format4 = cff2 && format == 4;
+  const std::size_t countBytes = format == 3 ? 2 : (format4 ? 4 : 0);
+  const std::size_t glyphBytes = format == 3 ? 2 : (format4 ? 4 : 0);
+  const std::size_t fdBytes = format == 3 ? 1 : (format4 ? 2 : 0);
+  if (countBytes == 0 || !HasBytes(table, offset, countBytes)) return std::nullopt;
+  const std::size_t ranges =
+      countBytes == 2 ? ReadBe16(table.data() + offset) : ReadBe32(table.data() + offset);
+  offset += countBytes;
+  if (ranges == 0 || ranges > glyphCount || !budget->charge(ranges) ||
+      !HasBytes(table, offset, ranges * (glyphBytes + fdBytes) + glyphBytes)) {
+    return std::nullopt;
+  }
+  std::size_t previousFirst = 0;
+  uint16_t previousFd = 0;
+  for (std::size_t range = 0; range < ranges; ++range) {
+    const std::size_t first =
+        glyphBytes == 2 ? ReadBe16(table.data() + offset) : ReadBe32(table.data() + offset);
+    offset += glyphBytes;
+    const uint16_t fd = fdBytes == 1 ? table[offset] : ReadBe16(table.data() + offset);
+    offset += fdBytes;
+    if ((range == 0 && first != 0) || (range != 0 && first <= previousFirst) || fd >= fdCount) {
+      return std::nullopt;
+    }
+    for (std::size_t glyph = previousFirst; range != 0 && glyph < first; ++glyph) {
+      result[glyph] = previousFd;
+    }
+    previousFirst = first;
+    previousFd = fd;
+  }
+  const std::size_t sentinel =
+      glyphBytes == 2 ? ReadBe16(table.data() + offset) : ReadBe32(table.data() + offset);
+  if (sentinel != glyphCount || previousFirst >= sentinel) return std::nullopt;
+  for (std::size_t glyph = previousFirst; glyph < sentinel; ++glyph) result[glyph] = previousFd;
+  return result;
+}
+
+struct ParsedCff {
+  CffIndexView charStrings;
+  CffIndexView globalSubrs;
+  std::vector<CffIndexView> localSubrs;
+  std::vector<uint16_t> glyphFd;
+  bool unsupportedVariation = false;
+};
+
+std::optional<ParsedCff> ParseCff1(std::span<const uint8_t> table, std::size_t glyphCount,
+                                   ValidationBudget* budget) {
+  if (table.size() < 4 || table[0] != 1 || table[2] < 4 || table[2] > table.size() ||
+      table[3] == 0 || table[3] > 4) {
+    return std::nullopt;
+  }
+  const std::optional<CffIndexView> names = ParseIndex(table, table[2], false, budget);
+  if (!names.has_value() || names->count != 1) return std::nullopt;
+  const std::optional<CffIndexView> top = ParseIndex(table, names->endOffset, false, budget);
+  if (!top.has_value() || top->count != 1) return std::nullopt;
+  const std::optional<std::span<const uint8_t>> topBytes = IndexItem(*top, 0);
+  const std::optional<DictFields> topFields =
+      topBytes.has_value() ? ParseDict(*topBytes, table.size(), false, budget) : std::nullopt;
+  if (!topFields.has_value() || !topFields->charStrings.has_value()) return std::nullopt;
+  const std::optional<CffIndexView> strings = ParseIndex(table, top->endOffset, false, budget);
+  if (!strings.has_value()) return std::nullopt;
+  const std::optional<CffIndexView> globals = ParseIndex(table, strings->endOffset, false, budget);
+  const std::optional<CffIndexView> chars =
+      ParseIndex(table, *topFields->charStrings, false, budget);
+  if (!globals.has_value() || !chars.has_value() || chars->count != glyphCount) {
+    return std::nullopt;
+  }
+  ParsedCff result{.charStrings = *chars,
+                   .globalSubrs = *globals,
+                   .glyphFd = std::vector<uint16_t>(glyphCount, 0)};
+  if (!topFields->cid) {
+    const std::optional<CffIndexView> local = ParsePrivateSubrs(table, *topFields, false, budget);
+    if (!local.has_value()) return std::nullopt;
+    result.localSubrs.push_back(*local);
+    return result;
+  }
+  if (!topFields->fdArray.has_value() || !topFields->fdSelect.has_value()) return std::nullopt;
+  const std::optional<CffIndexView> fdArray = ParseIndex(table, *topFields->fdArray, false, budget);
+  if (!fdArray.has_value() || fdArray->count == 0 || fdArray->count > 256) {
+    return std::nullopt;
+  }
+  for (std::size_t fd = 0; fd < fdArray->count; ++fd) {
+    const std::optional<std::span<const uint8_t>> bytes = IndexItem(*fdArray, fd);
+    const std::optional<DictFields> fields =
+        bytes.has_value() ? ParseDict(*bytes, table.size(), false, budget) : std::nullopt;
+    const std::optional<CffIndexView> local =
+        fields.has_value() ? ParsePrivateSubrs(table, *fields, false, budget) : std::nullopt;
+    if (!local.has_value()) return std::nullopt;
+    result.localSubrs.push_back(*local);
+  }
+  const auto selected =
+      ParseFdSelect(table, *topFields->fdSelect, glyphCount, fdArray->count, false, budget);
+  if (!selected.has_value()) return std::nullopt;
+  result.glyphFd = *selected;
+  return result;
+}
+
+std::optional<ParsedCff> ParseCff2(std::span<const uint8_t> table, std::size_t glyphCount,
+                                   ValidationBudget* budget) {
+  if (table.size() < 5 || table[0] != 2 || table[2] < 5 || table[2] > table.size()) {
+    return std::nullopt;
+  }
+  const std::size_t topLength = ReadBe16(table.data() + 3);
+  if (!HasBytes(table, table[2], topLength)) return std::nullopt;
+  const std::optional<DictFields> top =
+      ParseDict(table.subspan(table[2], topLength), table.size(), true, budget);
+  if (!top.has_value() || !top->charStrings.has_value() || !top->fdArray.has_value()) {
+    return std::nullopt;
+  }
+  const std::optional<CffIndexView> globals = ParseIndex(table, table[2] + topLength, true, budget);
+  const std::optional<CffIndexView> chars = ParseIndex(table, *top->charStrings, true, budget);
+  const std::optional<CffIndexView> fdArray = ParseIndex(table, *top->fdArray, true, budget);
+  if (!globals.has_value() || !chars.has_value() || chars->count != glyphCount ||
+      !fdArray.has_value() || fdArray->count == 0 || fdArray->count > kMaximumGlyphs) {
+    return std::nullopt;
+  }
+  ParsedCff result{.charStrings = *chars,
+                   .globalSubrs = *globals,
+                   .glyphFd = std::vector<uint16_t>(glyphCount, 0),
+                   .unsupportedVariation = top->unsupportedVariation};
+  for (std::size_t fd = 0; fd < fdArray->count; ++fd) {
+    const std::optional<std::span<const uint8_t>> bytes = IndexItem(*fdArray, fd);
+    const std::optional<DictFields> fields =
+        bytes.has_value() ? ParseDict(*bytes, table.size(), true, budget) : std::nullopt;
+    if (!fields.has_value()) return std::nullopt;
+    result.unsupportedVariation = result.unsupportedVariation || fields->unsupportedVariation;
+    const std::optional<CffIndexView> local = ParsePrivateSubrs(table, *fields, true, budget);
+    if (!local.has_value()) return std::nullopt;
+    result.localSubrs.push_back(*local);
+  }
+  if (fdArray->count == 1) return result;
+  if (!top->fdSelect.has_value()) return std::nullopt;
+  const auto selected =
+      ParseFdSelect(table, *top->fdSelect, glyphCount, fdArray->count, true, budget);
+  if (!selected.has_value()) return std::nullopt;
+  result.glyphFd = *selected;
+  return result;
+}
+
+std::optional<Number> ParseCharStringNumber(std::span<const uint8_t> bytes, std::size_t* cursor,
+                                            uint8_t first) {
+  if (first == 255 && HasBytes(bytes, *cursor, 4)) {
+    const int32_t fixed = std::bit_cast<int32_t>(ReadBe32(bytes.data() + *cursor));
+    *cursor += 4;
+    return Number{static_cast<double>(fixed) / 65536.0, true};
+  }
+  return ParseDictNumber(bytes, cursor, first);
+}
+
+struct ActiveCall {
+  bool global = false;
+  std::size_t index = 0;
+  bool operator==(const ActiveCall&) const = default;
+};
+
+enum class Flow : uint8_t {
+  Return,
+  EndGlyph,
+  Error,
+  Unsupported,
+};
+
+class CharStringValidator {
+public:
+  CharStringValidator(const ParsedCff& parsed, bool cff2, std::size_t fd,
+                      ValidationBudget* validationBudget)
+      : parsed_(parsed), cff2_(cff2), fd_(fd), validationBudget_(validationBudget) {}
+
+  CffOutlineValidationResult validate(std::span<const uint8_t> bytes) {
+    const Flow flow = run(bytes, false, 0);
+    if (flow == Flow::Unsupported) {
+      return {.status = CffOutlineValidationStatus::UnsupportedVariation};
+    }
+    if (flow != Flow::EndGlyph || !closeContour()) {
+      return {.status = CffOutlineValidationStatus::Invalid};
+    }
+    return {.status = CffOutlineValidationStatus::Complete,
+            .glyphs = {{static_cast<uint32_t>(vertices_), static_cast<uint32_t>(work_)}}};
+  }
+
+private:
+  bool charge(std::size_t count) {
+    if (work_ > kMaximumGlyphWork || count > kMaximumGlyphWork - work_ ||
+        !validationBudget_->charge(count)) {
+      return false;
+    }
+    work_ += count;
+    return true;
+  }
+
+  bool addVertices(std::size_t count) {
+    if (vertices_ > kMaximumVertices || count > kMaximumVertices - vertices_ ||
+        count > std::numeric_limits<std::size_t>::max() / 4 || !charge(count * 4)) {
+      return false;
+    }
+    vertices_ += count;
+    return true;
+  }
+
+  bool closeContour() {
+    if (!contourOpen_) return true;
+    contourOpen_ = false;
+    return addVertices(1);
+  }
+
+  bool clearStack(std::size_t expected) {
+    if (stackSize_ != expected) return false;
+    stackSize_ = 0;
+    return true;
+  }
+
+  bool beginMove(std::size_t expected) {
+    if (!consumeOptionalWidth(expected) || stackSize_ != expected || !closeContour() ||
+        !addVertices(1)) {
+      return false;
+    }
+    stackSize_ = 0;
+    contourOpen_ = true;
+    return true;
+  }
+
+  bool consumeOptionalWidth(std::size_t expected) {
+    if (cff2_ || widthSeen_) return true;
+    widthSeen_ = true;
+    if (stackSize_ == expected + 1) {
+      for (std::size_t index = 1; index < stackSize_; ++index) stack_[index - 1] = stack_[index];
+      --stackSize_;
+    }
+    return true;
+  }
+
+  bool applyStems() {
+    if (!cff2_ && !widthSeen_ && (stackSize_ & 1u) != 0) {
+      for (std::size_t index = 1; index < stackSize_; ++index) stack_[index - 1] = stack_[index];
+      --stackSize_;
+    }
+    widthSeen_ = true;
+    if ((stackSize_ & 1u) != 0 || hints_ + stackSize_ / 2 > kMaximumStemHints) return false;
+    hints_ += stackSize_ / 2;
+    stackSize_ = 0;
+    return true;
+  }
+
+  bool push(Number value) {
+    const std::size_t limit = cff2_ ? kMaximumCff2Stack : kMaximumCff1Stack;
+    if (stackSize_ >= limit) return false;
+    stack_[stackSize_++] = value;
+    return true;
+  }
+
+  std::optional<int64_t> popKnownInteger() {
+    if (stackSize_ == 0) return std::nullopt;
+    const Number value = stack_[--stackSize_];
+    if (!value.known || !std::isfinite(value.value) || std::floor(value.value) != value.value ||
+        value.value < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
+        value.value > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+      return std::nullopt;
+    }
+    return static_cast<int64_t>(value.value);
+  }
+
+  Flow callSubroutine(bool global, std::size_t depth) {
+    const std::optional<int64_t> encoded = popKnownInteger();
+    const CffIndexView& index = global ? parsed_.globalSubrs : parsed_.localSubrs[fd_];
+    if (!encoded.has_value() || depth >= kMaximumSubroutineDepth) return Flow::Error;
+    const int64_t bias = index.count < 1240 ? 107 : (index.count < 33900 ? 1131 : 32768);
+    if (*encoded > std::numeric_limits<int64_t>::max() - bias) return Flow::Error;
+    const int64_t resolved = *encoded + bias;
+    if (resolved < 0 || static_cast<uint64_t>(resolved) >= index.count) return Flow::Error;
+    const ActiveCall call{global, static_cast<std::size_t>(resolved)};
+    if (std::find(active_.begin(), active_.begin() + depth, call) != active_.begin() + depth) {
+      return Flow::Error;
+    }
+    const auto bytes = IndexItem(index, call.index);
+    if (!bytes.has_value() || bytes->size() > kMaximumCharStringLength) return Flow::Error;
+    active_[depth] = call;
+    return run(*bytes, true, depth + 1);
+  }
+
+  bool applyLines(std::size_t count) {
+    if (!contourOpen_ || count == 0 || !addVertices(count)) return false;
+    stackSize_ = 0;
+    return true;
+  }
+
+  bool applyCurves(std::size_t count) {
+    if (!contourOpen_ || count == 0 || count > kMaximumVertices / 3 || !addVertices(count * 3)) {
+      return false;
+    }
+    stackSize_ = 0;
+    return true;
+  }
+
+  bool applyPathOperator(uint8_t op) {
+    if (op == 4 || op == 22) return beginMove(1);
+    if (op == 21) return beginMove(2);
+    if (op == 5) return stackSize_ >= 2 && (stackSize_ & 1u) == 0 && applyLines(stackSize_ / 2);
+    if (op == 6 || op == 7) return applyLines(stackSize_);
+    if (op == 8) return stackSize_ >= 6 && stackSize_ % 6 == 0 && applyCurves(stackSize_ / 6);
+    if (op == 24)
+      return stackSize_ >= 8 && (stackSize_ - 2) % 6 == 0 && applyCurves((stackSize_ - 2) / 6) &&
+             addVertices(1);
+    if (op == 25)
+      return stackSize_ >= 8 && (stackSize_ - 6) % 2 == 0 && applyLines((stackSize_ - 6) / 2) &&
+             addVertices(3);
+    if (op == 26 || op == 27 || op == 30 || op == 31) {
+      return stackSize_ >= 4 && (stackSize_ % 4 == 0 || stackSize_ % 4 == 1) &&
+             applyCurves(stackSize_ / 4);
+    }
+    return false;
+  }
+
+  bool binaryArithmetic(uint8_t op) {
+    if (stackSize_ < 2) return false;
+    const Number rhs = stack_[--stackSize_];
+    Number& lhs = stack_[stackSize_ - 1];
+    if (!lhs.known || !rhs.known) {
+      lhs = Number{0.0, false};
+      return true;
+    }
+    if (op == 3) lhs.value = (lhs.value != 0.0 && rhs.value != 0.0) ? 1.0 : 0.0;
+    if (op == 4) lhs.value = (lhs.value != 0.0 || rhs.value != 0.0) ? 1.0 : 0.0;
+    if (op == 10) lhs.value += rhs.value;
+    if (op == 11) lhs.value -= rhs.value;
+    if (op == 12) {
+      if (rhs.value == 0.0) return false;
+      lhs.value /= rhs.value;
+    }
+    if (op == 15) lhs.value = lhs.value == rhs.value ? 1.0 : 0.0;
+    if (op == 24) lhs.value *= rhs.value;
+    return std::isfinite(lhs.value);
+  }
+
+  bool unaryArithmetic(uint8_t op) {
+    if (stackSize_ == 0) return false;
+    Number& value = stack_[stackSize_ - 1];
+    if (!value.known) return true;
+    if (op == 5) value.value = value.value == 0.0 ? 1.0 : 0.0;
+    if (op == 9) value.value = std::abs(value.value);
+    if (op == 14) value.value = -value.value;
+    if (op == 26) {
+      if (value.value < 0.0) return false;
+      value.value = std::sqrt(value.value);
+    }
+    return std::isfinite(value.value);
+  }
+
+  bool transientOperator(uint8_t op) {
+    if (op == 18) return stackSize_ != 0 && (--stackSize_, true);
+    if (op == 20) {
+      const auto index = popKnownInteger();
+      if (!index.has_value() || *index < 0 || *index >= 32 || stackSize_ == 0) return false;
+      transient_[*index] = stack_[--stackSize_];
+      return true;
+    }
+    if (op == 21) {
+      const auto index = popKnownInteger();
+      return index.has_value() && *index >= 0 && *index < 32 && push(transient_[*index]);
+    }
+    if (op == 27) return stackSize_ != 0 && push(stack_[stackSize_ - 1]);
+    if (op == 28) {
+      if (stackSize_ < 2) return false;
+      std::swap(stack_[stackSize_ - 1], stack_[stackSize_ - 2]);
+      return true;
+    }
+    if (op == 29) {
+      const auto index = popKnownInteger();
+      if (!index.has_value() || *index < 0 || static_cast<std::size_t>(*index) >= stackSize_)
+        return false;
+      return push(stack_[stackSize_ - 1 - *index]);
+    }
+    return false;
+  }
+
+  bool conditionalOperator(uint8_t op) {
+    if (op == 22) {
+      if (stackSize_ < 4) return false;
+      const Number v2 = stack_[--stackSize_];
+      const Number v1 = stack_[--stackSize_];
+      const Number s2 = stack_[--stackSize_];
+      const Number s1 = stack_[--stackSize_];
+      return push(v1.known && v2.known ? (v1.value <= v2.value ? s1 : s2) : Number{0.0, false});
+    }
+    if (op == 23) return push(Number{0.0, false});
+    if (op != 30 || stackSize_ < 2) return false;
+    const auto shift = popKnownInteger();
+    const auto count = popKnownInteger();
+    if (!shift.has_value() || !count.has_value() || *count < 0 ||
+        static_cast<std::size_t>(*count) > stackSize_) {
+      return false;
+    }
+    if (*count == 0) return true;
+    const std::size_t n = static_cast<std::size_t>(*count);
+    const int64_t normalized = ((*shift % static_cast<int64_t>(n)) + n) % n;
+    std::rotate(stack_.begin() + stackSize_ - n,
+                stack_.begin() + stackSize_ - static_cast<std::size_t>(normalized),
+                stack_.begin() + stackSize_);
+    return charge(n);
+  }
+
+  bool applyEscaped(uint8_t op) {
+    if (op == 34) return clearStack(7) && applyCurves(2);
+    if (op == 35) return clearStack(13) && applyCurves(2);
+    if (op == 36) return clearStack(9) && applyCurves(2);
+    if (op == 37) return clearStack(11) && applyCurves(2);
+    if (cff2_) return false;
+    if (op == 3 || op == 4 || op == 10 || op == 11 || op == 12 || op == 15 || op == 24)
+      return binaryArithmetic(op);
+    if (op == 5 || op == 9 || op == 14 || op == 26) return unaryArithmetic(op);
+    if (op == 18 || op == 20 || op == 21 || op == 27 || op == 28 || op == 29)
+      return transientOperator(op);
+    return conditionalOperator(op);
+  }
+
+  Flow finishCff1() {
+    if (!consumeOptionalWidth(0) || stackSize_ != 0 || !closeContour()) return Flow::Error;
+    return Flow::EndGlyph;
+  }
+
+  Flow applyOperator(uint8_t op, std::span<const uint8_t> bytes, std::size_t* cursor,
+                     bool subroutine, std::size_t depth) {
+    if (op == 1 || op == 3 || op == 18 || op == 23)
+      return applyStems() ? Flow::Return : Flow::Error;
+    if (op == 19 || op == 20) {
+      if (!applyStems() || hints_ == 0) return Flow::Error;
+      const std::size_t maskBytes = (hints_ + 7) / 8;
+      if (!HasBytes(bytes, *cursor, maskBytes) || !charge(maskBytes)) return Flow::Error;
+      *cursor += maskBytes;
+      return Flow::Return;
+    }
+    if (op == 10 || op == 29) return callSubroutine(op == 29, depth);
+    if (op == 11) return !cff2_ && subroutine ? Flow::Return : Flow::Error;
+    if (op == 14) return !cff2_ ? finishCff1() : Flow::Error;
+    if (op == 15 || op == 16) return cff2_ ? Flow::Unsupported : Flow::Error;
+    return applyPathOperator(op) ? Flow::Return : Flow::Error;
+  }
+
+  Flow run(std::span<const uint8_t> bytes, bool subroutine, std::size_t depth) {
+    if (bytes.size() > kMaximumCharStringLength) return Flow::Error;
+    std::size_t cursor = 0;
+    while (cursor < bytes.size()) {
+      const std::size_t tokenStart = cursor;
+      const uint8_t first = bytes[cursor++];
+      if (first >= 32 || first == 28 || first == 255) {
+        const auto number = ParseCharStringNumber(bytes, &cursor, first);
+        if (!number.has_value() || !push(*number) || !charge(cursor - tokenStart))
+          return Flow::Error;
+        continue;
+      }
+      if (!charge(1)) return Flow::Error;
+      if (first == 12) {
+        if (cursor >= bytes.size() || !charge(1)) return Flow::Error;
+        if (!applyEscaped(bytes[cursor++])) return Flow::Error;
+        continue;
+      }
+      const Flow flow = applyOperator(first, bytes, &cursor, subroutine, depth);
+      if (flow == Flow::Error || flow == Flow::Unsupported || flow == Flow::EndGlyph) return flow;
+      if (first == 11) return Flow::Return;
+    }
+    if (cff2_) return subroutine ? Flow::Return : Flow::EndGlyph;
+    return Flow::Error;
+  }
+
+  const ParsedCff& parsed_;
+  bool cff2_ = false;
+  std::size_t fd_ = 0;
+  ValidationBudget* validationBudget_ = nullptr;
+  std::array<Number, kMaximumCff2Stack> stack_{};
+  std::array<Number, 32> transient_{};
+  std::array<ActiveCall, kMaximumSubroutineDepth> active_{};
+  std::size_t stackSize_ = 0;
+  std::size_t hints_ = 0;
+  std::size_t vertices_ = 0;
+  std::size_t work_ = 0;
+  bool widthSeen_ = false;
+  bool contourOpen_ = false;
+};
+
+}  // namespace
+
+CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> table, bool cff2,
+                                                          std::size_t expectedGlyphs) {
+  if (expectedGlyphs == 0 || expectedGlyphs > kMaximumGlyphs) {
+    return {};
+  }
+  ValidationBudget validationBudget;
+  const std::optional<ParsedCff> parsed = cff2
+                                              ? ParseCff2(table, expectedGlyphs, &validationBudget)
+                                              : ParseCff1(table, expectedGlyphs, &validationBudget);
+  if (!parsed.has_value()) {
+    return {};
+  }
+  if (parsed->unsupportedVariation) {
+    return {.status = CffOutlineValidationStatus::UnsupportedVariation};
+  }
+
+  CffOutlineValidationResult result{.status = CffOutlineValidationStatus::Complete};
+  result.glyphs.reserve(expectedGlyphs);
+  for (std::size_t glyph = 0; glyph < expectedGlyphs; ++glyph) {
+    const auto bytes = IndexItem(parsed->charStrings, glyph);
+    if (!bytes.has_value() || parsed->glyphFd[glyph] >= parsed->localSubrs.size()) return {};
+    CharStringValidator validator(*parsed, cff2, parsed->glyphFd[glyph], &validationBudget);
+    CffOutlineValidationResult glyphResult = validator.validate(*bytes);
+    if (glyphResult.status != CffOutlineValidationStatus::Complete) {
+      return {.status = glyphResult.status};
+    }
+    result.glyphs.push_back(glyphResult.glyphs.front());
+  }
+  return result;
 }
 
 }  // namespace donner::fonts

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -974,7 +974,7 @@ public:
 
   std::optional<std::vector<CffGlyphOutlineComplexity>> resolveAll() {
     for (std::size_t glyph = 0; glyph < raw_.size(); ++glyph) {
-      if (!resolve(glyph)) return std::nullopt;
+      if (!resolve(glyph, 0)) return std::nullopt;
     }
     return resolved_;
   }
@@ -1000,8 +1000,11 @@ private:
     return true;
   }
 
-  bool resolve(std::size_t glyph) {
-    if (states_[glyph] == State::Complete) return true;
+  bool resolve(std::size_t glyph, std::size_t currentDepth) {
+    if (currentDepth > kMaximumSubroutineDepth) return false;
+    if (states_[glyph] == State::Complete) {
+      return depths_[glyph] <= kMaximumSubroutineDepth - currentDepth;
+    }
     if (states_[glyph] == State::Visiting) return false;
     states_[glyph] = State::Visiting;
 
@@ -1009,10 +1012,9 @@ private:
     std::size_t work = raw_[glyph].direct.work;
     std::size_t depth = 0;
     if (raw_[glyph].components.has_value()) {
-      if (!budget_->charge(2)) return false;
-      resolutionWork_ += 2;
+      if (currentDepth >= kMaximumSubroutineDepth) return false;
       for (const std::size_t component : *raw_[glyph].components) {
-        if (component >= raw_.size() || !resolve(component)) return false;
+        if (component >= raw_.size() || !resolve(component, currentDepth + 1)) return false;
         depth = std::max(depth, depths_[component] + 1);
         const CffGlyphOutlineComplexity& child = resolved_[component];
         if (!addVertices(&vertices, child.maximumVertices) || !addWork(&work, child.work) ||
@@ -1021,6 +1023,8 @@ private:
         }
       }
       if (depth > kMaximumSubroutineDepth) return false;
+      if (!budget_->charge(2)) return false;
+      resolutionWork_ += 2;
     }
 
     resolved_[glyph] = {.maximumVertices = static_cast<uint32_t>(vertices),

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -1,0 +1,11 @@
+#include "donner/base/fonts/CffOutlineComplexity.h"
+
+namespace donner::fonts {
+
+CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> /*table*/,
+                                                          bool /*cff2*/,
+                                                          std::size_t /*expectedGlyphs*/) {
+  return {};
+}
+
+}  // namespace donner::fonts

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -909,7 +909,7 @@ private:
       return Flow::Return;
     }
     if (op == 10 || op == 29) return callSubroutine(op == 29, depth);
-    if (op == 11) return !cff2_ && subroutine ? Flow::Return : Flow::Error;
+    if (op == 11) return subroutine ? Flow::Return : Flow::Error;
     if (op == 14) return !cff2_ ? finishCff1() : Flow::Error;
     if (op == 15 || op == 16) return cff2_ ? Flow::Unsupported : Flow::Error;
     return applyPathOperator(op) ? Flow::Return : Flow::Error;

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -19,6 +19,40 @@ constexpr std::size_t kMaximumStemHints = 96;
 constexpr std::size_t kMaximumCharStringLength = 65535;
 constexpr std::size_t kMaximumVertices = 1024 * 1024;
 constexpr std::size_t kMaximumGlyphWork = 16 * 1024 * 1024;
+
+constexpr std::array<uint16_t, 166> kExpertCharset{
+    0,   1,   229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 13,  14,  15,  99,  239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 27,  28,  249, 250, 251, 252, 253, 254, 255, 256, 257, 258,
+    259, 260, 261, 262, 263, 264, 265, 266, 109, 110, 267, 268, 269, 270, 271, 272, 273, 274, 275,
+    276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294,
+    295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313,
+    314, 315, 316, 317, 318, 158, 155, 163, 319, 320, 321, 322, 323, 324, 325, 326, 150, 164, 169,
+    327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345,
+    346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364,
+    365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378};
+
+constexpr std::array<uint16_t, 87> kExpertSubsetCharset{
+    0,   1,   231, 232, 235, 236, 237, 238, 13,  14,  15,  99,  239, 240, 241, 242, 243, 244,
+    245, 246, 247, 248, 27,  28,  249, 250, 251, 253, 254, 255, 256, 257, 258, 259, 260, 261,
+    262, 263, 264, 265, 266, 109, 110, 267, 268, 269, 270, 272, 300, 301, 302, 305, 314, 315,
+    158, 155, 163, 320, 321, 322, 323, 324, 325, 326, 150, 164, 169, 327, 328, 329, 330, 331,
+    332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346};
+
+constexpr std::array<uint16_t, 256> kStandardEncodingSid{
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   2,   3,   4,   5,   6,
+    7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,
+    26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+    45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,
+    64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  81,  82,
+    83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   96,  97,  98,  99,  100, 101, 102, 103, 104, 105,
+    106, 107, 108, 109, 110, 0,   111, 112, 113, 114, 0,   115, 116, 117, 118, 119, 120, 121, 122,
+    0,   123, 0,   124, 125, 126, 127, 128, 129, 130, 131, 0,   132, 133, 0,   134, 135, 136, 137,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   138, 0,   139,
+    0,   0,   0,   0,   140, 141, 142, 143, 0,   0,   0,   0,   0,   144, 0,   0,   0,   145, 0,
+    0,   146, 147, 148, 149, 0,   0,   0,   0};
 struct ValidationBudget {
   explicit ValidationBudget(std::size_t maximumWork) : maximumWork(maximumWork) {}
 
@@ -234,6 +268,7 @@ std::optional<Number> ParseDictNumber(std::span<const uint8_t> bytes, std::size_
 }
 
 struct DictFields {
+  std::optional<std::size_t> charset;
   std::optional<std::size_t> charStrings;
   std::optional<std::size_t> privateSize;
   std::optional<std::size_t> privateOffset;
@@ -257,6 +292,7 @@ bool AssignOffset(std::span<const Number> stack, std::size_t tableSize,
 
 bool ApplyDictOperator(uint16_t op, std::span<const Number> stack, std::size_t tableSize, bool cff2,
                        DictFields* fields) {
+  if (op == 15 && !cff2) return AssignOffset(stack, tableSize, &fields->charset);
   if (op == 17) return AssignOffset(stack, tableSize, &fields->charStrings);
   if (op == 18) {
     const std::optional<std::size_t> size =
@@ -396,11 +432,65 @@ std::optional<std::vector<uint16_t>> ParseFdSelect(std::span<const uint8_t> tabl
   return result;
 }
 
+std::optional<std::vector<uint16_t>> ParseCff1Charset(std::span<const uint8_t> table,
+                                                      std::size_t offset, std::size_t glyphCount,
+                                                      ValidationBudget* budget) {
+  if (!budget->charge(glyphCount)) return std::nullopt;
+  if (offset == 0) {
+    if (glyphCount > 229) return std::nullopt;
+    std::vector<uint16_t> result(glyphCount);
+    for (std::size_t glyph = 0; glyph < glyphCount; ++glyph) {
+      result[glyph] = static_cast<uint16_t>(glyph);
+    }
+    return result;
+  }
+  if (offset == 1 || offset == 2) {
+    const std::span<const uint16_t> predefined =
+        offset == 1 ? std::span<const uint16_t>(kExpertCharset)
+                    : std::span<const uint16_t>(kExpertSubsetCharset);
+    if (glyphCount > predefined.size()) return std::nullopt;
+    return std::vector<uint16_t>(predefined.begin(), predefined.begin() + glyphCount);
+  }
+  if (!HasBytes(table, offset, 1)) return std::nullopt;
+
+  std::vector<uint16_t> result(glyphCount, 0);
+  const uint8_t format = table[offset++];
+  if (format == 0) {
+    const std::size_t entries = glyphCount - 1;
+    if (!HasBytes(table, offset, entries * 2)) return std::nullopt;
+    for (std::size_t glyph = 1; glyph < glyphCount; ++glyph) {
+      result[glyph] = ReadBe16(table.data() + offset);
+      offset += 2;
+    }
+    return result;
+  }
+  if (format != 1 && format != 2) return std::nullopt;
+
+  std::size_t glyph = 1;
+  const std::size_t leftBytes = format == 1 ? 1 : 2;
+  while (glyph < glyphCount) {
+    if (!HasBytes(table, offset, 2 + leftBytes)) return std::nullopt;
+    const uint16_t firstSid = ReadBe16(table.data() + offset);
+    offset += 2;
+    const std::size_t left = leftBytes == 1 ? table[offset] : ReadBe16(table.data() + offset);
+    offset += leftBytes;
+    if (left > std::numeric_limits<uint16_t>::max() - firstSid || left + 1 > glyphCount - glyph) {
+      return std::nullopt;
+    }
+    for (std::size_t item = 0; item <= left; ++item) {
+      result[glyph++] = static_cast<uint16_t>(firstSid + item);
+    }
+  }
+  return result;
+}
+
 struct ParsedCff {
   CffIndexView charStrings;
   CffIndexView globalSubrs;
   std::vector<CffIndexView> localSubrs;
   std::vector<uint16_t> glyphFd;
+  std::vector<uint16_t> charsetSids;
+  bool cid = false;
   bool unsupportedVariation = false;
 };
 
@@ -428,8 +518,13 @@ std::optional<ParsedCff> ParseCff1(std::span<const uint8_t> table, std::size_t g
   }
   ParsedCff result{.charStrings = *chars,
                    .globalSubrs = *globals,
-                   .glyphFd = std::vector<uint16_t>(glyphCount, 0)};
+                   .glyphFd = std::vector<uint16_t>(glyphCount, 0),
+                   .cid = topFields->cid};
   if (!topFields->cid) {
+    const auto charset =
+        ParseCff1Charset(table, topFields->charset.value_or(0), glyphCount, budget);
+    if (!charset.has_value()) return std::nullopt;
+    result.charsetSids = *charset;
     const std::optional<CffIndexView> local = ParsePrivateSubrs(table, *topFields, false, budget);
     if (!local.has_value()) return std::nullopt;
     result.localSubrs.push_back(*local);
@@ -521,13 +616,19 @@ enum class Flow : uint8_t {
   Unsupported,
 };
 
+struct CharStringValidationResult {
+  CffOutlineValidationStatus status = CffOutlineValidationStatus::Invalid;
+  CffGlyphOutlineComplexity complexity;
+  std::optional<std::array<uint8_t, 2>> seacCodes;
+};
+
 class CharStringValidator {
 public:
   CharStringValidator(const ParsedCff& parsed, bool cff2, std::size_t fd,
                       ValidationBudget* validationBudget)
       : parsed_(parsed), cff2_(cff2), fd_(fd), validationBudget_(validationBudget) {}
 
-  CffOutlineValidationResult validate(std::span<const uint8_t> bytes) {
+  CharStringValidationResult validate(std::span<const uint8_t> bytes) {
     const Flow flow = run(bytes, false, 0);
     if (flow == Flow::Unsupported) {
       return {.status = CffOutlineValidationStatus::UnsupportedVariation};
@@ -536,10 +637,9 @@ public:
       return {.status = CffOutlineValidationStatus::Invalid};
     }
     return {.status = CffOutlineValidationStatus::Complete,
-            .work = work_,
-            .glyphs = {{.maximumVertices = static_cast<uint32_t>(vertices_),
-                        .work = static_cast<uint32_t>(work_),
-                        .renderable = renderable_}}};
+            .complexity = {.maximumVertices = static_cast<uint32_t>(vertices_),
+                           .work = static_cast<uint32_t>(work_)},
+            .seacCodes = seacCodes_};
   }
 
 private:
@@ -790,8 +890,9 @@ private:
         return Flow::Error;
       }
     }
+    seacCodes_ = std::array<uint8_t, 2>{static_cast<uint8_t>(stack_[2].value),
+                                        static_cast<uint8_t>(stack_[3].value)};
     stackSize_ = 0;
-    renderable_ = false;
     if (!closeContour()) return Flow::Error;
     return Flow::EndGlyph;
   }
@@ -853,7 +954,84 @@ private:
   std::size_t work_ = 0;
   bool widthSeen_ = false;
   bool contourOpen_ = false;
-  bool renderable_ = true;
+  std::optional<std::array<uint8_t, 2>> seacCodes_;
+};
+
+struct RawCffGlyphComplexity {
+  CffGlyphOutlineComplexity direct;
+  std::optional<std::array<std::size_t, 2>> components;
+};
+
+class CffComponentComplexityResolver {
+public:
+  CffComponentComplexityResolver(std::span<const RawCffGlyphComplexity> raw,
+                                 ValidationBudget* budget)
+      : raw_(raw),
+        budget_(budget),
+        states_(raw.size()),
+        resolved_(raw.size()),
+        depths_(raw.size()) {}
+
+  std::optional<std::vector<CffGlyphOutlineComplexity>> resolveAll() {
+    for (std::size_t glyph = 0; glyph < raw_.size(); ++glyph) {
+      if (!resolve(glyph)) return std::nullopt;
+    }
+    return resolved_;
+  }
+
+private:
+  enum class State : uint8_t {
+    Unvisited,
+    Visiting,
+    Complete,
+  };
+
+  bool addWork(std::size_t* work, std::size_t count) const {
+    if (*work > kMaximumGlyphWork || count > kMaximumGlyphWork - *work) return false;
+    *work += count;
+    return true;
+  }
+
+  bool addVertices(std::size_t* vertices, std::size_t count) const {
+    if (*vertices > kMaximumVertices || count > kMaximumVertices - *vertices) return false;
+    *vertices += count;
+    return true;
+  }
+
+  bool resolve(std::size_t glyph) {
+    if (states_[glyph] == State::Complete) return true;
+    if (states_[glyph] == State::Visiting) return false;
+    states_[glyph] = State::Visiting;
+
+    std::size_t vertices = raw_[glyph].direct.maximumVertices;
+    std::size_t work = raw_[glyph].direct.work;
+    std::size_t depth = 0;
+    if (raw_[glyph].components.has_value()) {
+      if (!budget_->charge(2)) return false;
+      for (const std::size_t component : *raw_[glyph].components) {
+        if (component >= raw_.size() || !resolve(component)) return false;
+        depth = std::max(depth, depths_[component] + 1);
+        const CffGlyphOutlineComplexity& child = resolved_[component];
+        if (!addVertices(&vertices, child.maximumVertices) || !addWork(&work, child.work) ||
+            !addWork(&work, child.maximumVertices * 2)) {
+          return false;
+        }
+      }
+      if (depth > kMaximumSubroutineDepth) return false;
+    }
+
+    resolved_[glyph] = {.maximumVertices = static_cast<uint32_t>(vertices),
+                        .work = static_cast<uint32_t>(work)};
+    depths_[glyph] = depth;
+    states_[glyph] = State::Complete;
+    return true;
+  }
+
+  std::span<const RawCffGlyphComplexity> raw_;
+  ValidationBudget* budget_ = nullptr;
+  std::vector<State> states_;
+  std::vector<CffGlyphOutlineComplexity> resolved_;
+  std::vector<std::size_t> depths_;
 };
 
 }  // namespace
@@ -878,25 +1056,66 @@ CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_
             .work = validationBudget.work};
   }
 
-  CffOutlineValidationResult result{.status = CffOutlineValidationStatus::Complete,
-                                    .work = validationBudget.work};
-  result.glyphs.reserve(expectedGlyphs);
+  constexpr uint32_t kMissingGlyph = std::numeric_limits<uint32_t>::max();
+  std::vector<uint32_t> glyphBySid;
+  if (!cff2 && !parsed->cid) {
+    if (parsed->charsetSids.size() != expectedGlyphs || !validationBudget.charge(expectedGlyphs)) {
+      return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
+                                                   : CffOutlineValidationStatus::Invalid,
+              .work = validationBudget.work};
+    }
+    glyphBySid.assign(std::numeric_limits<uint16_t>::max() + std::size_t{1}, kMissingGlyph);
+    for (std::size_t glyph = 0; glyph < expectedGlyphs; ++glyph) {
+      const uint16_t sid = parsed->charsetSids[glyph];
+      if (glyphBySid[sid] == kMissingGlyph) {
+        glyphBySid[sid] = static_cast<uint32_t>(glyph);
+      }
+    }
+  }
+
+  std::vector<RawCffGlyphComplexity> rawGlyphs;
+  rawGlyphs.reserve(expectedGlyphs);
   for (std::size_t glyph = 0; glyph < expectedGlyphs; ++glyph) {
     const auto bytes = IndexItem(parsed->charStrings, glyph);
     if (!bytes.has_value() || parsed->glyphFd[glyph] >= parsed->localSubrs.size()) {
       return {.status = CffOutlineValidationStatus::Invalid, .work = validationBudget.work};
     }
     CharStringValidator validator(*parsed, cff2, parsed->glyphFd[glyph], &validationBudget);
-    CffOutlineValidationResult glyphResult = validator.validate(*bytes);
+    CharStringValidationResult glyphResult = validator.validate(*bytes);
     if (glyphResult.status != CffOutlineValidationStatus::Complete) {
       return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
                                                    : glyphResult.status,
               .work = validationBudget.work};
     }
-    result.glyphs.push_back(glyphResult.glyphs.front());
+    RawCffGlyphComplexity raw{.direct = glyphResult.complexity};
+    if (glyphResult.seacCodes.has_value()) {
+      if (cff2 || parsed->cid || glyphBySid.empty()) {
+        return {.status = CffOutlineValidationStatus::Invalid, .work = validationBudget.work};
+      }
+      std::array<std::size_t, 2> components{};
+      for (std::size_t component = 0; component < components.size(); ++component) {
+        const uint16_t sid = kStandardEncodingSid[(*glyphResult.seacCodes)[component]];
+        const uint32_t componentGlyph = glyphBySid[sid];
+        if (componentGlyph == kMissingGlyph) {
+          return {.status = CffOutlineValidationStatus::Invalid, .work = validationBudget.work};
+        }
+        components[component] = componentGlyph;
+      }
+      raw.components = components;
+    }
+    rawGlyphs.push_back(raw);
   }
-  result.work = validationBudget.work;
-  return result;
+
+  CffComponentComplexityResolver resolver(rawGlyphs, &validationBudget);
+  auto resolved = resolver.resolveAll();
+  if (!resolved.has_value()) {
+    return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
+                                                 : CffOutlineValidationStatus::Invalid,
+            .work = validationBudget.work};
+  }
+  return {.status = CffOutlineValidationStatus::Complete,
+          .work = validationBudget.work,
+          .glyphs = std::move(*resolved)};
 }
 
 }  // namespace donner::fonts

--- a/donner/base/fonts/CffOutlineComplexity.cc
+++ b/donner/base/fonts/CffOutlineComplexity.cc
@@ -979,6 +979,8 @@ public:
     return resolved_;
   }
 
+  std::size_t work() const { return resolutionWork_; }
+
 private:
   enum class State : uint8_t {
     Unvisited,
@@ -1008,6 +1010,7 @@ private:
     std::size_t depth = 0;
     if (raw_[glyph].components.has_value()) {
       if (!budget_->charge(2)) return false;
+      resolutionWork_ += 2;
       for (const std::size_t component : *raw_[glyph].components) {
         if (component >= raw_.size() || !resolve(component)) return false;
         depth = std::max(depth, depths_[component] + 1);
@@ -1032,6 +1035,7 @@ private:
   std::vector<State> states_;
   std::vector<CffGlyphOutlineComplexity> resolved_;
   std::vector<std::size_t> depths_;
+  std::size_t resolutionWork_ = 0;
 };
 
 }  // namespace
@@ -1111,10 +1115,12 @@ CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_
   if (!resolved.has_value()) {
     return {.status = validationBudget.exhausted ? CffOutlineValidationStatus::WorkLimitExceeded
                                                  : CffOutlineValidationStatus::Invalid,
-            .work = validationBudget.work};
+            .work = validationBudget.work,
+            .componentResolutionWork = resolver.work()};
   }
   return {.status = CffOutlineValidationStatus::Complete,
           .work = validationBudget.work,
+          .componentResolutionWork = resolver.work(),
           .glyphs = std::move(*resolved)};
 }
 

--- a/donner/base/fonts/CffOutlineComplexity.h
+++ b/donner/base/fonts/CffOutlineComplexity.h
@@ -15,8 +15,6 @@ inline constexpr std::size_t kMaximumCffOutlineValidationWork = 64 * 1024 * 1024
 struct CffGlyphOutlineComplexity {
   uint32_t maximumVertices = 0;
   uint32_t work = 0;
-  /// False when the glyph uses a legacy composite form that untrusted decoders must not enter.
-  bool renderable = true;
 };
 
 /// Outcome of bounded CFF outline validation.
@@ -40,7 +38,7 @@ struct CffOutlineValidationResult {
  *
  * Variable CFF2 operators return \ref CffOutlineValidationStatus::UnsupportedVariation so callers
  * can retain directory validation while failing closed before an untrusted outline decoder.
- * Legacy CFF1 endchar composites validate successfully but return a non-renderable glyph bound.
+ * Legacy CFF1 endchar composites include their resolved component costs in the returned bound.
  *
  * @param table Exact CFF or CFF2 table bytes.
  * @param cff2 Whether @p table uses CFF2 structures and CharStrings.

--- a/donner/base/fonts/CffOutlineComplexity.h
+++ b/donner/base/fonts/CffOutlineComplexity.h
@@ -30,6 +30,8 @@ struct CffOutlineValidationResult {
   CffOutlineValidationStatus status = CffOutlineValidationStatus::Invalid;
   /// Structure and CharString work actually consumed, including failed validation.
   std::size_t work = 0;
+  /// Work spent resolving legacy CFF1 endchar component graphs.
+  std::size_t componentResolutionWork = 0;
   std::vector<CffGlyphOutlineComplexity> glyphs;
 };
 

--- a/donner/base/fonts/CffOutlineComplexity.h
+++ b/donner/base/fonts/CffOutlineComplexity.h
@@ -15,6 +15,7 @@ inline constexpr std::size_t kMaximumCffOutlineValidationWork = 64 * 1024 * 1024
 struct CffGlyphOutlineComplexity {
   uint32_t maximumVertices = 0;
   uint32_t work = 0;
+  /// False when the glyph uses a legacy composite form that untrusted decoders must not enter.
   bool renderable = true;
 };
 
@@ -29,6 +30,7 @@ enum class CffOutlineValidationStatus : uint8_t {
 /// Per-glyph complexities returned by the bounded CFF interpreter.
 struct CffOutlineValidationResult {
   CffOutlineValidationStatus status = CffOutlineValidationStatus::Invalid;
+  /// Structure and CharString work actually consumed, including failed validation.
   std::size_t work = 0;
   std::vector<CffGlyphOutlineComplexity> glyphs;
 };
@@ -38,6 +40,12 @@ struct CffOutlineValidationResult {
  *
  * Variable CFF2 operators return \ref CffOutlineValidationStatus::UnsupportedVariation so callers
  * can retain directory validation while failing closed before an untrusted outline decoder.
+ * Legacy CFF1 endchar composites validate successfully but return a non-renderable glyph bound.
+ *
+ * @param table Exact CFF or CFF2 table bytes.
+ * @param cff2 Whether @p table uses CFF2 structures and CharStrings.
+ * @param expectedGlyphs Glyph count from the sfnt `maxp` table.
+ * @param maximumWork Caller-owned work remaining for this validation.
  */
 CffOutlineValidationResult ValidateCffOutlineComplexities(
     std::span<const uint8_t> table, bool cff2, std::size_t expectedGlyphs,

--- a/donner/base/fonts/CffOutlineComplexity.h
+++ b/donner/base/fonts/CffOutlineComplexity.h
@@ -1,0 +1,39 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace donner::fonts {
+
+/// Bounded outline cost proved for one CFF or CFF2 glyph.
+struct CffGlyphOutlineComplexity {
+  uint32_t maximumVertices = 0;
+  uint32_t work = 0;
+};
+
+/// Outcome of bounded CFF outline validation.
+enum class CffOutlineValidationStatus : uint8_t {
+  Complete,
+  UnsupportedVariation,
+  Invalid,
+};
+
+/// Per-glyph complexities returned by the bounded CFF interpreter.
+struct CffOutlineValidationResult {
+  CffOutlineValidationStatus status = CffOutlineValidationStatus::Invalid;
+  std::vector<CffGlyphOutlineComplexity> glyphs;
+};
+
+/**
+ * Validate CFF1 or non-variable CFF2 charstrings without materializing outlines.
+ *
+ * Variable CFF2 operators return \ref CffOutlineValidationStatus::UnsupportedVariation so callers
+ * can retain directory validation while failing closed before an untrusted outline decoder.
+ */
+CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> table, bool cff2,
+                                                          std::size_t expectedGlyphs);
+
+}  // namespace donner::fonts

--- a/donner/base/fonts/CffOutlineComplexity.h
+++ b/donner/base/fonts/CffOutlineComplexity.h
@@ -8,22 +8,28 @@
 
 namespace donner::fonts {
 
+/// Default whole-font work ceiling for one bounded CFF validation.
+inline constexpr std::size_t kMaximumCffOutlineValidationWork = 64 * 1024 * 1024;
+
 /// Bounded outline cost proved for one CFF or CFF2 glyph.
 struct CffGlyphOutlineComplexity {
   uint32_t maximumVertices = 0;
   uint32_t work = 0;
+  bool renderable = true;
 };
 
 /// Outcome of bounded CFF outline validation.
 enum class CffOutlineValidationStatus : uint8_t {
   Complete,
   UnsupportedVariation,
+  WorkLimitExceeded,
   Invalid,
 };
 
 /// Per-glyph complexities returned by the bounded CFF interpreter.
 struct CffOutlineValidationResult {
   CffOutlineValidationStatus status = CffOutlineValidationStatus::Invalid;
+  std::size_t work = 0;
   std::vector<CffGlyphOutlineComplexity> glyphs;
 };
 
@@ -33,7 +39,8 @@ struct CffOutlineValidationResult {
  * Variable CFF2 operators return \ref CffOutlineValidationStatus::UnsupportedVariation so callers
  * can retain directory validation while failing closed before an untrusted outline decoder.
  */
-CffOutlineValidationResult ValidateCffOutlineComplexities(std::span<const uint8_t> table, bool cff2,
-                                                          std::size_t expectedGlyphs);
+CffOutlineValidationResult ValidateCffOutlineComplexities(
+    std::span<const uint8_t> table, bool cff2, std::size_t expectedGlyphs,
+    std::size_t maximumWork = kMaximumCffOutlineValidationWork);
 
 }  // namespace donner::fonts

--- a/donner/base/fonts/SfntUtils.cc
+++ b/donner/base/fonts/SfntUtils.cc
@@ -489,7 +489,6 @@ std::optional<CffComplexityIndex> BuildCffComplexityIndex(const SfntFont& font,
       index.glyphs[glyph] = {
           .maximumVertices = validated.glyphs[glyph].maximumVertices,
           .work = validated.glyphs[glyph].work,
-          .renderable = validated.glyphs[glyph].renderable,
       };
     }
   }
@@ -608,8 +607,7 @@ bool SfntFont::hasTable(std::string_view tag) const {
 
 std::optional<SfntFont::GlyphOutlineComplexity> SfntFont::glyphOutlineComplexity(
     size_t glyphIndex) const {
-  if (!glyphComplexities_ || glyphIndex >= numGlyphs_ ||
-      !glyphComplexities_[glyphIndex].renderable) {
+  if (!glyphComplexities_ || glyphIndex >= numGlyphs_) {
     return std::nullopt;
   }
   return glyphComplexities_[glyphIndex];

--- a/donner/base/fonts/SfntUtils.cc
+++ b/donner/base/fonts/SfntUtils.cc
@@ -454,6 +454,41 @@ std::optional<std::vector<GlyphComplexity>> ValidateGlyphOutlines(std::span<cons
   return complexities;
 }
 
+struct CffComplexityIndex {
+  std::unique_ptr<SfntFont::GlyphOutlineComplexity[]> glyphs;
+  std::size_t count = 0;
+};
+
+std::optional<CffComplexityIndex> BuildCffComplexityIndex(const SfntFont& font,
+                                                          std::span<const uint8_t> data,
+                                                          std::span<const uint8_t> cff,
+                                                          bool isCff2) {
+  const auto maxp = font.findTable(data, "maxp");
+  if (!maxp.has_value() || maxp->size() < 6 || (isCff2 && font.hasTable("fvar"))) {
+    return std::nullopt;
+  }
+  const std::size_t expectedGlyphs = ReadBe16(maxp->data() + 4);
+  const CffOutlineValidationResult validated =
+      ValidateCffOutlineComplexities(cff, isCff2, expectedGlyphs);
+  if (validated.status != CffOutlineValidationStatus::Complete ||
+      validated.glyphs.size() != expectedGlyphs) {
+    return std::nullopt;
+  }
+
+  CffComplexityIndex index;
+  index.count = expectedGlyphs;
+  if (index.count != 0) {
+    index.glyphs = std::make_unique<SfntFont::GlyphOutlineComplexity[]>(index.count);
+    for (std::size_t glyph = 0; glyph < index.count; ++glyph) {
+      index.glyphs[glyph] = {
+          .maximumVertices = validated.glyphs[glyph].maximumVertices,
+          .work = validated.glyphs[glyph].work,
+      };
+    }
+  }
+  return index;
+}
+
 }  // namespace
 
 uint32_t SfntTag(std::string_view tag) {
@@ -490,27 +525,10 @@ std::optional<SfntFont> SfntFont::Validate(std::span<const uint8_t> data) {
     return font;
   }
   if (!glyf.has_value()) {
-    const auto maxp = font.findTable(data, "maxp");
-    if (!maxp.has_value() || maxp->size() < 6 || (cff2.has_value() && font.hasTable("fvar"))) {
-      return font;
-    }
-    const std::size_t expectedGlyphs = ReadBe16(maxp->data() + 4);
-    const CffOutlineValidationResult validated = ValidateCffOutlineComplexities(
-        cff2.has_value() ? *cff2 : *cff1, cff2.has_value(), expectedGlyphs);
-    if (validated.status != CffOutlineValidationStatus::Complete ||
-        validated.glyphs.size() != expectedGlyphs) {
-      return font;
-    }
-    font.numGlyphs_ = expectedGlyphs;
-    if (font.numGlyphs_ != 0) {
-      font.glyphComplexities_ =
-          std::make_unique<SfntFont::GlyphOutlineComplexity[]>(font.numGlyphs_);
-      for (std::size_t glyph = 0; glyph < font.numGlyphs_; ++glyph) {
-        font.glyphComplexities_[glyph] = {
-            .maximumVertices = validated.glyphs[glyph].maximumVertices,
-            .work = validated.glyphs[glyph].work,
-        };
-      }
+    if (auto cffIndex = BuildCffComplexityIndex(font, data, cff2.has_value() ? *cff2 : *cff1,
+                                                cff2.has_value())) {
+      font.numGlyphs_ = cffIndex->count;
+      font.glyphComplexities_ = std::move(cffIndex->glyphs);
     }
     return font;
   }

--- a/donner/base/fonts/SfntUtils.cc
+++ b/donner/base/fonts/SfntUtils.cc
@@ -461,15 +461,21 @@ struct CffComplexityIndex {
 
 std::optional<CffComplexityIndex> BuildCffComplexityIndex(const SfntFont& font,
                                                           std::span<const uint8_t> data,
-                                                          std::span<const uint8_t> cff,
-                                                          bool isCff2) {
+                                                          std::span<const uint8_t> cff, bool isCff2,
+                                                          const SfntValidationOptions& options,
+                                                          SfntValidationMetrics* metrics) {
   const auto maxp = font.findTable(data, "maxp");
   if (!maxp.has_value() || maxp->size() < 6 || (isCff2 && font.hasTable("fvar"))) {
     return std::nullopt;
   }
   const std::size_t expectedGlyphs = ReadBe16(maxp->data() + 4);
   const CffOutlineValidationResult validated =
-      ValidateCffOutlineComplexities(cff, isCff2, expectedGlyphs);
+      ValidateCffOutlineComplexities(cff, isCff2, expectedGlyphs, options.maximumCffValidationWork);
+  if (metrics) {
+    metrics->cffValidationWork = validated.work;
+    metrics->cffWorkLimitExceeded =
+        validated.status == CffOutlineValidationStatus::WorkLimitExceeded;
+  }
   if (validated.status != CffOutlineValidationStatus::Complete ||
       validated.glyphs.size() != expectedGlyphs) {
     return std::nullopt;
@@ -483,10 +489,17 @@ std::optional<CffComplexityIndex> BuildCffComplexityIndex(const SfntFont& font,
       index.glyphs[glyph] = {
           .maximumVertices = validated.glyphs[glyph].maximumVertices,
           .work = validated.glyphs[glyph].work,
+          .renderable = validated.glyphs[glyph].renderable,
       };
     }
   }
   return index;
+}
+
+void ResetValidationMetrics(SfntValidationMetrics* metrics) {
+  if (metrics) {
+    *metrics = {};
+  }
 }
 
 }  // namespace
@@ -506,7 +519,10 @@ SfntFont::~SfntFont() = default;
 SfntFont::SfntFont(SfntFont&&) noexcept = default;
 SfntFont& SfntFont::operator=(SfntFont&&) noexcept = default;
 
-std::optional<SfntFont> SfntFont::Validate(std::span<const uint8_t> data) {
+std::optional<SfntFont> SfntFont::Validate(std::span<const uint8_t> data,
+                                           const SfntValidationOptions& options,
+                                           SfntValidationMetrics* metrics) {
+  ResetValidationMetrics(metrics);
   std::optional<ParsedTableDirectory> directory = ParseTableDirectory(data);
   if (!directory.has_value()) {
     return std::nullopt;
@@ -526,7 +542,7 @@ std::optional<SfntFont> SfntFont::Validate(std::span<const uint8_t> data) {
   }
   if (!glyf.has_value()) {
     if (auto cffIndex = BuildCffComplexityIndex(font, data, cff2.has_value() ? *cff2 : *cff1,
-                                                cff2.has_value())) {
+                                                cff2.has_value(), options, metrics)) {
       font.numGlyphs_ = cffIndex->count;
       font.glyphComplexities_ = std::move(cffIndex->glyphs);
     }
@@ -592,7 +608,8 @@ bool SfntFont::hasTable(std::string_view tag) const {
 
 std::optional<SfntFont::GlyphOutlineComplexity> SfntFont::glyphOutlineComplexity(
     size_t glyphIndex) const {
-  if (!glyphComplexities_ || glyphIndex >= numGlyphs_) {
+  if (!glyphComplexities_ || glyphIndex >= numGlyphs_ ||
+      !glyphComplexities_[glyphIndex].renderable) {
     return std::nullopt;
   }
   return glyphComplexities_[glyphIndex];

--- a/donner/base/fonts/SfntUtils.cc
+++ b/donner/base/fonts/SfntUtils.cc
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "donner/base/fonts/CffOutlineComplexity.h"
+
 namespace donner::fonts {
 
 namespace {
@@ -479,7 +481,37 @@ std::optional<SfntFont> SfntFont::Validate(std::span<const uint8_t> data) {
   font.numTables_ = directory->count;
   font.tables_ = std::move(directory->tables);
   const auto glyf = font.findTable(data, "glyf");
+  const auto cff1 = font.findTable(data, "CFF ");
+  const auto cff2 = font.findTable(data, "CFF2");
+  const std::size_t outlineTableCount = static_cast<std::size_t>(glyf.has_value()) +
+                                        static_cast<std::size_t>(cff1.has_value()) +
+                                        static_cast<std::size_t>(cff2.has_value());
+  if (outlineTableCount != 1) {
+    return font;
+  }
   if (!glyf.has_value()) {
+    const auto maxp = font.findTable(data, "maxp");
+    if (!maxp.has_value() || maxp->size() < 6 || (cff2.has_value() && font.hasTable("fvar"))) {
+      return font;
+    }
+    const std::size_t expectedGlyphs = ReadBe16(maxp->data() + 4);
+    const CffOutlineValidationResult validated = ValidateCffOutlineComplexities(
+        cff2.has_value() ? *cff2 : *cff1, cff2.has_value(), expectedGlyphs);
+    if (validated.status != CffOutlineValidationStatus::Complete ||
+        validated.glyphs.size() != expectedGlyphs) {
+      return font;
+    }
+    font.numGlyphs_ = expectedGlyphs;
+    if (font.numGlyphs_ != 0) {
+      font.glyphComplexities_ =
+          std::make_unique<SfntFont::GlyphOutlineComplexity[]>(font.numGlyphs_);
+      for (std::size_t glyph = 0; glyph < font.numGlyphs_; ++glyph) {
+        font.glyphComplexities_[glyph] = {
+            .maximumVertices = validated.glyphs[glyph].maximumVertices,
+            .work = validated.glyphs[glyph].work,
+        };
+      }
+    }
     return font;
   }
 

--- a/donner/base/fonts/SfntUtils.h
+++ b/donner/base/fonts/SfntUtils.h
@@ -51,9 +51,9 @@ uint32_t SfntTag(std::string_view tag);
  * caps. The work model includes repeated and shared descendants, simple point decoding, component
  * transforms, and stb_truetype's repeated prefix copies.
  *
- * CFF/CFF2 tables receive bounded directory validation only. They must be consumed by an
- * exact-span parser such as FreeType; stb_truetype's CFF parser uses a synthetic 512 MiB span and
- * must not be initialized for these fonts.
+ * CFF and non-variable CFF2 outlines also receive bounded CharString validation. CFF tables must
+ * still be consumed by an exact-span parser such as FreeType; stb_truetype's CFF parser uses a
+ * synthetic 512 MiB span and must not be initialized for untrusted CFF fonts.
  */
 class SfntFont {
 public:
@@ -64,7 +64,7 @@ public:
     uint32_t length = 0;
   };
 
-  /// Allocation and CPU-work ceiling proved for one TrueType glyph.
+  /// Allocation and CPU-work ceiling proved for one glyph outline.
   struct GlyphOutlineComplexity {
     uint32_t maximumVertices = 0;
     uint32_t work = 0;
@@ -104,13 +104,13 @@ public:
   /// Number of validated directory entries.
   size_t numTables() const { return numTables_; }
 
-  /// Number of glyphs represented by the retained `loca` index, or zero for non-TrueType fonts.
+  /// Number of glyphs with retained outline bounds, or zero when validation was unavailable.
   size_t numGlyphs() const { return numGlyphs_; }
 
-  /// Return the validation-time outline bound for a TrueType glyph.
+  /// Return the validation-time outline bound for a glyph.
   std::optional<GlyphOutlineComplexity> glyphOutlineComplexity(size_t glyphIndex) const;
 
-  /// Exact dynamic bytes retained by the sorted directory and `loca` index.
+  /// Exact dynamic bytes retained by the sorted directory and outline indexes.
   size_t retainedBytes() const;
 
 private:

--- a/donner/base/fonts/SfntUtils.h
+++ b/donner/base/fonts/SfntUtils.h
@@ -82,7 +82,6 @@ public:
   struct GlyphOutlineComplexity {
     uint32_t maximumVertices = 0;
     uint32_t work = 0;
-    bool renderable = true;
   };
 
   SfntFont();

--- a/donner/base/fonts/SfntUtils.h
+++ b/donner/base/fonts/SfntUtils.h
@@ -8,6 +8,8 @@
 #include <span>
 #include <string_view>
 
+#include "donner/base/fonts/CffOutlineComplexity.h"
+
 namespace donner::fonts {
 
 /// Maximum number of entries accepted in an sfnt table directory.
@@ -42,6 +44,18 @@ inline uint32_t ReadBe32(const uint8_t* p) {
 /// Convert a four-byte sfnt tag to its big-endian integer representation.
 uint32_t SfntTag(std::string_view tag);
 
+/// Caller-selected limits for one sfnt validation.
+struct SfntValidationOptions {
+  /// Maximum CFF structure and CharString work permitted for this call.
+  std::size_t maximumCffValidationWork = kMaximumCffOutlineValidationWork;
+};
+
+/// Work and limiting outcome observed while validating one sfnt.
+struct SfntValidationMetrics {
+  std::size_t cffValidationWork = 0;  ///< Actual CFF work consumed by this call.
+  bool cffWorkLimitExceeded = false;  ///< True when CFF validation stopped at the caller limit.
+};
+
 /**
  * Validated, allocation-bounded index for one sfnt font.
  *
@@ -68,6 +82,7 @@ public:
   struct GlyphOutlineComplexity {
     uint32_t maximumVertices = 0;
     uint32_t work = 0;
+    bool renderable = true;
   };
 
   SfntFont();
@@ -84,7 +99,9 @@ public:
    * @param data Complete sfnt byte stream.
    * @return A cached index on success, or std::nullopt for malformed or over-limit input.
    */
-  static std::optional<SfntFont> Validate(std::span<const uint8_t> data);
+  static std::optional<SfntFont> Validate(std::span<const uint8_t> data,
+                                          const SfntValidationOptions& options = {},
+                                          SfntValidationMetrics* metrics = nullptr);
 
   /**
    * Find a validated table in @p data.

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -30,10 +30,10 @@ struct TableSpec {
   std::vector<uint8_t> bytes;
 };
 
-std::vector<uint8_t> MakeSfnt(std::vector<TableSpec> tables) {
+std::vector<uint8_t> MakeSfnt(std::vector<TableSpec> tables, uint32_t magic = 0x00010000) {
   const size_t directorySize = 12 + tables.size() * 16;
   std::vector<uint8_t> result(directorySize, 0);
-  WriteBe32(&result, 0, 0x00010000);
+  WriteBe32(&result, 0, magic);
   WriteBe16(&result, 4, static_cast<uint16_t>(tables.size()));
 
   size_t dataOffset = directorySize;
@@ -49,6 +49,80 @@ std::vector<uint8_t> MakeSfnt(std::vector<TableSpec> tables) {
     dataOffset += tables[i].bytes.size();
   }
   return result;
+}
+
+uint8_t EncodeSmallInteger(size_t value) {
+  EXPECT_LE(value, 107u);
+  return static_cast<uint8_t>(value + 139);
+}
+
+std::vector<uint8_t> MakeCff1() {
+  constexpr size_t kCharStringsOffset = 21;
+  return {
+      1,   0,   4,  4,              // Header.
+      0,   1,   1,  1,   2,   'A',  // Name INDEX.
+      0,   1,   1,  1,   3,   EncodeSmallInteger(kCharStringsOffset),
+      17,                    // Top DICT INDEX.
+      0,   0,                // String INDEX.
+      0,   0,                // Global Subr INDEX.
+      0,   1,   1,  1,   8,  // CharStrings INDEX.
+      139, 139, 21, 149, 139, 5,
+      14,  // Move, line, endchar.
+  };
+}
+
+std::vector<uint8_t> MakeCff2(bool variableCharString = false) {
+  constexpr size_t kCharStringsOffset = 14;
+  constexpr size_t kFdArrayOffset = 27;
+  std::vector<uint8_t> result = {
+      2,
+      0,
+      5,
+      0,
+      5,  // Header.
+      EncodeSmallInteger(kCharStringsOffset),
+      17,  // CharStrings.
+      EncodeSmallInteger(kFdArrayOffset),
+      12,
+      36,  // FDArray.
+      0,
+      0,
+      0,
+      0,  // Global Subr INDEX.
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      7,  // CharStrings INDEX.
+      139,
+      139,
+      21,
+      149,
+      139,
+      5,  // Move and line.
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      4,
+      139,
+      176,
+      18,  // FDArray and empty Private.
+  };
+  if (variableCharString) {
+    result[26] = 16;  // Replace rlineto with the unsupported CFF2 blend operator.
+  }
+  return result;
+}
+
+std::vector<uint8_t> MakeCffSfnt(std::string_view tag, std::vector<uint8_t> cff) {
+  std::vector<uint8_t> maxp(6, 0);
+  WriteBe16(&maxp, 4, 1);
+  return MakeSfnt({{tag, std::move(cff)}, {"maxp", std::move(maxp)}}, 0x4F54544F);
 }
 
 std::vector<uint8_t> CompoundGlyph(std::span<const uint16_t> dependencies) {
@@ -314,6 +388,29 @@ TEST(SfntUtils, CffUsesBoundedDirectoryWithoutTrueTypeDependencyIndex) {
   ASSERT_TRUE(font.has_value());
   EXPECT_EQ(font->numGlyphs(), 0u);
   EXPECT_EQ(font->retainedBytes(), sizeof(SfntFont::TableRecord));
+}
+
+TEST(SfntUtils, RetainsCff1PerGlyphComplexity) {
+  const std::vector<uint8_t> data = MakeCffSfnt("CFF ", MakeCff1());
+  const auto font = SfntFont::Validate(data);
+  ASSERT_TRUE(font.has_value());
+
+  const auto complexity = font->glyphOutlineComplexity(0);
+  ASSERT_TRUE(complexity.has_value());
+  EXPECT_EQ(complexity->maximumVertices, 3u);
+  EXPECT_GT(complexity->work, 0u);
+}
+
+TEST(SfntUtils, RetainsNonVariableCff2ComplexityAndFailsClosedForBlend) {
+  const std::vector<uint8_t> staticData = MakeCffSfnt("CFF2", MakeCff2());
+  const auto staticFont = SfntFont::Validate(staticData);
+  ASSERT_TRUE(staticFont.has_value());
+  EXPECT_TRUE(staticFont->glyphOutlineComplexity(0).has_value());
+
+  const std::vector<uint8_t> variableData = MakeCffSfnt("CFF2", MakeCff2(true));
+  const auto variableFont = SfntFont::Validate(variableData);
+  ASSERT_TRUE(variableFont.has_value());
+  EXPECT_FALSE(variableFont->glyphOutlineComplexity(0).has_value());
 }
 
 TEST(SfntUtils, ReportsExactRetainedIndexBytes) {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -558,6 +558,27 @@ TEST(SfntUtils, CffLocalSubroutineEndcharTerminatesEveryCallFrame) {
   EXPECT_EQ(result.glyphs.front().maximumVertices, 3u);
 }
 
+TEST(SfntUtils, CffReportsActualWorkAndStopsAtCallerBudget) {
+  const std::vector<uint8_t> cff = MakeCff1();
+  const CffOutlineValidationResult complete = ValidateCffOutlineComplexities(cff, false, 1);
+  ASSERT_EQ(complete.status, CffOutlineValidationStatus::Complete);
+  EXPECT_GT(complete.work, 1u);
+
+  const CffOutlineValidationResult limited = ValidateCffOutlineComplexities(cff, false, 1, 1);
+  EXPECT_EQ(limited.status, CffOutlineValidationStatus::WorkLimitExceeded);
+  EXPECT_EQ(limited.work, 1u);
+  EXPECT_THAT(limited.glyphs, testing::IsEmpty());
+}
+
+TEST(SfntUtils, Cff1LegacyEndcharCompositeIsValidatedButNotRenderable) {
+  const std::vector<uint8_t> cff = MakeCff1WithSubrs({139, 139, 139, 139, 14}, {});
+  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 1);
+
+  ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
+  ASSERT_EQ(result.glyphs.size(), 1u);
+  EXPECT_FALSE(result.glyphs.front().renderable);
+}
+
 TEST(SfntUtils, CffSubroutinesShareOperandsAndHintState) {
   const std::vector<uint8_t> cff =
       MakeCff1WithSubrs({32, 10, 19, 0x80, 33, 10, 21, 149, 139, 5, 14}, {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -658,7 +658,6 @@ TEST(SfntUtils, Cff1LegacyEndcharCompositeAggregatesRenderableComponents) {
 
   ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
   ASSERT_EQ(result.glyphs.size(), 4u);
-  EXPECT_TRUE(result.glyphs[3].renderable);
   EXPECT_EQ(result.glyphs[3].maximumVertices,
             result.glyphs[1].maximumVertices + result.glyphs[2].maximumVertices);
   EXPECT_GT(result.glyphs[3].work, result.glyphs[1].work + result.glyphs[2].work);

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -571,12 +571,23 @@ TEST(SfntUtils, CffReportsActualWorkAndStopsAtCallerBudget) {
 }
 
 TEST(SfntUtils, Cff1LegacyEndcharCompositeIsValidatedButNotRenderable) {
-  const std::vector<uint8_t> cff = MakeCff1WithSubrs({139, 139, 139, 139, 14}, {});
+  const std::vector<uint8_t> cff = MakeCff1WithSubrs({139, 139, 204, 247, 86, 14}, {});
   const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 1);
 
   ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
   ASSERT_EQ(result.glyphs.size(), 1u);
   EXPECT_FALSE(result.glyphs.front().renderable);
+
+  const CffOutlineValidationResult withWidth = ValidateCffOutlineComplexities(
+      MakeCff1WithSubrs({149, 139, 139, 204, 247, 86, 14}, {}), false, 1);
+  ASSERT_EQ(withWidth.status, CffOutlineValidationStatus::Complete);
+  ASSERT_EQ(withWidth.glyphs.size(), 1u);
+  EXPECT_FALSE(withWidth.glyphs.front().renderable);
+
+  const auto font = SfntFont::Validate(MakeCffSfnt("CFF ", cff));
+  ASSERT_TRUE(font.has_value());
+  EXPECT_EQ(font->numGlyphs(), 1u);
+  EXPECT_FALSE(font->glyphOutlineComplexity(0).has_value());
 }
 
 TEST(SfntUtils, CffSubroutinesShareOperandsAndHintState) {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -681,10 +681,13 @@ TEST(SfntUtils, Cff1SeacRejectsMissingComponentsAndCycles) {
 
 TEST(SfntUtils, Cff1SeacEnforcesComponentDepthPointAndWorkCaps) {
   const std::vector<uint8_t> leaf{139, 139, 21, 149, 139, 5, 14};
-  EXPECT_EQ(ValidateCffOutlineComplexities(MakeCff1SeacChain(10, leaf), false, 12).status,
-            CffOutlineValidationStatus::Complete);
-  EXPECT_EQ(ValidateCffOutlineComplexities(MakeCff1SeacChain(11, leaf), false, 13).status,
-            CffOutlineValidationStatus::Invalid);
+  const CffOutlineValidationResult maximumDepth =
+      ValidateCffOutlineComplexities(MakeCff1SeacChain(10, leaf), false, 12);
+  ASSERT_EQ(maximumDepth.status, CffOutlineValidationStatus::Complete);
+  const CffOutlineValidationResult excessiveDepth =
+      ValidateCffOutlineComplexities(MakeCff1SeacChain(11, leaf), false, 13);
+  EXPECT_EQ(excessiveDepth.status, CffOutlineValidationStatus::Invalid);
+  EXPECT_EQ(excessiveDepth.componentResolutionWork, maximumDepth.componentResolutionWork);
 
   std::vector<uint8_t> pointLeaf{139, 139, 21};
   for (size_t batch = 0; batch < 100; ++batch) {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -7,8 +7,11 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string_view>
 #include <vector>
+
+#include "donner/base/fonts/CffOutlineComplexity.h"
 
 namespace donner::fonts {
 namespace {
@@ -54,6 +57,139 @@ std::vector<uint8_t> MakeSfnt(std::vector<TableSpec> tables, uint32_t magic = 0x
 uint8_t EncodeSmallInteger(size_t value) {
   EXPECT_LE(value, 107u);
   return static_cast<uint8_t>(value + 139);
+}
+
+std::vector<uint8_t> EncodeDictInteger(size_t value) {
+  if (value <= 107) {
+    return {EncodeSmallInteger(value)};
+  }
+  if (value <= 32767) {
+    return {28, static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value)};
+  }
+  EXPECT_LE(value, uint32_t{0x7FFFFFFF});
+  return {29, static_cast<uint8_t>(value >> 24), static_cast<uint8_t>(value >> 16),
+          static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value)};
+}
+
+void AppendIndexOffset(std::vector<uint8_t>* result, size_t offset, uint8_t offsetSize) {
+  for (uint8_t byte = offsetSize; byte != 0; --byte) {
+    result->push_back(static_cast<uint8_t>(offset >> ((byte - 1) * 8)));
+  }
+}
+
+std::vector<uint8_t> MakeCffIndex(const std::vector<std::vector<uint8_t>>& objects, bool cff2) {
+  std::vector<uint8_t> result(cff2 ? 4u : 2u, 0);
+  if (cff2) {
+    WriteBe32(&result, 0, static_cast<uint32_t>(objects.size()));
+  } else {
+    WriteBe16(&result, 0, static_cast<uint16_t>(objects.size()));
+  }
+  if (objects.empty()) {
+    return result;
+  }
+
+  size_t dataSize = 0;
+  for (const std::vector<uint8_t>& object : objects) {
+    dataSize += object.size();
+  }
+  const size_t finalOffset = dataSize + 1;
+  const uint8_t offsetSize =
+      finalOffset <= 0xFF ? 1 : (finalOffset <= 0xFFFF ? 2 : (finalOffset <= 0xFFFFFF ? 3 : 4));
+  result.push_back(offsetSize);
+  size_t offset = 1;
+  for (const std::vector<uint8_t>& object : objects) {
+    AppendIndexOffset(&result, offset, offsetSize);
+    offset += object.size();
+  }
+  AppendIndexOffset(&result, offset, offsetSize);
+  for (const std::vector<uint8_t>& object : objects) {
+    result.insert(result.end(), object.begin(), object.end());
+  }
+  return result;
+}
+
+std::vector<uint8_t> MakeCff1WithSubrs(std::vector<uint8_t> charString,
+                                       std::vector<std::vector<uint8_t>> localSubrs,
+                                       std::vector<std::vector<uint8_t>> globalSubrs = {}) {
+  const std::vector<uint8_t> nameIndex = MakeCffIndex({{'A'}}, false);
+  const std::vector<uint8_t> stringIndex = MakeCffIndex({}, false);
+  const std::vector<uint8_t> globalIndex = MakeCffIndex(globalSubrs, false);
+  const std::vector<uint8_t> localIndex = MakeCffIndex(localSubrs, false);
+  const std::vector<uint8_t> charStrings = MakeCffIndex({std::move(charString)}, false);
+
+  std::vector<uint8_t> topDict;
+  std::vector<uint8_t> topIndex;
+  std::vector<uint8_t> privateDict;
+  size_t previousPrivateOffset = std::numeric_limits<size_t>::max();
+  for (int iteration = 0; iteration < 8; ++iteration) {
+    topIndex = MakeCffIndex({topDict}, false);
+    const size_t privateOffset =
+        4 + nameIndex.size() + topIndex.size() + stringIndex.size() + globalIndex.size();
+    privateDict.clear();
+    if (!localSubrs.empty()) {
+      privateDict = EncodeDictInteger(2);
+      privateDict.push_back(19);
+    }
+    const size_t charStringsOffset =
+        privateOffset + privateDict.size() + (localSubrs.empty() ? 0 : localIndex.size());
+
+    std::vector<uint8_t> nextTop = EncodeDictInteger(charStringsOffset);
+    nextTop.push_back(17);
+    if (!privateDict.empty()) {
+      const std::vector<uint8_t> privateSize = EncodeDictInteger(privateDict.size());
+      const std::vector<uint8_t> encodedPrivateOffset = EncodeDictInteger(privateOffset);
+      nextTop.insert(nextTop.end(), privateSize.begin(), privateSize.end());
+      nextTop.insert(nextTop.end(), encodedPrivateOffset.begin(), encodedPrivateOffset.end());
+      nextTop.push_back(18);
+    }
+    if (nextTop == topDict && privateOffset == previousPrivateOffset) {
+      break;
+    }
+    topDict = std::move(nextTop);
+    previousPrivateOffset = privateOffset;
+  }
+  topIndex = MakeCffIndex({topDict}, false);
+
+  std::vector<uint8_t> result{1, 0, 4, 4};
+  result.insert(result.end(), nameIndex.begin(), nameIndex.end());
+  result.insert(result.end(), topIndex.begin(), topIndex.end());
+  result.insert(result.end(), stringIndex.begin(), stringIndex.end());
+  result.insert(result.end(), globalIndex.begin(), globalIndex.end());
+  result.insert(result.end(), privateDict.begin(), privateDict.end());
+  if (!localSubrs.empty()) {
+    result.insert(result.end(), localIndex.begin(), localIndex.end());
+  }
+  result.insert(result.end(), charStrings.begin(), charStrings.end());
+  return result;
+}
+
+std::vector<uint8_t> MakeCff2WithCharString(std::vector<uint8_t> charString) {
+  const std::vector<uint8_t> globalIndex = MakeCffIndex({}, true);
+  const std::vector<uint8_t> charStrings = MakeCffIndex({std::move(charString)}, true);
+  const std::vector<uint8_t> fdArray = MakeCffIndex({{139, 139, 18}}, true);
+
+  std::vector<uint8_t> topDict;
+  for (int iteration = 0; iteration < 8; ++iteration) {
+    const size_t charStringsOffset = 5 + topDict.size() + globalIndex.size();
+    const size_t fdArrayOffset = charStringsOffset + charStrings.size();
+    std::vector<uint8_t> nextTop = EncodeDictInteger(charStringsOffset);
+    nextTop.push_back(17);
+    const std::vector<uint8_t> encodedFdArrayOffset = EncodeDictInteger(fdArrayOffset);
+    nextTop.insert(nextTop.end(), encodedFdArrayOffset.begin(), encodedFdArrayOffset.end());
+    nextTop.push_back(12);
+    nextTop.push_back(36);
+    if (nextTop == topDict) {
+      break;
+    }
+    topDict = std::move(nextTop);
+  }
+
+  std::vector<uint8_t> result{2, 0, 5, 0, static_cast<uint8_t>(topDict.size())};
+  result.insert(result.end(), topDict.begin(), topDict.end());
+  result.insert(result.end(), globalIndex.begin(), globalIndex.end());
+  result.insert(result.end(), charStrings.begin(), charStrings.end());
+  result.insert(result.end(), fdArray.begin(), fdArray.end());
+  return result;
 }
 
 std::vector<uint8_t> MakeCff1() {
@@ -411,6 +547,152 @@ TEST(SfntUtils, RetainsNonVariableCff2ComplexityAndFailsClosedForBlend) {
   const auto variableFont = SfntFont::Validate(variableData);
   ASSERT_TRUE(variableFont.has_value());
   EXPECT_FALSE(variableFont->glyphOutlineComplexity(0).has_value());
+}
+
+TEST(SfntUtils, CffLocalSubroutineEndcharTerminatesEveryCallFrame) {
+  const std::vector<uint8_t> cff = MakeCff1WithSubrs({32, 10}, {{139, 139, 21, 149, 139, 5, 14}});
+  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 1);
+
+  ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
+  ASSERT_EQ(result.glyphs.size(), 1u);
+  EXPECT_EQ(result.glyphs.front().maximumVertices, 3u);
+}
+
+TEST(SfntUtils, CffSubroutinesShareOperandsAndHintState) {
+  const std::vector<uint8_t> cff =
+      MakeCff1WithSubrs({32, 10, 19, 0x80, 33, 10, 21, 149, 139, 5, 14}, {
+                                                                             {139, 149, 1, 11},
+                                                                             {139, 139, 11},
+                                                                         });
+  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 1);
+
+  ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
+  ASSERT_EQ(result.glyphs.size(), 1u);
+  EXPECT_EQ(result.glyphs.front().maximumVertices, 3u);
+}
+
+TEST(SfntUtils, CffRejectsTruncatedHintMasksAndRecursiveSubroutines) {
+  const std::vector<uint8_t> truncatedMask = MakeCff1WithSubrs({32, 10, 19}, {{139, 149, 1, 11}});
+  EXPECT_EQ(ValidateCffOutlineComplexities(truncatedMask, false, 1).status,
+            CffOutlineValidationStatus::Invalid);
+
+  const std::vector<uint8_t> recursive = MakeCff1WithSubrs({32, 10}, {{32, 10, 11}});
+  EXPECT_EQ(ValidateCffOutlineComplexities(recursive, false, 1).status,
+            CffOutlineValidationStatus::Invalid);
+}
+
+TEST(SfntUtils, CffAcceptsTenSubroutineFramesAndRejectsEleven) {
+  const auto makeDepth = [](size_t depth) {
+    std::vector<std::vector<uint8_t>> subrs(depth);
+    for (size_t index = 0; index + 1 < depth; ++index) {
+      subrs[index] = {static_cast<uint8_t>(33 + index), 10};
+    }
+    subrs.back() = {139, 139, 21, 149, 139, 5, 14};
+    return MakeCff1WithSubrs({32, 10}, std::move(subrs));
+  };
+
+  EXPECT_EQ(ValidateCffOutlineComplexities(makeDepth(10), false, 1).status,
+            CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(ValidateCffOutlineComplexities(makeDepth(11), false, 1).status,
+            CffOutlineValidationStatus::Invalid);
+}
+
+TEST(SfntUtils, CffEnforcesVersionSpecificOperandStackCaps) {
+  const auto makeLines = [](size_t operands, bool cff2) {
+    std::vector<uint8_t> charString{139, 139, 21};
+    charString.insert(charString.end(), operands, 139);
+    charString.push_back(6);
+    if (!cff2) {
+      charString.push_back(14);
+    }
+    return charString;
+  };
+
+  EXPECT_EQ(
+      ValidateCffOutlineComplexities(MakeCff1WithSubrs(makeLines(48, false), {}), false, 1).status,
+      CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(
+      ValidateCffOutlineComplexities(MakeCff1WithSubrs(makeLines(49, false), {}), false, 1).status,
+      CffOutlineValidationStatus::Invalid);
+  EXPECT_EQ(
+      ValidateCffOutlineComplexities(MakeCff2WithCharString(makeLines(513, true)), true, 1).status,
+      CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(
+      ValidateCffOutlineComplexities(MakeCff2WithCharString(makeLines(514, true)), true, 1).status,
+      CffOutlineValidationStatus::Invalid);
+}
+
+TEST(SfntUtils, CffEnforcesExpandedPointAndExecutionWorkCaps) {
+  std::vector<uint8_t> lineSubr(48, 139);
+  lineSubr.push_back(6);
+  lineSubr.push_back(11);
+  const size_t acceptedCalls = (kMaximumExpandedGlyphVertices - 2) / 48;
+  const auto repeatedCalls = [](size_t count) {
+    std::vector<uint8_t> charString{139, 139, 21};
+    for (size_t call = 0; call < count; ++call) {
+      charString.push_back(32);
+      charString.push_back(10);
+    }
+    charString.push_back(14);
+    return charString;
+  };
+  EXPECT_EQ(ValidateCffOutlineComplexities(
+                MakeCff1WithSubrs(repeatedCalls(acceptedCalls), {lineSubr}), false, 1)
+                .status,
+            CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(ValidateCffOutlineComplexities(
+                MakeCff1WithSubrs(repeatedCalls(acceptedCalls + 1), {lineSubr}), false, 1)
+                .status,
+            CffOutlineValidationStatus::Invalid);
+
+  std::vector<uint8_t> expensiveSubr;
+  expensiveSubr.reserve(65535);
+  for (size_t operation = 0; operation < 21844; ++operation) {
+    expensiveSubr.insert(expensiveSubr.end(), {139, 12, 18});
+  }
+  expensiveSubr.push_back(11);
+  EXPECT_EQ(ValidateCffOutlineComplexities(MakeCff1WithSubrs(repeatedCalls(256), {expensiveSubr}),
+                                           false, 1)
+                .status,
+            CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(ValidateCffOutlineComplexities(
+                MakeCff1WithSubrs(repeatedCalls(257), {std::move(expensiveSubr)}), false, 1)
+                .status,
+            CffOutlineValidationStatus::Invalid);
+}
+
+TEST(SfntUtils, CffCharStringCountMustMatchMaxp) {
+  std::vector<uint8_t> maxp(6, 0);
+  WriteBe16(&maxp, 4, 2);
+  const std::vector<uint8_t> data =
+      MakeSfnt({{"CFF ", MakeCff1()}, {"maxp", std::move(maxp)}}, 0x4F54544F);
+  const auto font = SfntFont::Validate(data);
+
+  ASSERT_TRUE(font.has_value());
+  EXPECT_EQ(font->numGlyphs(), 0u);
+  EXPECT_FALSE(font->glyphOutlineComplexity(0).has_value());
+}
+
+TEST(SfntUtils, VariableCff2AndCompetingOutlineTablesFailClosed) {
+  std::vector<uint8_t> maxp(6, 0);
+  WriteBe16(&maxp, 4, 1);
+  const std::vector<uint8_t> variableCff2 =
+      MakeSfnt({{"CFF2", MakeCff2()}, {"fvar", {}}, {"maxp", maxp}}, 0x4F54544F);
+  const auto variableFont = SfntFont::Validate(variableCff2);
+  ASSERT_TRUE(variableFont.has_value());
+  EXPECT_FALSE(variableFont->glyphOutlineComplexity(0).has_value());
+
+  std::vector<uint8_t> head(54, 0);
+  WriteBe16(&head, 50, 1);
+  const std::vector<uint8_t> competing = MakeSfnt({{"CFF ", MakeCff1()},
+                                                   {"glyf", {}},
+                                                   {"head", std::move(head)},
+                                                   {"loca", std::vector<uint8_t>(8, 0)},
+                                                   {"maxp", std::move(maxp)}},
+                                                  0x4F54544F);
+  const auto competingFont = SfntFont::Validate(competing);
+  ASSERT_TRUE(competingFont.has_value());
+  EXPECT_FALSE(competingFont->glyphOutlineComplexity(0).has_value());
 }
 
 TEST(SfntUtils, ReportsExactRetainedIndexBytes) {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -241,8 +241,9 @@ std::vector<uint8_t> MakeCff1SeacChain(size_t depth, std::vector<uint8_t> leaf,
   return MakeCff1WithCharset(std::move(charStrings), std::move(charsetSids), std::move(localSubrs));
 }
 
-std::vector<uint8_t> MakeCff2WithCharString(std::vector<uint8_t> charString) {
-  const std::vector<uint8_t> globalIndex = MakeCffIndex({}, true);
+std::vector<uint8_t> MakeCff2WithCharString(std::vector<uint8_t> charString,
+                                            std::vector<std::vector<uint8_t>> globalSubrs = {}) {
+  const std::vector<uint8_t> globalIndex = MakeCffIndex(globalSubrs, true);
   const std::vector<uint8_t> charStrings = MakeCffIndex({std::move(charString)}, true);
   const std::vector<uint8_t> fdArray = MakeCffIndex({{139, 139, 18}}, true);
 
@@ -626,6 +627,16 @@ TEST(SfntUtils, RetainsNonVariableCff2ComplexityAndFailsClosedForBlend) {
   const auto variableFont = SfntFont::Validate(variableData);
   ASSERT_TRUE(variableFont.has_value());
   EXPECT_FALSE(variableFont->glyphOutlineComplexity(0).has_value());
+}
+
+TEST(SfntUtils, Cff2GlobalSubroutineReturnCompletesTheCaller) {
+  const std::vector<uint8_t> cff =
+      MakeCff2WithCharString({32, 29}, {{139, 139, 21, 149, 139, 5, 11}});
+  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, true, 1);
+
+  ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
+  ASSERT_EQ(result.glyphs.size(), 1u);
+  EXPECT_EQ(result.glyphs.front().maximumVertices, 3u);
 }
 
 TEST(SfntUtils, CffLocalSubroutineEndcharTerminatesEveryCallFrame) {

--- a/donner/base/fonts/tests/SfntUtils_tests.cc
+++ b/donner/base/fonts/tests/SfntUtils_tests.cc
@@ -163,6 +163,84 @@ std::vector<uint8_t> MakeCff1WithSubrs(std::vector<uint8_t> charString,
   return result;
 }
 
+std::vector<uint8_t> MakeCff1WithCharset(std::vector<std::vector<uint8_t>> charStrings,
+                                         std::vector<uint16_t> charsetSids,
+                                         std::vector<std::vector<uint8_t>> localSubrs = {}) {
+  EXPECT_EQ(charStrings.size(), charsetSids.size());
+  EXPECT_FALSE(charStrings.empty());
+  EXPECT_EQ(charsetSids.front(), 0u);
+  const std::vector<uint8_t> nameIndex = MakeCffIndex({{'A'}}, false);
+  const std::vector<uint8_t> stringIndex = MakeCffIndex({}, false);
+  const std::vector<uint8_t> globalIndex = MakeCffIndex({}, false);
+  const std::vector<uint8_t> localIndex = MakeCffIndex(localSubrs, false);
+  const std::vector<uint8_t> encodedCharStrings = MakeCffIndex(charStrings, false);
+  std::vector<uint8_t> charset{0};
+  for (size_t glyph = 1; glyph < charsetSids.size(); ++glyph) {
+    charset.push_back(static_cast<uint8_t>(charsetSids[glyph] >> 8));
+    charset.push_back(static_cast<uint8_t>(charsetSids[glyph]));
+  }
+
+  std::vector<uint8_t> topDict;
+  std::vector<uint8_t> topIndex;
+  std::vector<uint8_t> privateDict;
+  for (int iteration = 0; iteration < 8; ++iteration) {
+    topIndex = MakeCffIndex({topDict}, false);
+    const size_t charsetOffset =
+        4 + nameIndex.size() + topIndex.size() + stringIndex.size() + globalIndex.size();
+    privateDict.clear();
+    if (!localSubrs.empty()) {
+      privateDict = EncodeDictInteger(2);
+      privateDict.push_back(19);
+    }
+    const size_t privateOffset = charsetOffset + charset.size();
+    const size_t charStringsOffset =
+        privateOffset + privateDict.size() + (localSubrs.empty() ? 0 : localIndex.size());
+
+    std::vector<uint8_t> nextTop = EncodeDictInteger(charsetOffset);
+    nextTop.push_back(15);
+    const std::vector<uint8_t> encodedCharStringsOffset = EncodeDictInteger(charStringsOffset);
+    nextTop.insert(nextTop.end(), encodedCharStringsOffset.begin(), encodedCharStringsOffset.end());
+    nextTop.push_back(17);
+    if (!privateDict.empty()) {
+      const std::vector<uint8_t> privateSize = EncodeDictInteger(privateDict.size());
+      const std::vector<uint8_t> encodedPrivateOffset = EncodeDictInteger(privateOffset);
+      nextTop.insert(nextTop.end(), privateSize.begin(), privateSize.end());
+      nextTop.insert(nextTop.end(), encodedPrivateOffset.begin(), encodedPrivateOffset.end());
+      nextTop.push_back(18);
+    }
+    if (nextTop == topDict) break;
+    topDict = std::move(nextTop);
+  }
+  topIndex = MakeCffIndex({topDict}, false);
+
+  std::vector<uint8_t> result{1, 0, 4, 4};
+  const auto append = [&](const std::vector<uint8_t>& section) {
+    result.insert(result.end(), section.begin(), section.end());
+  };
+  append(nameIndex);
+  append(topIndex);
+  append(stringIndex);
+  append(globalIndex);
+  append(charset);
+  append(privateDict);
+  if (!localSubrs.empty()) result.insert(result.end(), localIndex.begin(), localIndex.end());
+  result.insert(result.end(), encodedCharStrings.begin(), encodedCharStrings.end());
+  return result;
+}
+
+std::vector<uint8_t> MakeCff1SeacChain(size_t depth, std::vector<uint8_t> leaf,
+                                       std::vector<std::vector<uint8_t>> localSubrs = {}) {
+  std::vector<std::vector<uint8_t>> charStrings{{14}, std::move(leaf)};
+  std::vector<uint16_t> charsetSids{0, 34};
+  for (size_t level = 1; level <= depth; ++level) {
+    const uint8_t previousCode = static_cast<uint8_t>(64 + level);
+    const uint8_t encodedPreviousCode = static_cast<uint8_t>(previousCode + 139);
+    charStrings.push_back({139, 139, encodedPreviousCode, encodedPreviousCode, 14});
+    charsetSids.push_back(static_cast<uint16_t>(34 + level));
+  }
+  return MakeCff1WithCharset(std::move(charStrings), std::move(charsetSids), std::move(localSubrs));
+}
+
 std::vector<uint8_t> MakeCff2WithCharString(std::vector<uint8_t> charString) {
   const std::vector<uint8_t> globalIndex = MakeCffIndex({}, true);
   const std::vector<uint8_t> charStrings = MakeCffIndex({std::move(charString)}, true);
@@ -255,9 +333,10 @@ std::vector<uint8_t> MakeCff2(bool variableCharString = false) {
   return result;
 }
 
-std::vector<uint8_t> MakeCffSfnt(std::string_view tag, std::vector<uint8_t> cff) {
+std::vector<uint8_t> MakeCffSfnt(std::string_view tag, std::vector<uint8_t> cff,
+                                 size_t glyphCount = 1) {
   std::vector<uint8_t> maxp(6, 0);
-  WriteBe16(&maxp, 4, 1);
+  WriteBe16(&maxp, 4, static_cast<uint16_t>(glyphCount));
   return MakeSfnt({{tag, std::move(cff)}, {"maxp", std::move(maxp)}}, 0x4F54544F);
 }
 
@@ -570,24 +649,68 @@ TEST(SfntUtils, CffReportsActualWorkAndStopsAtCallerBudget) {
   EXPECT_THAT(limited.glyphs, testing::IsEmpty());
 }
 
-TEST(SfntUtils, Cff1LegacyEndcharCompositeIsValidatedButNotRenderable) {
-  const std::vector<uint8_t> cff = MakeCff1WithSubrs({139, 139, 204, 247, 86, 14}, {});
-  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 1);
+TEST(SfntUtils, Cff1LegacyEndcharCompositeAggregatesRenderableComponents) {
+  const std::vector<uint8_t> base{139, 139, 21, 149, 139, 5, 14};
+  const std::vector<uint8_t> accent{139, 139, 21, 139, 149, 5, 14};
+  const std::vector<uint8_t> cff =
+      MakeCff1WithCharset({{14}, base, accent, {139, 139, 204, 247, 86, 14}}, {0, 34, 125, 150});
+  const CffOutlineValidationResult result = ValidateCffOutlineComplexities(cff, false, 4);
 
   ASSERT_EQ(result.status, CffOutlineValidationStatus::Complete);
-  ASSERT_EQ(result.glyphs.size(), 1u);
-  EXPECT_FALSE(result.glyphs.front().renderable);
+  ASSERT_EQ(result.glyphs.size(), 4u);
+  EXPECT_TRUE(result.glyphs[3].renderable);
+  EXPECT_EQ(result.glyphs[3].maximumVertices,
+            result.glyphs[1].maximumVertices + result.glyphs[2].maximumVertices);
+  EXPECT_GT(result.glyphs[3].work, result.glyphs[1].work + result.glyphs[2].work);
 
-  const CffOutlineValidationResult withWidth = ValidateCffOutlineComplexities(
-      MakeCff1WithSubrs({149, 139, 139, 204, 247, 86, 14}, {}), false, 1);
-  ASSERT_EQ(withWidth.status, CffOutlineValidationStatus::Complete);
-  ASSERT_EQ(withWidth.glyphs.size(), 1u);
-  EXPECT_FALSE(withWidth.glyphs.front().renderable);
-
-  const auto font = SfntFont::Validate(MakeCffSfnt("CFF ", cff));
+  const auto font = SfntFont::Validate(MakeCffSfnt("CFF ", cff, 4));
   ASSERT_TRUE(font.has_value());
-  EXPECT_EQ(font->numGlyphs(), 1u);
-  EXPECT_FALSE(font->glyphOutlineComplexity(0).has_value());
+  EXPECT_EQ(font->numGlyphs(), 4u);
+  EXPECT_TRUE(font->glyphOutlineComplexity(3).has_value());
+}
+
+TEST(SfntUtils, Cff1SeacRejectsMissingComponentsAndCycles) {
+  const std::vector<uint8_t> missing =
+      MakeCff1WithCharset({{14}, {14}, {14}, {139, 139, 204, 247, 86, 14}}, {0, 34, 126, 150});
+  EXPECT_EQ(ValidateCffOutlineComplexities(missing, false, 4).status,
+            CffOutlineValidationStatus::Invalid);
+
+  const std::vector<uint8_t> cycle = MakeCff1WithCharset({{14}, {139, 139, 204, 139, 14}}, {0, 34});
+  EXPECT_EQ(ValidateCffOutlineComplexities(cycle, false, 2).status,
+            CffOutlineValidationStatus::Invalid);
+}
+
+TEST(SfntUtils, Cff1SeacEnforcesComponentDepthPointAndWorkCaps) {
+  const std::vector<uint8_t> leaf{139, 139, 21, 149, 139, 5, 14};
+  EXPECT_EQ(ValidateCffOutlineComplexities(MakeCff1SeacChain(10, leaf), false, 12).status,
+            CffOutlineValidationStatus::Complete);
+  EXPECT_EQ(ValidateCffOutlineComplexities(MakeCff1SeacChain(11, leaf), false, 13).status,
+            CffOutlineValidationStatus::Invalid);
+
+  std::vector<uint8_t> pointLeaf{139, 139, 21};
+  for (size_t batch = 0; batch < 100; ++batch) {
+    pointLeaf.insert(pointLeaf.end(), 48, 139);
+    pointLeaf.push_back(6);
+  }
+  pointLeaf.push_back(14);
+  EXPECT_EQ(
+      ValidateCffOutlineComplexities(MakeCff1SeacChain(8, std::move(pointLeaf)), false, 10).status,
+      CffOutlineValidationStatus::Invalid);
+
+  std::vector<uint8_t> expensiveSubr;
+  for (size_t operation = 0; operation < 5000; ++operation) {
+    expensiveSubr.insert(expensiveSubr.end(), {139, 12, 18});
+  }
+  expensiveSubr.push_back(11);
+  std::vector<uint8_t> workLeaf{139, 139, 21};
+  for (size_t call = 0; call < 400; ++call) {
+    workLeaf.insert(workLeaf.end(), {32, 10});
+  }
+  workLeaf.push_back(14);
+  EXPECT_EQ(ValidateCffOutlineComplexities(
+                MakeCff1SeacChain(2, std::move(workLeaf), {std::move(expensiveSubr)}), false, 4)
+                .status,
+            CffOutlineValidationStatus::Invalid);
 }
 
 TEST(SfntUtils, CffSubroutinesShareOperandsAndHintState) {

--- a/donner/base/tests/Path_tests.cc
+++ b/donner/base/tests/Path_tests.cc
@@ -681,6 +681,25 @@ TEST(Path, RecursiveGeometryQueriesFailClosedAtAggregateWorkLimit) {
   EXPECT_FALSE(path.isOnPath({2000.0, 2000.0}, 0.001));
 }
 
+TEST(Path, CallerBoundedMeasurementPreservesResultsAndFailsAtOneUnitUnder) {
+  const Path path =
+      PathBuilder().moveTo({0.0, 0.0}).curveTo({0.0, 1.0}, {1.0, 0.0}, {1.0, 1.0}).build();
+  const Path::MeasuredPath full = path.measure();
+  ASSERT_TRUE(full.valid());
+  ASSERT_GT(full.measurementWorkUnits(), 1u);
+
+  const Path::MeasuredPath exact = path.measure(full.measurementWorkUnits());
+  EXPECT_TRUE(exact.valid());
+  EXPECT_EQ(exact.measurementWorkUnits(), full.measurementWorkUnits());
+  EXPECT_DOUBLE_EQ(exact.pathLength(), full.pathLength());
+
+  const Path::MeasuredPath under = path.measure(full.measurementWorkUnits() - 1u);
+  EXPECT_FALSE(under.valid());
+  EXPECT_EQ(under.measurementWorkUnits(), full.measurementWorkUnits() - 1u);
+  EXPECT_EQ(under.segmentCount(), 0u);
+  EXPECT_TRUE(std::isinf(under.pathLength()));
+}
+
 TEST(Path, RecursiveSubdivisionDepthLimitsBoundWork) {
   const Path path =
       PathBuilder().moveTo({0.0, 0.0}).curveTo({1e100, 1e100}, {-1e100, 1e100}, {0.0, 0.0}).build();

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -43,6 +43,18 @@ namespace donner::svg::compositor {
 
 namespace {
 
+class ScopedFrameResourceBudget {
+public:
+  explicit ScopedFrameResourceBudget(RendererInterface& renderer) : renderer_(renderer) {
+    renderer_.beginFrameResourceScope();
+  }
+
+  ~ScopedFrameResourceBudget() { renderer_.endFrameResourceScope(); }
+
+private:
+  RendererInterface& renderer_;
+};
+
 bool HasAssignedDescendant(Registry& registry, Entity entity) {
   using TreeComponent = donner::components::TreeComponent;
   std::vector<Entity> stack;
@@ -1164,6 +1176,7 @@ void CompositorController::renderFrame(const RenderViewport& viewport,
 void CompositorController::renderFrameImpl(const RenderViewport& viewport,
                                            const Transform2d& surfaceFromCanvas) {
   ZoneScopedN("Compositor::renderFrame");
+  const ScopedFrameResourceBudget frameResourceBudget(renderer());
   // Any foreground render supersedes the deferred cold-frame warmup. The normal frame path below
   // will populate whatever retained payloads are still missing, with the current viewport and DOM.
   firstFrameWarmupPending_ = false;

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -412,6 +412,7 @@ donner_cc_library(
         "//donner/svg/renderer/geode:geode_path_cache_component",
         "//donner/svg/renderer/geode:geode_resident_path_component",
         "//donner/svg/renderer/geode:geode_path_encoder",
+        "//donner/svg/renderer/geode:geode_resource_budget",
         "//donner/svg/renderer/geode:geode_stroke_tolerance",
         "//donner/svg/renderer/geode:geode_wgpu_util",
         "//donner/svg/resources:image_resource",

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -503,6 +503,14 @@ RendererImage Renderer::renderElement(SVGElement element, Vector2i sizePx) {
       elementThumbnailRenderer_ != nullptr ? *elementThumbnailRenderer_ : *impl_, element, sizePx);
 }
 
+void Renderer::beginFrameResourceScope() {
+  impl_->beginFrameResourceScope();
+}
+
+void Renderer::endFrameResourceScope() {
+  impl_->endFrameResourceScope();
+}
+
 void Renderer::beginFrame(const RenderViewport& viewport) {
   impl_->beginFrame(viewport);
 }

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -152,6 +152,9 @@ public:
    */
   [[nodiscard]] RendererImage renderElement(SVGElement element, Vector2i sizePx);
 
+  void beginFrameResourceScope() override;
+  void endFrameResourceScope() override;
+
   /**
    * Begins a render pass for the given viewport.
    *

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -1185,13 +1185,15 @@ RendererDriver::RendererDriver(RendererInterface& renderer, bool verbose,
                                SecurityStats* securityStats)
     : renderer_(renderer), verbose_(verbose), securityStats_(securityStats) {}
 
-void RendererDriver::resetOwnedFilterPreparationBudget() {
-  if (filterPreparationBudget_ != &ownedFilterPreparationBudget_) {
-    return;
+void RendererDriver::resetOwnedSecurityBudgets() {
+  if (filterPreparationBudget_ == &ownedFilterPreparationBudget_) {
+    ownedFilterPreparationBudget_ = {};
+    if (securityStats_) {
+      *securityStats_ = {};
+    }
   }
-  ownedFilterPreparationBudget_ = {};
-  if (securityStats_) {
-    *securityStats_ = {};
+  if (clipGeometryCopyBudget_ == &ownedClipGeometryCopyBudget_) {
+    ownedClipGeometryCopyBudget_.reset();
   }
 }
 
@@ -1326,7 +1328,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document) {
 
 void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderViewport& viewport,
                                           const Transform2d& surfaceFromCanvas) {
-  resetOwnedFilterPreparationBudget();
+  resetOwnedSecurityBudgets();
   renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1373,7 +1375,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderVie
 void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Entity lastEntity,
                                      const RenderViewport& viewport,
                                      const Transform2d& surfaceFromCanvas) {
-  resetOwnedFilterPreparationBudget();
+  resetOwnedSecurityBudgets();
   renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1389,7 +1391,7 @@ bool RendererDriver::drawEntityRangeInterruptibly(Registry& registry, Entity fir
                                                   Entity lastEntity, const RenderViewport& viewport,
                                                   const Transform2d& surfaceFromCanvas,
                                                   const std::function<bool()>& shouldCancel) {
-  resetOwnedFilterPreparationBudget();
+  resetOwnedSecurityBudgets();
   renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
@@ -1487,7 +1489,6 @@ bool RendererDriver::drawPreparedEntityRange(Registry& registry, Entity firstEnt
   }
 
   // Traverse from first to last (inclusive).
-  RendererTextMaterializationBudget clipGeometryCopyBudget;
   bool reachedLast = false;
   bool completed = true;
   while (!view.done() && !reachedLast) {
@@ -1547,7 +1548,7 @@ bool RendererDriver::drawPreparedEntityRange(Registry& registry, Entity firstEnt
       subtreeConsumedBySubRendering = true;
     }
 
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
     entityClip.clipRect = std::nullopt;
     // Mask is handled separately from clip - access it directly from instance.
     const bool hasEntityClip = !entityClip.empty();
@@ -2018,7 +2019,6 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
 }
 
 void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
-  RendererTextMaterializationBudget clipGeometryCopyBudget;
   while (!view.done()) {
     const components::RenderingInstanceComponent& instance = view.get();
     const Entity entity = view.currentEntity();
@@ -2083,7 +2083,7 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
     // Per SVG spec, the rendering order is: paint → filter → clip-path → mask → opacity.
     // Push in reverse so pop order applies the effects in spec order: mask outermost,
     // then clip-path, then filter innermost.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
     entityClip.clipRect = std::nullopt;  // Already handled above as viewport clip.
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {
@@ -2309,7 +2309,6 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
 
   // Use a local deferred-pop stack for the marker subtree.
   std::vector<DeferredPop> localDeferred;
-  RendererTextMaterializationBudget clipGeometryCopyBudget;
 
   // Draw until (and including) the end entity.
   bool foundEnd = false;
@@ -2358,7 +2357,7 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     }
 
     // Per SVG spec, apply paint → filter → clip-path → mask.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
     entityClip.clipRect = std::nullopt;
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {
@@ -3262,6 +3261,7 @@ void RendererDriver::preRenderSvgFeImages(components::FilterGraph& filterGraph,
     RendererDriver subDriver(*offscreen, verbose_);
     subDriver.renderingSize_ = targetSize;
     subDriver.filterPreparationBudget_ = filterPreparationBudget_;
+    subDriver.clipGeometryCopyBudget_ = clipGeometryCopyBudget_;
     subDriver.securityStats_ = securityStats_;
     subDriver.drawSubDocument(subDoc, Box2d::FromXYWH(0.0, 0.0, targetSize.x, targetSize.y),
                               imageNode->preserveAspectRatio, 1.0, Transform2d());
@@ -3409,6 +3409,7 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     subDriver.feImageFragmentGuard_ = feImageFragmentGuard_;
     subDriver.feImageFragmentDepth_ = feImageFragmentDepth_ + 1;
     subDriver.filterPreparationBudget_ = filterPreparationBudget_;
+    subDriver.clipGeometryCopyBudget_ = clipGeometryCopyBudget_;
     subDriver.securityStats_ = securityStats_;
 
     // The fragment is rendered at its natural position in the document coordinate system

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -503,7 +503,34 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
       }
     }
 
-    clip.clipPaths.reserve(clipPaths->clipPaths.size());
+    RendererTextMaterializationBudget copyBudget;
+    const std::size_t shapeCount = clipPaths->clipPaths.size();
+    const bool shapeStorageFits =
+        shapeCount <= std::numeric_limits<std::size_t>::max() / sizeof(ClipPathShape) &&
+        copyBudget.reserve({.bytes = shapeCount * sizeof(ClipPathShape), .decodeWork = shapeCount});
+    bool geometryFits = shapeStorageFits;
+    for (const auto& path : clipPaths->clipPaths) {
+      const std::size_t commands = path.path.commands().size();
+      const std::size_t points = path.path.points().size();
+      const std::optional<std::size_t> retainedBytes = path.path.retainedBytes();
+      if (!geometryFits || !retainedBytes.has_value() ||
+          commands > std::numeric_limits<std::size_t>::max() - points ||
+          !copyBudget.reserve({.uniqueOutlines = 1,
+                               .commands = commands,
+                               .points = points,
+                               .bytes = *retainedBytes,
+                               .decodeWork = commands + points})) {
+        geometryFits = false;
+        break;
+      }
+    }
+
+    if (!geometryFits) {
+      clip.clipPaths.emplace_back();
+      return clip;
+    }
+
+    clip.clipPaths.reserve(shapeCount);
     for (const auto& path : clipPaths->clipPaths) {
       ClipPathShape shape;
       shape.path = path.path;

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -488,7 +488,8 @@ PaintParams toPaintParams(Registry& registry,
 
 ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instance,
                             const components::ComputedStyleComponent& style, Registry& registry,
-                            RendererTextMaterializationBudget& copyBudget) {
+                            RendererTextMaterializationBudget& copyBudget,
+                            RendererDriver::SecurityStats* securityStats) {
   ResolvedClip clip;
   clip.clipRect = instance.clipRect;
   // Note: mask is handled separately by the caller, not through ResolvedClip.
@@ -512,6 +513,9 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
             {.bytes = shapeCount * sizeof(ClipPathShape), .decodeWork = shapeCount});
     bool geometryFits = shapeStorageFits;
     for (const auto& path : clipPaths->clipPaths) {
+      if (securityStats) {
+        ++securityStats->clipGeometryPathsPreflighted;
+      }
       const std::size_t commands = path.path.commands().size();
       const std::size_t points = path.path.points().size();
       const std::optional<std::size_t> retainedBytes = path.path.retainedBytes();
@@ -528,6 +532,9 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
     }
 
     if (!geometryFits) {
+      if (securityStats) {
+        securityStats->clipGeometryCopyRejected = true;
+      }
       clip.clipPaths.emplace_back();
       return clip;
     }
@@ -1548,7 +1555,8 @@ bool RendererDriver::drawPreparedEntityRange(Registry& registry, Entity firstEnt
       subtreeConsumedBySubRendering = true;
     }
 
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
+    ResolvedClip entityClip =
+        toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_, securityStats_);
     entityClip.clipRect = std::nullopt;
     // Mask is handled separately from clip - access it directly from instance.
     const bool hasEntityClip = !entityClip.empty();
@@ -2083,7 +2091,8 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
     // Per SVG spec, the rendering order is: paint → filter → clip-path → mask → opacity.
     // Push in reverse so pop order applies the effects in spec order: mask outermost,
     // then clip-path, then filter innermost.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
+    ResolvedClip entityClip =
+        toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_, securityStats_);
     entityClip.clipRect = std::nullopt;  // Already handled above as viewport clip.
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {
@@ -2357,7 +2366,8 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     }
 
     // Per SVG spec, apply paint → filter → clip-path → mask.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_);
+    ResolvedClip entityClip =
+        toResolvedClip(instance, style, registry, *clipGeometryCopyBudget_, securityStats_);
     entityClip.clipRect = std::nullopt;
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <span>
 #include <unordered_set>
@@ -79,6 +80,16 @@ inline constexpr int kMaxFeImageFragmentDepth = 32;
 /// culling. Keeps fractional-pixel strokes at the viewport edge safely on-screen
 /// - we'd rather do a little extra work than cull content the user should see.
 inline constexpr double kViewportCullSlackDevicePx = 1.0;
+
+Vector2i CheckedRenderingSize(const RenderViewport& viewport) {
+  constexpr double kMaximumDimension = static_cast<double>(std::numeric_limits<int>::max());
+  if (!std::isfinite(viewport.size.x) || !std::isfinite(viewport.size.y) || viewport.size.x < 0.0 ||
+      viewport.size.y < 0.0 || viewport.size.x > kMaximumDimension ||
+      viewport.size.y > kMaximumDimension) {
+    return Vector2i::Zero();
+  }
+  return Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
+}
 
 /// Compute the draw call's local-space AABB (inclusive of stroke width) for
 /// the given entity, or `std::nullopt` if the entity has no drawable content
@@ -1286,7 +1297,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document) {
 void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderViewport& viewport,
                                           const Transform2d& surfaceFromCanvas) {
   resetOwnedFilterPreparationBudget();
-  renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
+  renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
@@ -1333,7 +1344,7 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
                                      const RenderViewport& viewport,
                                      const Transform2d& surfaceFromCanvas) {
   resetOwnedFilterPreparationBudget();
-  renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
+  renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
@@ -1349,7 +1360,7 @@ bool RendererDriver::drawEntityRangeInterruptibly(Registry& registry, Entity fir
                                                   const Transform2d& surfaceFromCanvas,
                                                   const std::function<bool()>& shouldCancel) {
   resetOwnedFilterPreparationBudget();
-  renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
+  renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
@@ -1391,7 +1402,7 @@ void RendererDriver::drawEntityRangeIntoCurrentFrame(Registry& registry, Entity 
                                                      Entity lastEntity,
                                                      const RenderViewport& viewport,
                                                      const Transform2d& surfaceFromCanvas) {
-  renderingSize_ = Vector2i(static_cast<int>(viewport.size.x), static_cast<int>(viewport.size.y));
+  renderingSize_ = CheckedRenderingSize(viewport);
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   (void)drawPreparedEntityRange(registry, firstEntity, lastEntity, {});

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -487,7 +487,8 @@ PaintParams toPaintParams(Registry& registry,
 }
 
 ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instance,
-                            const components::ComputedStyleComponent& style, Registry& registry) {
+                            const components::ComputedStyleComponent& style, Registry& registry,
+                            RendererTextMaterializationBudget& copyBudget) {
   ResolvedClip clip;
   clip.clipRect = instance.clipRect;
   // Note: mask is handled separately by the caller, not through ResolvedClip.
@@ -503,11 +504,12 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
       }
     }
 
-    RendererTextMaterializationBudget copyBudget;
+    RendererTextMaterializationBudget candidateBudget = copyBudget;
     const std::size_t shapeCount = clipPaths->clipPaths.size();
     const bool shapeStorageFits =
         shapeCount <= std::numeric_limits<std::size_t>::max() / sizeof(ClipPathShape) &&
-        copyBudget.reserve({.bytes = shapeCount * sizeof(ClipPathShape), .decodeWork = shapeCount});
+        candidateBudget.reserve(
+            {.bytes = shapeCount * sizeof(ClipPathShape), .decodeWork = shapeCount});
     bool geometryFits = shapeStorageFits;
     for (const auto& path : clipPaths->clipPaths) {
       const std::size_t commands = path.path.commands().size();
@@ -515,11 +517,11 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
       const std::optional<std::size_t> retainedBytes = path.path.retainedBytes();
       if (!geometryFits || !retainedBytes.has_value() ||
           commands > std::numeric_limits<std::size_t>::max() - points ||
-          !copyBudget.reserve({.uniqueOutlines = 1,
-                               .commands = commands,
-                               .points = points,
-                               .bytes = *retainedBytes,
-                               .decodeWork = commands + points})) {
+          !candidateBudget.reserve({.uniqueOutlines = 1,
+                                    .commands = commands,
+                                    .points = points,
+                                    .bytes = *retainedBytes,
+                                    .decodeWork = commands + points})) {
         geometryFits = false;
         break;
       }
@@ -530,6 +532,7 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
       return clip;
     }
 
+    copyBudget = std::move(candidateBudget);
     clip.clipPaths.reserve(shapeCount);
     for (const auto& path : clipPaths->clipPaths) {
       ClipPathShape shape;
@@ -1484,6 +1487,7 @@ bool RendererDriver::drawPreparedEntityRange(Registry& registry, Entity firstEnt
   }
 
   // Traverse from first to last (inclusive).
+  RendererTextMaterializationBudget clipGeometryCopyBudget;
   bool reachedLast = false;
   bool completed = true;
   while (!view.done() && !reachedLast) {
@@ -1543,7 +1547,7 @@ bool RendererDriver::drawPreparedEntityRange(Registry& registry, Entity firstEnt
       subtreeConsumedBySubRendering = true;
     }
 
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
     entityClip.clipRect = std::nullopt;
     // Mask is handled separately from clip - access it directly from instance.
     const bool hasEntityClip = !entityClip.empty();
@@ -2014,6 +2018,7 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
 }
 
 void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
+  RendererTextMaterializationBudget clipGeometryCopyBudget;
   while (!view.done()) {
     const components::RenderingInstanceComponent& instance = view.get();
     const Entity entity = view.currentEntity();
@@ -2078,7 +2083,7 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
     // Per SVG spec, the rendering order is: paint → filter → clip-path → mask → opacity.
     // Push in reverse so pop order applies the effects in spec order: mask outermost,
     // then clip-path, then filter innermost.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
     entityClip.clipRect = std::nullopt;  // Already handled above as viewport clip.
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {
@@ -2304,6 +2309,7 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
 
   // Use a local deferred-pop stack for the marker subtree.
   std::vector<DeferredPop> localDeferred;
+  RendererTextMaterializationBudget clipGeometryCopyBudget;
 
   // Draw until (and including) the end entity.
   bool foundEnd = false;
@@ -2352,7 +2358,7 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     }
 
     // Per SVG spec, apply paint → filter → clip-path → mask.
-    ResolvedClip entityClip = toResolvedClip(instance, style, registry);
+    ResolvedClip entityClip = toResolvedClip(instance, style, registry, clipGeometryCopyBudget);
     entityClip.clipRect = std::nullopt;
     const bool hasEntityClip = !entityClip.empty();
     if (hasEntityClip) {

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -512,14 +512,15 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
         candidateBudget.reserve(
             {.bytes = shapeCount * sizeof(ClipPathShape), .decodeWork = shapeCount});
     bool geometryFits = shapeStorageFits;
-    for (const auto& path : clipPaths->clipPaths) {
+    for (auto path = clipPaths->clipPaths.begin();
+         geometryFits && path != clipPaths->clipPaths.end(); ++path) {
       if (securityStats) {
         ++securityStats->clipGeometryPathsPreflighted;
       }
-      const std::size_t commands = path.path.commands().size();
-      const std::size_t points = path.path.points().size();
-      const std::optional<std::size_t> retainedBytes = path.path.retainedBytes();
-      if (!geometryFits || !retainedBytes.has_value() ||
+      const std::size_t commands = path->path.commands().size();
+      const std::size_t points = path->path.points().size();
+      const std::optional<std::size_t> retainedBytes = path->path.retainedBytes();
+      if (!retainedBytes.has_value() ||
           commands > std::numeric_limits<std::size_t>::max() - points ||
           !candidateBudget.reserve({.uniqueOutlines = 1,
                                     .commands = commands,
@@ -532,6 +533,7 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
     }
 
     if (!geometryFits) {
+      copyBudget.reject();
       if (securityStats) {
         securityStats->clipGeometryCopyRejected = true;
       }

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -264,7 +264,7 @@ private:
   void drawPreparedDocument(SVGDocument& document);
   void drawPreparedDocument(SVGDocument& document, const RenderViewport& viewport,
                             const Transform2d& surfaceFromCanvas);
-  void resetOwnedFilterPreparationBudget();
+  void resetOwnedSecurityBudgets();
   [[nodiscard]] bool drawPreparedEntityRange(Registry& registry, Entity firstEntity,
                                              Entity lastEntity,
                                              const std::function<bool()>& shouldCancel);
@@ -404,6 +404,8 @@ private:
 
   FilterPreparationBudget ownedFilterPreparationBudget_;
   FilterPreparationBudget* filterPreparationBudget_ = &ownedFilterPreparationBudget_;
+  RendererTextMaterializationBudget ownedClipGeometryCopyBudget_;
+  RendererTextMaterializationBudget* clipGeometryCopyBudget_ = &ownedClipGeometryCopyBudget_;
   SecurityStats* securityStats_ = nullptr;
 
   /// Filter graphs resolved and pre-rendered by \ref prepareFilterGraphs. Keyed by the entity

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -39,6 +39,8 @@ public:
 
   /// Optional diagnostics for structured fuzzers and embedders auditing rejected preparation.
   struct SecurityStats {
+    std::size_t clipGeometryPathsPreflighted = 0;
+    bool clipGeometryCopyRejected = false;
     std::size_t filterPreparationAttempts = 0;
     std::size_t preparedFilterGraphs = 0;
     std::size_t preparedFilterNodes = 0;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2602,11 +2602,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return static_cast<bool>(slot.recordSlot.buffer);
   }
 
-  /// Glyph-residency budget, in distinct cached outlines and in summed encode
-  /// bytes. Defaults come from `GeodeGlyphCache`; a test shrinks them to reach
+  /// Glyph-residency budget, in distinct cached outlines and summed retained
+  /// outline plus encode bytes. Defaults come from `GeodeGlyphCache`; a test shrinks them to reach
   /// eviction without building a font-sized working set.
   size_t glyphCacheMaxEntries = geode::GeodeGlyphCache::kDefaultMaxEntries;
-  uint64_t glyphCacheMaxEncodedBytes = geode::GeodeGlyphCache::kDefaultMaxEncodedBytes;
+  uint64_t glyphCacheMaxRetainedBytes = geode::GeodeGlyphCache::kDefaultMaxRetainedBytes;
 
   /// Non-cached glyphs needed after the document cache reaches its admission cap. The deque keeps
   /// entry addresses stable for the frame's pending scene batches; beginFrame clears it only after
@@ -2635,7 +2635,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // covers the multi-document tile paths that never reach `draw()`.
     device->countGlyphResidencyEvictions(
         cache->beginFrame(currentFrameIndex, device->oldestOpenFrameGeneration(),
-                          glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
+                          glyphCacheMaxEntries, glyphCacheMaxRetainedBytes));
     return cache;
   }
 
@@ -2743,7 +2743,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       if (cacheAdmissionAvailable && cache->size() >= glyphCacheMaxEntries) {
         const size_t evicted =
             cache->evictToBudget(device->oldestOpenFrameGeneration(), glyphCacheMaxEntries - 1u,
-                                 glyphCacheMaxEncodedBytes);
+                                 glyphCacheMaxRetainedBytes);
         device->countGlyphResidencyEvictions(evicted);
         if (cache->size() >= glyphCacheMaxEntries) {
           cacheAdmissionAvailable = false;
@@ -2756,9 +2756,16 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         encoded = geode::GeodePathEncoder::encode(outline, FillRule::NonZero);
       }
       if (cacheAdmissionAvailable) {
-        entry = cache->insert(key, std::move(outline), std::move(encoded));
-        device->countGlyphResidencyUpload();
-      } else {
+        size_t evicted = 0;
+        entry = cache->insertWithinBudget(key, std::move(outline), std::move(encoded),
+                                          device->oldestOpenFrameGeneration(), glyphCacheMaxEntries,
+                                          glyphCacheMaxRetainedBytes, &evicted);
+        device->countGlyphResidencyEvictions(evicted);
+        if (entry != nullptr) {
+          device->countGlyphResidencyUpload();
+        }
+      }
+      if (entry == nullptr) {
         transientGlyphEntries.emplace_back();
         entry = &transientGlyphEntries.back();
         entry->outline = std::move(outline);
@@ -4277,9 +4284,10 @@ bool RendererGeode::sceneBatchingEnabledForTesting() {
   return kEnableSceneBatching;
 }
 
-void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxEncodedBytes) {
+void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
+                                                      uint64_t maxRetainedBytes) {
   impl_->glyphCacheMaxEntries = maxEntries;
-  impl_->glyphCacheMaxEncodedBytes = maxEncodedBytes;
+  impl_->glyphCacheMaxRetainedBytes = maxRetainedBytes;
 }
 
 size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1723,6 +1723,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     Box2d pixelRect;
     bool valid = false;
     bool hasPolygon = false;
+    bool allocationRejected = false;
     Vector2d polygonCorners[4];
     /// Path-clip mask. When non-null, `maskResolveView`
     /// references a 1-sample R8Unorm texture sampled by the fill /
@@ -1967,6 +1968,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     const ClipStackEntry* polygonEntry = nullptr;
     const ClipStackEntry* maskEntry = nullptr;
     for (const ClipStackEntry& entry : clipStack) {
+      if (entry.allocationRejected) {
+        encoder->clearClipPolygon();
+        encoder->clearClipMask();
+        encoder->setScissorRect(0, 0, 0, 0);
+        return;
+      }
       if (entry.valid) {
         if (!active.has_value()) {
           active = entry.pixelRect;
@@ -2655,6 +2662,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     return geometryBudget->reserve(logicalDraws, items * logicalDraws,
                                    static_cast<std::uint64_t>(retainedBytes) * logicalDraws);
   }
+
+  bool canEncodeGeometry() const override { return !geometryBudget->rejected(); }
 
   void releaseGeometry(const geode::EncodedPath& encoded, std::size_t logicalDraws) override {
     if (encoded.empty() || encoded.rejected() || logicalDraws == 0u) {
@@ -4907,7 +4916,8 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       wgpu::TextureDescriptor maskDesc = {};
       wgpu::Texture maskTexture = makeMaskTexture("RendererGeodeClipMask", maskDesc);
       if (!maskTexture) {
-        continue;
+        entry.allocationRejected = true;
+        break;
       }
 
       // Bind the previously-rendered nested mask (if any) so this

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2608,6 +2608,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   size_t glyphCacheMaxEntries = geode::GeodeGlyphCache::kDefaultMaxEntries;
   uint64_t glyphCacheMaxEncodedBytes = geode::GeodeGlyphCache::kDefaultMaxEncodedBytes;
 
+  /// Non-cached glyphs needed after the document cache reaches its admission cap. The deque keeps
+  /// entry addresses stable for the frame's pending scene batches; beginFrame clears it only after
+  /// the previous frame has submitted and its pending batch has been discarded.
+  std::deque<geode::GeodeGlyphResidentEntry> transientGlyphEntries;
+
   /// Document-scoped glyph-outline residency. Mirrors `residentSlab`'s
   /// registry-context wiring: one cache per document, replaced when a
   /// different device renders the document, because every cached entry holds
@@ -2729,14 +2734,36 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (entry != nullptr) {
       device->countGlyphResidencyHit();
     } else {
+      // Admission has to happen before outline decoding and before insertion. The frame-start
+      // trim cannot bound a cache that begins below its limit and creates a large working set in
+      // one frame; entries touched by that open frame are intentionally ineligible for eviction.
+      // Reclaim only entries no open frame can still reference, then fail closed if the new entry
+      // still would exceed the configured count cap.
+      bool cacheAdmissionAvailable = glyphCacheMaxEntries != 0u;
+      if (cacheAdmissionAvailable && cache->size() >= glyphCacheMaxEntries) {
+        const size_t evicted =
+            cache->evictToBudget(device->oldestOpenFrameGeneration(), glyphCacheMaxEntries - 1u,
+                                 glyphCacheMaxEncodedBytes);
+        device->countGlyphResidencyEvictions(evicted);
+        if (cache->size() >= glyphCacheMaxEntries) {
+          cacheAdmissionAvailable = false;
+        }
+      }
       Path outline = buildOutline();
       geode::EncodedPath encoded;
       if (!outline.empty()) {
         device->countPathEncode();
         encoded = geode::GeodePathEncoder::encode(outline, FillRule::NonZero);
       }
-      entry = cache->insert(key, std::move(outline), std::move(encoded));
-      device->countGlyphResidencyUpload();
+      if (cacheAdmissionAvailable) {
+        entry = cache->insert(key, std::move(outline), std::move(encoded));
+        device->countGlyphResidencyUpload();
+      } else {
+        transientGlyphEntries.emplace_back();
+        entry = &transientGlyphEntries.back();
+        entry->outline = std::move(outline);
+        entry->encoded = std::move(encoded);
+      }
     }
     entry->lastUsedFrame = currentFrameIndex;
 
@@ -3868,6 +3895,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     lastDrawSourceEntity = entt::null;
     pendingBatch.reset();
+    transientGlyphEntries.clear();
     counters.reset();
   }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3875,8 +3875,17 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       device->drainDeferredDestroys();
     }
     viewport = nextViewport;
-    pixelWidth = static_cast<int>(nextViewport.size.x * nextViewport.devicePixelRatio);
-    pixelHeight = static_cast<int>(nextViewport.size.y * nextViewport.devicePixelRatio);
+    const double nextPixelWidth = nextViewport.size.x * nextViewport.devicePixelRatio;
+    const double nextPixelHeight = nextViewport.size.y * nextViewport.devicePixelRatio;
+    constexpr double kMaximumPixelDimension = static_cast<double>(std::numeric_limits<int>::max());
+    const bool invalidViewport =
+        !std::isfinite(nextViewport.size.x) || !std::isfinite(nextViewport.size.y) ||
+        !std::isfinite(nextViewport.devicePixelRatio) || nextViewport.size.x < 0.0 ||
+        nextViewport.size.y < 0.0 || nextViewport.devicePixelRatio <= 0.0 ||
+        !std::isfinite(nextPixelWidth) || !std::isfinite(nextPixelHeight) ||
+        nextPixelWidth > kMaximumPixelDimension || nextPixelHeight > kMaximumPixelDimension;
+    pixelWidth = invalidViewport ? 0 : static_cast<int>(nextPixelWidth);
+    pixelHeight = invalidViewport ? 0 : static_cast<int>(nextPixelHeight);
     deviceFromLocalTransform = Transform2d();
     deviceFromLocalTransformStack.clear();
     paint = PaintParams();

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3689,6 +3689,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           // referenced by any batch).
           claimSceneSlot(*residentSlot, paint);
           flushPendingBatch();
+          if (!paint.isGradient()) {
+            encoder->releasePreparedSceneAdmission(*encoded);
+          }
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
                        chunk, recordBuf, chunkId, recordBufId, recordIndex,
                        effectiveRecordSlot.offset, clipVersion, current);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1259,7 +1259,9 @@ std::optional<GeodeFilterAdmission> AdmitGeodeFilter(const components::FilterGra
 /// record slab, its buffers and its per-entity slots entirely uncreated.
 constexpr bool kEnableSceneBatching = true;
 
-struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::FilterTextureAllocator {
+struct RendererGeode::Impl : public geode::GeometryDebugSink,
+                             public geode::GeometryAdmission,
+                             public geode::FilterTextureAllocator {
   bool verbose = false;
   bool antialias = true;
   std::function<void()> offscreenCreationHookForTesting;
@@ -1280,8 +1282,22 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   bool ownsTextMaterializationBudget = true;
   std::shared_ptr<geode::GeodeDocumentGeometryBudget::Limits> documentGeometryLimits =
       std::make_shared<geode::GeodeDocumentGeometryBudget::Limits>();
-  std::shared_ptr<std::weak_ptr<geode::GeodeDocumentGeometryBudget>> lastDocumentGeometryBudget =
-      std::make_shared<std::weak_ptr<geode::GeodeDocumentGeometryBudget>>();
+  struct DocumentGeometryFrameState {
+    std::vector<std::shared_ptr<geode::GeodeDocumentGeometryBudget>> touched;
+
+    void reset() { touched.clear(); }
+
+    void touch(const std::shared_ptr<geode::GeodeDocumentGeometryBudget>& budget) {
+      const auto existing = std::find_if(touched.begin(), touched.end(), [&](const auto& value) {
+        return value.get() == budget.get();
+      });
+      if (existing == touched.end()) {
+        touched.push_back(budget);
+      }
+    }
+  };
+  std::shared_ptr<DocumentGeometryFrameState> documentGeometryFrameState =
+      std::make_shared<DocumentGeometryFrameState>();
 
   // GPU resources. Created in the constructor; if device creation fails,
   // `device` is null and the renderer enters a no-op state.
@@ -1475,6 +1491,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// this renderer constructs: arena buffer recycling and the antialias mode.
   void configureEncoder(geode::GeoEncoder& encoderToConfigure) {
     encoderToConfigure.setBufferPool(&arenaBufferPool);
+    encoderToConfigure.setGeometryAdmission(this);
     encoderToConfigure.setAntialias(antialias);
   }
 
@@ -2588,6 +2605,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   Path strokeScratchPath;
   std::optional<geode::EncodedPath> fillScratchEncode;
   std::optional<geode::EncodedPath> strokeScratchEncode;
+  geode::EncodedPath emptyGeometry;
   geode::EncodedPath rejectedGeometry = [] {
     geode::EncodedPath encoded;
     encoded.outcome = geode::EncodedPath::Outcome::Rejected;
@@ -2618,17 +2636,39 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     FillRule fillRule = FillRule::NonZero;
   };
 
-  [[nodiscard]] bool reserveEncodedGeometry(const geode::EncodedPath& encoded) {
+  bool admitGeometry(const geode::EncodedPath& encoded, std::size_t logicalDraws) override {
     if (encoded.rejected()) {
       geometryBudget->reject();
       return false;
     }
     const std::size_t retainedBytes = encoded.retainedBytes();
-    if (retainedBytes == std::numeric_limits<std::size_t>::max()) {
+    const std::size_t items = encoded.geometryItemCount();
+    if (encoded.empty()) {
+      return true;
+    }
+    if (logicalDraws == 0u || retainedBytes == std::numeric_limits<std::size_t>::max() ||
+        items > std::numeric_limits<std::size_t>::max() / logicalDraws ||
+        retainedBytes > std::numeric_limits<std::uint64_t>::max() / logicalDraws) {
       geometryBudget->reject();
       return false;
     }
-    return geometryBudget->reserve(/*draws=*/1u, encoded.geometryItemCount(), retainedBytes);
+    return geometryBudget->reserve(logicalDraws, items * logicalDraws,
+                                   static_cast<std::uint64_t>(retainedBytes) * logicalDraws);
+  }
+
+  void releaseGeometry(const geode::EncodedPath& encoded, std::size_t logicalDraws) override {
+    if (encoded.empty() || encoded.rejected() || logicalDraws == 0u) {
+      return;
+    }
+    const std::size_t retainedBytes = encoded.retainedBytes();
+    const std::size_t items = encoded.geometryItemCount();
+    if (retainedBytes == std::numeric_limits<std::size_t>::max() ||
+        items > std::numeric_limits<std::size_t>::max() / logicalDraws ||
+        retainedBytes > std::numeric_limits<std::uint64_t>::max() / logicalDraws) {
+      return;
+    }
+    geometryBudget->release(logicalDraws, items * logicalDraws,
+                            static_cast<std::uint64_t>(retainedBytes) * logicalDraws);
   }
 
   std::optional<geode::EncodedPath> encodeGeometry(const Path& path, FillRule rule) {
@@ -2637,7 +2677,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     device->countPathEncode();
     geode::EncodedPath encoded = geode::GeodePathEncoder::encode(path, rule);
-    if (!reserveEncodedGeometry(encoded)) {
+    if (encoded.rejected()) {
+      geometryBudget->reject();
       return std::nullopt;
     }
     return encoded;
@@ -2659,10 +2700,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       return {fillScratchEncode ? &*fillScratchEncode : &rejectedGeometry, false};
     }
     ensureCacheInvalidationWired(*source.registry());
+    std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+        documentGeometryBudget(*source.registry());
     auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
     if (cache.fillEncode) {
-      return reserveEncodedGeometry(*cache.fillEncode) ? AdmittedEncode{&*cache.fillEncode, true}
-                                                       : AdmittedEncode{&rejectedGeometry, false};
+      return {&*cache.fillEncode, true};
     }
 
     std::optional<geode::EncodedPath> encoded = encodeGeometry(path, rule);
@@ -2670,8 +2712,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       return {&rejectedGeometry, false};
     }
     const std::size_t retainedBytes = encoded->retainedBytes();
-    std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
-        documentGeometryBudget(*source.registry());
     if (retainedBytes != std::numeric_limits<std::size_t>::max() &&
         cache.fillReservation.replace(documentBudget, retainedBytes)) {
       cache.fillEncode = std::move(*encoded);
@@ -2679,6 +2719,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     fillScratchEncode = std::move(*encoded);
     return {&*fillScratchEncode, false};
+  }
+
+  AdmittedEncode getFillEncodeForPaint(EntityHandle source, const Path& path, FillRule rule) {
+    if (!paint.drawFillComponent || std::holds_alternative<PaintServer::None>(paint.fill)) {
+      return {&emptyGeometry, false};
+    }
+    return getFillEncode(source, path, rule);
   }
 
   /// GPU-residence slot for `source`'s fill encode. Returns null for a null
@@ -2694,6 +2741,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// batching). Mirrors `residentSlab`'s registry-context wiring: one slab
   /// per document, swapped when a different device renders the document.
   std::shared_ptr<geode::GeodeRecordSlab> recordSlab(Registry& registry) {
+    std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+        documentGeometryBudget(registry);
     auto* slabPtr = registry.ctx().find<std::shared_ptr<geode::GeodeRecordSlab>>();
     if (slabPtr == nullptr) {
       registry.ctx().emplace<std::shared_ptr<geode::GeodeRecordSlab>>(nullptr);
@@ -2701,8 +2750,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     std::shared_ptr<geode::GeodeRecordSlab>& slab = *slabPtr;
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
-      slab = std::make_shared<geode::GeodeRecordSlab>(device->deviceId(),
-                                                      documentGeometryBudget(registry));
+      slab =
+          std::make_shared<geode::GeodeRecordSlab>(device->deviceId(), std::move(documentBudget));
     }
     return slab;
   }
@@ -3073,11 +3122,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     std::shared_ptr<geode::GeodeDocumentGeometryBudget> budget = *budgetPtr;
     budget->setLimitsForTesting(*documentGeometryLimits);
-    *lastDocumentGeometryBudget = budget;
+    documentGeometryFrameState->touch(budget);
     return budget;
   }
 
   std::shared_ptr<geode::GeodeResidentSlab> residentSlab(Registry& registry) {
+    std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+        documentGeometryBudget(registry);
     auto* slabPtr = registry.ctx().find<std::shared_ptr<geode::GeodeResidentSlab>>();
     if (slabPtr == nullptr) {
       registry.ctx().emplace<std::shared_ptr<geode::GeodeResidentSlab>>(nullptr);
@@ -3086,7 +3137,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     std::shared_ptr<geode::GeodeResidentSlab>& slab = *slabPtr;
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
       slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId(),
-                                                        documentGeometryBudget(registry));
+                                                        std::move(documentBudget));
     }
     // Merge the previous frame's freed ranges, at most once per frame (the
     // slab gates on the index). Gating here rather than at one draw entry
@@ -3778,12 +3829,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     const double flattenTolerance = strokeFlattenTolerance();
     if (source) {
       ensureCacheInvalidationWired(*source.registry());
+      std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+          documentGeometryBudget(*source.registry());
       auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
       if (cache.strokeSlot && cache.strokeSlot->strokeKey == strokeStyle &&
           cache.strokeSlot->flattenTolerance == flattenTolerance) {
-        if (!reserveEncodedGeometry(cache.strokeSlot->strokedEncode)) {
-          return result;
-        }
         result.strokedPath = &cache.strokeSlot->strokedPath;
         result.encoded = &cache.strokeSlot->strokedEncode;
         result.persistent = true;
@@ -3817,20 +3867,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         if (!encoded.has_value()) {
           return result;
         }
-        const std::optional<std::size_t> strokedBytes = stroked.retainedBytes();
-        const std::size_t encodedBytes = encoded->retainedBytes();
-        const bool retainedBytesValid =
-            strokedBytes.has_value() && encodedBytes != std::numeric_limits<std::size_t>::max() &&
-            *strokedBytes <= std::numeric_limits<std::size_t>::max() - encodedBytes;
-        const std::size_t retainedBytes = retainedBytesValid
-                                              ? *strokedBytes + encodedBytes
-                                              : std::numeric_limits<std::size_t>::max();
-        std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
-            documentGeometryBudget(*source.registry());
-        if (!retainedBytesValid ||
-            !cache.strokeReservation.replace(documentBudget, retainedBytes)) {
-          strokeScratchPath = std::move(stroked);
-          strokeScratchEncode = std::move(*encoded);
+        geode::GeodePathCacheComponent::StrokeSlot candidate{
+            .strokeKey = strokeStyle,
+            .flattenTolerance = flattenTolerance,
+            .strokedPath = std::move(stroked),
+            .strokedEncode = std::move(*encoded),
+            .strokeFillRule = fillRule,
+        };
+        const std::optional<std::size_t> retainedBytes = candidate.retainedBytes();
+        if (!retainedBytes.has_value() ||
+            !cache.strokeReservation.replace(documentBudget, *retainedBytes)) {
+          strokeScratchPath = std::move(candidate.strokedPath);
+          strokeScratchEncode = std::move(candidate.strokedEncode);
           result.strokedPath = &strokeScratchPath;
           result.encoded = &*strokeScratchEncode;
           result.fillRule = fillRule;
@@ -3844,16 +3892,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           resident->strokeSlot.reset();
           resident->gradientStrokeSlot.reset();
         }
-        // GCC 14 libstdc++ rejects `.emplace()` here with "is_constructible_v<StrokeSlot> was not
-        // satisfied"; clang + libc++ accepts it. Build the value explicitly and assign to sidestep
-        // the toolchain disagreement.
-        cache.strokeSlot = geode::GeodePathCacheComponent::StrokeSlot{
-            .strokeKey = strokeStyle,
-            .flattenTolerance = flattenTolerance,
-            .strokedPath = std::move(stroked),
-            .strokedEncode = std::move(*encoded),
-            .strokeFillRule = fillRule,
-        };
+        cache.strokeSlot = std::move(candidate);
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;
@@ -4120,6 +4159,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     if (ownsGeometryBudget) {
       geometryBudget->reset();
+      documentGeometryFrameState->reset();
     }
     if (ownsSurfaceBudget) {
       surfaceBudget->reset();
@@ -4556,8 +4596,8 @@ void RendererGeode::setGeometryBudgetForTesting(std::size_t maximumDraws, std::s
       std::min(impl_->documentGeometryLimits->cacheBytes, maximumCacheBytes);
   impl_->documentGeometryLimits->residentBytes =
       std::min(impl_->documentGeometryLimits->residentBytes, maximumResidentBytes);
-  if (std::shared_ptr<geode::GeodeDocumentGeometryBudget> document =
-          impl_->lastDocumentGeometryBudget->lock()) {
+  for (const std::shared_ptr<geode::GeodeDocumentGeometryBudget>& document :
+       impl_->documentGeometryFrameState->touched) {
     document->setLimitsForTesting(*impl_->documentGeometryLimits);
   }
 }
@@ -4574,10 +4614,16 @@ void RendererGeode::setTextMaterializationBudgetForTesting(
 }
 
 RendererResourceStats RendererGeode::resourceStats() const {
-  std::shared_ptr<geode::GeodeDocumentGeometryBudget> document =
-      impl_->lastDocumentGeometryBudget->lock();
-  const std::uint64_t documentBytes =
-      document ? document->cacheBytes() + document->residentBytes() : 0;
+  std::uint64_t documentBytes = 0;
+  bool documentRejected = false;
+  for (const std::shared_ptr<geode::GeodeDocumentGeometryBudget>& document :
+       impl_->documentGeometryFrameState->touched) {
+    const std::uint64_t retained = document->cacheBytes() + document->residentBytes();
+    documentBytes = retained > std::numeric_limits<std::uint64_t>::max() - documentBytes
+                        ? std::numeric_limits<std::uint64_t>::max()
+                        : documentBytes + retained;
+    documentRejected = documentRejected || document->rejected();
+  }
   const std::uint64_t geometryBytes = impl_->geometryBudget->retainedBytes();
   const std::uint64_t totalGeometryBytes =
       documentBytes > std::numeric_limits<std::uint64_t>::max() - geometryBytes
@@ -4598,8 +4644,7 @@ RendererResourceStats RendererGeode::resourceStats() const {
       .geometryDraws = impl_->geometryBudget->draws(),
       .geometryItems = impl_->geometryBudget->items(),
       .geometryRetainedBytes = reportedGeometryBytes,
-      .geometryBudgetRejected =
-          impl_->geometryBudget->rejected() || (document && document->rejected()),
+      .geometryBudgetRejected = impl_->geometryBudget->rejected() || documentRejected,
       .surfaceBudgetSupported = true,
       .surfaceCount = impl_->surfaceBudget->surfaces(),
       .surfaceBytes = impl_->surfaceBudget->bytes(),
@@ -5623,7 +5668,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // overlay, test-harness direct draws) returns nullptr and `GeoEncoder`
   // falls back to the inline encode path.
   const Impl::AdmittedEncode fillAdmission =
-      impl_->getFillEncode(path.sourceEntity, drawPathGeometry, path.fillRule);
+      impl_->getFillEncodeForPaint(path.sourceEntity, drawPathGeometry, path.fillRule);
   const geode::EncodedPath* fillEncoded = fillAdmission.encoded;
 
   // Try to append to a pending batch. Preconditions:
@@ -6576,7 +6621,7 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
   renderer->impl_->textMaterializationBudget = impl_->textMaterializationBudget;
   renderer->impl_->ownsTextMaterializationBudget = false;
   renderer->impl_->documentGeometryLimits = impl_->documentGeometryLimits;
-  renderer->impl_->lastDocumentGeometryBudget = impl_->lastDocumentGeometryBudget;
+  renderer->impl_->documentGeometryFrameState = impl_->documentGeometryFrameState;
   return renderer;
 }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1280,6 +1280,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   std::shared_ptr<RendererTextMaterializationBudget> textMaterializationBudget =
       std::make_shared<RendererTextMaterializationBudget>();
   bool ownsTextMaterializationBudget = true;
+  std::size_t frameResourceScopeDepth = 0;
   std::shared_ptr<geode::GeodeDocumentGeometryBudget::Limits> documentGeometryLimits =
       std::make_shared<geode::GeodeDocumentGeometryBudget::Limits>();
   struct DocumentGeometryFrameState {
@@ -1555,6 +1556,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (!texture) {
       return;
     }
+    const bool releasedSurface =
+        desc.size.width <= static_cast<uint32_t>(std::numeric_limits<int>::max()) &&
+        desc.size.height <= static_cast<uint32_t>(std::numeric_limits<int>::max()) &&
+        surfaceBudget->release(static_cast<int>(desc.size.width),
+                               static_cast<int>(desc.size.height),
+                               static_cast<std::size_t>(desc.size.depthOrArrayLayers));
+    UTILS_RELEASE_ASSERT(releasedSurface);
     if (texturePool) {
       texturePool->release(std::move(texture), desc);
     } else {
@@ -4177,18 +4185,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frameFinishedEncoders.clear();
     geometryDebugEdges.clear();
     rejectedFilterDepth = 0;
-    if (ownsFilterExecutionBudget) {
-      filterExecutionBudget->reset();
-    }
-    if (ownsGeometryBudget) {
-      geometryBudget->reset();
-      documentGeometryFrameState->reset();
-    }
-    if (ownsSurfaceBudget) {
-      surfaceBudget->reset();
-    }
-    if (ownsTextMaterializationBudget) {
-      textMaterializationBudget->reset();
+    if (frameResourceScopeDepth == 0) {
+      resetOwnedFrameBudgets();
     }
     if (device) {
       device->filterEngine().beginFrame();
@@ -4208,6 +4206,22 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     transientGlyphEntries.clear();
     transientTextEncodes.clear();
     counters.reset();
+  }
+
+  void resetOwnedFrameBudgets() {
+    if (ownsFilterExecutionBudget) {
+      filterExecutionBudget->reset();
+    }
+    if (ownsGeometryBudget) {
+      geometryBudget->reset();
+      documentGeometryFrameState->reset();
+    }
+    if (ownsSurfaceBudget) {
+      surfaceBudget->reset();
+    }
+    if (ownsTextMaterializationBudget) {
+      textMaterializationBudget->reset();
+    }
   }
 
   bool prepareFrameTarget() {
@@ -4700,6 +4714,18 @@ size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
     return 0;
   }
   return (*cachePtr)->size();
+}
+
+void RendererGeode::beginFrameResourceScope() {
+  if (impl_->frameResourceScopeDepth == 0) {
+    impl_->resetOwnedFrameBudgets();
+  }
+  ++impl_->frameResourceScopeDepth;
+}
+
+void RendererGeode::endFrameResourceScope() {
+  UTILS_RELEASE_ASSERT(impl_->frameResourceScopeDepth > 0);
+  --impl_->frameResourceScopeDepth;
 }
 
 int RendererGeode::width() const {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3136,8 +3136,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     }
     std::shared_ptr<geode::GeodeResidentSlab>& slab = *slabPtr;
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
-      slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId(),
-                                                        std::move(documentBudget));
+      slab =
+          std::make_shared<geode::GeodeResidentSlab>(device->deviceId(), std::move(documentBudget));
     }
     // Merge the previous frame's freed ranges, at most once per frame (the
     // slab gates on the index). Gating here rather than at one draw entry
@@ -3689,6 +3689,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           // referenced by any batch).
           claimSceneSlot(*residentSlot, paint);
           flushPendingBatch();
+          if (!paint.isGradient()) {
+            encoder->releasePreparedSceneAdmission(*encoded);
+          }
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
                        chunk, recordBuf, chunkId, recordBufId, recordIndex,
                        effectiveRecordSlot.offset, clipVersion, current);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2812,7 +2812,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     }
     std::shared_ptr<geode::GeodeGlyphCache>& cache = *cachePtr;
     if (!cache || cache->owningDeviceId() != device->deviceId()) {
-      cache = std::make_shared<geode::GeodeGlyphCache>(device->deviceId());
+      cache = std::make_shared<geode::GeodeGlyphCache>(device->deviceId(),
+                                                       documentGeometryBudget(registry));
+    } else {
+      (void)documentGeometryBudget(registry);
     }
     // Trim to budget at the first touch of each frame, the same shape (and for
     // the same reason) as the slabs' pending-free merge: dropping an entry
@@ -2885,9 +2888,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (cursor.component != nullptr) {
       auto& occurrences = cursor.component->occurrences;
       if (cursor.next == occurrences.size() && cursor.component->recordSlab) {
-        geode::GeodeRecordSlab::Slot slot;
-        if (cursor.component->recordSlab->allocateSlot(*device, slot)) {
-          occurrences.push_back(geode::GeodeTextInstanceRecordComponent::Occurrence{slot, {}});
+        std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+            documentGeometryBudget(registry);
+        if (cursor.component->reserveOccurrence(documentBudget)) {
+          geode::GeodeRecordSlab::Slot slot;
+          if (cursor.component->recordSlab->allocateSlot(*device, slot)) {
+            occurrences.push_back(geode::GeodeTextInstanceRecordComponent::Occurrence{slot, {}});
+          } else {
+            cursor.component->rollbackOccurrence();
+          }
         }
       }
       if (cursor.next < occurrences.size()) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -134,6 +134,19 @@ const Box2d kUnitPathBounds(Vector2d::Zero(), Vector2d(1, 1));
 /// Source UV rect that samples an entire texture.
 const Box2d kWholeTextureUv(Vector2d::Zero(), Vector2d(1, 1));
 
+std::optional<Vector2i> CheckedViewportPixels(const RenderViewport& viewport) {
+  const double width = viewport.size.x * viewport.devicePixelRatio;
+  const double height = viewport.size.y * viewport.devicePixelRatio;
+  constexpr double kMaximum = static_cast<double>(std::numeric_limits<int>::max());
+  if (!std::isfinite(viewport.size.x) || !std::isfinite(viewport.size.y) ||
+      !std::isfinite(viewport.devicePixelRatio) || viewport.size.x < 0.0 || viewport.size.y < 0.0 ||
+      viewport.devicePixelRatio <= 0.0 || !std::isfinite(width) || !std::isfinite(height) ||
+      width > kMaximum || height > kMaximum) {
+    return std::nullopt;
+  }
+  return Vector2i(static_cast<int>(width), static_cast<int>(height));
+}
+
 bool IsBgraTextureFormat(wgpu::TextureFormat format) {
   return static_cast<WGPUTextureFormat>(format) == WGPUTextureFormat_BGRA8Unorm;
 }
@@ -3875,17 +3888,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       device->drainDeferredDestroys();
     }
     viewport = nextViewport;
-    const double nextPixelWidth = nextViewport.size.x * nextViewport.devicePixelRatio;
-    const double nextPixelHeight = nextViewport.size.y * nextViewport.devicePixelRatio;
-    constexpr double kMaximumPixelDimension = static_cast<double>(std::numeric_limits<int>::max());
-    const bool invalidViewport =
-        !std::isfinite(nextViewport.size.x) || !std::isfinite(nextViewport.size.y) ||
-        !std::isfinite(nextViewport.devicePixelRatio) || nextViewport.size.x < 0.0 ||
-        nextViewport.size.y < 0.0 || nextViewport.devicePixelRatio <= 0.0 ||
-        !std::isfinite(nextPixelWidth) || !std::isfinite(nextPixelHeight) ||
-        nextPixelWidth > kMaximumPixelDimension || nextPixelHeight > kMaximumPixelDimension;
-    pixelWidth = invalidViewport ? 0 : static_cast<int>(nextPixelWidth);
-    pixelHeight = invalidViewport ? 0 : static_cast<int>(nextPixelHeight);
+    const Vector2i pixelSize = CheckedViewportPixels(nextViewport).value_or(Vector2i::Zero());
+    pixelWidth = pixelSize.x;
+    pixelHeight = pixelSize.y;
     deviceFromLocalTransform = Transform2d();
     deviceFromLocalTransformStack.clear();
     paint = PaintParams();

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -4304,6 +4304,22 @@ void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
   impl_->glyphCacheMaxRetainedBytes = maxRetainedBytes;
 }
 
+void RendererGeode::setGeometryBudgetForTesting(std::size_t /*maximumDraws*/,
+                                                std::size_t /*maximumItems*/,
+                                                std::uint64_t /*maximumFrameBytes*/,
+                                                std::uint64_t /*maximumCacheBytes*/,
+                                                std::uint64_t /*maximumResidentBytes*/) {}
+
+void RendererGeode::setSurfaceBudgetForTesting(std::size_t /*maximumSurfaces*/,
+                                               std::uint64_t /*maximumBytes*/) {}
+
+void RendererGeode::setTextMaterializationBudgetForTesting(
+    RendererTextMaterializationBudget::Cost /*limits*/, std::size_t /*maximumGlyphOccurrences*/) {}
+
+RendererResourceStats RendererGeode::resourceStats() const {
+  return {};
+}
+
 size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
   if (!impl_->device) {
     return 0;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2893,15 +2893,17 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
         if (cursor.component->reserveOccurrence(documentBudget)) {
           geode::GeodeRecordSlab::Slot slot;
           if (cursor.component->recordSlab->allocateSlot(*device, slot)) {
-            occurrences.push_back(geode::GeodeTextInstanceRecordComponent::Occurrence{slot, {}});
+            if (!cursor.component->appendReservedOccurrence(slot)) {
+              cursor.component->recordSlab->freeSlot(slot);
+            }
           } else {
             cursor.component->rollbackOccurrence();
           }
         }
       }
       if (cursor.next < occurrences.size()) {
-        outSlot = &occurrences[cursor.next].slot;
-        outCache = &occurrences[cursor.next].lastRecord;
+        outSlot = &occurrences[cursor.next]->slot;
+        outCache = &occurrences[cursor.next]->lastRecord;
         ++cursor.next;
         return;
       }

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -25,6 +25,7 @@
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/components/layout/TransformComponent.h"
@@ -48,6 +49,7 @@
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
+#include "donner/svg/renderer/geode/GeodeResourceBudget.h"
 #include "donner/svg/renderer/geode/GeodeStrokeTolerance.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/resources/ImageResource.h"
@@ -55,6 +57,7 @@
 #include "donner/base/MathUtils.h"
 #include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/renderer/PlacedTextGeometry.h"
+#include "donner/svg/resources/FontManager.h"
 #include "donner/svg/text/TextEngine.h"
 #include "donner/svg/text/TextLayoutParams.h"
 #endif
@@ -171,6 +174,32 @@ TextLayoutParams toTextLayoutParams(const TextParams& params) {
   layoutParams.lengthAdjust = params.lengthAdjust;
   layoutParams.inlineSizePx = params.inlineSizePx;
   return layoutParams;
+}
+
+std::optional<RendererTextMaterializationBudget::Cost> GlyphPredecodeCost(
+    const FontManager::GlyphOutlineComplexity& complexity) {
+  constexpr std::size_t kCommandCopiesPerVertex = 6;
+  constexpr std::size_t kPointCopiesPerVertex = 9;
+  if (complexity.maximumVertices >
+      std::numeric_limits<std::size_t>::max() / kPointCopiesPerVertex) {
+    return std::nullopt;
+  }
+  const std::size_t commands = complexity.maximumVertices * kCommandCopiesPerVertex;
+  const std::size_t points = complexity.maximumVertices * kPointCopiesPerVertex;
+  if (commands > std::numeric_limits<std::size_t>::max() / sizeof(Path::Command) ||
+      points > std::numeric_limits<std::size_t>::max() / sizeof(Vector2d)) {
+    return std::nullopt;
+  }
+  const std::size_t commandBytes = commands * sizeof(Path::Command);
+  const std::size_t pointBytes = points * sizeof(Vector2d);
+  if (pointBytes > std::numeric_limits<std::size_t>::max() - commandBytes) {
+    return std::nullopt;
+  }
+  return RendererTextMaterializationBudget::Cost{.uniqueOutlines = 1,
+                                                 .commands = commands,
+                                                 .points = points,
+                                                 .bytes = commandBytes + pointBytes,
+                                                 .decodeWork = complexity.work};
 }
 #endif
 
@@ -1241,6 +1270,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget =
       std::make_shared<components::FilterExecutionBudget>();
   bool ownsFilterExecutionBudget = true;
+  std::shared_ptr<geode::GeodeFrameGeometryBudget> geometryBudget =
+      std::make_shared<geode::GeodeFrameGeometryBudget>();
+  bool ownsGeometryBudget = true;
+  std::shared_ptr<RendererSurfaceBudget> surfaceBudget = std::make_shared<RendererSurfaceBudget>();
+  bool ownsSurfaceBudget = true;
+  std::shared_ptr<RendererTextMaterializationBudget> textMaterializationBudget =
+      std::make_shared<RendererTextMaterializationBudget>();
+  bool ownsTextMaterializationBudget = true;
+  std::shared_ptr<geode::GeodeDocumentGeometryBudget::Limits> documentGeometryLimits =
+      std::make_shared<geode::GeodeDocumentGeometryBudget::Limits>();
+  std::shared_ptr<std::weak_ptr<geode::GeodeDocumentGeometryBudget>> lastDocumentGeometryBudget =
+      std::make_shared<std::weak_ptr<geode::GeodeDocumentGeometryBudget>>();
 
   // GPU resources. Created in the constructor; if device creation fails,
   // `device` is null and the renderer enters a no-op state.
@@ -1459,11 +1500,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     frameGenerationOpen = false;
   }
 
+  [[nodiscard]] bool reserveTextureSurface(const wgpu::TextureDescriptor& desc) {
+    if (!device || desc.size.width > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        desc.size.height > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        !surfaceBudget->reserve(static_cast<int>(desc.size.width),
+                                static_cast<int>(desc.size.height),
+                                static_cast<std::size_t>(desc.size.depthOrArrayLayers))) {
+      return false;
+    }
+    return true;
+  }
+
   /// Acquire a pooled texture matching `desc`, or create a fresh one
   /// on miss. Always increments the `textureCreates` counter on miss;
   /// never on hit. Returns a null texture on device failure.
   wgpu::Texture acquireTexture(const wgpu::TextureDescriptor& desc) {
-    return texturePool && device ? texturePool->acquire(*device, desc) : wgpu::Texture{};
+    if (!texturePool || !reserveTextureSurface(desc)) {
+      return wgpu::Texture{};
+    }
+    return texturePool->acquire(*device, desc);
   }
 
   wgpu::Texture acquireFilterTexture(const wgpu::TextureDescriptor& desc) override {
@@ -2531,6 +2586,19 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// to live on (e.g. `drawRect` / `drawEllipse` convenience draws). Only
   /// one active draw at a time, so a single slot is safe.
   Path strokeScratchPath;
+  std::optional<geode::EncodedPath> fillScratchEncode;
+  std::optional<geode::EncodedPath> strokeScratchEncode;
+  geode::EncodedPath rejectedGeometry = [] {
+    geode::EncodedPath encoded;
+    encoded.outcome = geode::EncodedPath::Outcome::Rejected;
+    return encoded;
+  }();
+  std::deque<geode::EncodedPath> transientTextEncodes;
+
+  struct AdmittedEncode {
+    const geode::EncodedPath* encoded = nullptr;
+    bool persistent = false;
+  };
 
   /// Value returned by `getFillEncode` / `getStrokeDerived` describing
   /// which encode the caller should pass down to `GeoEncoder`.
@@ -2543,27 +2611,74 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     /// the stroke came from a cache slot - the no-entity fallback
     /// leaves this null and lets `GeoEncoder` encode inline.
     const geode::EncodedPath* encoded = nullptr;
+    /// True when both `strokedPath` and `encoded` live in the entity cache.
+    bool persistent = false;
     /// Fill rule to use. For open-path strokes, `strokeToFill` emits one
     /// subpath → NonZero; for closed-path strokes, two → EvenOdd.
     FillRule fillRule = FillRule::NonZero;
   };
 
-  /// Encode-side of the cache. If `source` holds a valid entity handle,
-  /// installs / reuses a `GeodePathCacheComponent::fillEncode` on it and
-  /// returns a stable pointer into that component. If `source` is null
-  /// (non-driver callers), returns null and `GeoEncoder` will encode
-  /// inline - the old pre-cache code path.
-  const geode::EncodedPath* getFillEncode(EntityHandle source, const Path& path, FillRule rule) {
+  [[nodiscard]] bool reserveEncodedGeometry(const geode::EncodedPath& encoded) {
+    if (encoded.rejected()) {
+      geometryBudget->reject();
+      return false;
+    }
+    const std::size_t retainedBytes = encoded.retainedBytes();
+    if (retainedBytes == std::numeric_limits<std::size_t>::max()) {
+      geometryBudget->reject();
+      return false;
+    }
+    return geometryBudget->reserve(encoded.geometryItemCount(), retainedBytes);
+  }
+
+  std::optional<geode::EncodedPath> encodeGeometry(const Path& path, FillRule rule) {
+    if (geometryBudget->rejected()) {
+      return std::nullopt;
+    }
+    device->countPathEncode();
+    geode::EncodedPath encoded = geode::GeodePathEncoder::encode(path, rule);
+    if (!reserveEncodedGeometry(encoded)) {
+      return std::nullopt;
+    }
+    return encoded;
+  }
+
+  const geode::EncodedPath* encodeTransientGeometry(const Path& path, FillRule rule) {
+    std::optional<geode::EncodedPath> encoded = encodeGeometry(path, rule);
+    if (!encoded.has_value()) {
+      return &rejectedGeometry;
+    }
+    transientTextEncodes.push_back(std::move(*encoded));
+    return &transientTextEncodes.back();
+  }
+
+  /// Encode-side of the cache. Every path is admitted before insertion or transient upload.
+  AdmittedEncode getFillEncode(EntityHandle source, const Path& path, FillRule rule) {
     if (!source) {
-      return nullptr;
+      fillScratchEncode = encodeGeometry(path, rule);
+      return {fillScratchEncode ? &*fillScratchEncode : &rejectedGeometry, false};
     }
     ensureCacheInvalidationWired(*source.registry());
     auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
-    if (!cache.fillEncode) {
-      device->countPathEncode();
-      cache.fillEncode = geode::GeodePathEncoder::encode(path, rule);
+    if (cache.fillEncode) {
+      return reserveEncodedGeometry(*cache.fillEncode) ? AdmittedEncode{&*cache.fillEncode, true}
+                                                       : AdmittedEncode{&rejectedGeometry, false};
     }
-    return &*cache.fillEncode;
+
+    std::optional<geode::EncodedPath> encoded = encodeGeometry(path, rule);
+    if (!encoded.has_value()) {
+      return {&rejectedGeometry, false};
+    }
+    const std::size_t retainedBytes = encoded->retainedBytes();
+    std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+        documentGeometryBudget(*source.registry());
+    if (retainedBytes != std::numeric_limits<std::size_t>::max() &&
+        cache.fillReservation.replace(documentBudget, retainedBytes)) {
+      cache.fillEncode = std::move(*encoded);
+      return {&*cache.fillEncode, true};
+    }
+    fillScratchEncode = std::move(*encoded);
+    return {&*fillScratchEncode, false};
   }
 
   /// GPU-residence slot for `source`'s fill encode. Returns null for a null
@@ -2586,7 +2701,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     std::shared_ptr<geode::GeodeRecordSlab>& slab = *slabPtr;
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
-      slab = std::make_shared<geode::GeodeRecordSlab>(device->deviceId());
+      slab = std::make_shared<geode::GeodeRecordSlab>(device->deviceId(),
+                                                      documentGeometryBudget(registry));
     }
     return slab;
   }
@@ -2738,15 +2854,55 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// whose outline comes back empty (a glyph the font has no vector outline
   /// for) is still cached, so that miss also costs one backend call per
   /// document rather than one per occurrence per frame.
+#ifdef DONNER_TEXT_ENABLED
+  void admitTextRuns(std::vector<TextRun>& runs) {
+    std::size_t glyphOccurrences = 0;
+    for (const TextRun& run : runs) {
+      if (run.glyphs.size() > std::numeric_limits<std::size_t>::max() - glyphOccurrences) {
+        textMaterializationBudget->reject();
+        runs.clear();
+        return;
+      }
+      glyphOccurrences += run.glyphs.size();
+    }
+    if (!textMaterializationBudget->reserveGlyphOccurrences(glyphOccurrences)) {
+      runs.clear();
+    }
+  }
+
+  Path materializePlacedGlyph(const Path& outline, const Transform2d& glyphFromLocal) {
+    if (!textMaterializationBudget->reservePathCopy(outline)) {
+      return Path();
+    }
+    return TransformPath(outline, glyphFromLocal);
+  }
+
   template <typename BuildOutlineFn>
-  geode::GeodeGlyphResidentEntry* residentGlyphEntry(Registry& registry,
+  geode::GeodeGlyphResidentEntry* residentGlyphEntry(Registry& registry, FontManager& fontManager,
+                                                     FontHandle font, int glyphIndex,
                                                      const geode::GlyphGeometryKey& key,
                                                      BuildOutlineFn&& buildOutline) {
+    if (textMaterializationBudget->rejected()) {
+      return nullptr;
+    }
     std::shared_ptr<geode::GeodeGlyphCache> cache = glyphCache(registry);
     geode::GeodeGlyphResidentEntry* entry = cache->find(key);
     if (entry != nullptr) {
       device->countGlyphResidencyHit();
     } else {
+      const std::optional<FontManager::GlyphOutlineComplexity> complexity =
+          fontManager.glyphOutlineComplexity(font, glyphIndex);
+      if (complexity.has_value()) {
+        const std::optional<RendererTextMaterializationBudget::Cost> cost =
+            GlyphPredecodeCost(*complexity);
+        if (!cost.has_value() || !textMaterializationBudget->reserve(*cost)) {
+          return nullptr;
+        }
+      } else if (!fontManager.isTrustedFont(font)) {
+        textMaterializationBudget->reject();
+        return nullptr;
+      }
+
       // Admission has to happen before outline decoding and before insertion. The frame-start
       // trim cannot bound a cache that begins below its limit and creates a large working set in
       // one frame; entries touched by that open frame are intentionally ineligible for eviction.
@@ -2763,10 +2919,23 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         }
       }
       Path outline = buildOutline();
+      if (!complexity.has_value() && !outline.empty()) {
+        const std::optional<std::size_t> retainedBytes = outline.retainedBytes();
+        if (!retainedBytes.has_value() ||
+            !textMaterializationBudget->reserve({.uniqueOutlines = 1,
+                                                 .commands = outline.commands().size(),
+                                                 .points = outline.points().size(),
+                                                 .bytes = *retainedBytes})) {
+          return nullptr;
+        }
+      }
       geode::EncodedPath encoded;
       if (!outline.empty()) {
-        device->countPathEncode();
-        encoded = geode::GeodePathEncoder::encode(outline, FillRule::NonZero);
+        std::optional<geode::EncodedPath> admitted = encodeGeometry(outline, FillRule::NonZero);
+        if (!admitted.has_value()) {
+          return nullptr;
+        }
+        encoded = std::move(*admitted);
       }
       if (cacheAdmissionAvailable) {
         size_t evicted = 0;
@@ -2801,6 +2970,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     return entry;
   }
+#endif
 
   /// Draw one glyph occurrence over shared resident geometry.
   ///
@@ -2890,6 +3060,23 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return true;
   }
 
+  std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentGeometryBudget(Registry& registry) {
+    auto* budgetPtr = registry.ctx().find<std::shared_ptr<geode::GeodeDocumentGeometryBudget>>();
+    if (budgetPtr == nullptr) {
+      std::shared_ptr<components::DocumentResourceFamilyBudget> family;
+      if (const auto* context = registry.ctx().find<components::DocumentResourceFamilyContext>()) {
+        family = context->budget;
+      }
+      registry.ctx().emplace<std::shared_ptr<geode::GeodeDocumentGeometryBudget>>(
+          std::make_shared<geode::GeodeDocumentGeometryBudget>(std::move(family)));
+      budgetPtr = registry.ctx().find<std::shared_ptr<geode::GeodeDocumentGeometryBudget>>();
+    }
+    std::shared_ptr<geode::GeodeDocumentGeometryBudget> budget = *budgetPtr;
+    budget->setLimitsForTesting(*documentGeometryLimits);
+    *lastDocumentGeometryBudget = budget;
+    return budget;
+  }
+
   std::shared_ptr<geode::GeodeResidentSlab> residentSlab(Registry& registry) {
     auto* slabPtr = registry.ctx().find<std::shared_ptr<geode::GeodeResidentSlab>>();
     if (slabPtr == nullptr) {
@@ -2898,7 +3085,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     }
     std::shared_ptr<geode::GeodeResidentSlab>& slab = *slabPtr;
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
-      slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId());
+      slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId(),
+                                                        documentGeometryBudget(registry));
     }
     // Merge the previous frame's freed ranges, at most once per frame (the
     // slab gates on the index). Gating here rather than at one draw entry
@@ -3591,29 +3779,63 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (source) {
       ensureCacheInvalidationWired(*source.registry());
       auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
-      if (!cache.strokeSlot || cache.strokeSlot->strokeKey != strokeStyle ||
-          cache.strokeSlot->flattenTolerance != flattenTolerance) {
+      if (cache.strokeSlot && cache.strokeSlot->strokeKey == strokeStyle &&
+          cache.strokeSlot->flattenTolerance == flattenTolerance) {
+        if (!reserveEncodedGeometry(cache.strokeSlot->strokedEncode)) {
+          return result;
+        }
+        result.strokedPath = &cache.strokeSlot->strokedPath;
+        result.encoded = &cache.strokeSlot->strokedEncode;
+        result.persistent = true;
+        result.fillRule = cache.strokeSlot->strokeFillRule;
+        return result;
+      }
+
+      {
         // Miss (or stroke-params / device-scale changed) - rebuild. De-close
         // zero-area closed subpaths first (see `deCloseZeroAreaSubpaths`) so a
         // degenerate `M L Z` line strokes into a clean rectangle the analytic
         // shader covers correctly, instead of overlapping triangles.
-        // Drop the stale GPU residence FIRST, unconditionally for every
-        // exit of this miss branch: the encode is about to be replaced in
-        // place (or destroyed, in the empty-outline case below) without
-        // removing the entity's components, so the entt listener does not
-        // fire, and a resident slot keyed on the old encode storage would
-        // keep a dangling encodedKey plus a retained slab range. The
-        // GeoEncoder fingerprint guard is a second line of defense; this
-        // keeps the invariant obvious at the single mutation site.
-        //
-        // Drain the pending batch first when it still refers to THIS outline.
-        // Both the cached encode and the residence built from it are about to
-        // be replaced: the encode's storage is reused for the new outline, and
-        // resetting the residence lets the flush-time re-ensure land the
-        // geometry in a different slab chunk than the one the batch captured.
-        // Either way an appended-but-unflushed instance would draw the wrong
-        // shape. A run of DIFFERENT elements' strokes is untouched, so the
-        // ordinary first sight of a stroke does not break up a batch.
+        Path stroked =
+            deCloseZeroAreaSubpaths(geometry).strokeToFill(strokeStyle, flattenTolerance);
+        if (stroked.empty()) {
+          if (cache.strokeSlot.has_value() &&
+              pendingBatchReferences(&cache.strokeSlot->strokedEncode)) {
+            flushPendingBatch();
+          }
+          if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
+            resident->strokeSlot.reset();
+            resident->gradientStrokeSlot.reset();
+          }
+          cache.strokeReservation.reset();
+          cache.strokeSlot.reset();
+          return result;  // strokedPath stays null.
+        }
+        countStrokeOutline(stroked);
+        const FillRule fillRule = strokeFillRuleFor(stroked, strokeStyle);
+        std::optional<geode::EncodedPath> encoded = encodeGeometry(stroked, fillRule);
+        if (!encoded.has_value()) {
+          return result;
+        }
+        const std::optional<std::size_t> strokedBytes = stroked.retainedBytes();
+        const std::size_t encodedBytes = encoded->retainedBytes();
+        const bool retainedBytesValid =
+            strokedBytes.has_value() && encodedBytes != std::numeric_limits<std::size_t>::max() &&
+            *strokedBytes <= std::numeric_limits<std::size_t>::max() - encodedBytes;
+        const std::size_t retainedBytes = retainedBytesValid
+                                              ? *strokedBytes + encodedBytes
+                                              : std::numeric_limits<std::size_t>::max();
+        std::shared_ptr<geode::GeodeDocumentGeometryBudget> documentBudget =
+            documentGeometryBudget(*source.registry());
+        if (!retainedBytesValid ||
+            !cache.strokeReservation.replace(documentBudget, retainedBytes)) {
+          strokeScratchPath = std::move(stroked);
+          strokeScratchEncode = std::move(*encoded);
+          result.strokedPath = &strokeScratchPath;
+          result.encoded = &*strokeScratchEncode;
+          result.fillRule = fillRule;
+          return result;
+        }
         if (cache.strokeSlot.has_value() &&
             pendingBatchReferences(&cache.strokeSlot->strokedEncode)) {
           flushPendingBatch();
@@ -3622,16 +3844,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           resident->strokeSlot.reset();
           resident->gradientStrokeSlot.reset();
         }
-        Path stroked =
-            deCloseZeroAreaSubpaths(geometry).strokeToFill(strokeStyle, flattenTolerance);
-        if (stroked.empty()) {
-          cache.strokeSlot.reset();
-          return result;  // strokedPath stays null.
-        }
-        countStrokeOutline(stroked);
-        const FillRule fillRule = strokeFillRuleFor(stroked, strokeStyle);
-        device->countPathEncode();
-        geode::EncodedPath encoded = geode::GeodePathEncoder::encode(stroked, fillRule);
         // GCC 14 libstdc++ rejects `.emplace()` here with "is_constructible_v<StrokeSlot> was not
         // satisfied"; clang + libc++ accepts it. Build the value explicitly and assign to sidestep
         // the toolchain disagreement.
@@ -3639,17 +3851,17 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             .strokeKey = strokeStyle,
             .flattenTolerance = flattenTolerance,
             .strokedPath = std::move(stroked),
-            .strokedEncode = std::move(encoded),
+            .strokedEncode = std::move(*encoded),
             .strokeFillRule = fillRule,
         };
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;
+      result.persistent = true;
       result.fillRule = cache.strokeSlot->strokeFillRule;
       return result;
     }
-    // No-entity fallback: compute into the Impl-local scratch buffer.
-    // GeoEncoder will encode inline when `encoded` is left null.
+    // No-entity fallback: compute and admit into Impl-local scratch buffers.
     strokeScratchPath =
         deCloseZeroAreaSubpaths(geometry).strokeToFill(strokeStyle, flattenTolerance);
     if (strokeScratchPath.empty()) {
@@ -3658,6 +3870,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     countStrokeOutline(strokeScratchPath);
     result.strokedPath = &strokeScratchPath;
     result.fillRule = strokeFillRuleFor(strokeScratchPath, strokeStyle);
+    strokeScratchEncode = encodeGeometry(strokeScratchPath, result.fillRule);
+    if (!strokeScratchEncode.has_value()) {
+      return {};
+    }
+    result.encoded = &*strokeScratchEncode;
     return result;
   }
 
@@ -3901,6 +4118,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (ownsFilterExecutionBudget) {
       filterExecutionBudget->reset();
     }
+    if (ownsGeometryBudget) {
+      geometryBudget->reset();
+    }
+    if (ownsSurfaceBudget) {
+      surfaceBudget->reset();
+    }
+    if (ownsTextMaterializationBudget) {
+      textMaterializationBudget->reset();
+    }
     if (device) {
       device->filterEngine().beginFrame();
     }
@@ -3917,6 +4143,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     lastDrawSourceEntity = entt::null;
     pendingBatch.reset();
     transientGlyphEntries.clear();
+    transientTextEncodes.clear();
     counters.reset();
   }
 
@@ -3929,10 +4156,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     device->setCounters(&counters);
     if (hostTarget) {
       retireOwnedTargetAtFrameBoundary();
+      if (hostTarget.getWidth() > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+          hostTarget.getHeight() > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+        (void)surfaceBudget->reserve(-1, -1);
+        target = wgpu::Texture();
+        return false;
+      }
       pixelWidth = static_cast<int>(hostTarget.getWidth());
       pixelHeight = static_cast<int>(hostTarget.getHeight());
+      if (!surfaceBudget->reserve(pixelWidth, pixelHeight)) {
+        target = wgpu::Texture();
+        return false;
+      }
       target = hostTarget;
       return true;
+    }
+
+    if (!surfaceBudget->reserve(pixelWidth, pixelHeight)) {
+      target = wgpu::Texture();
+      return false;
     }
 
     const bool canReuseTargets =
@@ -4304,20 +4546,73 @@ void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
   impl_->glyphCacheMaxRetainedBytes = maxRetainedBytes;
 }
 
-void RendererGeode::setGeometryBudgetForTesting(std::size_t /*maximumDraws*/,
-                                                std::size_t /*maximumItems*/,
-                                                std::uint64_t /*maximumFrameBytes*/,
-                                                std::uint64_t /*maximumCacheBytes*/,
-                                                std::uint64_t /*maximumResidentBytes*/) {}
+void RendererGeode::setGeometryBudgetForTesting(std::size_t maximumDraws, std::size_t maximumItems,
+                                                std::uint64_t maximumFrameBytes,
+                                                std::uint64_t maximumCacheBytes,
+                                                std::uint64_t maximumResidentBytes) {
+  impl_->geometryBudget->setLimitsForTesting(
+      {.draws = maximumDraws, .items = maximumItems, .retainedBytes = maximumFrameBytes});
+  impl_->documentGeometryLimits->cacheBytes =
+      std::min(impl_->documentGeometryLimits->cacheBytes, maximumCacheBytes);
+  impl_->documentGeometryLimits->residentBytes =
+      std::min(impl_->documentGeometryLimits->residentBytes, maximumResidentBytes);
+  if (std::shared_ptr<geode::GeodeDocumentGeometryBudget> document =
+          impl_->lastDocumentGeometryBudget->lock()) {
+    document->setLimitsForTesting(*impl_->documentGeometryLimits);
+  }
+}
 
-void RendererGeode::setSurfaceBudgetForTesting(std::size_t /*maximumSurfaces*/,
-                                               std::uint64_t /*maximumBytes*/) {}
+void RendererGeode::setSurfaceBudgetForTesting(std::size_t maximumSurfaces,
+                                               std::uint64_t maximumBytes) {
+  impl_->surfaceBudget->setLimitsForTesting({.bytes = maximumBytes, .surfaces = maximumSurfaces});
+}
 
 void RendererGeode::setTextMaterializationBudgetForTesting(
-    RendererTextMaterializationBudget::Cost /*limits*/, std::size_t /*maximumGlyphOccurrences*/) {}
+    RendererTextMaterializationBudget::Cost limits, std::size_t maximumGlyphOccurrences) {
+  impl_->textMaterializationBudget->setLimitsForTesting(limits);
+  impl_->textMaterializationBudget->setGlyphOccurrenceLimitForTesting(maximumGlyphOccurrences);
+}
 
 RendererResourceStats RendererGeode::resourceStats() const {
-  return {};
+  std::shared_ptr<geode::GeodeDocumentGeometryBudget> document =
+      impl_->lastDocumentGeometryBudget->lock();
+  const std::uint64_t documentBytes =
+      document ? document->cacheBytes() + document->residentBytes() : 0;
+  const std::uint64_t geometryBytes = impl_->geometryBudget->retainedBytes();
+  const std::uint64_t totalGeometryBytes =
+      documentBytes > std::numeric_limits<std::uint64_t>::max() - geometryBytes
+          ? std::numeric_limits<std::uint64_t>::max()
+          : documentBytes + geometryBytes;
+  const std::size_t reportedGeometryBytes =
+      totalGeometryBytes > std::numeric_limits<std::size_t>::max()
+          ? std::numeric_limits<std::size_t>::max()
+          : static_cast<std::size_t>(totalGeometryBytes);
+  return {
+      .filterBudgetSupported = true,
+      .filterExecutions = impl_->filterExecutionBudget->executions(),
+      .filterWorkUnits = impl_->filterExecutionBudget->workUnits(),
+      .filterRetainedBytes = impl_->filterExecutionBudget->retainedBytes(),
+      .filterCaptureBytesReserved = impl_->filterExecutionBudget->captureBytesReserved(),
+      .filterBudgetRejected = impl_->filterExecutionBudget->rejected(),
+      .geometryBudgetSupported = true,
+      .geometryDraws = impl_->geometryBudget->draws(),
+      .geometryItems = impl_->geometryBudget->items(),
+      .geometryRetainedBytes = reportedGeometryBytes,
+      .geometryBudgetRejected =
+          impl_->geometryBudget->rejected() || (document && document->rejected()),
+      .surfaceBudgetSupported = true,
+      .surfaceCount = impl_->surfaceBudget->surfaces(),
+      .surfaceBytes = impl_->surfaceBudget->bytes(),
+      .surfaceBudgetRejected = impl_->surfaceBudget->rejected(),
+      .textMaterializationBudgetSupported = true,
+      .textUniqueOutlines = impl_->textMaterializationBudget->uniqueOutlines(),
+      .textMaterializationCommands = impl_->textMaterializationBudget->commands(),
+      .textMaterializationPoints = impl_->textMaterializationBudget->points(),
+      .textMaterializationBytes = impl_->textMaterializationBudget->bytes(),
+      .textGlyphDecodeWork = impl_->textMaterializationBudget->decodeWork(),
+      .textGlyphOccurrences = impl_->textMaterializationBudget->glyphOccurrences(),
+      .textMaterializationBudgetRejected = impl_->textMaterializationBudget->rejected(),
+  };
 }
 
 size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
@@ -5108,6 +5403,9 @@ bool RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
+  if (!impl_->reserveTextureSurface(td)) {
+    return false;
+  }
   geode::ScopedWgpuHandle<wgpu::Texture> tileTexture(impl_->device->device().createTexture(td));
   impl_->device->countTexture();
   if (!tileTexture) {
@@ -5324,8 +5622,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // Path-encode cache lookup for the fill. Null `sourceEntity` (editor
   // overlay, test-harness direct draws) returns nullptr and `GeoEncoder`
   // falls back to the inline encode path.
-  const geode::EncodedPath* fillEncoded =
+  const Impl::AdmittedEncode fillAdmission =
       impl_->getFillEncode(path.sourceEntity, drawPathGeometry, path.fillRule);
+  const geode::EncodedPath* fillEncoded = fillAdmission.encoded;
 
   // Try to append to a pending batch. Preconditions:
   //  - Source entity valid (non-null handle).
@@ -5356,7 +5655,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   const bool solidFill = std::holds_alternative<PaintServer::Solid>(impl_->paint.fill);
   const bool referenceFill =
       std::holds_alternative<components::PaintResolvedReference>(impl_->paint.fill);
-  const bool fillShapeBatchable = fillEncoded != nullptr &&
+  const bool fillShapeBatchable = fillAdmission.persistent &&
                                   path.sourceEntity.entity() != entt::null &&
                                   !impl_->patternFillPaint.has_value() &&
                                   impl_->encoder != nullptr && impl_->paint.drawFillComponent;
@@ -5390,7 +5689,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // solid fill re-uploads zero geometry on an unchanged frame however it
   // ends up being drawn.
   geode::GeodeResidentSlot* residentFill =
-      (fillEncoded != nullptr && (solidFill || gradientFillBatchable))
+      (fillAdmission.persistent && (solidFill || gradientFillBatchable))
           ? impl_->residentFillSlot(path.sourceEntity)
           : nullptr;
 
@@ -5399,8 +5698,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // pass through here and simply never use the slot (the resident
   // gradient methods only run for resolved gradients).
   geode::GeodeResidentGradientSlot* residentGradientFill =
-      (fillEncoded != nullptr && referenceFill) ? impl_->residentGradientFillSlot(path.sourceEntity)
-                                                : nullptr;
+      (fillAdmission.persistent && referenceFill)
+          ? impl_->residentGradientFillSlot(path.sourceEntity)
+          : nullptr;
 
   bool fillAbsorbed = false;
   if (fillBatchable) {
@@ -5514,14 +5814,14 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // GPU residence for solid strokes (the stroked outline is a solid
   // fill of the cached stroke encode).
   geode::GeodeResidentSlot* residentStroke =
-      (strokeDerived.encoded != nullptr && std::holds_alternative<PaintServer::Solid>(strokeServer))
+      (strokeDerived.persistent && std::holds_alternative<PaintServer::Solid>(strokeServer))
           ? impl_->residentStrokeSlot(path.sourceEntity)
           : nullptr;
   // Gradient residence for gradient-painted strokes: the cached
   // stroke-outline encode lives in a gradient slot so an unchanged outline
   // with an unchanged resolved gradient re-uploads zero geometry.
   geode::GeodeResidentGradientSlot* residentGradientStroke =
-      (strokeDerived.encoded != nullptr &&
+      (strokeDerived.persistent &&
        std::holds_alternative<components::PaintResolvedReference>(strokeServer))
           ? impl_->residentGradientStrokeSlot(path.sourceEntity)
           : nullptr;
@@ -5537,7 +5837,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // entity's `GeodePathCacheComponent::strokeSlot`, which is only replaced by
   // a `getStrokeDerived` miss on this same entity, and the pending batch is
   // always flushed within the frame that started it.
-  if (kEnableSceneBatching && residentStroke != nullptr && strokeDerived.encoded != nullptr &&
+  if (kEnableSceneBatching && residentStroke != nullptr && strokeDerived.persistent &&
       path.sourceEntity.entity() != entt::null && !impl_->patternStrokePaint.has_value()) {
     const auto& solidStroke = std::get<PaintServer::Solid>(strokeServer);
     geode::GeoEncoder::ScenePaint strokePaint;
@@ -5646,6 +5946,7 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
   }
 
   auto& textEngine = registry.ctx().get<TextEngine>();
+  auto& fontManager = registry.ctx().get<FontManager>();
 
   // Use cached layout runs from `ComputedTextGeometryComponent` when
   // available; otherwise lay out fresh via the engine. This matches
@@ -5661,6 +5962,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
     const TextLayoutParams layoutParams = toTextLayoutParams(params);
     runs = textEngine.layout(text, layoutParams);
   }
+
+  impl_->admitTextRuns(runs);
 
   const float textFontSizePx = static_cast<float>(
       params.fontSize.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::Mixed));
@@ -5902,8 +6205,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       key.stretchScaleY = glyph.stretchScaleY;
       key.rotateDegrees = glyph.rotateDegrees;
 
-      geode::GeodeGlyphResidentEntry* entry =
-          impl_->residentGlyphEntry(registry, key, [&]() -> Path {
+      geode::GeodeGlyphResidentEntry* entry = impl_->residentGlyphEntry(
+          registry, fontManager, run.font, glyph.glyphIndex, key, [&]() -> Path {
             return UnplacedGlyphOutline(textEngine, run.font, glyph, scale).outline;
           });
       if (entry == nullptr || entry->outline.empty()) {
@@ -5913,7 +6216,7 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       const Transform2d glyphFromLocal = GlyphPlacementTransform(glyph);
       runGlyphOccurrences.push_back(RunGlyphOccurrence{entry, glyphFromLocal});
       if (needPlacedGlyphPaths) {
-        runGlyphPaths.push_back(TransformPath(entry->outline, glyphFromLocal));
+        runGlyphPaths.push_back(impl_->materializePlacedGlyph(entry->outline, glyphFromLocal));
       }
     }
 
@@ -5946,11 +6249,15 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       }
       for (const Path& placed : runGlyphPaths) {
         if (fillIsGradient) {
+          const geode::EncodedPath* encoded =
+              impl_->encodeTransientGeometry(placed, FillRule::NonZero);
           // Gradient fill on text: resolve the gradient against the text bbox
           // (the gradient *geometry*), fill the glyph outline (the *draw* path).
           impl_->drawPaintedPathAgainst(textBoundsPath, placed, fillServer, fillOpacity,
-                                        FillRule::NonZero);
+                                        FillRule::NonZero, encoded);
         } else if (usePatternFill) {
+          const geode::EncodedPath* encoded =
+              impl_->encodeTransientGeometry(placed, FillRule::NonZero);
           // Fill the glyph outline with the staged pattern tile, same as a
           // pattern-filled `<path>` (see Impl::fillResolved). The glyph path is
           // already in the element's local space and `deviceFromLocalTransform`
@@ -5958,7 +6265,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
           impl_->syncTransform();
           impl_->encoder->fillPathPattern(
               placed, FillRule::NonZero,
-              impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity));
+              impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity),
+              encoded);
         }
       }
     };
@@ -5976,18 +6284,19 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
           if (!stroked.empty()) {
             impl_->countStrokeOutline(stroked);
             const FillRule strokeRule = Impl::strokeFillRuleFor(stroked, *strokeStyle);
+            const geode::EncodedPath* encoded = impl_->encodeTransientGeometry(stroked, strokeRule);
             if (strokeIsGradient) {
               // Gradient stroke: resolve against the text bbox (the *original*
               // geometry, per SVG), fill the stroked outline.
               impl_->drawPaintedPathAgainst(textBoundsPath, stroked, *strokeServer, strokeOpacity,
-                                            strokeRule);
+                                            strokeRule, encoded);
             } else if (usePatternStroke) {
               impl_->syncTransform();
               impl_->encoder->fillPathPattern(
                   stroked, strokeRule,
-                  impl_->buildPatternPaint(*impl_->patternStrokePaint, strokeOpacity));
+                  impl_->buildPatternPaint(*impl_->patternStrokePaint, strokeOpacity), encoded);
             } else {
-              impl_->encoder->fillPath(stroked, *strokeColor, strokeRule);
+              impl_->encoder->fillPath(stroked, *strokeColor, strokeRule, encoded);
             }
           }
         }
@@ -6077,21 +6386,25 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
         if (path.empty()) {
           return;
         }
+        const geode::EncodedPath* encoded = impl_->encodeTransientGeometry(path, FillRule::NonZero);
         if (decoUsesPattern) {
           impl_->syncTransform();
           impl_->encoder->fillPathPattern(
               path, FillRule::NonZero,
-              impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity));
+              impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity),
+              encoded);
         } else if (decoFill.a != 0) {
-          impl_->encoder->fillPath(path, decoFill, FillRule::NonZero);
+          impl_->encoder->fillPath(path, decoFill, FillRule::NonZero, encoded);
         }
         if (decoStrokeColor.has_value()) {
           // Device-aware flattening, as in every other renderer-side stroke.
           const Path stroked = path.strokeToFill(*decoStrokeStyle, impl_->strokeFlattenTolerance());
           if (!stroked.empty()) {
             impl_->countStrokeOutline(stroked);
-            impl_->encoder->fillPath(stroked, *decoStrokeColor,
-                                     Impl::strokeFillRuleFor(stroked, *decoStrokeStyle));
+            const FillRule strokeRule = Impl::strokeFillRuleFor(stroked, *decoStrokeStyle);
+            const geode::EncodedPath* strokeEncoded =
+                impl_->encodeTransientGeometry(stroked, strokeRule);
+            impl_->encoder->fillPath(stroked, *decoStrokeColor, strokeRule, strokeEncoded);
           }
         }
       };
@@ -6256,6 +6569,14 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
       new RendererGeode(impl_->device, impl_->verbose, impl_->offscreenCreationHookForTesting));
   renderer->impl_->filterExecutionBudget = impl_->filterExecutionBudget;
   renderer->impl_->ownsFilterExecutionBudget = false;
+  renderer->impl_->geometryBudget = impl_->geometryBudget;
+  renderer->impl_->ownsGeometryBudget = false;
+  renderer->impl_->surfaceBudget = impl_->surfaceBudget;
+  renderer->impl_->ownsSurfaceBudget = false;
+  renderer->impl_->textMaterializationBudget = impl_->textMaterializationBudget;
+  renderer->impl_->ownsTextMaterializationBudget = false;
+  renderer->impl_->documentGeometryLimits = impl_->documentGeometryLimits;
+  renderer->impl_->lastDocumentGeometryBudget = impl_->lastDocumentGeometryBudget;
   return renderer;
 }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3689,9 +3689,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           // referenced by any batch).
           claimSceneSlot(*residentSlot, paint);
           flushPendingBatch();
-          if (!paint.isGradient()) {
-            encoder->releasePreparedSceneAdmission(*encoded);
-          }
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
                        chunk, recordBuf, chunkId, recordBufId, recordIndex,
                        effectiveRecordSlot.offset, clipVersion, current);
@@ -4614,6 +4611,13 @@ void RendererGeode::setTextMaterializationBudgetForTesting(
     RendererTextMaterializationBudget::Cost limits, std::size_t maximumGlyphOccurrences) {
   impl_->textMaterializationBudget->setLimitsForTesting(limits);
   impl_->textMaterializationBudget->setGlyphOccurrenceLimitForTesting(maximumGlyphOccurrences);
+}
+
+void RendererGeode::injectScenePreparationFailureAfterForTesting(
+    std::size_t successfulPreparations) {
+  if (impl_->encoder) {
+    impl_->encoder->injectScenePreparationFailureAfterForTesting(successfulPreparations);
+  }
 }
 
 RendererResourceStats RendererGeode::resourceStats() const {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2628,7 +2628,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       geometryBudget->reject();
       return false;
     }
-    return geometryBudget->reserve(encoded.geometryItemCount(), retainedBytes);
+    return geometryBudget->reserve(/*draws=*/1u, encoded.geometryItemCount(), retainedBytes);
   }
 
   std::optional<geode::EncodedPath> encodeGeometry(const Path& path, FillRule rule) {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -280,6 +280,8 @@ public:
   [[nodiscard]] int width() const override;
   [[nodiscard]] int height() const override;
 
+  void beginFrameResourceScope() override;
+  void endFrameResourceScope() override;
   void beginFrame(const RenderViewport& viewport) override;
   void endFrame() override;
 

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -414,9 +414,9 @@ public:
    * building a font-sized working set.
    *
    * @param maxEntries Distinct cached glyph outlines to keep.
-   * @param maxEncodedBytes Summed encode bytes to keep.
+   * @param maxRetainedBytes Summed outline and encode bytes to keep.
    */
-  void setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxEncodedBytes);
+  void setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxRetainedBytes);
 
   /// Number of glyph outlines currently resident for `document`.
   [[nodiscard]] size_t residentGlyphCountForTesting(SVGDocument& document);

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -418,6 +418,21 @@ public:
    */
   void setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxRetainedBytes);
 
+  /// Shrink the aggregate geometry budget for boundary tests.
+  void setGeometryBudgetForTesting(std::size_t maximumDraws, std::size_t maximumItems,
+                                   std::uint64_t maximumFrameBytes, std::uint64_t maximumCacheBytes,
+                                   std::uint64_t maximumResidentBytes);
+
+  /// Shrink the aggregate frame-surface budget for boundary tests.
+  void setSurfaceBudgetForTesting(std::size_t maximumSurfaces, std::uint64_t maximumBytes);
+
+  /// Shrink the aggregate text-materialization budget for boundary tests.
+  void setTextMaterializationBudgetForTesting(RendererTextMaterializationBudget::Cost limits,
+                                              std::size_t maximumGlyphOccurrences);
+
+  /// Return aggregate resource-admission diagnostics for the current frame.
+  [[nodiscard]] RendererResourceStats resourceStats() const override;
+
   /// Number of glyph outlines currently resident for `document`.
   [[nodiscard]] size_t residentGlyphCountForTesting(SVGDocument& document);
 

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -430,6 +430,9 @@ public:
   void setTextMaterializationBudgetForTesting(RendererTextMaterializationBudget::Cost limits,
                                               std::size_t maximumGlyphOccurrences);
 
+  /// Fail one scene preparation after the requested number of successful preparations.
+  void injectScenePreparationFailureAfterForTesting(std::size_t successfulPreparations);
+
   /// Return aggregate resource-admission diagnostics for the current frame.
   [[nodiscard]] RendererResourceStats resourceStats() const override;
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -170,9 +170,33 @@ public:
     return true;
   }
 
-  /// Releases surfaces whose GPU use has completed. Implemented by the resource-budget repair.
-  [[nodiscard]] bool release(int /*width*/, int /*height*/, std::size_t /*surfaceCount*/ = 1,
-                             std::uint64_t /*bytesPerPixel*/ = 4) {
+  /// Releases surfaces after their last submitted GPU use, restoring active-capacity accounting.
+  [[nodiscard]] bool release(int width, int height, std::size_t surfaceCount = 1,
+                             std::uint64_t bytesPerPixel = 4) {
+    if (width < 0 || height < 0 || bytesPerPixel == 0) {
+      rejected_ = true;
+      return false;
+    }
+    if (width == 0 || height == 0 || surfaceCount == 0) {
+      return true;
+    }
+
+    const std::uint64_t pixelWidth = static_cast<std::uint64_t>(width);
+    const std::uint64_t pixelHeight = static_cast<std::uint64_t>(height);
+    if (pixelWidth > limits_.bytes / pixelHeight ||
+        pixelWidth * pixelHeight > limits_.bytes / bytesPerPixel ||
+        pixelWidth * pixelHeight * bytesPerPixel > limits_.bytes / surfaceCount) {
+      rejected_ = true;
+      return false;
+    }
+    const std::uint64_t byteCount = pixelWidth * pixelHeight * bytesPerPixel * surfaceCount;
+    if (surfaceCount > surfaces_ || byteCount > bytes_) {
+      rejected_ = true;
+      return false;
+    }
+
+    bytes_ -= byteCount;
+    surfaces_ -= surfaceCount;
     return true;
   }
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -262,7 +262,7 @@ public:
    * Reserves all remaining path-measurement work before a bounded query starts.
    *
    * The caller must pass the returned maximum to the query, then call
-   * ef reconcilePathMeasurement with the query's actual work and completion outcome.
+   * @ref reconcilePathMeasurement with the query's actual work and completion outcome.
    */
   [[nodiscard]] std::optional<PathMeasurementReservation> reservePathMeasurement() {
     if (rejected_ || pathMeasurementReservationActive_ ||

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -205,6 +205,22 @@ public:
     std::uint64_t imageBytes = 0;
   };
 
+  /** Exclusive reservation for one bounded path-measurement query. */
+  class PathMeasurementReservation {
+  public:
+    /// Maximum work the reserved query may consume.
+    [[nodiscard]] std::size_t maximumWorkUnits() const { return maximumWorkUnits_; }
+
+  private:
+    friend class RendererDrawBudget;
+
+    PathMeasurementReservation(std::size_t previousWorkUnits, std::size_t maximumWorkUnits)
+        : previousWorkUnits_(previousWorkUnits), maximumWorkUnits_(maximumWorkUnits) {}
+
+    std::size_t previousWorkUnits_ = 0;
+    std::size_t maximumWorkUnits_ = 0;
+  };
+
   void reset() {
     drawCalls_ = 0;
     pathCommands_ = 0;
@@ -212,6 +228,7 @@ public:
     gradientStops_ = 0;
     imageDraws_ = 0;
     imageBytes_ = 0;
+    pathMeasurementReservationActive_ = false;
     rejected_ = false;
   }
   void reject() { rejected_ = true; }
@@ -220,7 +237,8 @@ public:
   }
 
   [[nodiscard]] bool reserve(const Cost& cost) {
-    if (rejected_ || cost.drawCalls > kMaximumDrawCalls - drawCalls_ ||
+    if (rejected_ || pathMeasurementReservationActive_ ||
+        cost.drawCalls > kMaximumDrawCalls - drawCalls_ ||
         cost.pathCommands > kMaximumPathCommands - pathCommands_ ||
         cost.pathMeasurementWorkUnits >
             kMaximumPathMeasurementWorkUnits - pathMeasurementWorkUnits_ ||
@@ -240,6 +258,54 @@ public:
     return true;
   }
 
+  /**
+   * Reserves all remaining path-measurement work before a bounded query starts.
+   *
+   * The caller must pass the returned maximum to the query, then call
+   * ef reconcilePathMeasurement with the query's actual work and completion outcome.
+   */
+  [[nodiscard]] std::optional<PathMeasurementReservation> reservePathMeasurement() {
+    if (rejected_ || pathMeasurementReservationActive_ ||
+        pathMeasurementWorkUnits_ >= kMaximumPathMeasurementWorkUnits) {
+      rejected_ = true;
+      return std::nullopt;
+    }
+
+    const std::size_t previousWorkUnits = pathMeasurementWorkUnits_;
+    const std::size_t maximumWorkUnits = kMaximumPathMeasurementWorkUnits - previousWorkUnits;
+    pathMeasurementWorkUnits_ = kMaximumPathMeasurementWorkUnits;
+    pathMeasurementReservationActive_ = true;
+    return PathMeasurementReservation(previousWorkUnits, maximumWorkUnits);
+  }
+
+  /**
+   * Reconciles an exclusive path-measurement reservation to work actually consumed.
+   *
+   * An incomplete query consumes its reported work and rejects the aggregate budget.
+   */
+  [[nodiscard]] bool reconcilePathMeasurement(const PathMeasurementReservation& reservation,
+                                              std::size_t actualWorkUnits, bool completed) {
+    const bool reservationMatches =
+        pathMeasurementReservationActive_ &&
+        reservation.previousWorkUnits_ <= kMaximumPathMeasurementWorkUnits &&
+        reservation.maximumWorkUnits_ ==
+            kMaximumPathMeasurementWorkUnits - reservation.previousWorkUnits_ &&
+        pathMeasurementWorkUnits_ == kMaximumPathMeasurementWorkUnits;
+    if (!reservationMatches || actualWorkUnits > reservation.maximumWorkUnits_) {
+      pathMeasurementReservationActive_ = false;
+      rejected_ = true;
+      return false;
+    }
+
+    pathMeasurementWorkUnits_ = reservation.previousWorkUnits_ + actualWorkUnits;
+    pathMeasurementReservationActive_ = false;
+    if (!completed) {
+      rejected_ = true;
+      return false;
+    }
+    return true;
+  }
+
   [[nodiscard]] std::size_t drawCalls() const { return drawCalls_; }
   [[nodiscard]] std::size_t pathCommands() const { return pathCommands_; }
   [[nodiscard]] std::size_t pathMeasurementWorkUnits() const { return pathMeasurementWorkUnits_; }
@@ -256,6 +322,7 @@ private:
   std::size_t imageDraws_ = 0;
   std::uint64_t imageBytes_ = 0;
   std::size_t gradientStopLimit_ = kMaximumGradientStops;
+  bool pathMeasurementReservationActive_ = false;
   bool rejected_ = false;
 };
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -194,15 +194,27 @@ public:
     std::uint64_t imageBytes = 0;
   };
 
-  void reset() { *this = {}; }
+  void reset() {
+    drawCalls_ = 0;
+    pathCommands_ = 0;
+    pathMeasurementWorkUnits_ = 0;
+    gradientStops_ = 0;
+    imageDraws_ = 0;
+    imageBytes_ = 0;
+    rejected_ = false;
+  }
   void reject() { rejected_ = true; }
+  void setGradientStopLimitForTesting(std::size_t maximum) {
+    gradientStopLimit_ = std::min(gradientStopLimit_, maximum);
+  }
 
   [[nodiscard]] bool reserve(const Cost& cost) {
     if (rejected_ || cost.drawCalls > kMaximumDrawCalls - drawCalls_ ||
         cost.pathCommands > kMaximumPathCommands - pathCommands_ ||
         cost.pathMeasurementWorkUnits >
             kMaximumPathMeasurementWorkUnits - pathMeasurementWorkUnits_ ||
-        cost.gradientStops > kMaximumGradientStops - gradientStops_ ||
+        gradientStops_ > gradientStopLimit_ ||
+        cost.gradientStops > gradientStopLimit_ - gradientStops_ ||
         cost.imageDraws > kMaximumImageDraws - imageDraws_ ||
         cost.imageBytes > kMaximumImageBytes - imageBytes_) {
       rejected_ = true;
@@ -232,6 +244,7 @@ private:
   std::size_t gradientStops_ = 0;
   std::size_t imageDraws_ = 0;
   std::uint64_t imageBytes_ = 0;
+  std::size_t gradientStopLimit_ = kMaximumGradientStops;
   bool rejected_ = false;
 };
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -367,6 +367,7 @@ struct RendererResourceStats {
   std::size_t textMaterializationPoints = 0;
   std::uint64_t textMaterializationBytes = 0;
   std::size_t textGlyphDecodeWork = 0;
+  std::size_t textGlyphOccurrences = 0;
   bool textMaterializationBudgetRejected = false;
 };
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -170,6 +170,12 @@ public:
     return true;
   }
 
+  /// Releases surfaces whose GPU use has completed. Implemented by the resource-budget repair.
+  [[nodiscard]] bool release(int /*width*/, int /*height*/, std::size_t /*surfaceCount*/ = 1,
+                             std::uint64_t /*bytesPerPixel*/ = 4) {
+    return true;
+  }
+
   [[nodiscard]] std::uint64_t bytes() const { return bytes_; }
   [[nodiscard]] std::size_t surfaces() const { return surfaces_; }
   [[nodiscard]] bool rejected() const { return rejected_; }
@@ -787,6 +793,19 @@ public:
 
   /// Returns the rendered height in device pixels.
   [[nodiscard]] virtual int height() const = 0;
+
+  /**
+   * Begins one aggregate resource-budget scope around a controller-managed frame.
+   *
+   * A controller may render several offscreen passes before the root render pass. Backends that
+   * share frame budgets with their offscreen instances override this pair so every pass consumes
+   * one budget epoch instead of resetting independently. Ordinary single-pass callers may omit
+   * the scope and continue to rely on \ref beginFrame.
+   */
+  virtual void beginFrameResourceScope() {}
+
+  /// Completes a scope opened by \ref beginFrameResourceScope.
+  virtual void endFrameResourceScope() {}
 
   /**
    * Begins a render pass with the given viewport. Implementations may allocate or reset

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -120,6 +121,240 @@ struct RendererReadbackStats {
   /// Wall time that wait spent before giving up, in milliseconds. Zero while
   /// \ref timedOutWaitSite is \ref GpuWaitTimeoutSite::None.
   int timedOutWaitMs = 0;
+};
+
+/** Aggregate budget for render targets, layers, masks, clips, and pattern tiles. */
+class RendererSurfaceBudget {
+public:
+  static constexpr std::uint64_t kMaximumBytes = 256ULL * 1024 * 1024;
+  static constexpr std::size_t kMaximumSurfaces = 256;
+
+  void reset() {
+    bytes_ = 0;
+    surfaces_ = 0;
+    rejected_ = false;
+  }
+
+  [[nodiscard]] bool reserve(int width, int height, std::size_t surfaceCount = 1,
+                             std::uint64_t bytesPerPixel = 4) {
+    if (rejected_ || width < 0 || height < 0 || bytesPerPixel == 0 ||
+        surfaceCount > kMaximumSurfaces - surfaces_) {
+      rejected_ = true;
+      return false;
+    }
+    if (width == 0 || height == 0 || surfaceCount == 0) {
+      return true;
+    }
+
+    const std::uint64_t pixelWidth = static_cast<std::uint64_t>(width);
+    const std::uint64_t pixelHeight = static_cast<std::uint64_t>(height);
+    if (pixelWidth > kMaximumBytes / pixelHeight ||
+        pixelWidth * pixelHeight > kMaximumBytes / bytesPerPixel ||
+        pixelWidth * pixelHeight * bytesPerPixel > kMaximumBytes / surfaceCount) {
+      rejected_ = true;
+      return false;
+    }
+    const std::uint64_t byteCount = pixelWidth * pixelHeight * bytesPerPixel * surfaceCount;
+    if (byteCount > kMaximumBytes - bytes_) {
+      rejected_ = true;
+      return false;
+    }
+
+    bytes_ += byteCount;
+    surfaces_ += surfaceCount;
+    return true;
+  }
+
+  [[nodiscard]] std::uint64_t bytes() const { return bytes_; }
+  [[nodiscard]] std::size_t surfaces() const { return surfaces_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+private:
+  std::uint64_t bytes_ = 0;
+  std::size_t surfaces_ = 0;
+  bool rejected_ = false;
+};
+
+/** Aggregate conversion, rasterization, and upload work shared by a render frame. */
+class RendererDrawBudget {
+public:
+  static constexpr std::size_t kMaximumDrawCalls = 64 * 1024;
+  static constexpr std::size_t kMaximumPathCommands = 256 * 1024;
+  static constexpr std::size_t kMaximumPathMeasurementWorkUnits = Path::kMaximumGeometryQueryWork;
+  static constexpr std::size_t kMaximumGradientStops = 256 * 1024;
+  static constexpr std::size_t kMaximumImageDraws = 128;
+  static constexpr std::uint64_t kMaximumImageBytes = 256ULL * 1024 * 1024;
+
+  struct Cost {
+    std::size_t drawCalls = 0;
+    std::size_t pathCommands = 0;
+    std::size_t pathMeasurementWorkUnits = 0;
+    std::size_t gradientStops = 0;
+    std::size_t imageDraws = 0;
+    std::uint64_t imageBytes = 0;
+  };
+
+  void reset() { *this = {}; }
+  void reject() { rejected_ = true; }
+
+  [[nodiscard]] bool reserve(const Cost& cost) {
+    if (rejected_ || cost.drawCalls > kMaximumDrawCalls - drawCalls_ ||
+        cost.pathCommands > kMaximumPathCommands - pathCommands_ ||
+        cost.pathMeasurementWorkUnits >
+            kMaximumPathMeasurementWorkUnits - pathMeasurementWorkUnits_ ||
+        cost.gradientStops > kMaximumGradientStops - gradientStops_ ||
+        cost.imageDraws > kMaximumImageDraws - imageDraws_ ||
+        cost.imageBytes > kMaximumImageBytes - imageBytes_) {
+      rejected_ = true;
+      return false;
+    }
+    drawCalls_ += cost.drawCalls;
+    pathCommands_ += cost.pathCommands;
+    pathMeasurementWorkUnits_ += cost.pathMeasurementWorkUnits;
+    gradientStops_ += cost.gradientStops;
+    imageDraws_ += cost.imageDraws;
+    imageBytes_ += cost.imageBytes;
+    return true;
+  }
+
+  [[nodiscard]] std::size_t drawCalls() const { return drawCalls_; }
+  [[nodiscard]] std::size_t pathCommands() const { return pathCommands_; }
+  [[nodiscard]] std::size_t pathMeasurementWorkUnits() const { return pathMeasurementWorkUnits_; }
+  [[nodiscard]] std::size_t gradientStops() const { return gradientStops_; }
+  [[nodiscard]] std::size_t imageDraws() const { return imageDraws_; }
+  [[nodiscard]] std::uint64_t imageBytes() const { return imageBytes_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+private:
+  std::size_t drawCalls_ = 0;
+  std::size_t pathCommands_ = 0;
+  std::size_t pathMeasurementWorkUnits_ = 0;
+  std::size_t gradientStops_ = 0;
+  std::size_t imageDraws_ = 0;
+  std::uint64_t imageBytes_ = 0;
+  bool rejected_ = false;
+};
+
+/** Aggregate decoded-outline and path-copy budget shared by one renderer frame. */
+class RendererTextMaterializationBudget {
+public:
+  static constexpr std::size_t kMaximumUniqueOutlines = 1024;
+  static constexpr std::size_t kMaximumCommands = 4 * 1024 * 1024;
+  static constexpr std::size_t kMaximumPoints = 8 * 1024 * 1024;
+  static constexpr std::uint64_t kMaximumBytes = 64ULL * 1024 * 1024;
+  static constexpr std::size_t kMaximumDecodeWork = 64 * 1024 * 1024;
+
+  struct Cost {
+    std::size_t uniqueOutlines = 0;
+    std::size_t commands = 0;
+    std::size_t points = 0;
+    std::uint64_t bytes = 0;
+    std::size_t decodeWork = 0;
+  };
+
+  void reset() {
+    uniqueOutlines_ = 0;
+    commands_ = 0;
+    points_ = 0;
+    bytes_ = 0;
+    decodeWork_ = 0;
+    rejected_ = false;
+  }
+
+  [[nodiscard]] bool reserve(const Cost& cost) {
+    if (rejected_ || uniqueOutlines_ > limits_.uniqueOutlines || commands_ > limits_.commands ||
+        points_ > limits_.points || bytes_ > limits_.bytes || decodeWork_ > limits_.decodeWork ||
+        cost.uniqueOutlines > limits_.uniqueOutlines - uniqueOutlines_ ||
+        cost.commands > limits_.commands - commands_ || cost.points > limits_.points - points_ ||
+        cost.bytes > limits_.bytes - bytes_ || cost.decodeWork > limits_.decodeWork - decodeWork_) {
+      rejected_ = true;
+      return false;
+    }
+    uniqueOutlines_ += cost.uniqueOutlines;
+    commands_ += cost.commands;
+    points_ += cost.points;
+    bytes_ += cost.bytes;
+    decodeWork_ += cost.decodeWork;
+    return true;
+  }
+
+  void reject() { rejected_ = true; }
+
+  [[nodiscard]] bool reservePathCopy(const Path& path) {
+    const std::size_t commands = path.commands().size();
+    const std::size_t points = path.points().size();
+    const std::optional<std::size_t> retainedBytes = path.retainedBytes();
+    if (commands > kMaximumCommands || points > kMaximumPoints || !retainedBytes.has_value() ||
+        *retainedBytes > kMaximumBytes / 2) {
+      rejected_ = true;
+      return false;
+    }
+    return reserve({.commands = commands, .points = points, .bytes = *retainedBytes * 2});
+  }
+
+  void setLimitsForTesting(Cost limits) {
+    limits_.uniqueOutlines = std::min(limits_.uniqueOutlines, limits.uniqueOutlines);
+    limits_.commands = std::min(limits_.commands, limits.commands);
+    limits_.points = std::min(limits_.points, limits.points);
+    limits_.bytes = std::min(limits_.bytes, limits.bytes);
+    limits_.decodeWork = std::min(limits_.decodeWork, limits.decodeWork);
+  }
+
+  [[nodiscard]] const Cost& limits() const { return limits_; }
+  [[nodiscard]] std::size_t uniqueOutlines() const { return uniqueOutlines_; }
+  [[nodiscard]] std::size_t commands() const { return commands_; }
+  [[nodiscard]] std::size_t points() const { return points_; }
+  [[nodiscard]] std::uint64_t bytes() const { return bytes_; }
+  [[nodiscard]] std::size_t decodeWork() const { return decodeWork_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+private:
+  Cost limits_{.uniqueOutlines = kMaximumUniqueOutlines,
+               .commands = kMaximumCommands,
+               .points = kMaximumPoints,
+               .bytes = kMaximumBytes,
+               .decodeWork = kMaximumDecodeWork};
+  std::size_t uniqueOutlines_ = 0;
+  std::size_t commands_ = 0;
+  std::size_t points_ = 0;
+  std::uint64_t bytes_ = 0;
+  std::size_t decodeWork_ = 0;
+  bool rejected_ = false;
+};
+
+/** Bounded-resource diagnostics for the most recently started render frame. */
+struct RendererResourceStats {
+  bool filterBudgetSupported = false;
+  std::uint64_t filterExecutions = 0;
+  std::uint64_t filterWorkUnits = 0;
+  std::uint64_t filterRetainedBytes = 0;
+  std::uint64_t filterCaptureBytesReserved = 0;
+  bool filterBudgetRejected = false;
+  bool geometryBudgetSupported = false;
+  std::size_t geometryDraws = 0;
+  std::size_t geometryItems = 0;
+  std::size_t geometryRetainedBytes = 0;
+  bool geometryBudgetRejected = false;
+  bool surfaceBudgetSupported = false;
+  std::size_t surfaceCount = 0;
+  std::uint64_t surfaceBytes = 0;
+  bool surfaceBudgetRejected = false;
+  bool drawBudgetSupported = false;
+  std::size_t drawCalls = 0;
+  std::size_t pathCommands = 0;
+  bool pathMeasurementWorkSupported = false;
+  std::size_t pathMeasurementWorkUnits = 0;
+  std::size_t gradientStops = 0;
+  std::size_t imageDraws = 0;
+  std::uint64_t imageBytes = 0;
+  bool drawBudgetRejected = false;
+  bool textMaterializationBudgetSupported = false;
+  std::size_t textUniqueOutlines = 0;
+  std::size_t textMaterializationCommands = 0;
+  std::size_t textMaterializationPoints = 0;
+  std::uint64_t textMaterializationBytes = 0;
+  std::size_t textGlyphDecodeWork = 0;
+  bool textMaterializationBudgetRejected = false;
 };
 
 /// Backend type for \ref RendererTextureSnapshot payloads.
@@ -662,6 +897,12 @@ public:
    * Backends without asynchronous GPU readback return zeroed stats.
    */
   [[nodiscard]] virtual RendererReadbackStats consumeReadbackStats() { return {}; }
+
+  /// Return resource-admission diagnostics for the current frame.
+  [[nodiscard]] virtual RendererResourceStats resourceStats() const { return {}; }
+
+  /// Cause the next local filter raster allocation to fail in a boundary test.
+  virtual void injectFilterLocalRasterAllocationFailureForTesting() {}
 
   /**
    * Captures the current frame buffer as a backend-owned GPU texture.

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -129,6 +129,11 @@ public:
   static constexpr std::uint64_t kMaximumBytes = 256ULL * 1024 * 1024;
   static constexpr std::size_t kMaximumSurfaces = 256;
 
+  struct Limits {
+    std::uint64_t bytes = kMaximumBytes;
+    std::size_t surfaces = kMaximumSurfaces;
+  };
+
   void reset() {
     bytes_ = 0;
     surfaces_ = 0;
@@ -138,7 +143,7 @@ public:
   [[nodiscard]] bool reserve(int width, int height, std::size_t surfaceCount = 1,
                              std::uint64_t bytesPerPixel = 4) {
     if (rejected_ || width < 0 || height < 0 || bytesPerPixel == 0 ||
-        surfaceCount > kMaximumSurfaces - surfaces_) {
+        surfaces_ > limits_.surfaces || surfaceCount > limits_.surfaces - surfaces_) {
       rejected_ = true;
       return false;
     }
@@ -148,14 +153,14 @@ public:
 
     const std::uint64_t pixelWidth = static_cast<std::uint64_t>(width);
     const std::uint64_t pixelHeight = static_cast<std::uint64_t>(height);
-    if (pixelWidth > kMaximumBytes / pixelHeight ||
-        pixelWidth * pixelHeight > kMaximumBytes / bytesPerPixel ||
-        pixelWidth * pixelHeight * bytesPerPixel > kMaximumBytes / surfaceCount) {
+    if (pixelWidth > limits_.bytes / pixelHeight ||
+        pixelWidth * pixelHeight > limits_.bytes / bytesPerPixel ||
+        pixelWidth * pixelHeight * bytesPerPixel > limits_.bytes / surfaceCount) {
       rejected_ = true;
       return false;
     }
     const std::uint64_t byteCount = pixelWidth * pixelHeight * bytesPerPixel * surfaceCount;
-    if (byteCount > kMaximumBytes - bytes_) {
+    if (bytes_ > limits_.bytes || byteCount > limits_.bytes - bytes_) {
       rejected_ = true;
       return false;
     }
@@ -169,7 +174,13 @@ public:
   [[nodiscard]] std::size_t surfaces() const { return surfaces_; }
   [[nodiscard]] bool rejected() const { return rejected_; }
 
+  void setLimitsForTesting(Limits limits) {
+    limits_.bytes = std::min(limits_.bytes, limits.bytes);
+    limits_.surfaces = std::min(limits_.surfaces, limits.surfaces);
+  }
+
 private:
+  Limits limits_;
   std::uint64_t bytes_ = 0;
   std::size_t surfaces_ = 0;
   bool rejected_ = false;
@@ -256,6 +267,7 @@ public:
   static constexpr std::size_t kMaximumPoints = 8 * 1024 * 1024;
   static constexpr std::uint64_t kMaximumBytes = 64ULL * 1024 * 1024;
   static constexpr std::size_t kMaximumDecodeWork = 64 * 1024 * 1024;
+  static constexpr std::size_t kMaximumGlyphOccurrences = 64 * 1024;
 
   struct Cost {
     std::size_t uniqueOutlines = 0;
@@ -271,6 +283,7 @@ public:
     points_ = 0;
     bytes_ = 0;
     decodeWork_ = 0;
+    glyphOccurrences_ = 0;
     rejected_ = false;
   }
 
@@ -293,6 +306,16 @@ public:
 
   void reject() { rejected_ = true; }
 
+  [[nodiscard]] bool reserveGlyphOccurrences(std::size_t count) {
+    if (rejected_ || glyphOccurrences_ > glyphOccurrenceLimit_ ||
+        count > glyphOccurrenceLimit_ - glyphOccurrences_) {
+      rejected_ = true;
+      return false;
+    }
+    glyphOccurrences_ += count;
+    return true;
+  }
+
   [[nodiscard]] bool reservePathCopy(const Path& path) {
     const std::size_t commands = path.commands().size();
     const std::size_t points = path.points().size();
@@ -313,12 +336,17 @@ public:
     limits_.decodeWork = std::min(limits_.decodeWork, limits.decodeWork);
   }
 
+  void setGlyphOccurrenceLimitForTesting(std::size_t maximum) {
+    glyphOccurrenceLimit_ = std::min(glyphOccurrenceLimit_, maximum);
+  }
+
   [[nodiscard]] const Cost& limits() const { return limits_; }
   [[nodiscard]] std::size_t uniqueOutlines() const { return uniqueOutlines_; }
   [[nodiscard]] std::size_t commands() const { return commands_; }
   [[nodiscard]] std::size_t points() const { return points_; }
   [[nodiscard]] std::uint64_t bytes() const { return bytes_; }
   [[nodiscard]] std::size_t decodeWork() const { return decodeWork_; }
+  [[nodiscard]] std::size_t glyphOccurrences() const { return glyphOccurrences_; }
   [[nodiscard]] bool rejected() const { return rejected_; }
 
 private:
@@ -332,6 +360,8 @@ private:
   std::size_t points_ = 0;
   std::uint64_t bytes_ = 0;
   std::size_t decodeWork_ = 0;
+  std::size_t glyphOccurrences_ = 0;
+  std::size_t glyphOccurrenceLimit_ = kMaximumGlyphOccurrences;
   bool rejected_ = false;
 };
 

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -47,15 +47,6 @@ namespace donner::svg {
 
 namespace {
 
-std::size_t ConservativePathMeasurementWorkUnits(const Path& path) {
-  for (const Path::Command& command : path.commands()) {
-    if (command.verb == Path::Verb::QuadTo || command.verb == Path::Verb::CurveTo) {
-      return RendererDrawBudget::kMaximumPathMeasurementWorkUnits;
-    }
-  }
-  return std::min(path.commands().size(), RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
-}
-
 std::optional<int> CheckedPixelDimension(double logicalDimension, double devicePixelRatio) {
   const double pixelDimension = logicalDimension * devicePixelRatio;
   if (!std::isfinite(logicalDimension) || !std::isfinite(devicePixelRatio) ||
@@ -2263,12 +2254,19 @@ bool RendererTinySkia::applyPathLengthAdjustment(const Path& path, StrokeParams&
   if (stroke.dashArray.empty() || stroke.pathLength <= 0.0 || NearZero(stroke.pathLength)) {
     return true;
   }
-  if (!drawBudget_->reserve(
-          {.pathMeasurementWorkUnits = ConservativePathMeasurementWorkUnits(path)})) {
+  const std::optional<RendererDrawBudget::PathMeasurementReservation> reservation =
+      drawBudget_->reservePathMeasurement();
+  if (!reservation.has_value()) {
     return false;
   }
 
-  const double dashUnitsScale = path.pathLength() / stroke.pathLength;
+  const Path::MeasuredPath measured = path.measure(reservation->maximumWorkUnits());
+  if (!drawBudget_->reconcilePathMeasurement(*reservation, measured.measurementWorkUnits(),
+                                             measured.valid())) {
+    return false;
+  }
+
+  const double dashUnitsScale = measured.pathLength() / stroke.pathLength;
   for (double& dash : stroke.dashArray) {
     dash *= dashUnitsScale;
   }

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -47,6 +47,15 @@ namespace donner::svg {
 
 namespace {
 
+std::size_t ConservativePathMeasurementWorkUnits(const Path& path) {
+  for (const Path::Command& command : path.commands()) {
+    if (command.verb == Path::Verb::QuadTo || command.verb == Path::Verb::CurveTo) {
+      return RendererDrawBudget::kMaximumPathMeasurementWorkUnits;
+    }
+  }
+  return std::min(path.commands().size(), RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+}
+
 std::optional<int> CheckedPixelDimension(double logicalDimension, double devicePixelRatio) {
   const double pixelDimension = logicalDimension * devicePixelRatio;
   if (!std::isfinite(logicalDimension) || !std::isfinite(devicePixelRatio) ||
@@ -1319,6 +1328,26 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
     pixelHeight = 0;
   }
 
+  const tiny_skia::IntSize admittedFrameSize(static_cast<std::uint32_t>(pixelWidth),
+                                             static_cast<std::uint32_t>(pixelHeight));
+  if (admittedFrameSize != previousFrameSize_) {
+    clipEpochSlots_.clear();
+  }
+
+  clipEpochRetentionActive_ = false;
+  if (retainedSpansEnabled_ && pixelWidth > 0 && pixelHeight > 0) {
+    RendererSurfaceBudget withClipEpochEnvelope = *surfaceBudget_;
+    if (withClipEpochEnvelope.reserve(pixelWidth, pixelHeight, kMaxRetainedClipDepth,
+                                      /*bytesPerPixel=*/1)) {
+      *surfaceBudget_ = withClipEpochEnvelope;
+      clipEpochRetentionActive_ = true;
+    } else {
+      clipEpochSlots_.clear();
+    }
+  } else {
+    clipEpochSlots_.clear();
+  }
+
   // Keep the frame buffer's allocation across frames. A renderer that draws the
   // same viewport repeatedly (editor, compositor, animation loop) otherwise
   // releases and re-acquires the whole buffer every frame, which costs a
@@ -1338,6 +1367,8 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
+  clipRestoreStack_.clear();
+  clipMaskAllocationRejected_ = false;
   surfaceStack_.clear();
   filterLayerStack_.clear();
   rejectedFilterDepth_ = 0;
@@ -1377,6 +1408,8 @@ void RendererTinySkia::endFrame() {
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
+  clipRestoreStack_.clear();
+  clipMaskAllocationRejected_ = false;
   cacheWiringCheckedRegistry_ = nullptr;
 }
 
@@ -1415,8 +1448,15 @@ void RendererTinySkia::popTransform() {
 }
 
 void RendererTinySkia::pushClip(const ResolvedClip& clip) {
-  clipStack_.push_back(currentClipMask_);
   clipEpochStack_.push_back(clipEpoch_);
+  if (clip.empty()) {
+    clipStack_.emplace_back();
+    clipRestoreStack_.push_back(false);
+    return;
+  }
+
+  clipStack_.push_back(std::move(currentClipMask_));
+  clipRestoreStack_.push_back(true);
 
   if (rejectedFilterDepth_ != 0) {
     return;
@@ -1424,11 +1464,12 @@ void RendererTinySkia::pushClip(const ResolvedClip& clip) {
 
   std::optional<tiny_skia::Mask> clipMask = buildClipMask(clip);
   if (!clipMask.has_value()) {
+    clipMaskAllocationRejected_ = true;
     return;
   }
 
-  if (currentClipMask_.has_value()) {
-    intersectMaskInPlace(*clipMask, *currentClipMask_);
+  if (clipStack_.back().has_value()) {
+    intersectMaskInPlace(*clipMask, *clipStack_.back());
   }
 
   currentClipMask_ = std::move(clipMask);
@@ -1444,8 +1485,11 @@ void RendererTinySkia::popClip() {
     return;
   }
 
-  currentClipMask_ = std::move(clipStack_.back());
+  if (clipRestoreStack_.back()) {
+    currentClipMask_ = std::move(clipStack_.back());
+  }
   clipStack_.pop_back();
+  clipRestoreStack_.pop_back();
   clipEpoch_ = clipEpochStack_.back();
   clipEpochStack_.pop_back();
 }
@@ -1453,6 +1497,10 @@ void RendererTinySkia::popClip() {
 std::uint64_t RendererTinySkia::assignClipEpoch(std::size_t depth) {
   if (!retainedSpansEnabled_ || !currentClipMask_.has_value()) {
     return 0;
+  }
+
+  if (!clipEpochRetentionActive_ || !surfaceStack_.empty()) {
+    return nextClipEpoch_++;
   }
 
   // Remembering one mask per depth is what makes the identity useful: a document's clip stack
@@ -1701,10 +1749,12 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   // The clip mask is restored in popFilterLayer and applied when compositing the filter output.
   frame.savedClipMask = std::move(currentClipMask_);
   frame.savedClipStack = std::move(clipStack_);
+  frame.savedClipRestoreStack = std::move(clipRestoreStack_);
   frame.savedClipEpoch = clipEpoch_;
   frame.savedClipEpochStack = std::move(clipEpochStack_);
   currentClipMask_.reset();
   clipStack_.clear();
+  clipRestoreStack_.clear();
   clipEpoch_ = 0;
   clipEpochStack_.clear();
 
@@ -1856,6 +1906,7 @@ void RendererTinySkia::popFilterLayer() {
   // paint → filter → clip-path → mask → opacity.
   currentClipMask_ = std::move(frame.savedClipMask);
   clipStack_ = std::move(frame.savedClipStack);
+  clipRestoreStack_ = std::move(frame.savedClipRestoreStack);
   clipEpoch_ = frame.savedClipEpoch;
   clipEpochStack_ = std::move(frame.savedClipEpochStack);
 
@@ -2008,6 +2059,7 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   frame.savedTransformStack = std::move(deviceFromLocalTransformStack_);
   frame.savedClipMask = std::move(currentClipMask_);
   frame.savedClipStack = std::move(clipStack_);
+  frame.savedClipRestoreStack = std::move(clipRestoreStack_);
   frame.savedClipEpoch = clipEpoch_;
   frame.savedClipEpochStack = std::move(clipEpochStack_);
 
@@ -2024,6 +2076,7 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
+  clipRestoreStack_.clear();
   clipEpoch_ = 0;
   clipEpochStack_.clear();
   return true;
@@ -2041,6 +2094,7 @@ void RendererTinySkia::endPatternTile(bool forStroke) {
   deviceFromLocalTransformStack_ = std::move(frame.savedTransformStack);
   currentClipMask_ = std::move(frame.savedClipMask);
   clipStack_ = std::move(frame.savedClipStack);
+  clipRestoreStack_ = std::move(frame.savedClipRestoreStack);
   clipEpoch_ = frame.savedClipEpoch;
   clipEpochStack_ = std::move(frame.savedClipEpochStack);
   patternFillPaint_ = std::move(frame.savedPatternFillPaint);
@@ -2138,6 +2192,10 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   StrokeParams adjustedStroke = stroke;
   if (!adjustedStroke.dashArray.empty() && adjustedStroke.pathLength > 0.0 &&
       !NearZero(adjustedStroke.pathLength)) {
+    if (!drawBudget_->reserve(
+            {.pathMeasurementWorkUnits = ConservativePathMeasurementWorkUnits(pathGeometry)})) {
+      return;
+    }
     const double actualLength = pathGeometry.pathLength();
     const double dashUnitsScale = actualLength / adjustedStroke.pathLength;
     for (double& dash : adjustedStroke.dashArray) {
@@ -3240,14 +3298,14 @@ int RendererTinySkia::height() const {
 }
 
 tiny_skia::Pixmap& RendererTinySkia::currentPixmap() {
-  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected()) {
+  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected() || clipMaskAllocationRejected_) {
     return rejectedPixmap_;
   }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
 }
 
 const tiny_skia::Pixmap& RendererTinySkia::currentPixmap() const {
-  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected()) {
+  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected() || clipMaskAllocationRejected_) {
     return rejectedPixmap_;
   }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
@@ -3257,7 +3315,7 @@ tiny_skia::MutablePixmapView RendererTinySkia::currentPixmapView() {
   return currentPixmap().mutableView();
 }
 
-std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedClip& clip) const {
+std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedClip& clip) {
   if (clip.empty()) {
     return std::nullopt;
   }
@@ -3274,11 +3332,21 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
               << "  clipPathUnitsTransform=" << clip.clipPathUnitsTransform;
   }
 
+  const int maskWidth = static_cast<int>(currentPixmap().width());
+  const int maskHeight = static_cast<int>(currentPixmap().height());
+  bool allocationFailed = false;
   const auto createMask = [&]() {
-    std::optional<tiny_skia::Mask> mask =
-        createMaskForSize(currentPixmap().width(), currentPixmap().height());
+    if (!surfaceBudget_->reserve(maskWidth, maskHeight, /*surfaceCount=*/1,
+                                 /*bytesPerPixel=*/1)) {
+      allocationFailed = true;
+      return std::optional<tiny_skia::Mask>();
+    }
+    std::optional<tiny_skia::Mask> mask = createMaskForSize(static_cast<std::uint32_t>(maskWidth),
+                                                            static_cast<std::uint32_t>(maskHeight));
     if (mask.has_value()) {
       std::fill(mask->data().begin(), mask->data().end(), 0);
+    } else {
+      allocationFailed = true;
     }
     return mask;
   };
@@ -3372,6 +3440,9 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
     std::cout << "\n";
   }
 
+  if (allocationFailed) {
+    return std::nullopt;
+  }
   return result;
 }
 

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -1468,14 +1468,39 @@ void RendererTinySkia::prepareRetainedClipEpochBudget(int pixelWidth, int pixelH
   }
 }
 
-void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
-  viewport_ = viewport;
+void RendererTinySkia::resetOwnedFrameBudgets() {
   if (ownsDrawBudget_) {
     drawBudget_->reset();
     textGlyphWorkBudget_->reset();
     dashedPathWorkBudget_->reset();
+  }
+  if (ownsTextMaterializationBudget_) {
     textMaterializationBudget_->reset();
+  }
+  if (ownsSurfaceBudget_) {
     surfaceBudget_->reset();
+  }
+  if (ownsFilterExecutionBudget_) {
+    filterExecutionBudget_->reset();
+  }
+}
+
+void RendererTinySkia::beginFrameResourceScope() {
+  if (frameResourceScopeDepth_ == 0) {
+    resetOwnedFrameBudgets();
+  }
+  ++frameResourceScopeDepth_;
+}
+
+void RendererTinySkia::endFrameResourceScope() {
+  UTILS_RELEASE_ASSERT(frameResourceScopeDepth_ > 0);
+  --frameResourceScopeDepth_;
+}
+
+void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
+  viewport_ = viewport;
+  if (frameResourceScopeDepth_ == 0) {
+    resetOwnedFrameBudgets();
   }
   int pixelWidth = CheckedPixelDimension(viewport.size.x, viewport.devicePixelRatio).value_or(0);
   int pixelHeight = CheckedPixelDimension(viewport.size.y, viewport.devicePixelRatio).value_or(0);
@@ -1510,9 +1535,6 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   surfaceStack_.clear();
   filterLayerStack_.clear();
   rejectedFilterDepth_ = 0;
-  if (ownsFilterExecutionBudget_) {
-    filterExecutionBudget_->reset();
-  }
   patternFillPaint_.reset();
   patternStrokePaint_.reset();
   frameCounters_ = RendererTinySkiaFrameCounters();

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -46,6 +46,16 @@ namespace donner::svg {
 
 namespace {
 
+std::optional<int> CheckedPixelDimension(double logicalDimension, double devicePixelRatio) {
+  const double pixelDimension = logicalDimension * devicePixelRatio;
+  if (!std::isfinite(logicalDimension) || !std::isfinite(devicePixelRatio) ||
+      logicalDimension < 0.0 || devicePixelRatio <= 0.0 || !std::isfinite(pixelDimension) ||
+      pixelDimension > static_cast<double>(std::numeric_limits<int>::max())) {
+    return std::nullopt;
+  }
+  return static_cast<int>(pixelDimension);
+}
+
 #ifdef DONNER_TEXT_ENABLED
 TextLayoutParams toTextLayoutParams(const TextParams& params) {
   TextLayoutParams layoutParams;
@@ -1060,8 +1070,10 @@ void RendererTinySkia::draw(SVGDocument& document) {
 
 void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   viewport_ = viewport;
-  const int pixelWidth = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
-  const int pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
+  const int pixelWidth =
+      CheckedPixelDimension(viewport.size.x, viewport.devicePixelRatio).value_or(0);
+  const int pixelHeight =
+      CheckedPixelDimension(viewport.size.y, viewport.devicePixelRatio).value_or(0);
 
   // Keep the frame buffer's allocation across frames. A renderer that draws the
   // same viewport repeatedly (editor, compositor, animation loop) otherwise

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -3482,8 +3482,10 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
   const int maskHeight = static_cast<int>(currentPixmap().height());
   ClipMaskBuilder builder(*surfaceBudget_, maskWidth, maskHeight, clip.clipPathUnitsTransform,
                           deviceFromLocalTransform_, antialias_, verbose_);
+  std::optional<tiny_skia::Mask> rectMask = builder.buildRect(clip.clipRect);
+  std::optional<tiny_skia::Mask> pathMask = builder.buildPaths(clip.clipPaths);
   std::optional<tiny_skia::Mask> result =
-      CombineClipMasks(builder.buildRect(clip.clipRect), builder.buildPaths(clip.clipPaths));
+      CombineClipMasks(std::move(rectMask), std::move(pathMask));
 
   if (verbose_) {
     std::cout << "\n";

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -39,6 +39,7 @@
 #include "donner/svg/text/TextLayoutParams.h"
 #endif
 #include "tiny_skia/Painter.h"
+#include "tiny_skia/Path.h"
 #include "tiny_skia/PathBuilder.h"
 #include "tiny_skia/shaders/Shaders.h"
 
@@ -72,9 +73,189 @@ TextLayoutParams toTextLayoutParams(const TextParams& params) {
   layoutParams.inlineSizePx = params.inlineSizePx;
   return layoutParams;
 }
+
+std::optional<RendererTextMaterializationBudget::Cost> GlyphPredecodeCost(
+    const FontManager::GlyphOutlineComplexity& complexity) {
+  constexpr std::size_t kCommandCopiesPerVertex = 6;
+  constexpr std::size_t kPointCopiesPerVertex = 9;
+  if (complexity.maximumVertices >
+      std::numeric_limits<std::size_t>::max() / kPointCopiesPerVertex) {
+    return std::nullopt;
+  }
+  const std::size_t commands = complexity.maximumVertices * kCommandCopiesPerVertex;
+  const std::size_t points = complexity.maximumVertices * kPointCopiesPerVertex;
+  if (commands > std::numeric_limits<std::size_t>::max() / sizeof(Path::Command) ||
+      points > std::numeric_limits<std::size_t>::max() / sizeof(Vector2d)) {
+    return std::nullopt;
+  }
+  const std::size_t commandBytes = commands * sizeof(Path::Command);
+  const std::size_t pointBytes = points * sizeof(Vector2d);
+  if (pointBytes > std::numeric_limits<std::size_t>::max() - commandBytes) {
+    return std::nullopt;
+  }
+  return RendererTextMaterializationBudget::Cost{.uniqueOutlines = 1,
+                                                 .commands = commands,
+                                                 .points = points,
+                                                 .bytes = commandBytes + pointBytes,
+                                                 .decodeWork = complexity.work};
+}
 #endif
 
 const Box2d kUnitPathBounds(Vector2d::Zero(), Vector2d(1, 1));
+constexpr std::size_t kMaximumTinySkiaDashWorkUnits = 1000000;
+
+std::optional<std::size_t> EstimateDashWorkUnits(const tiny_skia::Path& path,
+                                                 const tiny_skia::StrokeDash& dash) {
+  double intervalLength = 0.0;
+  for (const float interval : dash.array) {
+    if (!std::isfinite(interval) || interval < 0.0 ||
+        intervalLength > std::numeric_limits<double>::max() - interval) {
+      return std::nullopt;
+    }
+    intervalLength += interval;
+  }
+  if (dash.array.size() < 2 || (dash.array.size() & 1u) != 0u || intervalLength <= 0.0) {
+    return std::nullopt;
+  }
+
+  const std::span<const tiny_skia::Point> points = path.points();
+  std::size_t pointIndex = 0;
+  std::optional<tiny_skia::Point> contourStart;
+  std::optional<tiny_skia::Point> current;
+  double contourLength = 0.0;
+  std::size_t workUnits = 0;
+  const std::size_t dashPairCount = dash.array.size() / 2;
+  const auto finishContour = [&]() -> bool {
+    if (contourLength == 0.0) {
+      return true;
+    }
+    const double repeatedWork =
+        std::ceil(contourLength * static_cast<double>(dashPairCount) / intervalLength);
+    contourLength = 0.0;
+    if (!std::isfinite(repeatedWork) || repeatedWork < 0.0) {
+      return false;
+    }
+    if (repeatedWork > static_cast<double>(kMaximumTinySkiaDashWorkUnits) ||
+        dashPairCount > kMaximumTinySkiaDashWorkUnits - static_cast<std::size_t>(repeatedWork)) {
+      workUnits = kMaximumTinySkiaDashWorkUnits + 1;
+      return true;
+    }
+    const std::size_t contourWork = static_cast<std::size_t>(repeatedWork) + dashPairCount;
+    if (workUnits > kMaximumTinySkiaDashWorkUnits ||
+        contourWork > kMaximumTinySkiaDashWorkUnits - workUnits) {
+      workUnits = kMaximumTinySkiaDashWorkUnits + 1;
+    } else {
+      workUnits += contourWork;
+    }
+    return true;
+  };
+  const auto addEdge = [&](tiny_skia::Point start, tiny_skia::Point end) -> bool {
+    const double length =
+        std::hypot(static_cast<double>(end.x) - start.x, static_cast<double>(end.y) - start.y);
+    if (!std::isfinite(length) || contourLength > std::numeric_limits<double>::max() - length) {
+      return false;
+    }
+    contourLength += length;
+    return true;
+  };
+
+  for (const tiny_skia::PathVerb verb : path.verbs()) {
+    switch (verb) {
+      case tiny_skia::PathVerb::Move:
+        if (!finishContour() || pointIndex >= points.size()) return std::nullopt;
+        current = points[pointIndex++];
+        contourStart = current;
+        break;
+      case tiny_skia::PathVerb::Line:
+        if (!current.has_value() || pointIndex >= points.size() ||
+            !addEdge(*current, points[pointIndex])) {
+          return std::nullopt;
+        }
+        current = points[pointIndex++];
+        break;
+      case tiny_skia::PathVerb::Quad:
+        if (!current.has_value() || pointIndex > points.size() || points.size() - pointIndex < 2 ||
+            !addEdge(*current, points[pointIndex]) ||
+            !addEdge(points[pointIndex], points[pointIndex + 1])) {
+          return std::nullopt;
+        }
+        current = points[pointIndex + 1];
+        pointIndex += 2;
+        break;
+      case tiny_skia::PathVerb::Cubic:
+        if (!current.has_value() || pointIndex > points.size() || points.size() - pointIndex < 3 ||
+            !addEdge(*current, points[pointIndex]) ||
+            !addEdge(points[pointIndex], points[pointIndex + 1]) ||
+            !addEdge(points[pointIndex + 1], points[pointIndex + 2])) {
+          return std::nullopt;
+        }
+        current = points[pointIndex + 2];
+        pointIndex += 3;
+        break;
+      case tiny_skia::PathVerb::Close:
+        if (current.has_value() && contourStart.has_value() && !addEdge(*current, *contourStart)) {
+          return std::nullopt;
+        }
+        if (!finishContour()) return std::nullopt;
+        current = contourStart;
+        break;
+    }
+  }
+  if (!finishContour() || pointIndex != points.size()) {
+    return std::nullopt;
+  }
+  return workUnits;
+}
+
+template <typename ResolvePath, typename Reserve>
+void ReserveEstimatedDashWork(const std::optional<tiny_skia::StrokeDash>& dash,
+                              std::size_t targetCount, ResolvePath&& resolvePath, Reserve&& reserve,
+                              RendererDrawBudget& drawBudget) {
+  if (!dash.has_value()) {
+    return;
+  }
+  const std::optional<std::size_t> workUnits = EstimateDashWorkUnits(resolvePath(), *dash);
+  if (!workUnits.has_value() ||
+      *workUnits > std::numeric_limits<std::size_t>::max() / targetCount ||
+      !reserve(*workUnits * targetCount)) {
+    drawBudget.reject();
+  }
+}
+
+bool HasOpenDashSeam(const std::optional<tiny_skia::StrokeDash>& dash,
+                     bool dashHasOnlyZeroLengthGaps) {
+  return dash.has_value() && dashHasOnlyZeroLengthGaps;
+}
+
+#ifdef DONNER_TEXT_ENABLED
+bool CanRenderTextRun(bool isBitmapFont, float scale) {
+  return isBitmapFont || scale != 0.0f;
+}
+
+template <typename Bitmap>
+std::optional<Bitmap> AdmitBitmapGlyph(std::optional<Bitmap> bitmap,
+                                       RendererTextMaterializationBudget& materializationBudget,
+                                       RendererDrawBudget& drawBudget) {
+  if (!bitmap.has_value()) {
+    return std::nullopt;
+  }
+  const std::size_t bytes = bitmap->rgbaPixels.size();
+  if (bytes > std::numeric_limits<std::size_t>::max() / 2u ||
+      !materializationBudget.reserve({.uniqueOutlines = 1, .bytes = bytes * 2u})) {
+    drawBudget.reject();
+    return std::nullopt;
+  }
+  return bitmap;
+}
+
+std::vector<TextRun> CachedTextRuns(Registry& registry, Entity textRootEntity) {
+  if (textRootEntity == entt::null) {
+    return {};
+  }
+  const auto* cache = registry.try_get<components::ComputedTextGeometryComponent>(textRootEntity);
+  return cache ? cache->runs : std::vector<TextRun>();
+}
+#endif
 
 tiny_skia::Color toTinyColor(const css::RGBA& rgba) {
   return tiny_skia::Color::fromRgba8(rgba.r, rgba.g, rgba.b, rgba.a);
@@ -95,6 +276,16 @@ std::optional<tiny_skia::Rect> toTinyRect(const Box2d& box) {
   return tiny_skia::Rect::fromLTRB(NarrowToFloat(box.topLeft.x), NarrowToFloat(box.topLeft.y),
                                    NarrowToFloat(box.bottomRight.x),
                                    NarrowToFloat(box.bottomRight.y));
+}
+
+std::optional<tiny_skia::Rect> AdmittedEllipseRect(RendererDrawBudget& drawBudget,
+                                                   const tiny_skia::Pixmap& pixmap,
+                                                   const Box2d& bounds) {
+  (void)drawBudget.reserve({.drawCalls = 1, .pathCommands = 6});
+  if (pixmap.width() == 0 || pixmap.height() == 0) {
+    return std::nullopt;
+  }
+  return toTinyRect(bounds);
 }
 
 tiny_skia::FillRule toTinyFillRule(FillRule fillRule) {
@@ -490,8 +681,8 @@ Transform2d resolveGradientTransform(
 }
 
 std::optional<tiny_skia::Shader> instantiateGradientShader(
-    const components::PaintResolvedReference& ref, const Box2d& pathBounds, const Box2d& viewBox,
-    const css::RGBA& currentColor, float opacity) {
+    RendererDrawBudget& drawBudget, const components::PaintResolvedReference& ref,
+    const Box2d& pathBounds, const Box2d& viewBox, const css::RGBA& currentColor, float opacity) {
   const EntityHandle handle = ref.reference.handle;
   if (!handle) {
     return std::nullopt;
@@ -538,6 +729,9 @@ std::optional<tiny_skia::Shader> instantiateGradientShader(
 
   const Box2d& bounds = objectBoundingBox ? kUnitPathBounds : viewBox;
 
+  if (!drawBudget.reserve({.gradientStops = computedGradient->stops.size()})) {
+    return std::nullopt;
+  }
   std::vector<tiny_skia::GradientStop> stops;
   stops.reserve(computedGradient->stops.size());
   for (const GradientStop& stop : computedGradient->stops) {
@@ -1045,7 +1239,48 @@ double computeBlurPadding(const components::FilterGraph& filterGraph) {
 
 }  // namespace
 
-RendererTinySkia::RendererTinySkia(bool verbose) : verbose_(verbose) {}
+struct RendererTinySkia::DashedPathWorkBudget {
+  void reset() {
+    workUnits = 0;
+    rejected = false;
+  }
+
+  [[nodiscard]] bool reserve(std::size_t count) {
+    if (rejected || workUnits > maximumWorkUnits || count > maximumWorkUnits - workUnits) {
+      rejected = true;
+      return false;
+    }
+    workUnits += count;
+    return true;
+  }
+
+  std::size_t maximumWorkUnits = kMaximumTinySkiaDashWorkUnits;
+  std::size_t workUnits = 0;
+  bool rejected = false;
+};
+
+struct RendererTinySkia::TextGlyphWorkBudget {
+  void reset() {
+    glyphs = 0;
+    rejected = false;
+  }
+
+  [[nodiscard]] bool canReserve(std::size_t count) const {
+    return !rejected && glyphs <= maximumGlyphs && count <= maximumGlyphs - glyphs;
+  }
+
+  void commit(std::size_t count) { glyphs += count; }
+  void reject() { rejected = true; }
+
+  std::size_t maximumGlyphs = RendererDrawBudget::kMaximumDrawCalls / 2;
+  std::size_t glyphs = 0;
+  bool rejected = false;
+};
+
+RendererTinySkia::RendererTinySkia(bool verbose)
+    : verbose_(verbose),
+      textGlyphWorkBudget_(std::make_shared<TextGlyphWorkBudget>()),
+      dashedPathWorkBudget_(std::make_shared<DashedPathWorkBudget>()) {}
 
 RendererTinySkia::~RendererTinySkia() = default;
 RendererTinySkia::RendererTinySkia(RendererTinySkia&&) noexcept = default;
@@ -1070,10 +1305,19 @@ void RendererTinySkia::draw(SVGDocument& document) {
 
 void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   viewport_ = viewport;
-  const int pixelWidth =
-      CheckedPixelDimension(viewport.size.x, viewport.devicePixelRatio).value_or(0);
-  const int pixelHeight =
-      CheckedPixelDimension(viewport.size.y, viewport.devicePixelRatio).value_or(0);
+  if (ownsDrawBudget_) {
+    drawBudget_->reset();
+    textGlyphWorkBudget_->reset();
+    dashedPathWorkBudget_->reset();
+    textMaterializationBudget_->reset();
+    surfaceBudget_->reset();
+  }
+  int pixelWidth = CheckedPixelDimension(viewport.size.x, viewport.devicePixelRatio).value_or(0);
+  int pixelHeight = CheckedPixelDimension(viewport.size.y, viewport.devicePixelRatio).value_or(0);
+  if (!surfaceBudget_->reserve(pixelWidth, pixelHeight)) {
+    pixelWidth = 0;
+    pixelHeight = 0;
+  }
 
   // Keep the frame buffer's allocation across frames. A renderer that draws the
   // same viewport repeatedly (editor, compositor, animation loop) otherwise
@@ -1301,6 +1545,15 @@ void RendererTinySkia::pushIsolatedLayer(double opacity, MixBlendMode blendMode)
   }
   const int width = static_cast<int>(currentPixmap().width());
   const int height = static_cast<int>(currentPixmap().height());
+  std::size_t surfaceCount = 1;
+  if (!surfaceStack_.empty()) {
+    surfaceCount += surfaceStack_.back().fillPaintPixmap.has_value() ? 1u : 0u;
+    surfaceCount += surfaceStack_.back().strokePaintPixmap.has_value() ? 1u : 0u;
+  }
+  if (!surfaceBudget_->reserve(width, height, surfaceCount)) {
+    surfaceStack_.push_back(std::move(frame));
+    return;
+  }
   frame.pixmap = createTransparentPixmap(width, height);
   if (!surfaceStack_.empty()) {
     const SurfaceFrame& parent = surfaceStack_.back();
@@ -1631,8 +1884,19 @@ void RendererTinySkia::pushMask(const std::optional<Box2d>& maskBounds, MaskType
     surfaceStack_.push_back(std::move(frame));
     return;
   }
-  frame.pixmap = createTransparentPixmap(static_cast<int>(currentPixmap().width()),
-                                         static_cast<int>(currentPixmap().height()));
+  const int width = static_cast<int>(currentPixmap().width());
+  const int height = static_cast<int>(currentPixmap().height());
+  std::size_t surfaceCount = 2u + (maskBounds.has_value() ? 1u : 0u);
+  if (!surfaceStack_.empty()) {
+    surfaceCount += surfaceStack_.back().fillPaintPixmap.has_value() ? 1u : 0u;
+    surfaceCount += surfaceStack_.back().strokePaintPixmap.has_value() ? 1u : 0u;
+  }
+  if (!surfaceBudget_->reserve(width, height, surfaceCount)) {
+    frame.allocationRejected = true;
+    surfaceStack_.push_back(std::move(frame));
+    return;
+  }
+  frame.pixmap = createTransparentPixmap(width, height);
   surfaceStack_.push_back(std::move(frame));
 }
 
@@ -1727,6 +1991,9 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   frame.patternRasterFromTile = Transform2d::Scale(rasterMetrics->rasterFromPatternScale);
   frame.targetFromPattern =
       TargetFromPatternRaster(targetFromPattern, rasterMetrics->rasterFromPatternScale);
+  if (!surfaceBudget_->reserve(rasterMetrics->pixelWidth, rasterMetrics->pixelHeight)) {
+    return false;
+  }
   frame.pixmap = createTransparentPixmap(rasterMetrics->pixelWidth, rasterMetrics->pixelHeight);
   if (frame.pixmap.width() == 0 || frame.pixmap.height() == 0) {
     return false;
@@ -1792,11 +2059,12 @@ void RendererTinySkia::setPaint(const PaintParams& paint) {
 }
 
 void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& stroke) {
+  const Path& pathGeometry = path.pathOrEmpty();
+  (void)drawBudget_->reserve(
+      {.drawCalls = 1, .pathCommands = static_cast<std::size_t>(pathGeometry.verbCount())});
   if (currentPixmap().width() == 0 || currentPixmap().height() == 0) {
     return;
   }
-
-  const Path& pathGeometry = path.pathOrEmpty();
 
   const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
   tiny_skia::Pixmap* fillPaintPixmap =
@@ -1916,7 +2184,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     // those ranges across ClosePath, filling the seam as if the stroke were solid. Replace only
     // the stroke's ClosePath commands with explicit closing lines so the dash stroker emits caps
     // at that boundary; fills and ordinary dashed/solid strokes keep their closed contours.
-    const bool openDashSeam = tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps;
+    const bool openDashSeam = HasOpenDashSeam(tinyStroke.dash, dashHasOnlyZeroLengthGaps);
     tiny_skia::Path uncachedDashSeamPath;
     const tiny_skia::Path* resolvedDashSeamPath = nullptr;
     const auto strokePath = [&]() -> const tiny_skia::Path& {
@@ -1930,6 +2198,14 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
       }
       return *resolvedDashSeamPath;
     };
+
+    const std::size_t targetCount = 1u + static_cast<std::size_t>(strokePaintPixmap != nullptr);
+    ReserveEstimatedDashWork(
+        tinyStroke.dash, targetCount, strokePath,
+        [&](std::size_t work) { return dashedPathWorkBudget_->reserve(work); }, *drawBudget_);
+    if (drawBudget_->rejected()) {
+      return;
+    }
 
     auto pixmapView = currentPixmapView();
 
@@ -1984,6 +2260,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
 }
 
 void RendererTinySkia::drawRect(const Box2d& rect, const StrokeParams& stroke) {
+  (void)drawBudget_->reserve({.drawCalls = 1, .pathCommands = 5});
   if (currentPixmap().width() == 0 || currentPixmap().height() == 0) {
     return;
   }
@@ -2046,7 +2323,8 @@ void RendererTinySkia::drawRect(const Box2d& rect, const StrokeParams& stroke) {
 }
 
 void RendererTinySkia::drawEllipse(const Box2d& bounds, const StrokeParams& stroke) {
-  const std::optional<tiny_skia::Rect> oval = toTinyRect(bounds);
+  const std::optional<tiny_skia::Rect> oval =
+      AdmittedEllipseRect(*drawBudget_, currentPixmap(), bounds);
   if (!oval.has_value()) {
     return;
   }
@@ -2163,6 +2441,9 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
   if (!HasExactRgbaPayload(image.data, image.width, image.height)) {
     return;
   }
+  if (!drawBudget_->reserve({.drawCalls = 1, .imageDraws = 1, .imageBytes = image.data.size()})) {
+    return;
+  }
 
   // `ImageResource` publishes straight alpha and tiny-skia samples premultiplied, so the
   // conversion is unavoidable, but it does not have to recur. The pixels belong to the element's
@@ -2186,6 +2467,10 @@ void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParam
     return;
   }
   if (bitmap.empty()) {
+    return;
+  }
+  if (!drawBudget_->reserve(
+          {.drawCalls = 1, .imageDraws = 1, .imageBytes = bitmap.pixels.size()})) {
     return;
   }
 
@@ -2237,31 +2522,88 @@ void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParam
   drawImagePixmap(*sourceView, bitmap.dimensions.x, bitmap.dimensions.y, params);
 }
 
+#ifdef DONNER_TEXT_ENABLED
+bool RendererTinySkia::admitTextGlyphBatch(const std::vector<TextRun>& runs) {
+  constexpr std::size_t kMaximumGlyphs = RendererDrawBudget::kMaximumDrawCalls / 2;
+  std::size_t glyphCount = 0;
+  for (const TextRun& run : runs) {
+    if (run.glyphs.size() > kMaximumGlyphs - glyphCount) {
+      drawBudget_->reject();
+      return false;
+    }
+    glyphCount += run.glyphs.size();
+  }
+  if (!textGlyphWorkBudget_->canReserve(glyphCount) ||
+      !drawBudget_->reserve({.drawCalls = glyphCount * 2})) {
+    textGlyphWorkBudget_->reject();
+    drawBudget_->reject();
+    return false;
+  }
+  textGlyphWorkBudget_->commit(glyphCount);
+  return true;
+}
+
+bool RendererTinySkia::admitGlyphPredecode(const FontManager& fontManager, FontHandle font,
+                                           int glyphIndex, bool& hasComplexity) {
+  if (drawBudget_->rejected()) {
+    return false;
+  }
+  const std::optional<FontManager::GlyphOutlineComplexity> complexity =
+      fontManager.glyphOutlineComplexity(font, glyphIndex);
+  hasComplexity = complexity.has_value();
+  if (complexity.has_value()) {
+    const std::optional<RendererTextMaterializationBudget::Cost> cost =
+        GlyphPredecodeCost(*complexity);
+    return cost.has_value() && textMaterializationBudget_->reserve(*cost);
+  }
+  if (!fontManager.isTrustedFont(font)) {
+    textMaterializationBudget_->reject();
+    return false;
+  }
+  return true;
+}
+
+bool RendererTinySkia::admitPlacedGlyph(bool hasPredecodeComplexity, const Path& path) {
+  if (hasPredecodeComplexity || path.empty()) {
+    return true;
+  }
+  const std::optional<std::size_t> retainedBytes = path.retainedBytes();
+  if (!retainedBytes.has_value() ||
+      path.commands().size() > std::numeric_limits<std::size_t>::max() / 2u ||
+      path.points().size() > std::numeric_limits<std::size_t>::max() / 2u ||
+      *retainedBytes > std::numeric_limits<std::size_t>::max() / 2u) {
+    textMaterializationBudget_->reject();
+    return false;
+  }
+  return textMaterializationBudget_->reserve({.uniqueOutlines = 1,
+                                              .commands = path.commands().size() * 2u,
+                                              .points = path.points().size() * 2u,
+                                              .bytes = *retainedBytes * 2u});
+}
+
+#endif  // DONNER_TEXT_ENABLED
+
 void RendererTinySkia::drawText(Registry& registry, const components::ComputedTextComponent& text,
                                 const TextParams& params) {
 #ifdef DONNER_TEXT_ENABLED
-  if (currentPixmap().width() == 0 || currentPixmap().height() == 0) {
-    return;
-  }
-
   if (!registry.ctx().contains<TextEngine>()) {
     maybeWarnUnsupportedText();
     return;
   }
 
   auto& textEngine = registry.ctx().get<TextEngine>();
+  auto& fontManager = registry.ctx().get<FontManager>();
 
   // Use cached layout runs from ComputedTextGeometryComponent when available.
-  std::vector<TextRun> runs;
-  if (params.textRootEntity != entt::null) {
-    if (const auto* cache =
-            registry.try_get<components::ComputedTextGeometryComponent>(params.textRootEntity)) {
-      runs = cache->runs;
-    }
-  }
+  std::vector<TextRun> runs = CachedTextRuns(registry, params.textRootEntity);
   if (runs.empty()) {
     const TextLayoutParams layoutParams = toTextLayoutParams(params);
     runs = textEngine.layout(text, layoutParams);
+  }
+
+  (void)admitTextGlyphBatch(runs);
+  if (currentPixmap().width() == 0 || currentPixmap().height() == 0) {
+    return;
   }
 
   float scale = 0.0f;
@@ -2318,7 +2660,7 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
     }
 
     const bool isBitmapFont = run.font && textEngine.isBitmapOnly(run.font);
-    if (!isBitmapFont && scale == 0.0f) {
+    if (!CanRenderTextRun(isBitmapFont, scale)) {
       continue;
     }
 
@@ -2346,7 +2688,7 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         // Per-span gradient/pattern fill. Uses the text element's bbox (textBounds)
         // for objectBoundingBox mapping, per SVG spec ("tspan doesn't have a bbox").
         const float combinedOpacity = spanFillOpacity * static_cast<float>(span.opacity);
-        if (auto shader = instantiateGradientShader(*ref, textBounds, paint_.viewBox,
+        if (auto shader = instantiateGradientShader(*drawBudget_, *ref, textBounds, paint_.viewBox,
                                                     spanCurrentColor, combinedOpacity)) {
           tiny_skia::Paint paint = makeBasePaint(antialias_);
           paint.shader = std::move(*shader);
@@ -2382,8 +2724,9 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         } else if (const auto* ref =
                        std::get_if<components::PaintResolvedReference>(&span.resolvedStroke)) {
           const float combinedOpacity = spanStrokeOpacity * static_cast<float>(span.opacity);
-          if (auto shader = instantiateGradientShader(*ref, textBounds, paint_.viewBox,
-                                                      spanCurrentColor, combinedOpacity)) {
+          if (auto shader =
+                  instantiateGradientShader(*drawBudget_, *ref, textBounds, paint_.viewBox,
+                                            spanCurrentColor, combinedOpacity)) {
             tiny_skia::Paint paint = makeBasePaint(antialias_);
             paint.shader = std::move(*shader);
             spanStrokePaint = paint;
@@ -2414,6 +2757,7 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
       if (glyph.glyphIndex == 0) {
         continue;  // .notdef glyph, skip.
       }
+      ++frameCounters_.textGlyphMaterializations;
 
       // Placed outline in document space (outline -> stretch -> translate ->
       // rotate). Shared with RendererGeode via PlacedTextGeometry so the two
@@ -2422,13 +2766,25 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
       // exactly as before.
       Path glyphPath;
       if (!isBitmapFont) {
+        bool hasComplexity = false;
+        if (!admitGlyphPredecode(fontManager, run.font, glyph.glyphIndex, hasComplexity)) {
+          drawBudget_->reject();
+          return;
+        }
         glyphPath = PlacedGlyphOutline(textEngine, run.font, glyph, scale);
+        if (!admitPlacedGlyph(hasComplexity, glyphPath)) {
+          drawBudget_->reject();
+          return;
+        }
       }
 
       // For bitmap fonts (color emoji), extract and draw the bitmap directly.
       if (glyphPath.empty()) {
-        auto bitmap = textEngine.bitmapGlyph(run.font, glyph.glyphIndex, scale);
-        // DEBUG
+        auto bitmap = AdmitBitmapGlyph(textEngine.bitmapGlyph(run.font, glyph.glyphIndex, scale),
+                                       *textMaterializationBudget_, *drawBudget_);
+        if (drawBudget_->rejected()) {
+          return;
+        }
         if (bitmap) {
           // Premultiply alpha for correct blending.
           std::vector<uint8_t> premul = PremultiplyRgba(bitmap->rgbaPixels);
@@ -2559,7 +2915,7 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         const css::RGBA spanCurrentColor = paint_.currentColor.rgba();
         const float combinedOpacity =
             NarrowToFloat(span.decorationFillOpacity) * static_cast<float>(span.opacity);
-        if (auto shader = instantiateGradientShader(*ref, textBounds, paint_.viewBox,
+        if (auto shader = instantiateGradientShader(*drawBudget_, *ref, textBounds, paint_.viewBox,
                                                     spanCurrentColor, combinedOpacity)) {
           tiny_skia::Paint paint = makeBasePaint(antialias_);
           paint.shader = std::move(*shader);
@@ -2582,7 +2938,7 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         const css::RGBA spanCurrentColor = paint_.currentColor.rgba();
         const float combinedOpacity =
             NarrowToFloat(span.decorationStrokeOpacity) * static_cast<float>(span.opacity);
-        if (auto shader = instantiateGradientShader(*ref, textBounds, paint_.viewBox,
+        if (auto shader = instantiateGradientShader(*drawBudget_, *ref, textBounds, paint_.viewBox,
                                                     spanCurrentColor, combinedOpacity)) {
           tiny_skia::Paint paint = makeBasePaint(antialias_);
           paint.shader = std::move(*shader);
@@ -2820,7 +3176,59 @@ std::unique_ptr<RendererInterface> RendererTinySkia::createOffscreenInstance() c
   auto renderer = std::make_unique<RendererTinySkia>(verbose_);
   renderer->filterExecutionBudget_ = filterExecutionBudget_;
   renderer->ownsFilterExecutionBudget_ = false;
+  renderer->drawBudget_ = drawBudget_;
+  renderer->ownsDrawBudget_ = false;
+  renderer->surfaceBudget_ = surfaceBudget_;
+  renderer->ownsSurfaceBudget_ = false;
+  renderer->textGlyphWorkBudget_ = textGlyphWorkBudget_;
+  renderer->dashedPathWorkBudget_ = dashedPathWorkBudget_;
+  renderer->textMaterializationBudget_ = textMaterializationBudget_;
+  renderer->ownsTextMaterializationBudget_ = false;
   return renderer;
+}
+
+void RendererTinySkia::setDashWorkBudgetForTesting(std::size_t maximumWorkUnits) {
+  dashedPathWorkBudget_->maximumWorkUnits =
+      std::min(dashedPathWorkBudget_->maximumWorkUnits, maximumWorkUnits);
+}
+
+void RendererTinySkia::setGradientStopBudgetForTesting(std::size_t maximumStops) {
+  drawBudget_->setGradientStopLimitForTesting(maximumStops);
+}
+
+void RendererTinySkia::setTextGlyphBudgetForTesting(std::size_t maximumGlyphs) {
+  textGlyphWorkBudget_->maximumGlyphs =
+      std::min(textGlyphWorkBudget_->maximumGlyphs, maximumGlyphs);
+}
+
+void RendererTinySkia::setTextMaterializationBudgetForTesting(
+    RendererTextMaterializationBudget::Cost limits) {
+  textMaterializationBudget_->setLimitsForTesting(limits);
+}
+
+RendererResourceStats RendererTinySkia::resourceStats() const {
+  return RendererResourceStats{
+      .surfaceBudgetSupported = true,
+      .surfaceCount = surfaceBudget_->surfaces(),
+      .surfaceBytes = surfaceBudget_->bytes(),
+      .surfaceBudgetRejected = surfaceBudget_->rejected(),
+      .drawBudgetSupported = true,
+      .drawCalls = drawBudget_->drawCalls(),
+      .pathCommands = drawBudget_->pathCommands(),
+      .pathMeasurementWorkSupported = true,
+      .pathMeasurementWorkUnits = drawBudget_->pathMeasurementWorkUnits(),
+      .gradientStops = drawBudget_->gradientStops(),
+      .imageDraws = drawBudget_->imageDraws(),
+      .imageBytes = drawBudget_->imageBytes(),
+      .drawBudgetRejected = drawBudget_->rejected(),
+      .textMaterializationBudgetSupported = true,
+      .textUniqueOutlines = textMaterializationBudget_->uniqueOutlines(),
+      .textMaterializationCommands = textMaterializationBudget_->commands(),
+      .textMaterializationPoints = textMaterializationBudget_->points(),
+      .textMaterializationBytes = textMaterializationBudget_->bytes(),
+      .textGlyphDecodeWork = textMaterializationBudget_->decodeWork(),
+      .textMaterializationBudgetRejected = textMaterializationBudget_->rejected(),
+  };
 }
 
 int RendererTinySkia::width() const {
@@ -2832,14 +3240,14 @@ int RendererTinySkia::height() const {
 }
 
 tiny_skia::Pixmap& RendererTinySkia::currentPixmap() {
-  if (rejectedFilterDepth_ != 0) {
+  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected()) {
     return rejectedPixmap_;
   }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
 }
 
 const tiny_skia::Pixmap& RendererTinySkia::currentPixmap() const {
-  if (rejectedFilterDepth_ != 0) {
+  if (rejectedFilterDepth_ != 0 || drawBudget_->rejected()) {
     return rejectedPixmap_;
   }
   return surfaceStack_.empty() ? frame_ : surfaceStack_.back().pixmap;
@@ -2991,8 +3399,8 @@ std::optional<tiny_skia::Paint> RendererTinySkia::makeFillPaint(const Box2d& bou
   }
 
   if (const auto* ref = std::get_if<components::PaintResolvedReference>(&paint_.fill)) {
-    if (std::optional<tiny_skia::Shader> shader =
-            instantiateGradientShader(*ref, bounds, paint_.viewBox, currentColor, fillOpacity)) {
+    if (std::optional<tiny_skia::Shader> shader = instantiateGradientShader(
+            *drawBudget_, *ref, bounds, paint_.viewBox, currentColor, fillOpacity)) {
       paint.shader = std::move(*shader);
       return paint;
     }
@@ -3031,8 +3439,8 @@ std::optional<tiny_skia::Paint> RendererTinySkia::makeStrokePaint(const Box2d& b
   }
 
   if (const auto* ref = std::get_if<components::PaintResolvedReference>(&paint_.stroke)) {
-    if (std::optional<tiny_skia::Shader> shader =
-            instantiateGradientShader(*ref, bounds, paint_.viewBox, currentColor, strokeOpacity)) {
+    if (std::optional<tiny_skia::Shader> shader = instantiateGradientShader(
+            *drawBudget_, *ref, bounds, paint_.viewBox, currentColor, strokeOpacity)) {
       paint.shader = std::move(*shader);
       return paint;
     }

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -936,6 +936,148 @@ void drawRectIntoMask(tiny_skia::Mask& mask, const Box2d& rect, const Transform2
   mask.fillPath(path, tiny_skia::FillRule::Winding, antialias, toTinyTransform(transform));
 }
 
+void LogClipMaskHeader(const ResolvedClip& clip, const Transform2d& deviceFromLocal) {
+  std::cout << "[TinySkia::buildClipMask] clipRect=";
+  if (clip.clipRect.has_value()) {
+    std::cout << *clip.clipRect;
+  } else {
+    std::cout << "none";
+  }
+  std::cout << " clipPaths=" << clip.clipPaths.size() << "\n  currentTransform=" << deviceFromLocal
+            << "  clipPathUnitsTransform=" << clip.clipPathUnitsTransform;
+}
+
+std::optional<tiny_skia::Mask> CombineClipMasks(std::optional<tiny_skia::Mask> rectMask,
+                                                std::optional<tiny_skia::Mask> pathMask) {
+  if (!rectMask.has_value()) {
+    return pathMask;
+  }
+  if (pathMask.has_value()) {
+    intersectMaskInPlace(*rectMask, *pathMask);
+  }
+  return rectMask;
+}
+
+class ClipMaskBuilder {
+public:
+  ClipMaskBuilder(RendererSurfaceBudget& surfaceBudget, int width, int height,
+                  const Transform2d& clipPathUnitsTransform, const Transform2d& deviceFromLocal,
+                  bool antialias, bool verbose)
+      : surfaceBudget_(surfaceBudget),
+        width_(width),
+        height_(height),
+        clipPathUnitsTransform_(clipPathUnitsTransform),
+        deviceFromLocal_(deviceFromLocal),
+        antialias_(antialias),
+        verbose_(verbose) {}
+
+  std::optional<tiny_skia::Mask> buildRect(const std::optional<Box2d>& rect) {
+    if (!rect.has_value()) {
+      return std::nullopt;
+    }
+    std::optional<tiny_skia::Mask> mask = createMask();
+    if (mask.has_value()) {
+      drawRectIntoMask(*mask, *rect, deviceFromLocal_, antialias_);
+    }
+    return mask;
+  }
+
+  std::optional<tiny_skia::Mask> buildPaths(std::span<const ClipPathShape> paths) {
+    if (paths.empty()) {
+      return std::nullopt;
+    }
+    paths_ = paths;
+    index_ = static_cast<std::ptrdiff_t>(paths.size()) - 1;
+    return buildLayer(paths.back().layer);
+  }
+
+  bool allocationFailed() const { return allocationFailed_; }
+
+private:
+  std::optional<tiny_skia::Mask> createMask() {
+    if (!surfaceBudget_.reserve(width_, height_, /*surfaceCount=*/1, /*bytesPerPixel=*/1)) {
+      allocationFailed_ = true;
+      return std::nullopt;
+    }
+    std::optional<tiny_skia::Mask> mask =
+        createMaskForSize(static_cast<std::uint32_t>(width_), static_cast<std::uint32_t>(height_));
+    if (!mask.has_value()) {
+      allocationFailed_ = true;
+      return std::nullopt;
+    }
+    std::fill(mask->data().begin(), mask->data().end(), 0);
+    return mask;
+  }
+
+  std::optional<tiny_skia::Mask> renderShape(const ClipPathShape& shape) {
+    std::optional<tiny_skia::Mask> shapeMask = createMask();
+    if (!shapeMask.has_value()) {
+      return std::nullopt;
+    }
+
+    const tiny_skia::Path path = toTinyPath(shape.path);
+    if (path.empty()) {
+      if (verbose_) {
+        std::cout << "\n  shape layer=" << shape.layer << " empty path";
+      }
+      return shapeMask;
+    }
+
+    const Transform2d clipPathTransform =
+        clipPathUnitsTransform_ * shape.parentFromEntity * deviceFromLocal_;
+    if (verbose_) {
+      const Box2d pathBounds = shape.path.bounds();
+      std::cout << "\n  shape layer=" << shape.layer << " bounds=" << pathBounds
+                << "\n    parentFromEntity=" << shape.parentFromEntity
+                << "    combinedTransform=" << clipPathTransform
+                << "    transformedBounds=" << clipPathTransform.transformBox(pathBounds);
+    }
+    shapeMask->fillPath(path, toTinyFillRule(shape.fillRule), antialias_,
+                        toTinyTransform(clipPathTransform));
+    return shapeMask;
+  }
+
+  std::optional<tiny_skia::Mask> buildLayer(int layer) {
+    std::optional<tiny_skia::Mask> layerMask;
+    while (!allocationFailed_ && index_ >= 0 &&
+           paths_[static_cast<std::size_t>(index_)].layer == layer) {
+      std::optional<tiny_skia::Mask> shapeMask =
+          renderShape(paths_[static_cast<std::size_t>(index_)]);
+      --index_;
+
+      if (shapeMask.has_value() && index_ >= 0 &&
+          paths_[static_cast<std::size_t>(index_)].layer > layer) {
+        std::optional<tiny_skia::Mask> nestedMask =
+            buildLayer(paths_[static_cast<std::size_t>(index_)].layer);
+        if (nestedMask.has_value()) {
+          intersectMaskInPlace(*shapeMask, *nestedMask);
+        }
+      }
+
+      if (!shapeMask.has_value()) {
+        continue;
+      }
+      if (!layerMask.has_value()) {
+        layerMask = std::move(shapeMask);
+      } else {
+        unionMaskInPlace(*layerMask, *shapeMask);
+      }
+    }
+    return layerMask;
+  }
+
+  RendererSurfaceBudget& surfaceBudget_;
+  int width_;
+  int height_;
+  Transform2d clipPathUnitsTransform_;
+  Transform2d deviceFromLocal_;
+  bool antialias_;
+  bool verbose_;
+  bool allocationFailed_ = false;
+  std::span<const ClipPathShape> paths_;
+  std::ptrdiff_t index_ = -1;
+};
+
 #ifndef DONNER_FILTERS_ENABLED
 // When filters are disabled, FilterGraphExecutor.h is not included so PremultiplyRgba is not
 // available. Provide a local copy for drawImage().
@@ -1312,6 +1454,29 @@ void RendererTinySkia::draw(SVGDocument& document) {
   driver.draw(document);
 }
 
+void RendererTinySkia::prepareRetainedClipEpochBudget(int pixelWidth, int pixelHeight) {
+  const tiny_skia::IntSize admittedFrameSize(static_cast<std::uint32_t>(pixelWidth),
+                                             static_cast<std::uint32_t>(pixelHeight));
+  if (admittedFrameSize != previousFrameSize_) {
+    clipEpochSlots_.clear();
+  }
+
+  clipEpochRetentionActive_ = false;
+  if (!retainedSpansEnabled_ || pixelWidth <= 0 || pixelHeight <= 0) {
+    clipEpochSlots_.clear();
+    return;
+  }
+
+  RendererSurfaceBudget withClipEpochEnvelope = *surfaceBudget_;
+  if (withClipEpochEnvelope.reserve(pixelWidth, pixelHeight, kMaxRetainedClipDepth,
+                                    /*bytesPerPixel=*/1)) {
+    *surfaceBudget_ = withClipEpochEnvelope;
+    clipEpochRetentionActive_ = true;
+  } else {
+    clipEpochSlots_.clear();
+  }
+}
+
 void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   viewport_ = viewport;
   if (ownsDrawBudget_) {
@@ -1328,25 +1493,7 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
     pixelHeight = 0;
   }
 
-  const tiny_skia::IntSize admittedFrameSize(static_cast<std::uint32_t>(pixelWidth),
-                                             static_cast<std::uint32_t>(pixelHeight));
-  if (admittedFrameSize != previousFrameSize_) {
-    clipEpochSlots_.clear();
-  }
-
-  clipEpochRetentionActive_ = false;
-  if (retainedSpansEnabled_ && pixelWidth > 0 && pixelHeight > 0) {
-    RendererSurfaceBudget withClipEpochEnvelope = *surfaceBudget_;
-    if (withClipEpochEnvelope.reserve(pixelWidth, pixelHeight, kMaxRetainedClipDepth,
-                                      /*bytesPerPixel=*/1)) {
-      *surfaceBudget_ = withClipEpochEnvelope;
-      clipEpochRetentionActive_ = true;
-    } else {
-      clipEpochSlots_.clear();
-    }
-  } else {
-    clipEpochSlots_.clear();
-  }
+  prepareRetainedClipEpochBudget(pixelWidth, pixelHeight);
 
   // Keep the frame buffer's allocation across frames. A renderer that draws the
   // same viewport repeatedly (editor, compositor, animation loop) otherwise
@@ -2112,6 +2259,23 @@ void RendererTinySkia::setPaint(const PaintParams& paint) {
   paintOpacity_ = paint.opacity;
 }
 
+bool RendererTinySkia::applyPathLengthAdjustment(const Path& path, StrokeParams& stroke) {
+  if (stroke.dashArray.empty() || stroke.pathLength <= 0.0 || NearZero(stroke.pathLength)) {
+    return true;
+  }
+  if (!drawBudget_->reserve(
+          {.pathMeasurementWorkUnits = ConservativePathMeasurementWorkUnits(path)})) {
+    return false;
+  }
+
+  const double dashUnitsScale = path.pathLength() / stroke.pathLength;
+  for (double& dash : stroke.dashArray) {
+    dash *= dashUnitsScale;
+  }
+  stroke.dashOffset *= dashUnitsScale;
+  return true;
+}
+
 void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& stroke) {
   const Path& pathGeometry = path.pathOrEmpty();
   (void)drawBudget_->reserve(
@@ -2190,18 +2354,8 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   }
 
   StrokeParams adjustedStroke = stroke;
-  if (!adjustedStroke.dashArray.empty() && adjustedStroke.pathLength > 0.0 &&
-      !NearZero(adjustedStroke.pathLength)) {
-    if (!drawBudget_->reserve(
-            {.pathMeasurementWorkUnits = ConservativePathMeasurementWorkUnits(pathGeometry)})) {
-      return;
-    }
-    const double actualLength = pathGeometry.pathLength();
-    const double dashUnitsScale = actualLength / adjustedStroke.pathLength;
-    for (double& dash : adjustedStroke.dashArray) {
-      dash *= dashUnitsScale;
-    }
-    adjustedStroke.dashOffset *= dashUnitsScale;
+  if (!applyPathLengthAdjustment(pathGeometry, adjustedStroke)) {
+    return;
   }
 
   const bool usedPatternStroke = patternStrokePaint_.has_value();
@@ -3321,126 +3475,21 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
   }
 
   if (verbose_) {
-    std::cout << "[TinySkia::buildClipMask] clipRect=";
-    if (clip.clipRect.has_value()) {
-      std::cout << *clip.clipRect;
-    } else {
-      std::cout << "none";
-    }
-    std::cout << " clipPaths=" << clip.clipPaths.size()
-              << "\n  currentTransform=" << deviceFromLocalTransform_
-              << "  clipPathUnitsTransform=" << clip.clipPathUnitsTransform;
+    LogClipMaskHeader(clip, deviceFromLocalTransform_);
   }
 
   const int maskWidth = static_cast<int>(currentPixmap().width());
   const int maskHeight = static_cast<int>(currentPixmap().height());
-  bool allocationFailed = false;
-  const auto createMask = [&]() {
-    if (!surfaceBudget_->reserve(maskWidth, maskHeight, /*surfaceCount=*/1,
-                                 /*bytesPerPixel=*/1)) {
-      allocationFailed = true;
-      return std::optional<tiny_skia::Mask>();
-    }
-    std::optional<tiny_skia::Mask> mask = createMaskForSize(static_cast<std::uint32_t>(maskWidth),
-                                                            static_cast<std::uint32_t>(maskHeight));
-    if (mask.has_value()) {
-      std::fill(mask->data().begin(), mask->data().end(), 0);
-    } else {
-      allocationFailed = true;
-    }
-    return mask;
-  };
-
-  std::optional<tiny_skia::Mask> rectMask;
-  if (clip.clipRect.has_value()) {
-    rectMask = createMask();
-    if (rectMask.has_value()) {
-      drawRectIntoMask(*rectMask, *clip.clipRect, deviceFromLocalTransform_, antialias_);
-    }
-  }
-
-  const auto renderShapeMask = [&](const ClipPathShape& shape) -> std::optional<tiny_skia::Mask> {
-    std::optional<tiny_skia::Mask> shapeMask = createMask();
-    if (!shapeMask.has_value()) {
-      return std::nullopt;
-    }
-
-    const tiny_skia::Path path = toTinyPath(shape.path);
-    if (path.empty()) {
-      if (verbose_) {
-        std::cout << "\n  shape layer=" << shape.layer << " empty path";
-      }
-      return shapeMask;
-    }
-
-    const Transform2d clipPathTransform =
-        clip.clipPathUnitsTransform * shape.parentFromEntity * deviceFromLocalTransform_;
-    if (verbose_) {
-      const Box2d pathBounds = shape.path.bounds();
-      std::cout << "\n  shape layer=" << shape.layer << " bounds=" << pathBounds
-                << "\n    parentFromEntity=" << shape.parentFromEntity
-                << "    combinedTransform=" << clipPathTransform
-                << "    transformedBounds=" << clipPathTransform.transformBox(pathBounds);
-    }
-    shapeMask->fillPath(path, toTinyFillRule(shape.fillRule), antialias_,
-                        toTinyTransform(clipPathTransform));
-    return shapeMask;
-  };
-
-  std::optional<tiny_skia::Mask> pathMask;
-  if (!clip.clipPaths.empty()) {
-    std::ptrdiff_t index = static_cast<std::ptrdiff_t>(clip.clipPaths.size()) - 1;
-
-    std::function<std::optional<tiny_skia::Mask>(int)> buildLayerMask =
-        [&](int layer) -> std::optional<tiny_skia::Mask> {
-      std::optional<tiny_skia::Mask> layerMask;
-      while (index >= 0 && clip.clipPaths[static_cast<std::size_t>(index)].layer == layer) {
-        const ClipPathShape& shape = clip.clipPaths[static_cast<std::size_t>(index)];
-        std::optional<tiny_skia::Mask> shapeMask = renderShapeMask(shape);
-        --index;
-
-        if (shapeMask.has_value() && index >= 0 &&
-            clip.clipPaths[static_cast<std::size_t>(index)].layer > layer) {
-          std::optional<tiny_skia::Mask> nestedMask =
-              buildLayerMask(clip.clipPaths[static_cast<std::size_t>(index)].layer);
-          if (nestedMask.has_value()) {
-            intersectMaskInPlace(*shapeMask, *nestedMask);
-          }
-        }
-
-        if (!shapeMask.has_value()) {
-          continue;
-        }
-
-        if (!layerMask.has_value()) {
-          layerMask = std::move(shapeMask);
-        } else {
-          unionMaskInPlace(*layerMask, *shapeMask);
-        }
-      }
-      return layerMask;
-    };
-
-    pathMask = buildLayerMask(clip.clipPaths.back().layer);
-  }
-
-  std::optional<tiny_skia::Mask> result;
-  if (rectMask.has_value()) {
-    result = std::move(rectMask);
-  }
-  if (pathMask.has_value()) {
-    if (result.has_value()) {
-      intersectMaskInPlace(*result, *pathMask);
-    } else {
-      result = std::move(pathMask);
-    }
-  }
+  ClipMaskBuilder builder(*surfaceBudget_, maskWidth, maskHeight, clip.clipPathUnitsTransform,
+                          deviceFromLocalTransform_, antialias_, verbose_);
+  std::optional<tiny_skia::Mask> result =
+      CombineClipMasks(builder.buildRect(clip.clipRect), builder.buildPaths(clip.clipPaths));
 
   if (verbose_) {
     std::cout << "\n";
   }
 
-  if (allocationFailed) {
+  if (builder.allocationFailed()) {
     return std::nullopt;
   }
   return result;

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -358,6 +358,7 @@ private:
     std::vector<Transform2d> savedTransformStack;
     std::optional<tiny_skia::Mask> savedClipMask;
     std::vector<std::optional<tiny_skia::Mask>> savedClipStack;
+    std::vector<bool> savedClipRestoreStack;
     /// Pattern paints pending at `beginPatternTile` time, saved so tile-content draws don't
     /// consume the outer element's pattern shaders (e.g. a `context-fill` pattern shared between
     /// several consumers re-rendering the same tile subtree). Restored by `endPatternTile`.
@@ -418,7 +419,7 @@ private:
   [[nodiscard]] tiny_skia::Pixmap& currentPixmap();
   [[nodiscard]] const tiny_skia::Pixmap& currentPixmap() const;
   [[nodiscard]] tiny_skia::MutablePixmapView currentPixmapView();
-  [[nodiscard]] std::optional<tiny_skia::Mask> buildClipMask(const ResolvedClip& clip) const;
+  [[nodiscard]] std::optional<tiny_skia::Mask> buildClipMask(const ResolvedClip& clip);
   [[nodiscard]] std::optional<FilterAdmission> admitFilterLayer(
       const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
       const Transform2d& deviceFromFilter, int viewportWidth, int viewportHeight);
@@ -493,6 +494,8 @@ private:
   std::vector<Transform2d> deviceFromLocalTransformStack_;
   std::optional<tiny_skia::Mask> currentClipMask_;
   std::vector<std::optional<tiny_skia::Mask>> clipStack_;
+  std::vector<bool> clipRestoreStack_;
+  bool clipMaskAllocationRejected_ = false;
   tiny_skia::Pixmap rejectedPixmap_;
   std::vector<SurfaceFrame> surfaceStack_;
   std::vector<bool> filterLayerStack_;
@@ -550,6 +553,7 @@ private:
   std::uint64_t nextClipEpoch_ = 1;
   std::vector<std::uint64_t> clipEpochStack_;
   std::vector<ClipEpochSlot> clipEpochSlots_;
+  bool clipEpochRetentionActive_ = false;
   /// Surface size the remembered clip masks were built against.
   tiny_skia::IntSize previousFrameSize_;
 };

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -84,6 +84,9 @@ public:
    */
   void draw(SVGDocument& document) override;
 
+  void beginFrameResourceScope() override;
+  void endFrameResourceScope() override;
+
   /**
    * Begins a render pass for the given viewport.
    *
@@ -419,6 +422,7 @@ private:
   [[nodiscard]] tiny_skia::Pixmap& currentPixmap();
   [[nodiscard]] const tiny_skia::Pixmap& currentPixmap() const;
   [[nodiscard]] tiny_skia::MutablePixmapView currentPixmapView();
+  void resetOwnedFrameBudgets();
   void prepareRetainedClipEpochBudget(int pixelWidth, int pixelHeight);
   [[nodiscard]] bool applyPathLengthAdjustment(const Path& path, StrokeParams& stroke);
   [[nodiscard]] std::optional<tiny_skia::Mask> buildClipMask(const ResolvedClip& clip);
@@ -512,6 +516,7 @@ private:
   std::shared_ptr<RendererTextMaterializationBudget> textMaterializationBudget_ =
       std::make_shared<RendererTextMaterializationBudget>();
   bool ownsTextMaterializationBudget_ = true;
+  std::size_t frameResourceScopeDepth_ = 0;
   std::shared_ptr<TextGlyphWorkBudget> textGlyphWorkBudget_;
   std::shared_ptr<DashedPathWorkBudget> dashedPathWorkBudget_;
   std::optional<PatternPaintState> patternFillPaint_;

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -419,6 +419,8 @@ private:
   [[nodiscard]] tiny_skia::Pixmap& currentPixmap();
   [[nodiscard]] const tiny_skia::Pixmap& currentPixmap() const;
   [[nodiscard]] tiny_skia::MutablePixmapView currentPixmapView();
+  void prepareRetainedClipEpochBudget(int pixelWidth, int pixelHeight);
+  [[nodiscard]] bool applyPathLengthAdjustment(const Path& path, StrokeParams& stroke);
   [[nodiscard]] std::optional<tiny_skia::Mask> buildClipMask(const ResolvedClip& clip);
   [[nodiscard]] std::optional<FilterAdmission> admitFilterLayer(
       const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -19,6 +19,10 @@
 
 namespace donner::svg {
 
+class FontManager;
+class FontHandle;
+struct TextRun;
+
 /**
  * Per-frame counts of the conversions \ref RendererTinySkia caches.
  *
@@ -243,15 +247,16 @@ public:
    */
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
+  [[nodiscard]] RendererResourceStats resourceStats() const override;
 
   /// Reduce generated-dash work for a boundary test.
-  void setDashWorkBudgetForTesting(std::size_t) {}
+  void setDashWorkBudgetForTesting(std::size_t maximumWorkUnits);
   /// Reduce materialized gradient stops for a boundary test.
-  void setGradientStopBudgetForTesting(std::size_t) {}
+  void setGradientStopBudgetForTesting(std::size_t maximumStops);
   /// Reduce admitted text glyphs for a boundary test.
-  void setTextGlyphBudgetForTesting(std::size_t) {}
+  void setTextGlyphBudgetForTesting(std::size_t maximumGlyphs);
   /// Reduce decoded-outline and path-copy ceilings for a boundary test.
-  void setTextMaterializationBudgetForTesting(RendererTextMaterializationBudget::Cost) {}
+  void setTextMaterializationBudgetForTesting(RendererTextMaterializationBudget::Cost limits);
 
   /**
    * Saves the last rendered frame to a PNG file.
@@ -312,6 +317,9 @@ public:
   }
 
 private:
+  struct DashedPathWorkBudget;
+  struct TextGlyphWorkBudget;
+
   struct PatternPaintState {
     tiny_skia::Pixmap pixmap;
     Transform2d targetFromPattern;
@@ -418,6 +426,10 @@ private:
   bool compositeTransformedFilter(SurfaceFrame& frame);
   void compositeDeviceFilter(SurfaceFrame& frame);
   tiny_skia::Pixmap extractFilterViewport(const SurfaceFrame& frame, int width, int height);
+  bool admitTextGlyphBatch(const std::vector<TextRun>& runs);
+  bool admitGlyphPredecode(const FontManager& fontManager, FontHandle font, int glyphIndex,
+                           bool& hasComplexity);
+  bool admitPlacedGlyph(bool hasPredecodeComplexity, const Path& path);
   [[nodiscard]] std::optional<tiny_skia::Paint> makeFillPaint(const Box2d& bounds);
   [[nodiscard]] std::optional<tiny_skia::Paint> makeStrokePaint(const Box2d& bounds,
                                                                 const StrokeParams& stroke);
@@ -488,6 +500,15 @@ private:
   std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget_ =
       std::make_shared<components::FilterExecutionBudget>();
   bool ownsFilterExecutionBudget_ = true;
+  std::shared_ptr<RendererDrawBudget> drawBudget_ = std::make_shared<RendererDrawBudget>();
+  bool ownsDrawBudget_ = true;
+  std::shared_ptr<RendererSurfaceBudget> surfaceBudget_ = std::make_shared<RendererSurfaceBudget>();
+  bool ownsSurfaceBudget_ = true;
+  std::shared_ptr<RendererTextMaterializationBudget> textMaterializationBudget_ =
+      std::make_shared<RendererTextMaterializationBudget>();
+  bool ownsTextMaterializationBudget_ = true;
+  std::shared_ptr<TextGlyphWorkBudget> textGlyphWorkBudget_;
+  std::shared_ptr<DashedPathWorkBudget> dashedPathWorkBudget_;
   std::optional<PatternPaintState> patternFillPaint_;
   std::optional<PatternPaintState> patternStrokePaint_;
 

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -41,6 +41,9 @@ struct RendererTinySkiaFrameCounters {
   /// outside the cache and are not counted.
   /// @see pathConversions
   uint64_t imagePremultiplies = 0;
+
+  /// Vector-outline or bitmap materializations attempted for text glyphs in this frame.
+  uint64_t textGlyphMaterializations = 0;
 };
 
 /**
@@ -240,6 +243,15 @@ public:
    */
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
+
+  /// Reduce generated-dash work for a boundary test.
+  void setDashWorkBudgetForTesting(std::size_t) {}
+  /// Reduce materialized gradient stops for a boundary test.
+  void setGradientStopBudgetForTesting(std::size_t) {}
+  /// Reduce admitted text glyphs for a boundary test.
+  void setTextGlyphBudgetForTesting(std::size_t) {}
+  /// Reduce decoded-outline and path-copy ceilings for a boundary test.
+  void setTextMaterializationBudgetForTesting(RendererTextMaterializationBudget::Cost) {}
 
   /**
    * Saves the last rendered frame to a PNG file.

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -673,6 +673,7 @@ donner_cc_test(
         ":geo_encoder",
         ":geode_device",
         ":geode_gpu_wait",
+        ":geode_path_cache_component",
         ":geode_resource_budget",
         ":geode_wgpu_util",
         "//donner/base",

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -57,6 +57,13 @@ donner_cc_library(
     ],
 )
 
+donner_cc_library(
+    name = "geode_resource_budget",
+    hdrs = ["GeodeResourceBudget.h"],
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+    deps = ["//donner/svg/components"],
+)
+
 # Header-only ECS component for the M2 Geode path-encode cache. See
 # design doc 0030 §Milestone 2.
 donner_cc_library(
@@ -65,6 +72,7 @@ donner_cc_library(
     visibility = ["//donner/svg/renderer:__subpackages__"],
     deps = [
         ":geode_path_encoder",
+        ":geode_resource_budget",
         "//donner/base",
     ],
 )
@@ -135,6 +143,7 @@ donner_cc_library(
         # `GeodeDevice::AllocateBufferId`, which is defined out of line, so
         # this is a link dependency and not just an include.
         ":geode_device",
+        ":geode_resource_budget",
         ":geode_wgpu_util",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],
@@ -664,6 +673,7 @@ donner_cc_test(
         ":geo_encoder",
         ":geode_device",
         ":geode_gpu_wait",
+        ":geode_resource_budget",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -770,6 +770,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   bool submitResidentGradientDraw(GeodeResidentGradientSlot& slot, const EncodedPath& encoded,
                                   GradientUniforms& u);
 
+  /// Write and retain one gradient uniform snapshot when it changed. A
+  /// rejected CPU-mirror reservation keeps rendering but skips the cache.
+  void publishGradientUniform(GeodeResidentGradientSlot& slot, const GradientUniforms& u);
+
   /// Fill the common prefix of a gradient uniform (mvp, viewport, stops,
   /// spread, kind, clip flags, AA) for the linear variant, plus the
   /// linear-specific endpoints. Shared by the arena and resident paths so
@@ -984,6 +988,20 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 
   bool canEncodeGeometry() const {
     return geometryAdmission == nullptr || geometryAdmission->canEncodeGeometry();
+  }
+
+  const EncodedPath* resolveEncodedPath(const Path* path, FillRule rule,
+                                        const EncodedPath* precomputedEncoded,
+                                        EncodedPath& ownedEncoded) {
+    if (precomputedEncoded != nullptr) {
+      return precomputedEncoded;
+    }
+    if (path == nullptr || !canEncodeGeometry()) {
+      return nullptr;
+    }
+    device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(*path, rule);
+    return &ownedEncoded;
   }
 
   bool admitReadyGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
@@ -1523,14 +1541,10 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   // the bind group is always complete, even if `beginMaskPass` fires
   // before any main draw.
   EncodedPath ownedEncoded;
-  const EncodedPath* encodedPtr = precomputedEncoded;
-  if (!encodedPtr) {
-    if (!impl_->canEncodeGeometry()) {
-      return;
-    }
-    impl_->device->countPathEncode();
-    ownedEncoded = GeodePathEncoder::encode(path, rule);
-    encodedPtr = &ownedEncoded;
+  const EncodedPath* encodedPtr =
+      impl_->resolveEncodedPath(&path, rule, precomputedEncoded, ownedEncoded);
+  if (encodedPtr == nullptr) {
+    return;
   }
   const EncodedPath& encoded = *encodedPtr;
   if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
@@ -2161,7 +2175,9 @@ void GeoEncoder::Impl::publishSlotPaint(GeodeResidentSlot& slot, const FillDrawA
       std::memcmp(slot.lastPaint.data(), bytes, sizeof(rows)) != 0) {
     device->queue().writeBuffer(slot.buffer, slot.paint.offset, rows, sizeof(rows));
     device->countBufferWrite(sizeof(rows));
-    slot.lastPaint.assign(bytes, bytes + sizeof(rows));
+    if (slot.reservePaintMirror(sizeof(rows))) {
+      slot.lastPaint.assign(bytes, bytes + sizeof(rows));
+    }
   }
 }
 
@@ -2300,7 +2316,9 @@ void GeoEncoder::Impl::publishSoloUniform(GeodeResidentSlot& slot, const FillDra
 
   device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
   device->countBufferWrite(sizeof(Uniforms));
-  slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+  if (slot.reserveUniformMirror(sizeof(Uniforms))) {
+    slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+  }
 }
 
 bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const InstanceRecord& record,
@@ -2327,7 +2345,9 @@ bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const Inst
                               sizeof(InstanceRecord));
   device->countBufferWrite(sizeof(InstanceRecord));
   if (cache != nullptr) {
-    cache->assign(rBytes, rBytes + sizeof(InstanceRecord));
+    if (recordSlotOverride != nullptr || slot.reserveRecordMirror(sizeof(InstanceRecord))) {
+      cache->assign(rBytes, rBytes + sizeof(InstanceRecord));
+    }
   }
   return true;
 }
@@ -2653,14 +2673,10 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   }
 
   EncodedPath ownedEncoded;
-  const EncodedPath* encoded = precomputedEncoded;
+  const EncodedPath* encoded =
+      impl_->resolveEncodedPath(&path, rule, precomputedEncoded, ownedEncoded);
   if (encoded == nullptr) {
-    if (!impl_->canEncodeGeometry()) {
-      return;
-    }
-    impl_->device->countPathEncode();
-    ownedEncoded = GeodePathEncoder::encode(path, rule);
-    encoded = &ownedEncoded;
+    return;
   }
   if (!impl_->admitReadyGeometry(*encoded, 1u)) {
     return;
@@ -2713,14 +2729,10 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   // (`GeodePathCacheComponent`). Cache hits skip both the encode
   // work and the `pathEncodes` counter bump.
   EncodedPath ownedEncoded;
-  const EncodedPath* encodedPtr = args.precomputedEncoded;
-  if (!encodedPtr) {
-    if (!impl_->canEncodeGeometry()) {
-      return;
-    }
-    impl_->device->countPathEncode();
-    ownedEncoded = GeodePathEncoder::encode(*args.path, args.rule);
-    encodedPtr = &ownedEncoded;
+  const EncodedPath* encodedPtr =
+      impl_->resolveEncodedPath(args.path, args.rule, args.precomputedEncoded, ownedEncoded);
+  if (encodedPtr == nullptr) {
+    return;
   }
   const EncodedPath& encoded = *encodedPtr;
   if ((requireAdmission && !impl_->admitGeometry(encoded, args.instanceCount)) || encoded.empty()) {
@@ -3143,15 +3155,7 @@ bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
     return false;
   }
 
-  // Rewrite the gradient uniform only when it actually changed, mirroring
-  // the fill path. A static re-render produces byte-identical uniforms.
-  const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
-  if (slot.lastUniform.size() != sizeof(GradientUniforms) ||
-      std::memcmp(slot.lastUniform.data(), uBytes, sizeof(GradientUniforms)) != 0) {
-    device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(GradientUniforms));
-    device->countBufferWrite(sizeof(GradientUniforms));
-    slot.lastUniform.assign(uBytes, uBytes + sizeof(GradientUniforms));
-  }
+  publishGradientUniform(slot, u);
 
   if (!slot.bindGroup) {
     buildResidentGradientBindGroup(slot);
@@ -3164,6 +3168,20 @@ bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
   return true;
 }
 
+void GeoEncoder::Impl::publishGradientUniform(GeodeResidentGradientSlot& slot,
+                                              const GradientUniforms& u) {
+  const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
+  if (slot.lastUniform.size() == sizeof(GradientUniforms) &&
+      std::memcmp(slot.lastUniform.data(), uBytes, sizeof(GradientUniforms)) == 0) {
+    return;
+  }
+  device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(GradientUniforms));
+  device->countBufferWrite(sizeof(GradientUniforms));
+  if (slot.reserveUniformMirror(sizeof(GradientUniforms))) {
+    slot.lastUniform.assign(uBytes, uBytes + sizeof(GradientUniforms));
+  }
+}
+
 void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientParams& params,
                                         FillRule rule, const EncodedPath* precomputedEncoded) {
   if (params.stops.empty()) {
@@ -3173,14 +3191,10 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   // 1. CPU encode the path into Slug band data (same as fillPath) -
   // unless the path-encode cache already has a precomputed encode.
   EncodedPath ownedEncoded;
-  const EncodedPath* encodedPtr = precomputedEncoded;
-  if (!encodedPtr) {
-    if (!impl_->canEncodeGeometry()) {
-      return;
-    }
-    impl_->device->countPathEncode();
-    ownedEncoded = GeodePathEncoder::encode(path, rule);
-    encodedPtr = &ownedEncoded;
+  const EncodedPath* encodedPtr =
+      impl_->resolveEncodedPath(&path, rule, precomputedEncoded, ownedEncoded);
+  if (encodedPtr == nullptr) {
+    return;
   }
   const EncodedPath& encoded = *encodedPtr;
   if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
@@ -3205,14 +3219,10 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   }
 
   EncodedPath ownedEncoded;
-  const EncodedPath* encodedPtr = precomputedEncoded;
-  if (!encodedPtr) {
-    if (!impl_->canEncodeGeometry()) {
-      return;
-    }
-    impl_->device->countPathEncode();
-    ownedEncoded = GeodePathEncoder::encode(path, rule);
-    encodedPtr = &ownedEncoded;
+  const EncodedPath* encodedPtr =
+      impl_->resolveEncodedPath(&path, rule, precomputedEncoded, ownedEncoded);
+  if (encodedPtr == nullptr) {
+    return;
   }
   const EncodedPath& encoded = *encodedPtr;
   if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -2594,7 +2594,8 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
 }
 
 void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
-                                std::span<const float> instanceTransforms) {
+                                std::span<const float> instanceTransforms,
+                                bool /*requireAdmission*/) {
   // Dummy resources are pre-created in the encoder constructor; no
   // per-draw ensure call is needed.
   impl_->ensurePassOpen();

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -969,6 +969,40 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   // `rootFromTarget` canonicalizes offscreen target pixels for that observer.
   GeometryDebugSink* geometryDebugSink = nullptr;
   Transform2d geometryDebugRootFromTarget;
+  GeometryAdmission* geometryAdmission = nullptr;
+  std::size_t pendingSceneAdmissions = 0;
+
+  bool admitGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
+    if (geometryAdmission == nullptr) {
+      return !encoded.rejected();
+    }
+    return geometryAdmission->admitGeometry(encoded, logicalDraws);
+  }
+
+  bool admitReadyGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
+    return admitGeometry(encoded, logicalDraws) && !encoded.empty();
+  }
+
+  void releaseGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
+    if (geometryAdmission != nullptr) {
+      geometryAdmission->releaseGeometry(encoded, logicalDraws);
+    }
+  }
+
+  bool validateAndConsumeSceneBatch(const GeoEncoder::SceneBatchBinding& binding) {
+    if (!binding.chunkBuffer || !binding.recordBuffer || binding.instanceCount == 0u ||
+        binding.vertexCount == 0u) {
+      return false;
+    }
+    if (geometryAdmission == nullptr) {
+      return true;
+    }
+    if (binding.instanceCount > pendingSceneAdmissions) {
+      return false;
+    }
+    pendingSceneAdmissions -= binding.instanceCount;
+    return true;
+  }
 
   void recordGeometryDebugDraw(const EncodedPath& encoded,
                                std::span<const float> instanceTransforms = {}) const {
@@ -1485,7 +1519,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
     encodedPtr = &ownedEncoded;
   }
   const EncodedPath& encoded = *encodedPtr;
-  if (encoded.empty()) {
+  if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
     return;
   }
 
@@ -1652,6 +1686,10 @@ void GeoEncoder::clearClipMask() {
 
 void GeoEncoder::setBufferPool(GeodeBufferPool* pool) {
   impl_->bufferPool = pool;
+}
+
+void GeoEncoder::setGeometryAdmission(GeometryAdmission* admission) {
+  impl_->geometryAdmission = admission;
 }
 
 void GeoEncoder::recordGeometryDebugInstance(const EncodedPath& encoded,
@@ -2270,7 +2308,7 @@ bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const Inst
 
 void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                   const css::RGBA& color, FillRule rule, uint64_t frameId) {
-  if (encoded.empty()) {
+  if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
     return;
   }
 
@@ -2297,7 +2335,7 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   // when no clip mask / clip polygon / mask pass is active. Otherwise fall
   // back to the per-frame arena path so clipped / masked draws stay exact.
   if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen) {
-    submitFillDraw(args);
+    submitFillDraw(args, {}, /*requireAdmission=*/false);
     return;
   }
   // A slot's single uniform buffer can only carry one draw's uniform per
@@ -2323,12 +2361,12 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   if (slot.owningDeviceId == impl_->device->deviceId() &&
       (impl_->device->frameStampClaimed(slot.lastResidentFrame) ||
        impl_->device->frameStampClaimed(slot.lastSceneFrame))) {
-    submitFillDraw(args);
+    submitFillDraw(args, {}, /*requireAdmission=*/false);
     return;
   }
   slot.lastResidentFrame = frameId;
   if (!impl_->submitResidentFillDraw(slot, encoded, args)) {
-    submitFillDraw(args);
+    submitFillDraw(args, {}, /*requireAdmission=*/false);
   }
 }
 
@@ -2379,6 +2417,9 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
                                            const GeodeRecordSlab::Slot* recordSlotOverride,
                                            std::vector<uint8_t>* overrideRecordCache,
                                            SceneRecordState* recordState, bool publishPaint) {
+  if (publishPaint && !impl_->admitGeometry(encoded, 1u)) {
+    return false;
+  }
   if (encoded.empty()) {
     return false;
   }
@@ -2402,15 +2443,20 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.patternFromPath = Transform2d();
   args.linearGradient = paint.linearGradient;
   args.radialGradient = paint.radialGradient;
-  return impl_->ensureResidentSceneRecordImpl(slot, encoded, args, recordTransform,
-                                              recordSlotOverride, overrideRecordCache,
-                                              /*bakeTransform=*/false, recordState, publishPaint);
+  const bool prepared = impl_->ensureResidentSceneRecordImpl(
+      slot, encoded, args, recordTransform, recordSlotOverride, overrideRecordCache,
+      /*bakeTransform=*/false, recordState, publishPaint);
+  if (publishPaint && !prepared) {
+    impl_->releaseGeometry(encoded, 1u);
+  } else if (publishPaint && impl_->geometryAdmission != nullptr) {
+    ++impl_->pendingSceneAdmissions;
+  }
+  return prepared;
 }
 
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
                                     const SceneBatchBinding& binding) {
-  if (!binding.chunkBuffer || !binding.recordBuffer || binding.instanceCount == 0u ||
-      binding.vertexCount == 0u) {
+  if (!impl_->validateAndConsumeSceneBatch(binding)) {
     return;
   }
   impl_->ensurePassOpen();
@@ -2593,9 +2639,8 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   submitFillDraw(args);
 }
 
-void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
-                                std::span<const float> instanceTransforms,
-                                bool /*requireAdmission*/) {
+void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float> instanceTransforms,
+                                bool requireAdmission) {
   // Dummy resources are pre-created in the encoder constructor; no
   // per-draw ensure call is needed.
   impl_->ensurePassOpen();
@@ -2618,7 +2663,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
     encodedPtr = &ownedEncoded;
   }
   const EncodedPath& encoded = *encodedPtr;
-  if (encoded.empty()) {
+  if ((requireAdmission && !impl_->admitGeometry(encoded, args.instanceCount)) || encoded.empty()) {
     return;  // Nothing to draw.
   }
 
@@ -3075,7 +3120,7 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
     encodedPtr = &ownedEncoded;
   }
   const EncodedPath& encoded = *encodedPtr;
-  if (encoded.empty()) {
+  if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
     return;
   }
 
@@ -3104,7 +3149,7 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
     encodedPtr = &ownedEncoded;
   }
   const EncodedPath& encoded = *encodedPtr;
-  if (encoded.empty()) {
+  if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
     return;
   }
 
@@ -3117,7 +3162,7 @@ void GeoEncoder::fillPathLinearGradientResident(GeodeResidentGradientSlot& slot,
                                                 const EncodedPath& encoded,
                                                 const LinearGradientParams& params, FillRule rule,
                                                 uint64_t frameId) {
-  if (encoded.empty() || params.stops.empty()) {
+  if (params.stops.empty() || !impl_->admitReadyGeometry(encoded, 1u)) {
     return;
   }
 
@@ -3146,7 +3191,7 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
                                                 const EncodedPath& encoded,
                                                 const RadialGradientParams& params, FillRule rule,
                                                 uint64_t frameId) {
-  if (encoded.empty() || params.stops.empty()) {
+  if (params.stops.empty() || !impl_->admitReadyGeometry(encoded, 1u)) {
     return;
   }
   // Degenerate radius: nothing to draw meaningfully - match tiny-skia's

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -984,6 +984,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     return admitGeometry(encoded, logicalDraws) && !encoded.empty();
   }
 
+  bool admitResidentRadialGeometry(const EncodedPath& encoded, const RadialGradientParams& params) {
+    return !params.stops.empty() && params.radius > 0.0 && admitReadyGeometry(encoded, 1u);
+  }
+
   void releaseGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
     if (geometryAdmission != nullptr) {
       geometryAdmission->releaseGeometry(encoded, logicalDraws);
@@ -2463,6 +2467,14 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   return prepared;
 }
 
+void GeoEncoder::releasePreparedSceneAdmission(const EncodedPath& encoded) {
+  if (impl_->geometryAdmission == nullptr || impl_->pendingSceneAdmissions == 0u) {
+    return;
+  }
+  --impl_->pendingSceneAdmissions;
+  impl_->releaseGeometry(encoded, 1u);
+}
+
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
                                     const SceneBatchBinding& binding) {
   if (!impl_->validateAndConsumeSceneBatch(binding)) {
@@ -2619,6 +2631,17 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
     return;
   }
 
+  EncodedPath ownedEncoded;
+  const EncodedPath* encoded = precomputedEncoded;
+  if (encoded == nullptr) {
+    impl_->device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(path, rule);
+    encoded = &ownedEncoded;
+  }
+  if (!impl_->admitReadyGeometry(*encoded, 1u)) {
+    return;
+  }
+
   ++impl_->patternGpuPreparations;
   // Build a sampler for the tile. We use linear filtering with Repeat
   // wrap mode; the shader also performs explicit modulo-style wrapping
@@ -2638,7 +2661,7 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   FillDrawArgs args = {};
   args.path = &path;
   args.rule = rule;
-  args.precomputedEncoded = precomputedEncoded;
+  args.precomputedEncoded = encoded;
   args.paintMode = 1u;
   args.patternView = impl_->transientResources.retain(paint.tile.createView());
   args.patternSampler = sampler;
@@ -2646,7 +2669,7 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   args.tileSize = paint.tileSize;
   args.patternOpacity = static_cast<float>(paint.opacity);
 
-  submitFillDraw(args);
+  submitFillDraw(args, {}, /*requireAdmission=*/false);
 }
 
 void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float> instanceTransforms,
@@ -3201,12 +3224,7 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
                                                 const EncodedPath& encoded,
                                                 const RadialGradientParams& params, FillRule rule,
                                                 uint64_t frameId) {
-  if (params.stops.empty() || !impl_->admitReadyGeometry(encoded, 1u)) {
-    return;
-  }
-  // Degenerate radius: nothing to draw meaningfully - match tiny-skia's
-  // early return.
-  if (params.radius <= 0.0) {
+  if (!impl_->admitResidentRadialGeometry(encoded, params)) {
     return;
   }
 

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <optional>
 #include <vector>
 
 #include "donner/svg/renderer/PixelFormatUtils.h"
@@ -972,6 +973,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeometryAdmission* geometryAdmission = nullptr;
   std::size_t pendingSceneAdmissions = 0;
   std::size_t patternGpuPreparations = 0;
+  std::optional<std::size_t> scenePreparationFailureCountdown;
 
   bool admitGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
     if (geometryAdmission == nullptr) {
@@ -1705,6 +1707,10 @@ std::size_t GeoEncoder::pendingSceneAdmissionsForTesting() const {
   return impl_->pendingSceneAdmissions;
 }
 
+void GeoEncoder::injectScenePreparationFailureAfterForTesting(std::size_t successfulPreparations) {
+  impl_->scenePreparationFailureCountdown = successfulPreparations;
+}
+
 void GeoEncoder::recordGeometryDebugInstance(const EncodedPath& encoded,
                                              std::span<const float> instanceTransforms) {
   impl_->recordGeometryDebugDraw(encoded, instanceTransforms);
@@ -2435,6 +2441,14 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   }
   if (encoded.empty()) {
     return false;
+  }
+  if (publishPaint && impl_->scenePreparationFailureCountdown.has_value()) {
+    if (*impl_->scenePreparationFailureCountdown == 0u) {
+      impl_->scenePreparationFailureCountdown.reset();
+      impl_->releaseGeometry(encoded, 1u);
+      return false;
+    }
+    --*impl_->scenePreparationFailureCountdown;
   }
   const css::RGBA& color = paint.color;
   // Build the same solid-fill args fillPath would, so the shared ensure

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -971,6 +971,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   Transform2d geometryDebugRootFromTarget;
   GeometryAdmission* geometryAdmission = nullptr;
   std::size_t pendingSceneAdmissions = 0;
+  std::size_t patternGpuPreparations = 0;
 
   bool admitGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
     if (geometryAdmission == nullptr) {
@@ -1690,6 +1691,14 @@ void GeoEncoder::setBufferPool(GeodeBufferPool* pool) {
 
 void GeoEncoder::setGeometryAdmission(GeometryAdmission* admission) {
   impl_->geometryAdmission = admission;
+}
+
+std::size_t GeoEncoder::patternGpuPreparationsForTesting() const {
+  return impl_->patternGpuPreparations;
+}
+
+std::size_t GeoEncoder::pendingSceneAdmissionsForTesting() const {
+  return impl_->pendingSceneAdmissions;
 }
 
 void GeoEncoder::recordGeometryDebugInstance(const EncodedPath& encoded,
@@ -2610,6 +2619,7 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
     return;
   }
 
+  ++impl_->patternGpuPreparations;
   // Build a sampler for the tile. We use linear filtering with Repeat
   // wrap mode; the shader also performs explicit modulo-style wrapping
   // via `fract()` so texture sampling never steps outside [0,1] UVs, but

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -982,6 +982,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     return geometryAdmission->admitGeometry(encoded, logicalDraws);
   }
 
+  bool canEncodeGeometry() const {
+    return geometryAdmission == nullptr || geometryAdmission->canEncodeGeometry();
+  }
+
   bool admitReadyGeometry(const EncodedPath& encoded, std::size_t logicalDraws) {
     return admitGeometry(encoded, logicalDraws) && !encoded.empty();
   }
@@ -1521,6 +1525,9 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   EncodedPath ownedEncoded;
   const EncodedPath* encodedPtr = precomputedEncoded;
   if (!encodedPtr) {
+    if (!impl_->canEncodeGeometry()) {
+      return;
+    }
     impl_->device->countPathEncode();
     ownedEncoded = GeodePathEncoder::encode(path, rule);
     encodedPtr = &ownedEncoded;
@@ -2648,6 +2655,9 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   EncodedPath ownedEncoded;
   const EncodedPath* encoded = precomputedEncoded;
   if (encoded == nullptr) {
+    if (!impl_->canEncodeGeometry()) {
+      return;
+    }
     impl_->device->countPathEncode();
     ownedEncoded = GeodePathEncoder::encode(path, rule);
     encoded = &ownedEncoded;
@@ -2705,6 +2715,9 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   EncodedPath ownedEncoded;
   const EncodedPath* encodedPtr = args.precomputedEncoded;
   if (!encodedPtr) {
+    if (!impl_->canEncodeGeometry()) {
+      return;
+    }
     impl_->device->countPathEncode();
     ownedEncoded = GeodePathEncoder::encode(*args.path, args.rule);
     encodedPtr = &ownedEncoded;
@@ -3162,6 +3175,9 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   EncodedPath ownedEncoded;
   const EncodedPath* encodedPtr = precomputedEncoded;
   if (!encodedPtr) {
+    if (!impl_->canEncodeGeometry()) {
+      return;
+    }
     impl_->device->countPathEncode();
     ownedEncoded = GeodePathEncoder::encode(path, rule);
     encodedPtr = &ownedEncoded;
@@ -3191,6 +3207,9 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   EncodedPath ownedEncoded;
   const EncodedPath* encodedPtr = precomputedEncoded;
   if (!encodedPtr) {
+    if (!impl_->canEncodeGeometry()) {
+      return;
+    }
     impl_->device->countPathEncode();
     ownedEncoded = GeodePathEncoder::encode(path, rule);
     encodedPtr = &ownedEncoded;

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -147,8 +147,6 @@ constexpr uint32_t kPaintBlockRows = kGradientPaintBlockRows;
 constexpr uint64_t kPaintBlockBytes = kPaintBlockRows * 16u;
 
 /// Paint modes shared with `shaders/slug_fill.wgsl`.
-constexpr uint32_t kPaintModeSolid = 0u;
-constexpr uint32_t kPaintModePattern = 1u;
 constexpr uint32_t kPaintModeLinearGradient = 2u;
 constexpr uint32_t kPaintModeRadialGradient = 3u;
 

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -220,6 +220,9 @@ public:
   /// Number of admitted scene instances not yet consumed by a batch draw.
   [[nodiscard]] std::size_t pendingSceneAdmissionsForTesting() const;
 
+  /// Fail one scene preparation after `successfulPreparations` successful calls.
+  void injectScenePreparationFailureAfterForTesting(std::size_t successfulPreparations);
+
   /**
    * Observe Slug draws recorded by this encoder.
    *

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -2,6 +2,7 @@
 /// @file
 /// Drawing API for the Geode GPU renderer.
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -46,6 +47,18 @@ public:
   virtual void recordSlugDraw(const EncodedPath& encoded, const Transform2d& targetFromPath,
                               const Transform2d& rootFromTarget,
                               std::span<const float> instanceTransforms) = 0;
+};
+
+/** Frame-wide admission gate invoked before every Slug geometry upload or draw. */
+class GeometryAdmission {
+public:
+  virtual ~GeometryAdmission() = default;
+
+  /** Reserve one or more logical submissions of `encoded` before GPU work is recorded. */
+  virtual bool admitGeometry(const EncodedPath& encoded, std::size_t logicalDraws) = 0;
+
+  /** Release a successful reservation when submission preparation cannot complete. */
+  virtual void releaseGeometry(const EncodedPath& encoded, std::size_t logicalDraws) = 0;
 };
 
 class GeodeBufferPool;
@@ -197,6 +210,9 @@ public:
    * to disable (default).
    */
   void setBufferPool(GeodeBufferPool* pool);
+
+  /** Install the mandatory geometry admission gate for renderer-owned encoders. */
+  void setGeometryAdmission(GeometryAdmission* admission);
 
   /**
    * Observe Slug draws recorded by this encoder.
@@ -802,7 +818,8 @@ private:
 
   /// Shared path for solid and pattern fills: encode path, upload buffers,
   /// build bind group, record draw call.
-  void submitFillDraw(const FillDrawArgs& args, std::span<const float> instanceTransforms = {});
+  void submitFillDraw(const FillDrawArgs& args, std::span<const float> instanceTransforms = {},
+                      bool requireAdmission = true);
 
   /// Shared construction helpers used by both constructors. Factored out
   /// to avoid duplicating ~20 lines of setup. See GeoEncoder.cc.

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -214,6 +214,12 @@ public:
   /** Install the mandatory geometry admission gate for renderer-owned encoders. */
   void setGeometryAdmission(GeometryAdmission* admission);
 
+  /// Number of pattern sampler/view preparation attempts made by this encoder.
+  [[nodiscard]] std::size_t patternGpuPreparationsForTesting() const;
+
+  /// Number of admitted scene instances not yet consumed by a batch draw.
+  [[nodiscard]] std::size_t pendingSceneAdmissionsForTesting() const;
+
   /**
    * Observe Slug draws recorded by this encoder.
    *
@@ -655,6 +661,9 @@ public:
                                  const GeodeRecordSlab::Slot* recordSlotOverride = nullptr,
                                  std::vector<uint8_t>* overrideRecordCache = nullptr,
                                  SceneRecordState* recordState = nullptr, bool publishPaint = true);
+
+  /** Cancel one prepared scene instance before demoting it to a different draw path. */
+  void releasePreparedSceneAdmission(const EncodedPath& encoded);
 
   /// One cross-entity ordered batch: consecutive resident slots of one
   /// slab chunk plus a run of consecutive record-slab slots.

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -57,6 +57,9 @@ public:
   /** Reserve one or more logical submissions of `encoded` before GPU work is recorded. */
   virtual bool admitGeometry(const EncodedPath& encoded, std::size_t logicalDraws) = 0;
 
+  /** Whether another inline path encode may start in the current frame. */
+  [[nodiscard]] virtual bool canEncodeGeometry() const = 0;
+
   /** Release a successful reservation when submission preparation cannot complete. */
   virtual void releaseGeometry(const EncodedPath& encoded, std::size_t logicalDraws) = 0;
 };

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <deque>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -420,15 +419,16 @@ struct GeodeTextInstanceRecordComponent {
     GeodeRecordSlab::Slot slot;
     std::vector<uint8_t> lastRecord;
   };
+  using OccurrenceOwner = std::unique_ptr<Occurrence>;
+  static constexpr uint64_t kOccurrencePayloadBytes = sizeof(Occurrence) + sizeof(InstanceRecord);
   static constexpr uint64_t kProjectedBytesPerOccurrence =
-      sizeof(Occurrence) + sizeof(InstanceRecord);
+      sizeof(OccurrenceOwner) + kOccurrencePayloadBytes;
 
   /// Occurrence slots in paint order. Index is the occurrence's ordinal
-  /// within the element's draw, so it is stable across unchanged frames. A
-  /// deque, not a vector: a pending batch holds pointers into these entries
-  /// while later occurrences are still appending, and a reallocating growth
-  /// would leave the batch writing through dangling pointers at flush.
-  std::deque<Occurrence> occurrences;
+  /// within the element's draw, so it is stable across unchanged frames.
+  /// Owners may move when the vector grows, but each separately allocated
+  /// occurrence stays put while a pending batch holds pointers into it.
+  std::vector<OccurrenceOwner> occurrences;
   /// Slab the slots were allocated from; also keeps that slab alive so a
   /// device change cannot leave the slots pointing at a destroyed slab.
   std::shared_ptr<GeodeRecordSlab> recordSlab;
@@ -453,9 +453,13 @@ struct GeodeTextInstanceRecordComponent {
         lastFrame(other.lastFrame),
         cpuBudget(std::move(other.cpuBudget)),
         cpuReservation(std::move(other.cpuReservation)),
-        cpuRetainedBytes(other.cpuRetainedBytes) {
-    std::deque<Occurrence>().swap(other.occurrences);
+        cpuRetainedBytes(other.cpuRetainedBytes),
+        cpuOccurrenceBytes(other.cpuOccurrenceBytes),
+        occurrenceReservationPending(other.occurrenceReservationPending) {
+    std::vector<OccurrenceOwner>().swap(other.occurrences);
     other.cpuRetainedBytes = 0;
+    other.cpuOccurrenceBytes = 0;
+    other.occurrenceReservationPending = false;
   }
 
   GeodeTextInstanceRecordComponent& operator=(GeodeTextInstanceRecordComponent&& other) noexcept {
@@ -472,46 +476,146 @@ struct GeodeTextInstanceRecordComponent {
       cpuBudget = std::move(other.cpuBudget);
       cpuReservation = std::move(other.cpuReservation);
       cpuRetainedBytes = other.cpuRetainedBytes;
-      std::deque<Occurrence>().swap(other.occurrences);
+      cpuOccurrenceBytes = other.cpuOccurrenceBytes;
+      occurrenceReservationPending = other.occurrenceReservationPending;
+      std::vector<OccurrenceOwner>().swap(other.occurrences);
       other.cpuRetainedBytes = 0;
+      other.cpuOccurrenceBytes = 0;
+      other.occurrenceReservationPending = false;
     }
     return *this;
   }
 
   bool reserveOccurrence(std::shared_ptr<GeodeDocumentGeometryBudget> budget) {
-    if (cpuRetainedBytes > std::numeric_limits<uint64_t>::max() - kProjectedBytesPerOccurrence ||
-        !budget ||
-        !cpuReservation.replace(budget, cpuRetainedBytes + kProjectedBytesPerOccurrence)) {
+    if (occurrenceReservationPending || !budget || (cpuBudget && cpuBudget.get() != budget.get()) ||
+        occurrences.size() == std::numeric_limits<size_t>::max()) {
       return false;
     }
+    const size_t nextSize = occurrences.size() + 1u;
+    if (kOccurrencePayloadBytes > std::numeric_limits<uint64_t>::max() - cpuOccurrenceBytes) {
+      return false;
+    }
+    const uint64_t payloadBytes = cpuOccurrenceBytes + kOccurrencePayloadBytes;
+    const uint64_t oldBytes = cpuRetainedBytes;
+
+    if (nextSize > occurrences.capacity()) {
+      size_t targetCapacity = occurrences.capacity() == 0u ? 1u : occurrences.capacity();
+      while (targetCapacity < nextSize) {
+        if (targetCapacity > std::numeric_limits<size_t>::max() / 2u) {
+          return false;
+        }
+        targetCapacity *= 2u;
+      }
+      if (targetCapacity > std::numeric_limits<uint64_t>::max() / sizeof(OccurrenceOwner)) {
+        return false;
+      }
+      const uint64_t projectedOwnerBytes =
+          static_cast<uint64_t>(targetCapacity) * sizeof(OccurrenceOwner);
+      if (payloadBytes > std::numeric_limits<uint64_t>::max() - projectedOwnerBytes ||
+          !cpuReservation.replace(budget, projectedOwnerBytes + payloadBytes)) {
+        return false;
+      }
+
+      std::vector<OccurrenceOwner> replacement;
+      replacement.reserve(targetCapacity);
+      if (replacement.capacity() > std::numeric_limits<uint64_t>::max() / sizeof(OccurrenceOwner)) {
+        (void)cpuReservation.replace(budget, oldBytes);
+        return false;
+      }
+      const uint64_t actualOwnerBytes =
+          static_cast<uint64_t>(replacement.capacity()) * sizeof(OccurrenceOwner);
+      if (payloadBytes > std::numeric_limits<uint64_t>::max() - actualOwnerBytes ||
+          !cpuReservation.replace(budget, actualOwnerBytes + payloadBytes)) {
+        (void)cpuReservation.replace(budget, oldBytes);
+        return false;
+      }
+      for (OccurrenceOwner& occurrence : occurrences) {
+        replacement.push_back(std::move(occurrence));
+      }
+      occurrences.swap(replacement);
+      cpuRetainedBytes = actualOwnerBytes + payloadBytes;
+    } else {
+      const uint64_t ownerBytes =
+          static_cast<uint64_t>(occurrences.capacity()) * sizeof(OccurrenceOwner);
+      if (payloadBytes > std::numeric_limits<uint64_t>::max() - ownerBytes ||
+          !cpuReservation.replace(budget, ownerBytes + payloadBytes)) {
+        return false;
+      }
+      cpuRetainedBytes = ownerBytes + payloadBytes;
+    }
     cpuBudget = std::move(budget);
-    cpuRetainedBytes += kProjectedBytesPerOccurrence;
+    occurrenceReservationPending = true;
+    return true;
+  }
+
+  bool appendReservedOccurrence(const GeodeRecordSlab::Slot& slot) {
+    if (!occurrenceReservationPending) {
+      return false;
+    }
+    if (!cpuBudget || occurrences.size() == occurrences.capacity()) {
+      rollbackOccurrence();
+      return false;
+    }
+    auto occurrence = std::make_unique<Occurrence>();
+    occurrence->slot = slot;
+    occurrence->lastRecord.reserve(sizeof(InstanceRecord));
+    const uint64_t lastRecordBytes = occurrence->lastRecord.capacity();
+    if (lastRecordBytes > std::numeric_limits<uint64_t>::max() - sizeof(Occurrence) ||
+        sizeof(Occurrence) + lastRecordBytes >
+            std::numeric_limits<uint64_t>::max() - cpuOccurrenceBytes) {
+      rollbackOccurrence();
+      return false;
+    }
+    const uint64_t occurrenceBytes = sizeof(Occurrence) + lastRecordBytes;
+    const uint64_t ownerBytes =
+        static_cast<uint64_t>(occurrences.capacity()) * sizeof(OccurrenceOwner);
+    if (cpuOccurrenceBytes + occurrenceBytes > std::numeric_limits<uint64_t>::max() - ownerBytes ||
+        !cpuReservation.replace(cpuBudget, ownerBytes + cpuOccurrenceBytes + occurrenceBytes)) {
+      rollbackOccurrence();
+      return false;
+    }
+    occurrences.push_back(std::move(occurrence));
+    cpuOccurrenceBytes += occurrenceBytes;
+    cpuRetainedBytes = ownerBytes + cpuOccurrenceBytes;
+    occurrenceReservationPending = false;
     return true;
   }
 
   void rollbackOccurrence() {
-    if (cpuRetainedBytes < kProjectedBytesPerOccurrence || !cpuBudget) {
+    if (!cpuBudget) {
+      occurrenceReservationPending = false;
       return;
     }
-    cpuRetainedBytes -= kProjectedBytesPerOccurrence;
+    const uint64_t ownerBytes =
+        static_cast<uint64_t>(occurrences.capacity()) * sizeof(OccurrenceOwner);
+    cpuRetainedBytes = ownerBytes + cpuOccurrenceBytes;
     (void)cpuReservation.replace(cpuBudget, cpuRetainedBytes);
+    occurrenceReservationPending = false;
   }
+
+  uint64_t cpuRetainedBytesForTesting() const { return cpuRetainedBytes; }
 
   /// Return every slot to the slab (deferred to the next frame's merge, like
   /// every other record free) and drop them.
   void freeRecordSlots() {
     if (recordSlab) {
-      for (const Occurrence& occurrence : occurrences) {
-        if (occurrence.slot.buffer) {
-          recordSlab->freeSlot(occurrence.slot);
+      for (const OccurrenceOwner& occurrence : occurrences) {
+        if (occurrence && occurrence->slot.buffer) {
+          recordSlab->freeSlot(occurrence->slot);
         }
       }
     }
-    std::deque<Occurrence>().swap(occurrences);
+    std::vector<OccurrenceOwner>().swap(occurrences);
     cpuReservation.reset();
     cpuBudget.reset();
     cpuRetainedBytes = 0;
+    cpuOccurrenceBytes = 0;
+    occurrenceReservationPending = false;
   }
+
+private:
+  uint64_t cpuOccurrenceBytes = 0;
+  bool occurrenceReservationPending = false;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -22,7 +22,9 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -144,6 +146,8 @@ struct GeodeGlyphResidentEntry {
   /// Approximate CPU footprint of the encode, used as the residence budget's
   /// unit. Slab capacity is not usable here: the slab reports whole chunks.
   uint64_t encodedBytes = 0;
+  /// Total retained CPU bytes for the outline and encode.
+  uint64_t retainedBytes = 0;
 };
 
 /**
@@ -185,6 +189,16 @@ public:
   /// The returned address is stable for the entry's lifetime.
   GeodeGlyphResidentEntry* insert(const GlyphGeometryKey& key, Path&& outline,
                                   EncodedPath&& encoded) {
+    const std::optional<uint64_t> entryBytes = EntryRetainedBytes(outline, encoded);
+    if (!entryBytes.has_value() ||
+        *entryBytes > std::numeric_limits<uint64_t>::max() - retainedBytes_) {
+      return nullptr;
+    }
+    const std::optional<uint64_t> encodedBytes = EncodedBytes(encoded);
+    if (!encodedBytes.has_value() ||
+        *encodedBytes > std::numeric_limits<uint64_t>::max() - encodedBytes_) {
+      return nullptr;
+    }
     // try_emplace, not emplace: emplace constructs the node before it checks
     // for a duplicate key and destroys it on collision, which would hand the
     // caller a pointer into freed storage and leave the byte total crediting an
@@ -197,8 +211,10 @@ public:
     GeodeGlyphResidentEntry* entry = it->second.get();
     entry->outline = std::move(outline);
     entry->encoded = std::move(encoded);
-    entry->encodedBytes = EncodedBytes(entry->encoded);
+    entry->encodedBytes = *encodedBytes;
+    entry->retainedBytes = *entryBytes;
     encodedBytes_ += entry->encodedBytes;
+    retainedBytes_ += entry->retainedBytes;
     return entry;
   }
 
@@ -206,10 +222,23 @@ public:
   /// miss path; the implementation is tightened in the following security fix.
   GeodeGlyphResidentEntry* insertWithinBudget(const GlyphGeometryKey& key, Path&& outline,
                                               EncodedPath&& encoded, uint64_t oldestOpenFrame,
-                                              size_t maxEntries, uint64_t maxRetainedBytes) {
-    (void)oldestOpenFrame;
-    (void)maxEntries;
-    (void)maxRetainedBytes;
+                                              size_t maxEntries, uint64_t maxRetainedBytes,
+                                              size_t* evictedOut = nullptr) {
+    if (GeodeGlyphResidentEntry* existing = find(key)) {
+      return existing;
+    }
+    const std::optional<uint64_t> entryBytes = EntryRetainedBytes(outline, encoded);
+    if (maxEntries == 0u || !entryBytes.has_value() || *entryBytes > maxRetainedBytes) {
+      return nullptr;
+    }
+    const size_t evicted =
+        evictToBudget(oldestOpenFrame, maxEntries - 1u, maxRetainedBytes - *entryBytes);
+    if (evictedOut != nullptr) {
+      *evictedOut += evicted;
+    }
+    if (entries_.size() >= maxEntries || retainedBytes_ > maxRetainedBytes - *entryBytes) {
+      return nullptr;
+    }
     return insert(key, std::move(outline), std::move(encoded));
   }
 
@@ -220,19 +249,19 @@ public:
   uint64_t encodedBytes() const { return encodedBytes_; }
 
   /// Total CPU bytes retained by cached outlines and encodes.
-  uint64_t retainedBytes() const { return encodedBytes_; }
+  uint64_t retainedBytes() const { return retainedBytes_; }
 
   /// Trim to budget at most once per frame. The frame-index guard makes the
   /// call idempotent no matter how many times a frame touches the cache, so
   /// the caller can put it on the accessor and cover every draw entry point.
   /// Returns the number of entries dropped.
   size_t beginFrame(uint64_t frameIndex, uint64_t oldestOpenFrame, size_t maxEntries,
-                    uint64_t maxEncodedBytes) {
+                    uint64_t maxRetainedBytes) {
     if (frameIndex == lastEvictedFrame_) {
       return 0;
     }
     lastEvictedFrame_ = frameIndex;
-    return evictToBudget(oldestOpenFrame, maxEntries, maxEncodedBytes);
+    return evictToBudget(oldestOpenFrame, maxEntries, maxRetainedBytes);
   }
 
   /// Drop entries until the cache fits the budget, oldest-unused first.
@@ -243,8 +272,8 @@ public:
   /// later allocation to overwrite. `oldestOpenFrame` is device-scoped, so an
   /// offscreen pass nested inside an outer frame cannot free the outer frame's
   /// geometry out from under it. Returns the number of entries dropped.
-  size_t evictToBudget(uint64_t oldestOpenFrame, size_t maxEntries, uint64_t maxEncodedBytes) {
-    if (entries_.size() <= maxEntries && encodedBytes_ <= maxEncodedBytes) {
+  size_t evictToBudget(uint64_t oldestOpenFrame, size_t maxEntries, uint64_t maxRetainedBytes) {
+    if (entries_.size() <= maxEntries && retainedBytes_ <= maxRetainedBytes) {
       return 0;
     }
 
@@ -264,7 +293,7 @@ public:
 
     size_t evicted = 0;
     for (const auto& [unusedFrame, keyPtr] : candidates) {
-      if (entries_.size() <= maxEntries && encodedBytes_ <= maxEncodedBytes) {
+      if (entries_.size() <= maxEntries && retainedBytes_ <= maxRetainedBytes) {
         break;
       }
       auto it = entries_.find(*keyPtr);
@@ -272,6 +301,7 @@ public:
         continue;
       }
       encodedBytes_ -= it->second->encodedBytes;
+      retainedBytes_ -= it->second->retainedBytes;
       entries_.erase(it);
       ++evicted;
     }
@@ -282,30 +312,51 @@ public:
   /// in one font needs a few hundred; the cap bounds a document that animates
   /// font-size continuously, where every frame mints new keys.
   static constexpr size_t kDefaultMaxEntries = 1024u;
-  /// Default cap on summed encode bytes.
-  static constexpr uint64_t kDefaultMaxEncodedBytes = 8u << 20;
+  /// Default cap on summed retained outline and encode bytes.
+  static constexpr uint64_t kDefaultMaxRetainedBytes = 8u << 20;
 
 private:
-  /// CPU size of an encode. Used as the budget unit because it tracks the GPU
-  /// residence byte-for-byte (the resident slot uploads exactly these arrays).
-  ///
-  /// The entry's retained `Path outline` is NOT counted: it is CPU-only, it is
-  /// small next to the banded encode, and the entry-count cap already bounds
-  /// how many of them can be live. Add it here if the outline ever grows a
-  /// representation where that stops being true.
-  static uint64_t EncodedBytes(const EncodedPath& encoded) {
-    return encoded.bands.size() * sizeof(EncodedPath::Band) +
-           encoded.curves.size() * 6u * sizeof(float) +
-           encoded.curveIndices.size() * sizeof(uint32_t) +
-           encoded.vBands.size() * sizeof(EncodedPath::Band) +
-           encoded.vCurves.size() * 6u * sizeof(float) +
-           encoded.vCurveIndices.size() * sizeof(uint32_t) +
-           encoded.hBandGrid.size() * sizeof(uint32_t) +
-           encoded.vBandGrid.size() * sizeof(uint32_t);
+  template <typename T>
+  static bool AddCapacityBytes(uint64_t& total, const std::vector<T>& values) {
+    if (values.capacity() > std::numeric_limits<uint64_t>::max() / sizeof(T)) {
+      return false;
+    }
+    const uint64_t bytes = static_cast<uint64_t>(values.capacity()) * sizeof(T);
+    if (bytes > std::numeric_limits<uint64_t>::max() - total) {
+      return false;
+    }
+    total += bytes;
+    return true;
+  }
+
+  /// CPU vector capacities retained by one encoded path.
+  static std::optional<uint64_t> EncodedBytes(const EncodedPath& encoded) {
+    uint64_t total = 0;
+    if (!AddCapacityBytes(total, encoded.bands) || !AddCapacityBytes(total, encoded.curves) ||
+        !AddCapacityBytes(total, encoded.curveIndices) ||
+        !AddCapacityBytes(total, encoded.vBands) || !AddCapacityBytes(total, encoded.vCurves) ||
+        !AddCapacityBytes(total, encoded.vCurveIndices) ||
+        !AddCapacityBytes(total, encoded.hBandGrid) ||
+        !AddCapacityBytes(total, encoded.vBandGrid)) {
+      return std::nullopt;
+    }
+    return total;
+  }
+
+  static std::optional<uint64_t> EntryRetainedBytes(const Path& outline,
+                                                    const EncodedPath& encoded) {
+    const std::optional<std::size_t> outlineBytes = outline.retainedBytes();
+    const std::optional<uint64_t> encodedBytes = EncodedBytes(encoded);
+    if (!outlineBytes.has_value() || !encodedBytes.has_value() ||
+        *outlineBytes > std::numeric_limits<uint64_t>::max() - *encodedBytes) {
+      return std::nullopt;
+    }
+    return static_cast<uint64_t>(*outlineBytes) + *encodedBytes;
   }
 
   uint64_t owningDeviceId_ = 0;
   uint64_t encodedBytes_ = 0;
+  uint64_t retainedBytes_ = 0;
   /// Frame index of the last trim; `~0` = never trimmed. See beginFrame().
   uint64_t lastEvictedFrame_ = ~uint64_t{0};
   std::unordered_map<GlyphGeometryKey, std::unique_ptr<GeodeGlyphResidentEntry>,

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -454,7 +454,7 @@ struct GeodeTextInstanceRecordComponent {
         cpuBudget(std::move(other.cpuBudget)),
         cpuReservation(std::move(other.cpuReservation)),
         cpuRetainedBytes(other.cpuRetainedBytes) {
-    other.occurrences.clear();
+    std::deque<Occurrence>().swap(other.occurrences);
     other.cpuRetainedBytes = 0;
   }
 
@@ -472,7 +472,7 @@ struct GeodeTextInstanceRecordComponent {
       cpuBudget = std::move(other.cpuBudget);
       cpuReservation = std::move(other.cpuReservation);
       cpuRetainedBytes = other.cpuRetainedBytes;
-      other.occurrences.clear();
+      std::deque<Occurrence>().swap(other.occurrences);
       other.cpuRetainedBytes = 0;
     }
     return *this;
@@ -507,7 +507,7 @@ struct GeodeTextInstanceRecordComponent {
         }
       }
     }
-    occurrences.clear();
+    std::deque<Occurrence>().swap(occurrences);
     cpuReservation.reset();
     cpuBudget.reset();
     cpuRetainedBytes = 0;

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -191,6 +191,9 @@ public:
   /// The returned address is stable for the entry's lifetime.
   GeodeGlyphResidentEntry* insert(const GlyphGeometryKey& key, Path&& outline,
                                   EncodedPath&& encoded) {
+    if (GeodeGlyphResidentEntry* existing = find(key)) {
+      return existing;
+    }
     const std::optional<uint64_t> entryBytes = EntryRetainedBytes(outline, encoded);
     if (!entryBytes.has_value() ||
         *entryBytes > std::numeric_limits<uint64_t>::max() - retainedBytes_) {
@@ -201,12 +204,18 @@ public:
         *encodedBytes > std::numeric_limits<uint64_t>::max() - encodedBytes_) {
       return nullptr;
     }
+    if (budget_ && !budgetReservation_.replace(budget_, retainedBytes_ + *entryBytes)) {
+      return nullptr;
+    }
     // try_emplace, not emplace: emplace constructs the node before it checks
     // for a duplicate key and destroys it on collision, which would hand the
     // caller a pointer into freed storage and leave the byte total crediting an
     // entry that is not in the map.
     auto [it, inserted] = entries_.try_emplace(key);
     if (!inserted) {
+      if (budget_) {
+        (void)budgetReservation_.replace(budget_, retainedBytes_);
+      }
       return it->second.get();
     }
     it->second = std::make_unique<GeodeGlyphResidentEntry>();
@@ -220,8 +229,9 @@ public:
     return entry;
   }
 
-  /// Insert through the document retention envelope. This declaration is used by the renderer's
-  /// miss path; the implementation is tightened in the following security fix.
+  /// Insert through the per-cache entry/byte envelope after evicting entries
+  /// old enough to be safe. The family reservation in @ref insert remains
+  /// the aggregate cross-document admission gate.
   GeodeGlyphResidentEntry* insertWithinBudget(const GlyphGeometryKey& key, Path&& outline,
                                               EncodedPath&& encoded, uint64_t oldestOpenFrame,
                                               size_t maxEntries, uint64_t maxRetainedBytes,
@@ -304,6 +314,9 @@ public:
       }
       encodedBytes_ -= it->second->encodedBytes;
       retainedBytes_ -= it->second->retainedBytes;
+      if (budget_) {
+        (void)budgetReservation_.replace(budget_, retainedBytes_);
+      }
       entries_.erase(it);
       ++evicted;
     }
@@ -358,6 +371,7 @@ private:
 
   uint64_t owningDeviceId_ = 0;
   std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
+  GeodeGeometryCacheReservation budgetReservation_;
   uint64_t encodedBytes_ = 0;
   uint64_t retainedBytes_ = 0;
   /// Frame index of the last trim; `~0` = never trimmed. See beginFrame().
@@ -406,6 +420,8 @@ struct GeodeTextInstanceRecordComponent {
     GeodeRecordSlab::Slot slot;
     std::vector<uint8_t> lastRecord;
   };
+  static constexpr uint64_t kProjectedBytesPerOccurrence =
+      sizeof(Occurrence) + sizeof(InstanceRecord);
 
   /// Occurrence slots in paint order. Index is the occurrence's ordinal
   /// within the element's draw, so it is stable across unchanged frames. A
@@ -421,6 +437,9 @@ struct GeodeTextInstanceRecordComponent {
   /// this as "older than every open frame", which is what an untouched
   /// component is.
   uint64_t lastFrame = 0;
+  std::shared_ptr<GeodeDocumentGeometryBudget> cpuBudget;
+  GeodeGeometryCacheReservation cpuReservation;
+  uint64_t cpuRetainedBytes = 0;
 
   GeodeTextInstanceRecordComponent() = default;
   ~GeodeTextInstanceRecordComponent() { freeRecordSlots(); }
@@ -431,8 +450,12 @@ struct GeodeTextInstanceRecordComponent {
   GeodeTextInstanceRecordComponent(GeodeTextInstanceRecordComponent&& other) noexcept
       : occurrences(std::move(other.occurrences)),
         recordSlab(std::move(other.recordSlab)),
-        lastFrame(other.lastFrame) {
+        lastFrame(other.lastFrame),
+        cpuBudget(std::move(other.cpuBudget)),
+        cpuReservation(std::move(other.cpuReservation)),
+        cpuRetainedBytes(other.cpuRetainedBytes) {
     other.occurrences.clear();
+    other.cpuRetainedBytes = 0;
   }
 
   GeodeTextInstanceRecordComponent& operator=(GeodeTextInstanceRecordComponent&& other) noexcept {
@@ -446,9 +469,32 @@ struct GeodeTextInstanceRecordComponent {
       occurrences = std::move(other.occurrences);
       recordSlab = std::move(other.recordSlab);
       lastFrame = other.lastFrame;
+      cpuBudget = std::move(other.cpuBudget);
+      cpuReservation = std::move(other.cpuReservation);
+      cpuRetainedBytes = other.cpuRetainedBytes;
       other.occurrences.clear();
+      other.cpuRetainedBytes = 0;
     }
     return *this;
+  }
+
+  bool reserveOccurrence(std::shared_ptr<GeodeDocumentGeometryBudget> budget) {
+    if (cpuRetainedBytes > std::numeric_limits<uint64_t>::max() - kProjectedBytesPerOccurrence ||
+        !budget ||
+        !cpuReservation.replace(budget, cpuRetainedBytes + kProjectedBytesPerOccurrence)) {
+      return false;
+    }
+    cpuBudget = std::move(budget);
+    cpuRetainedBytes += kProjectedBytesPerOccurrence;
+    return true;
+  }
+
+  void rollbackOccurrence() {
+    if (cpuRetainedBytes < kProjectedBytesPerOccurrence || !cpuBudget) {
+      return;
+    }
+    cpuRetainedBytes -= kProjectedBytesPerOccurrence;
+    (void)cpuReservation.replace(cpuBudget, cpuRetainedBytes);
   }
 
   /// Return every slot to the slab (deferred to the next frame's merge, like
@@ -462,6 +508,9 @@ struct GeodeTextInstanceRecordComponent {
       }
     }
     occurrences.clear();
+    cpuReservation.reset();
+    cpuBudget.reset();
+    cpuRetainedBytes = 0;
   }
 };
 

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -506,7 +506,7 @@ struct GeodeTextInstanceRecordComponent {
         }
         targetCapacity *= 2u;
       }
-      if (targetCapacity > std::numeric_limits<uint64_t>::max() / sizeof(OccurrenceOwner)) {
+      if (targetCapacity > occurrences.max_size()) {
         return false;
       }
       const uint64_t projectedOwnerBytes =
@@ -518,10 +518,6 @@ struct GeodeTextInstanceRecordComponent {
 
       std::vector<OccurrenceOwner> replacement;
       replacement.reserve(targetCapacity);
-      if (replacement.capacity() > std::numeric_limits<uint64_t>::max() / sizeof(OccurrenceOwner)) {
-        (void)cpuReservation.replace(budget, oldBytes);
-        return false;
-      }
       const uint64_t actualOwnerBytes =
           static_cast<uint64_t>(replacement.capacity()) * sizeof(OccurrenceOwner);
       if (payloadBytes > std::numeric_limits<uint64_t>::max() - actualOwnerBytes ||

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -202,11 +202,25 @@ public:
     return entry;
   }
 
+  /// Insert through the document retention envelope. This declaration is used by the renderer's
+  /// miss path; the implementation is tightened in the following security fix.
+  GeodeGlyphResidentEntry* insertWithinBudget(const GlyphGeometryKey& key, Path&& outline,
+                                              EncodedPath&& encoded, uint64_t oldestOpenFrame,
+                                              size_t maxEntries, uint64_t maxRetainedBytes) {
+    (void)oldestOpenFrame;
+    (void)maxEntries;
+    (void)maxRetainedBytes;
+    return insert(key, std::move(outline), std::move(encoded));
+  }
+
   /// Number of live entries.
   size_t size() const { return entries_.size(); }
 
   /// Summed \ref GeodeGlyphResidentEntry::encodedBytes over live entries.
   uint64_t encodedBytes() const { return encodedBytes_; }
+
+  /// Total CPU bytes retained by cached outlines and encodes.
+  uint64_t retainedBytes() const { return encodedBytes_; }
 
   /// Trim to budget at most once per frame. The frame-index guard makes the
   /// call idempotent no matter how many times a frame touches the cache, so

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -170,7 +170,9 @@ struct GeodeGlyphResidentEntry {
 class GeodeGlyphCache {
 public:
   /// Create an empty cache bound to `deviceId`.
-  explicit GeodeGlyphCache(uint64_t deviceId) : owningDeviceId_(deviceId) {}
+  explicit GeodeGlyphCache(uint64_t deviceId,
+                           std::shared_ptr<GeodeDocumentGeometryBudget> budget = nullptr)
+      : owningDeviceId_(deviceId), budget_(std::move(budget)) {}
 
   GeodeGlyphCache(const GeodeGlyphCache&) = delete;
   GeodeGlyphCache& operator=(const GeodeGlyphCache&) = delete;
@@ -355,6 +357,7 @@ private:
   }
 
   uint64_t owningDeviceId_ = 0;
+  std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
   uint64_t encodedBytes_ = 0;
   uint64_t retainedBytes_ = 0;
   /// Frame index of the last trim; `~0` = never trimmed. See beginFrame().

--- a/donner/svg/renderer/geode/GeodePathCacheComponent.h
+++ b/donner/svg/renderer/geode/GeodePathCacheComponent.h
@@ -19,6 +19,7 @@
 
 #include "donner/base/Path.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
+#include "donner/svg/renderer/geode/GeodeResourceBudget.h"
 
 namespace donner::geode {
 
@@ -35,6 +36,8 @@ struct GeodePathCacheComponent {
   /// Fill-slot encode. Populated on first encode; reused on hit.
   /// Reset by the entt signal listener when geometry changes.
   std::optional<EncodedPath> fillEncode;
+  /// Live retained-byte charge for `fillEncode`.
+  GeodeGeometryCacheReservation fillReservation;
 
   /// Stroke-slot cache. Holds both the `Path::strokeToFill` output
   /// path and its encoded form, keyed by the source `StrokeStyle` plus
@@ -72,6 +75,8 @@ struct GeodePathCacheComponent {
     FillRule strokeFillRule = FillRule::NonZero;
   };
   std::optional<StrokeSlot> strokeSlot;
+  /// Live retained-byte charge for `strokeSlot`.
+  GeodeGeometryCacheReservation strokeReservation;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePathCacheComponent.h
+++ b/donner/svg/renderer/geode/GeodePathCacheComponent.h
@@ -15,6 +15,8 @@
 /// `emplaceComputedPathIfChanged`) ensures those signals only fire when
 /// the path actually changed, so idle re-renders leave the cache intact.
 
+#include <cstddef>
+#include <limits>
 #include <optional>
 
 #include "donner/base/Path.h"
@@ -73,6 +75,23 @@ struct GeodePathCacheComponent {
     /// NonZero vs EvenOdd based on subpath topology, so this is
     /// derived and cached alongside the encode.
     FillRule strokeFillRule = FillRule::NonZero;
+
+    /// Exact dynamic capacity retained by this cached stroke entry.
+    std::optional<std::size_t> retainedBytes() const {
+      const std::optional<std::size_t> pathBytes = strokedPath.retainedBytes();
+      const std::size_t encodedBytes = strokedEncode.retainedBytes();
+      if (!pathBytes.has_value() || encodedBytes == std::numeric_limits<std::size_t>::max() ||
+          strokeKey.dashArray.capacity() >
+              std::numeric_limits<std::size_t>::max() / sizeof(double)) {
+        return std::nullopt;
+      }
+      const std::size_t dashBytes = strokeKey.dashArray.capacity() * sizeof(double);
+      if (*pathBytes > std::numeric_limits<std::size_t>::max() - encodedBytes ||
+          *pathBytes + encodedBytes > std::numeric_limits<std::size_t>::max() - dashBytes) {
+        return std::nullopt;
+      }
+      return *pathBytes + encodedBytes + dashBytes;
+    }
   };
   std::optional<StrokeSlot> strokeSlot;
   /// Live retained-byte charge for `strokeSlot`.

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -869,8 +869,9 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule fillRule, double
   return encode(path, fillRule, tolerance, Limits{});
 }
 
-EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, double tolerance,
-                                     Limits limits) {
+namespace {
+
+EncodedPath EncodeBoundedPath(const Path& path, double tolerance, GeodePathEncoder::Limits limits) {
   EncodedPath result;
 
   if (path.empty()) {
@@ -975,6 +976,13 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   }
   result.outcome = EncodedPath::Outcome::Ready;
   return result;
+}
+
+}  // namespace
+
+EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, double tolerance,
+                                     Limits limits) {
+  return EncodeBoundedPath(path, tolerance, limits);
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -601,18 +601,51 @@ void storeBoundingPolygon(EncodedPath& result, const std::vector<CurveWithRange>
 /// its strip boundaries and `xMin`/`xMax` are the curves' X-extent. For `BandAxis::X`
 /// (vertical bands, vertical ray) the roles transpose: `xMin`/`xMax` are the strip
 /// boundaries and `yMin`/`yMax` are the curves' Y-extent.
-void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bounds, BandAxis axis,
+bool bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bounds, BandAxis axis,
                 std::vector<EncodedPath::Band>& outBands,
                 std::vector<EncodedPath::Curve>& outCurves, std::vector<uint32_t>& outCurveIndices,
                 uint16_t bandCount, std::vector<uint32_t>& outGrid,
-                EncodedPath::AxisStats& outStats) {
+                EncodedPath::AxisStats& outStats, std::size_t maximumItems) {
   // The fixed-size count/scratch arrays below index up to bandCount.
   UTILS_RELEASE_ASSERT(bandCount <= kMaxBands);
   // Dense cell → band-slot map (kNoBand for empty cells). Sized to the full grid even when
   // some cells are empty, so the fragment shader can index it directly by position.
   outGrid.assign(bandCount, EncodedPath::kNoBand);
   if (bandCount == 0 || allCurves.empty()) {
-    return;
+    return true;
+  }
+
+  std::size_t retainedItems = 0;
+  for (const std::size_t count :
+       {outBands.size(), outCurves.size(), outCurveIndices.size(), outGrid.size()}) {
+    if (retainedItems > maximumItems || count > maximumItems - retainedItems) {
+      return false;
+    }
+    retainedItems += count;
+  }
+  if (allCurves.size() > maximumItems - retainedItems) {
+    return false;
+  }
+
+  std::array<uint32_t, kMaxBands> preflightBandCounts;
+  std::fill_n(preflightBandCounts.begin(), bandCount, 0u);
+  for (const CurveWithRange& curve : allCurves) {
+    const std::optional<BandSpan> curveSpan = curveBandSpan(curve.range, bounds, axis, bandCount);
+    if (!curveSpan) continue;
+    for (uint16_t band = curveSpan->first; band <= curveSpan->last; ++band) {
+      ++preflightBandCounts[band];
+    }
+  }
+  std::uint64_t totalReferencesPreflight = 0;
+  std::size_t nonemptyBands = 0;
+  for (uint16_t band = 0; band < bandCount; ++band) {
+    totalReferencesPreflight += preflightBandCounts[band];
+    nonemptyBands += preflightBandCounts[band] != 0u;
+  }
+  const std::size_t afterCanonical = retainedItems + allCurves.size();
+  if (nonemptyBands > maximumItems - afterCanonical ||
+      totalReferencesPreflight > maximumItems - afterCanonical - nonemptyBands) {
+    return false;
   }
 
   UTILS_RELEASE_ASSERT_MSG(
@@ -711,6 +744,7 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
     outStats.meanCurvesPerBand =
         static_cast<double>(totalReferences) / static_cast<double>(nonemptyCount);
   }
+  return true;
 }
 
 std::optional<Path> CubicToQuadraticBounded(const Path& path, double tolerance,
@@ -792,6 +826,43 @@ std::optional<Path> CubicToQuadraticBounded(const Path& path, double tolerance,
   return builder.build();
 }
 
+bool MonotonicExpansionFits(const Path& path, Path::MonotonicAxis axis, std::size_t maximumItems) {
+  std::size_t commandCount = 0;
+  std::size_t pointCount = 0;
+  Vector2d currentPoint;
+  Vector2d subpathStart;
+  for (const Path::Command& command : path.commands()) {
+    std::size_t addedCommands = 1;
+    std::size_t addedPoints = Path::pointsPerVerb(command.verb);
+    if (command.verb == Path::Verb::QuadTo) {
+      const Vector2d& control = path.points()[command.pointIndex];
+      const Vector2d& end = path.points()[command.pointIndex + 1u];
+      const bool hasExtremum = axis == Path::MonotonicAxis::X
+                                   ? !QuadraticXExtrema(currentPoint, control, end).empty()
+                                   : !QuadraticYExtrema(currentPoint, control, end).empty();
+      if (hasExtremum) {
+        addedCommands = 2;
+        addedPoints = 4;
+      }
+      currentPoint = end;
+    } else if (command.verb == Path::Verb::MoveTo) {
+      currentPoint = path.points()[command.pointIndex];
+      subpathStart = currentPoint;
+    } else if (command.verb == Path::Verb::LineTo) {
+      currentPoint = path.points()[command.pointIndex];
+    } else if (command.verb == Path::Verb::ClosePath) {
+      currentPoint = subpathStart;
+    }
+    if (commandCount > maximumItems || pointCount > maximumItems ||
+        addedCommands > maximumItems - commandCount || addedPoints > maximumItems - pointCount) {
+      return false;
+    }
+    commandCount += addedCommands;
+    pointCount += addedPoints;
+  }
+  return true;
+}
+
 }  // namespace
 
 EncodedPath GeodePathEncoder::encode(const Path& path, FillRule fillRule, double tolerance) {
@@ -805,13 +876,16 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   if (path.empty()) {
     return result;
   }
-  if (!std::isfinite(tolerance) || tolerance < 0.0 || !PathCoordinatesFit(path)) {
+  if (!std::isfinite(tolerance) || tolerance < 0.0 || !PathCoordinatesFit(path) ||
+      path.commands().size() > limits.maximumEncodedGeometryItems ||
+      path.points().size() > limits.maximumEncodedGeometryItems) {
     return RejectedEncode();
   }
 
   // Cubic→quadratic once; the two monotonic splits share it.
-  const std::optional<Path> converted =
-      CubicToQuadraticBounded(path, tolerance, limits.maximumConvertedCommands);
+  const std::optional<Path> converted = CubicToQuadraticBounded(
+      path, tolerance,
+      std::min(limits.maximumConvertedCommands, limits.maximumEncodedGeometryItems));
   if (!converted.has_value()) {
     return RejectedEncode();
   }
@@ -821,6 +895,10 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   }
 
   // Bounds from the Y-monotonic form (same point set as X-monotonic; bounds are identical).
+  if (!MonotonicExpansionFits(quadPath, Path::MonotonicAxis::Y,
+                              limits.maximumEncodedGeometryItems)) {
+    return RejectedEncode();
+  }
   const Path monoPathY = quadPath.toMonotonic(Path::MonotonicAxis::Y);
   if (monoPathY.empty()) {
     return result;
@@ -854,8 +932,11 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     return result;
   }
   const uint16_t hBandCount = chooseBandCount(hCurves, bounds, BandAxis::Y);
-  bandCurves(hCurves, bounds, BandAxis::Y, result.bands, result.curves, result.curveIndices,
-             hBandCount, result.hBandGrid, result.stats.horizontal);
+  if (!bandCurves(hCurves, bounds, BandAxis::Y, result.bands, result.curves, result.curveIndices,
+                  hBandCount, result.hBandGrid, result.stats.horizontal,
+                  limits.maximumEncodedGeometryItems)) {
+    return RejectedEncode();
+  }
   if (result.bands.empty()) {
     return result;
   }
@@ -867,6 +948,10 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   // Degenerate-width paths (e.g. a vertical hairline) skip vertical banding; the
   // horizontal ray alone covers them.
   if (!NearZero(pathWidth)) {
+    if (!MonotonicExpansionFits(quadPath, Path::MonotonicAxis::X,
+                                limits.maximumEncodedGeometryItems)) {
+      return RejectedEncode();
+    }
     const Path monoPathX = quadPath.toMonotonic(Path::MonotonicAxis::X);
     const std::vector<CurveWithRange> vExtracted = extractCurves(monoPathX);
     const std::vector<CurveWithRange> vAll = omitRayParallelCurves(vExtracted, BandAxis::X);
@@ -874,14 +959,20 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
         static_cast<uint32_t>(vExtracted.size() - vAll.size());
     if (!vAll.empty()) {
       const uint16_t vBandCount = chooseBandCount(vAll, bounds, BandAxis::X);
-      bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, result.vCurveIndices,
-                 vBandCount, result.vBandGrid, result.stats.vertical);
+      if (!bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves,
+                      result.vCurveIndices, vBandCount, result.vBandGrid, result.stats.vertical,
+                      limits.maximumEncodedGeometryItems)) {
+        return RejectedEncode();
+      }
       result.xBase = static_cast<float>(bounds.topLeft.x);
       result.vStride = pathWidth / static_cast<float>(vBandCount);
       result.vBandCount = vBandCount;
     }
   }
 
+  if (result.geometryItemCount() > limits.maximumEncodedGeometryItems) {
+    return RejectedEncode();
+  }
   result.outcome = EncodedPath::Outcome::Ready;
   return result;
 }

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -21,6 +21,35 @@ namespace {
 /// Maximum number of bands - prevents runaway memory for huge paths.
 constexpr uint16_t kMaxBands = 256;
 
+EncodedPath RejectedEncode() {
+  EncodedPath result;
+  result.outcome = EncodedPath::Outcome::Rejected;
+  return result;
+}
+
+bool PathCoordinatesFit(const Path& path) {
+  constexpr double kMaximumFloat = static_cast<double>(std::numeric_limits<float>::max());
+  for (const Vector2d& point : path.points()) {
+    if (!std::isfinite(point.x) || !std::isfinite(point.y) || std::abs(point.x) > kMaximumFloat ||
+        std::abs(point.y) > kMaximumFloat) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool BoundsFitFloat(const Box2d& bounds) {
+  constexpr double kMaximumFloat = static_cast<double>(std::numeric_limits<float>::max());
+  return std::isfinite(bounds.topLeft.x) && std::isfinite(bounds.topLeft.y) &&
+         std::isfinite(bounds.bottomRight.x) && std::isfinite(bounds.bottomRight.y) &&
+         std::abs(bounds.topLeft.x) <= kMaximumFloat &&
+         std::abs(bounds.topLeft.y) <= kMaximumFloat &&
+         std::abs(bounds.bottomRight.x) <= kMaximumFloat &&
+         std::abs(bounds.bottomRight.y) <= kMaximumFloat && std::isfinite(bounds.width()) &&
+         std::isfinite(bounds.height()) && bounds.width() <= kMaximumFloat &&
+         bounds.height() <= kMaximumFloat;
+}
+
 /// Axis-aligned extent of a quadratic Bézier (control-point hull bounds).
 struct CurveRange {
   float yMin;
@@ -776,13 +805,15 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   if (path.empty()) {
     return result;
   }
+  if (!std::isfinite(tolerance) || tolerance < 0.0 || !PathCoordinatesFit(path)) {
+    return RejectedEncode();
+  }
 
   // Cubic→quadratic once; the two monotonic splits share it.
   const std::optional<Path> converted =
       CubicToQuadraticBounded(path, tolerance, limits.maximumConvertedCommands);
   if (!converted.has_value()) {
-    result.outcome = EncodedPath::Outcome::Rejected;
-    return result;
+    return RejectedEncode();
   }
   const Path& quadPath = *converted;
   if (quadPath.empty()) {
@@ -797,6 +828,9 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   const Box2d bounds = monoPathY.bounds();
   if (bounds.isEmpty()) {
     return result;
+  }
+  if (!BoundsFitFloat(bounds)) {
+    return RejectedEncode();
   }
   result.pathBounds = bounds;
   result.stats.aabbArea = bounds.width() * bounds.height();

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <tuple>
 
+#include "donner/base/BezierUtils.h"
 #include "donner/base/FillRule.h"
 #include "donner/base/MathUtils.h"
 #include "donner/base/Path.h"
@@ -683,9 +684,93 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
   }
 }
 
+std::optional<Path> CubicToQuadraticBounded(const Path& path, double tolerance,
+                                            std::size_t maximumCommands) {
+  if (!std::isfinite(tolerance) || tolerance < 0.0) {
+    return std::nullopt;
+  }
+
+  PathBuilder builder;
+  std::size_t outputCommands = 0;
+  Vector2d currentPoint;
+  Vector2d subpathStart;
+  bool hasCurrentPoint = false;
+  const std::span<const Vector2d> points = path.points();
+
+  const auto admitCommand = [&]() {
+    if (outputCommands >= maximumCommands) {
+      return false;
+    }
+    ++outputCommands;
+    return true;
+  };
+
+  for (const Path::Command& command : path.commands()) {
+    switch (command.verb) {
+      case Path::Verb::MoveTo:
+        if (!admitCommand()) return std::nullopt;
+        currentPoint = points[command.pointIndex];
+        subpathStart = currentPoint;
+        hasCurrentPoint = true;
+        builder.moveTo(currentPoint);
+        break;
+
+      case Path::Verb::LineTo:
+        if (!hasCurrentPoint || !admitCommand()) return std::nullopt;
+        currentPoint = points[command.pointIndex];
+        builder.lineTo(currentPoint);
+        break;
+
+      case Path::Verb::QuadTo:
+        if (!hasCurrentPoint || !admitCommand()) return std::nullopt;
+        currentPoint = points[command.pointIndex + 1u];
+        builder.quadTo(points[command.pointIndex], currentPoint);
+        break;
+
+      case Path::Verb::CurveTo: {
+        if (!hasCurrentPoint || outputCommands >= maximumCommands) return std::nullopt;
+        const std::size_t remainingCommands = maximumCommands - outputCommands;
+        const std::size_t maximumOutputPoints =
+            remainingCommands > std::numeric_limits<std::size_t>::max() / 2u
+                ? std::numeric_limits<std::size_t>::max()
+                : remainingCommands * 2u;
+        std::vector<Vector2d> quadratics;
+        if (!ApproximateCubicWithQuadratics(
+                currentPoint, points[command.pointIndex], points[command.pointIndex + 1u],
+                points[command.pointIndex + 2u], tolerance, maximumOutputPoints, quadratics)) {
+          return std::nullopt;
+        }
+        const std::size_t quadraticCount = quadratics.size() / 2u;
+        if (quadraticCount > remainingCommands) return std::nullopt;
+        for (std::size_t index = 0; index < quadratics.size(); index += 2u) {
+          builder.quadTo(quadratics[index], quadratics[index + 1u]);
+        }
+        outputCommands += quadraticCount;
+        currentPoint = points[command.pointIndex + 2u];
+        break;
+      }
+
+      case Path::Verb::ClosePath:
+        if (!hasCurrentPoint || !admitCommand()) return std::nullopt;
+        builder.closePath();
+        currentPoint = subpathStart;
+        break;
+    }
+    if (builder.exceededMaximumPoints()) {
+      return std::nullopt;
+    }
+  }
+  return builder.build();
+}
+
 }  // namespace
 
-EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, double tolerance) {
+EncodedPath GeodePathEncoder::encode(const Path& path, FillRule fillRule, double tolerance) {
+  return encode(path, fillRule, tolerance, Limits{});
+}
+
+EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, double tolerance,
+                                     Limits limits) {
   EncodedPath result;
 
   if (path.empty()) {
@@ -693,7 +778,13 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   }
 
   // Cubic→quadratic once; the two monotonic splits share it.
-  const Path quadPath = path.cubicToQuadratic(tolerance);
+  const std::optional<Path> converted =
+      CubicToQuadraticBounded(path, tolerance, limits.maximumConvertedCommands);
+  if (!converted.has_value()) {
+    result.outcome = EncodedPath::Outcome::Rejected;
+    return result;
+  }
+  const Path& quadPath = *converted;
   if (quadPath.empty()) {
     return result;
   }
@@ -757,6 +848,7 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     }
   }
 
+  result.outcome = EncodedPath::Outcome::Ready;
   return result;
 }
 

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <span>
 #include <vector>
 
@@ -117,6 +118,38 @@ struct EncodedPath {
 
   EncodingStats stats;  ///< Encode diagnostics; does not affect rendering.
   Outcome outcome = Outcome::Empty;
+
+  [[nodiscard]] std::size_t geometryItemCount() const {
+    std::size_t total = 0;
+    for (const std::size_t count :
+         {curves.size(), curveIndices.size(), bands.size(), vCurves.size(), vCurveIndices.size(),
+          vBands.size(), hBandGrid.size(), vBandGrid.size()}) {
+      if (count > std::numeric_limits<std::size_t>::max() - total) {
+        return std::numeric_limits<std::size_t>::max();
+      }
+      total += count;
+    }
+    return total;
+  }
+
+  [[nodiscard]] std::size_t retainedBytes() const {
+    std::size_t total = 0;
+    const auto add = [&](std::size_t capacity, std::size_t itemSize) {
+      if (capacity > std::numeric_limits<std::size_t>::max() / itemSize) return false;
+      const std::size_t bytes = capacity * itemSize;
+      if (bytes > std::numeric_limits<std::size_t>::max() - total) return false;
+      total += bytes;
+      return true;
+    };
+    if (!add(curves.capacity(), sizeof(Curve)) || !add(curveIndices.capacity(), sizeof(uint32_t)) ||
+        !add(bands.capacity(), sizeof(Band)) || !add(vCurves.capacity(), sizeof(Curve)) ||
+        !add(vCurveIndices.capacity(), sizeof(uint32_t)) || !add(vBands.capacity(), sizeof(Band)) ||
+        !add(hBandGrid.capacity(), sizeof(uint32_t)) ||
+        !add(vBandGrid.capacity(), sizeof(uint32_t))) {
+      return std::numeric_limits<std::size_t>::max();
+    }
+    return total;
+  }
 
   /// Triangle-list vertex count emitted by the vertex shader for the bounding fan.
   uint32_t boundingDrawVertexCount() const {

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -148,6 +148,7 @@ class GeodePathEncoder {
 public:
   struct Limits {
     std::size_t maximumConvertedCommands = 1u << 20;
+    std::size_t maximumEncodedGeometryItems = 1u << 20;
   };
 
   /**

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -160,11 +160,8 @@ public:
    */
   static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance = 0.1);
 
-  /// Resource-limited encode overload. The following implementation commit enforces `limits`.
-  static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance, Limits limits) {
-    (void)limits;
-    return encode(path, fillRule, tolerance);
-  }
+  /// Resource-limited encode overload.
+  static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance, Limits limits);
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -3,6 +3,7 @@
 /// CPU-side Slug band decomposition: converts a Path into GPU-ready band data.
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <vector>
@@ -31,6 +32,8 @@ namespace donner::geode {
  *   triangulates and dilates it from `vertex_index`, so no resident vertex buffer is required.
  */
 struct EncodedPath {
+  enum class Outcome { Empty, Ready, Rejected };
+
   /// A quadratic Bézier curve segment (3 control points) stored as floats for GPU consumption.
   struct Curve {
     float p0x, p0y;  ///< Start point.
@@ -113,6 +116,7 @@ struct EncodedPath {
   uint32_t vBandCount = 0;          ///< Number of vertical band cells.
 
   EncodingStats stats;  ///< Encode diagnostics; does not affect rendering.
+  Outcome outcome = Outcome::Empty;
 
   /// Triangle-list vertex count emitted by the vertex shader for the bounding fan.
   uint32_t boundingDrawVertexCount() const {
@@ -125,6 +129,7 @@ struct EncodedPath {
 
   /// Returns true if the encoded path has no bands (empty or degenerate path).
   bool empty() const { return bands.empty(); }
+  bool rejected() const { return outcome == Outcome::Rejected; }
 };
 
 /**
@@ -141,6 +146,10 @@ struct EncodedPath {
  */
 class GeodePathEncoder {
 public:
+  struct Limits {
+    std::size_t maximumConvertedCommands = 1u << 20;
+  };
+
   /**
    * Encode a path for GPU rendering.
    *
@@ -150,6 +159,12 @@ public:
    * @return Encoded path data ready for GPU upload, or empty if the path is degenerate.
    */
   static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance = 0.1);
+
+  /// Resource-limited encode overload. The following implementation commit enforces `limits`.
+  static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance, Limits limits) {
+    (void)limits;
+    return encode(path, fillRule, tolerance);
+  }
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -316,6 +316,10 @@ public:
     return total;
   }
 
+  uint64_t batchUniformMetadataBytesForTesting() const {
+    return batchUniforms_.capacity() * sizeof(BatchUniform);
+  }
+
 private:
   struct Chunk {
     ScopedWgpuHandle<wgpu::Buffer> buffer;

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "donner/svg/renderer/geode/GeodeDevice.h"
@@ -146,6 +147,8 @@ public:
 
   uint64_t owningDeviceId() const { return owningDeviceId_; }
 
+  const std::shared_ptr<GeodeDocumentGeometryBudget>& documentBudget() const { return budget_; }
+
   /// Merge the previous frame's freed slots into the reusable free list.
   /// The frame-index guard makes the merge idempotent per frame (mirrors
   /// the geometry slab's contract: a second renderer on the same device
@@ -232,6 +235,13 @@ public:
     uint64_t bufferId = 0;
   };
 
+  static std::optional<uint64_t> batchUniformRetainedBytes(uint64_t uniformBytes) {
+    if (uniformBytes > std::numeric_limits<uint64_t>::max() - sizeof(BatchUniform)) {
+      return std::nullopt;
+    }
+    return sizeof(BatchUniform) + uniformBytes;
+  }
+
   /**
    * Persistent buffer holding one distinct scene-batch uniform value.
    *
@@ -260,6 +270,13 @@ public:
     if (budget_ && !budget_->reserveResidentBytes(size)) {
       return BatchUniformHandle{};
     }
+    const std::optional<uint64_t> cpuBytes = batchUniformRetainedBytes(size);
+    if (!cpuBytes.has_value() || !reserveCpuBytes(*cpuBytes)) {
+      if (budget_) {
+        budget_->releaseResidentBytes(size);
+      }
+      return BatchUniformHandle{};
+    }
     wgpu::BufferDescriptor desc = {};
     desc.label = wgpuLabel("GeodeSceneBatchUniform");
     desc.size = size;
@@ -269,6 +286,7 @@ public:
       if (budget_) {
         budget_->releaseResidentBytes(size);
       }
+      releaseCpuBytes(*cpuBytes);
       return BatchUniformHandle{};
     }
     device.countBuffer();
@@ -318,6 +336,26 @@ private:
   /// batch.
   static constexpr size_t kMaxBatchUniforms = 8u;
 
+  bool reserveCpuBytes(uint64_t bytes) {
+    if (!budget_) {
+      return true;
+    }
+    if (bytes > std::numeric_limits<uint64_t>::max() - cpuRetainedBytes_ ||
+        !cpuReservation_.replace(budget_, cpuRetainedBytes_ + bytes)) {
+      return false;
+    }
+    cpuRetainedBytes_ += bytes;
+    return true;
+  }
+
+  void releaseCpuBytes(uint64_t bytes) {
+    if (!budget_ || bytes > cpuRetainedBytes_) {
+      return;
+    }
+    cpuRetainedBytes_ -= bytes;
+    (void)cpuReservation_.replace(budget_, cpuRetainedBytes_);
+  }
+
   Slot slotAt(uint32_t index) const {
     // Slots are never moved; walk the chunk sizes to find the owner.
     uint64_t offset = static_cast<uint64_t>(index) * sizeof(InstanceRecord);
@@ -338,6 +376,8 @@ private:
   std::vector<uint32_t> pendingFrees_;
   std::vector<BatchUniform> batchUniforms_;
   std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
+  GeodeGeometryCacheReservation cpuReservation_;
+  uint64_t cpuRetainedBytes_ = 0;
   uint64_t accountedBytes_ = 0;
 };
 
@@ -404,6 +444,8 @@ public:
 
   /// Device this slab's chunks were created on.
   uint64_t owningDeviceId() const { return owningDeviceId_; }
+
+  const std::shared_ptr<GeodeDocumentGeometryBudget>& documentBudget() const { return budget_; }
 
   /// Merge the previous frame's freed ranges into the reusable free list.
   /// Gated on `frameIndex` (the renderer's frame counter) so the merge runs
@@ -740,6 +782,20 @@ struct GeodeResidentSlot {
   /// static frame => zero buffer writes); a camera/color change rewrites
   /// only this 416-byte region and keeps the cached bind group.
   std::vector<uint8_t> lastUniform;
+  GeodeGeometryCacheReservation cpuMirrorReservation;
+  uint64_t cpuUniformBytes = 0;
+  uint64_t cpuRecordBytes = 0;
+  uint64_t cpuPaintBytes = 0;
+
+  bool reserveUniformMirror(uint64_t bytes) {
+    return reserveCpuMirrors(bytes, cpuRecordBytes, cpuPaintBytes);
+  }
+  bool reserveRecordMirror(uint64_t bytes) {
+    return reserveCpuMirrors(cpuUniformBytes, bytes, cpuPaintBytes);
+  }
+  bool reservePaintMirror(uint64_t bytes) {
+    return reserveCpuMirrors(cpuUniformBytes, cpuRecordBytes, bytes);
+  }
 
   GeodeResidentSlot() = default;
   ~GeodeResidentSlot() {
@@ -794,12 +850,19 @@ struct GeodeResidentSlot {
       lastUniform = std::move(other.lastUniform);
       lastRecord = std::move(other.lastRecord);
       lastPaint = std::move(other.lastPaint);
+      cpuMirrorReservation = std::move(other.cpuMirrorReservation);
+      cpuUniformBytes = other.cpuUniformBytes;
+      cpuRecordBytes = other.cpuRecordBytes;
+      cpuPaintBytes = other.cpuPaintBytes;
       paintMode = other.paintMode;
       gradientSpread = other.gradientSpread;
       gradientStopCount = other.gradientStopCount;
       other.resident = false;
       other.encodedKey = nullptr;
       other.owningDeviceId = 0;
+      other.cpuUniformBytes = 0;
+      other.cpuRecordBytes = 0;
+      other.cpuPaintBytes = 0;
     }
     return *this;
   }
@@ -835,12 +898,34 @@ struct GeodeResidentSlot {
     encodedKey = nullptr;
     encodedFingerprint = 0;
     owningDeviceId = 0;
-    lastUniform.clear();
-    lastRecord.clear();
-    lastPaint.clear();
+    std::vector<uint8_t>().swap(lastUniform);
+    std::vector<uint8_t>().swap(lastRecord);
+    std::vector<uint8_t>().swap(lastPaint);
+    cpuMirrorReservation.reset();
+    cpuUniformBytes = 0;
+    cpuRecordBytes = 0;
+    cpuPaintBytes = 0;
     paintMode = 0;
     gradientSpread = 0;
     gradientStopCount = 0;
+  }
+
+private:
+  bool reserveCpuMirrors(uint64_t uniformBytes, uint64_t recordBytes, uint64_t paintBytes) {
+    if (uniformBytes > std::numeric_limits<uint64_t>::max() - recordBytes ||
+        uniformBytes + recordBytes > std::numeric_limits<uint64_t>::max() - paintBytes) {
+      return false;
+    }
+    const uint64_t total = uniformBytes + recordBytes + paintBytes;
+    const std::shared_ptr<GeodeDocumentGeometryBudget> budget =
+        slab ? slab->documentBudget() : nullptr;
+    if (budget && !cpuMirrorReservation.replace(budget, total)) {
+      return false;
+    }
+    cpuUniformBytes = uniformBytes;
+    cpuRecordBytes = recordBytes;
+    cpuPaintBytes = paintBytes;
+    return true;
   }
 };
 
@@ -914,6 +999,18 @@ struct GeodeResidentGradientSlot {
 
   /// Bytes last written to the uniform region; unchanged draws skip the write.
   std::vector<uint8_t> lastUniform;
+  GeodeGeometryCacheReservation cpuMirrorReservation;
+  uint64_t cpuUniformBytes = 0;
+
+  bool reserveUniformMirror(uint64_t bytes) {
+    const std::shared_ptr<GeodeDocumentGeometryBudget> budget =
+        slab ? slab->documentBudget() : nullptr;
+    if (budget && !cpuMirrorReservation.replace(budget, bytes)) {
+      return false;
+    }
+    cpuUniformBytes = bytes;
+    return true;
+  }
 
   GeodeResidentGradientSlot() = default;
   ~GeodeResidentGradientSlot() { reset(); }
@@ -950,9 +1047,12 @@ struct GeodeResidentGradientSlot {
       encodedFingerprint = other.encodedFingerprint;
       owningDeviceId = other.owningDeviceId;
       lastUniform = std::move(other.lastUniform);
+      cpuMirrorReservation = std::move(other.cpuMirrorReservation);
+      cpuUniformBytes = other.cpuUniformBytes;
       other.resident = false;
       other.encodedKey = nullptr;
       other.owningDeviceId = 0;
+      other.cpuUniformBytes = 0;
     }
     return *this;
   }
@@ -977,7 +1077,9 @@ struct GeodeResidentGradientSlot {
     encodedKey = nullptr;
     encodedFingerprint = 0;
     owningDeviceId = 0;
-    lastUniform.clear();
+    std::vector<uint8_t>().swap(lastUniform);
+    cpuMirrorReservation.reset();
+    cpuUniformBytes = 0;
   }
 };
 

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -25,11 +25,13 @@
 #include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <vector>
 
-#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeResourceBudget.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
 
@@ -41,34 +43,34 @@ namespace donner::geode {
 /// order. All geometry bases are element offsets relative to the bound
 /// buffer range's start (chunk-relative for resident geometry).
 struct alignas(16) InstanceRecord {
-  float transformRow0[4];     //   0 ..  16 - (a, c, e, 0)
-  float transformRow1[4];     //  16 ..  32 - (b, d, f, 0)
-  float color[4];             //  32 ..  48 - premultiplied
-  uint32_t fillRule;          //  48 ..  52
-  uint32_t paintMode;         //  52 ..  56
-  float patternOpacity;       //  56 ..  60
-  uint32_t _pad0;             //  60 ..  64
-  float gridYBase;            //  64 ..  68
-  float gridHStride;          //  68 ..  72
-  uint32_t gridHBandCount;    //  72 ..  76
-  float gridXBase;            //  76 ..  80
-  float gridVStride;          //  80 ..  84
-  uint32_t gridVBandCount;    //  84 ..  88
-  uint32_t _gridPad0;         //  88 ..  92
-  uint32_t _gridPad1;         //  92 ..  96
-  uint32_t boundingVertexCount;  //  96 .. 100
-  uint32_t _boundingPad0;        // 100 .. 104
-  uint32_t _boundingPad1;        // 104 .. 108
-  uint32_t _boundingPad2;        // 108 .. 112
+  float transformRow0[4];         //   0 ..  16 - (a, c, e, 0)
+  float transformRow1[4];         //  16 ..  32 - (b, d, f, 0)
+  float color[4];                 //  32 ..  48 - premultiplied
+  uint32_t fillRule;              //  48 ..  52
+  uint32_t paintMode;             //  52 ..  56
+  float patternOpacity;           //  56 ..  60
+  uint32_t _pad0;                 //  60 ..  64
+  float gridYBase;                //  64 ..  68
+  float gridHStride;              //  68 ..  72
+  uint32_t gridHBandCount;        //  72 ..  76
+  float gridXBase;                //  76 ..  80
+  float gridVStride;              //  80 ..  84
+  uint32_t gridVBandCount;        //  84 ..  88
+  uint32_t _gridPad0;             //  88 ..  92
+  uint32_t _gridPad1;             //  92 ..  96
+  uint32_t boundingVertexCount;   //  96 .. 100
+  uint32_t _boundingPad0;         // 100 .. 104
+  uint32_t _boundingPad1;         // 104 .. 108
+  uint32_t _boundingPad2;         // 108 .. 112
   float boundingVertices[4 * 4];  // 112 .. 176
-  uint32_t bandBase;           // 176 .. 180
-  uint32_t curveBase;          // 180 .. 184
-  uint32_t vBandBase;          // 184 .. 188
-  uint32_t vCurveBase;         // 188 .. 192
-  uint32_t hGridBase;          // 192 .. 196
-  uint32_t vGridBase;          // 196 .. 200
-  uint32_t hRefsBase;          // 200 .. 204
-  uint32_t vRefsBase;          // 204 .. 208
+  uint32_t bandBase;              // 176 .. 180
+  uint32_t curveBase;             // 180 .. 184
+  uint32_t vBandBase;             // 184 .. 188
+  uint32_t vCurveBase;            // 188 .. 192
+  uint32_t hGridBase;             // 192 .. 196
+  uint32_t vGridBase;             // 196 .. 200
+  uint32_t hRefsBase;             // 200 .. 204
+  uint32_t vRefsBase;             // 204 .. 208
   // Axis-aligned device-pixel clip rectangle as a half-open range
   // `[minX, maxX) x [minY, maxY)` over integer pixel indices, matching what
   // a rasterizer scissor of the same rectangle keeps. Carrying it here
@@ -129,7 +131,15 @@ public:
     uint64_t bufferId = 0;
   };
 
-  explicit GeodeRecordSlab(uint64_t deviceId) : owningDeviceId_(deviceId) {}
+  explicit GeodeRecordSlab(uint64_t deviceId,
+                           std::shared_ptr<GeodeDocumentGeometryBudget> budget = nullptr)
+      : owningDeviceId_(deviceId), budget_(std::move(budget)) {}
+
+  ~GeodeRecordSlab() {
+    if (budget_ && accountedBytes_ != 0) {
+      budget_->releaseResidentBytes(accountedBytes_);
+    }
+  }
 
   GeodeRecordSlab(const GeodeRecordSlab&) = delete;
   GeodeRecordSlab& operator=(const GeodeRecordSlab&) = delete;
@@ -147,8 +157,7 @@ public:
     }
     lastMergedFrame_ = frameIndex;
     for (uint32_t index : pendingFrees_) {
-      freeIndices_.insert(std::upper_bound(freeIndices_.begin(), freeIndices_.end(), index),
-                          index);
+      freeIndices_.insert(std::upper_bound(freeIndices_.begin(), freeIndices_.end(), index), index);
     }
     pendingFrees_.clear();
   }
@@ -171,7 +180,13 @@ public:
     if (chunks_.empty() || usedBytes_ + sizeof(InstanceRecord) > chunks_.back().size) {
       uint64_t newSize = chunks_.empty() ? kInitialRecordSlabBytes : chunks_.back().size * 2u;
       while (newSize < sizeof(InstanceRecord)) {
+        if (newSize > std::numeric_limits<uint64_t>::max() / 2u) {
+          return false;
+        }
         newSize *= 2u;
+      }
+      if (budget_ && !budget_->reserveResidentBytes(newSize)) {
+        return false;
       }
       wgpu::BufferDescriptor desc = {};
       desc.label = wgpuLabel("GeodeRecordSlab");
@@ -179,10 +194,14 @@ public:
       desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
       ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
       if (!buffer) {
+        if (budget_) {
+          budget_->releaseResidentBytes(newSize);
+        }
         return false;
       }
       device.countBuffer();
       chunks_.push_back(Chunk{std::move(buffer), newSize, GeodeDevice::AllocateBufferId()});
+      accountedBytes_ += newSize;
       usedBytes_ = 0;
     }
     out.buffer = chunks_.back().buffer.get();
@@ -238,12 +257,18 @@ public:
     if (batchUniforms_.size() >= kMaxBatchUniforms) {
       return BatchUniformHandle{};
     }
+    if (budget_ && !budget_->reserveResidentBytes(size)) {
+      return BatchUniformHandle{};
+    }
     wgpu::BufferDescriptor desc = {};
     desc.label = wgpuLabel("GeodeSceneBatchUniform");
     desc.size = size;
     desc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
     ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
     if (!buffer) {
+      if (budget_) {
+        budget_->releaseResidentBytes(size);
+      }
       return BatchUniformHandle{};
     }
     device.countBuffer();
@@ -252,6 +277,7 @@ public:
     batchUniforms_.push_back(BatchUniform{std::move(buffer),
                                           std::vector<uint8_t>(first, first + size),
                                           GeodeDevice::AllocateBufferId()});
+    accountedBytes_ += size;
     return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
   }
 
@@ -311,6 +337,8 @@ private:
   std::vector<uint32_t> freeIndices_;
   std::vector<uint32_t> pendingFrees_;
   std::vector<BatchUniform> batchUniforms_;
+  std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
+  uint64_t accountedBytes_ = 0;
 };
 
 class GeodeDevice;
@@ -358,9 +386,14 @@ public:
 
   /// Create an empty slab bound to `deviceId` (usually the current
   /// renderer's device). Chunks are allocated lazily on first use.
-  explicit GeodeResidentSlab(uint64_t deviceId) : owningDeviceId_(deviceId) {}
+  explicit GeodeResidentSlab(uint64_t deviceId,
+                             std::shared_ptr<GeodeDocumentGeometryBudget> budget = nullptr)
+      : owningDeviceId_(deviceId), budget_(std::move(budget)) {}
 
   ~GeodeResidentSlab() {
+    if (budget_ && accountedBytes_ > 0) {
+      budget_->releaseResidentBytes(static_cast<uint64_t>(accountedBytes_));
+    }
     if (gauge_ && accountedBytes_ != 0) {
       gauge_->fetch_sub(accountedBytes_, std::memory_order_relaxed);
     }
@@ -465,16 +498,25 @@ public:
     if (chunks_.empty() || alignUp(chunks_.back().cursor, alignment) + size > chunks_.back().size) {
       uint64_t newSize = chunks_.empty() ? kInitialChunkBytes : chunks_.back().size * 2u;
       while (newSize < alignUp(size, alignment)) {
+        if (newSize > std::numeric_limits<uint64_t>::max() / 2u) {
+          return false;
+        }
         newSize *= 2u;
+      }
+      if (budget_ && !budget_->reserveResidentBytes(newSize)) {
+        return false;
       }
       wgpu::BufferDescriptor desc = {};
       desc.label = wgpuLabel("GeodeResidentSlab");
       desc.size = newSize;
-      desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform |
-                   wgpu::BufferUsage::CopyDst;
+      desc.usage =
+          wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
       Chunk chunk;
       chunk.buffer.reset(device.device().createBuffer(desc));
       if (!chunk.buffer) {
+        if (budget_) {
+          budget_->releaseResidentBytes(newSize);
+        }
         return false;
       }
       device.countBuffer();
@@ -547,6 +589,7 @@ private:
   std::vector<FreeRange> freeRanges_;
   std::vector<FreeRange> pendingFrees_;
   std::shared_ptr<std::atomic<int64_t>> gauge_;
+  std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
   int64_t accountedBytes_ = 0;
 };
 
@@ -604,8 +647,8 @@ struct GeodeResidentSlot {
     uint64_t size = 0;
   };
 
-  Region bands;    ///< Horizontal band SSBO (binding 1).
-  Region curves;   ///< Horizontal curve SSBO (binding 2).
+  Region bands;   ///< Horizontal band SSBO (binding 1).
+  Region curves;  ///< Horizontal curve SSBO (binding 2).
   // The four grid classes below share binding 10, whose range covers all of
   // them; each one is reached through an element base in the uniform.
   Region hRefs;    ///< Horizontal curve-reference SSBO (binding 10).

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -236,10 +236,11 @@ public:
   };
 
   static std::optional<uint64_t> batchUniformRetainedBytes(uint64_t uniformBytes) {
-    if (uniformBytes > std::numeric_limits<uint64_t>::max() - sizeof(BatchUniform)) {
+    constexpr uint64_t kMetadataBytes = kMaxBatchUniforms * sizeof(BatchUniform);
+    if (uniformBytes > std::numeric_limits<uint64_t>::max() - kMetadataBytes) {
       return std::nullopt;
     }
-    return sizeof(BatchUniform) + uniformBytes;
+    return kMetadataBytes + uniformBytes;
   }
 
   /**
@@ -270,8 +271,31 @@ public:
     if (budget_ && !budget_->reserveResidentBytes(size)) {
       return BatchUniformHandle{};
     }
-    const std::optional<uint64_t> cpuBytes = batchUniformRetainedBytes(size);
-    if (!cpuBytes.has_value() || !reserveCpuBytes(*cpuBytes)) {
+    if (size > std::numeric_limits<uint64_t>::max() - cpuPayloadBytes_) {
+      if (budget_) {
+        budget_->releaseResidentBytes(size);
+      }
+      return BatchUniformHandle{};
+    }
+    const uint64_t previousCpuBytes = cpuRetainedBytes_;
+    const uint64_t nextPayloadBytes = cpuPayloadBytes_ + size;
+    if (batchUniforms_.capacity() < kMaxBatchUniforms) {
+      const std::optional<uint64_t> projectedBytes = batchUniformRetainedBytes(nextPayloadBytes);
+      if (!projectedBytes.has_value() || !replaceCpuBytes(*projectedBytes)) {
+        if (budget_) {
+          budget_->releaseResidentBytes(size);
+        }
+        return BatchUniformHandle{};
+      }
+      batchUniforms_.reserve(kMaxBatchUniforms);
+    }
+    const uint64_t metadataBytes = batchUniformMetadataBytesForTesting();
+    if (nextPayloadBytes > std::numeric_limits<uint64_t>::max() - metadataBytes ||
+        !replaceCpuBytes(metadataBytes + nextPayloadBytes)) {
+      if (batchUniforms_.empty()) {
+        std::vector<BatchUniform>().swap(batchUniforms_);
+      }
+      (void)replaceCpuBytes(previousCpuBytes);
       if (budget_) {
         budget_->releaseResidentBytes(size);
       }
@@ -286,7 +310,7 @@ public:
       if (budget_) {
         budget_->releaseResidentBytes(size);
       }
-      releaseCpuBytes(*cpuBytes);
+      (void)replaceCpuBytes(metadataBytes + cpuPayloadBytes_);
       return BatchUniformHandle{};
     }
     device.countBuffer();
@@ -295,6 +319,7 @@ public:
     batchUniforms_.push_back(BatchUniform{std::move(buffer),
                                           std::vector<uint8_t>(first, first + size),
                                           GeodeDevice::AllocateBufferId()});
+    cpuPayloadBytes_ = nextPayloadBytes;
     accountedBytes_ += size;
     return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
   }
@@ -340,24 +365,16 @@ private:
   /// batch.
   static constexpr size_t kMaxBatchUniforms = 8u;
 
-  bool reserveCpuBytes(uint64_t bytes) {
+  bool replaceCpuBytes(uint64_t bytes) {
     if (!budget_) {
+      cpuRetainedBytes_ = bytes;
       return true;
     }
-    if (bytes > std::numeric_limits<uint64_t>::max() - cpuRetainedBytes_ ||
-        !cpuReservation_.replace(budget_, cpuRetainedBytes_ + bytes)) {
+    if (!cpuReservation_.replace(budget_, bytes)) {
       return false;
     }
-    cpuRetainedBytes_ += bytes;
+    cpuRetainedBytes_ = bytes;
     return true;
-  }
-
-  void releaseCpuBytes(uint64_t bytes) {
-    if (!budget_ || bytes > cpuRetainedBytes_) {
-      return;
-    }
-    cpuRetainedBytes_ -= bytes;
-    (void)cpuReservation_.replace(budget_, cpuRetainedBytes_);
   }
 
   Slot slotAt(uint32_t index) const {
@@ -382,6 +399,7 @@ private:
   std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
   GeodeGeometryCacheReservation cpuReservation_;
   uint64_t cpuRetainedBytes_ = 0;
+  uint64_t cpuPayloadBytes_ = 0;
   uint64_t accountedBytes_ = 0;
 };
 

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -301,6 +301,21 @@ public:
       }
       return BatchUniformHandle{};
     }
+    std::vector<uint8_t> retainedBytes(first, first + size);
+    const uint64_t retainedCapacity = retainedBytes.capacity();
+    if (retainedCapacity > std::numeric_limits<uint64_t>::max() - cpuPayloadBytes_ ||
+        cpuPayloadBytes_ + retainedCapacity >
+            std::numeric_limits<uint64_t>::max() - metadataBytes ||
+        !replaceCpuBytes(metadataBytes + cpuPayloadBytes_ + retainedCapacity)) {
+      if (batchUniforms_.empty()) {
+        std::vector<BatchUniform>().swap(batchUniforms_);
+      }
+      (void)replaceCpuBytes(previousCpuBytes);
+      if (budget_) {
+        budget_->releaseResidentBytes(size);
+      }
+      return BatchUniformHandle{};
+    }
     wgpu::BufferDescriptor desc = {};
     desc.label = wgpuLabel("GeodeSceneBatchUniform");
     desc.size = size;
@@ -316,10 +331,9 @@ public:
     device.countBuffer();
     device.queue().writeBuffer(buffer.get(), 0, first, size);
     device.countBufferWrite(size);
-    batchUniforms_.push_back(BatchUniform{std::move(buffer),
-                                          std::vector<uint8_t>(first, first + size),
-                                          GeodeDevice::AllocateBufferId()});
-    cpuPayloadBytes_ = nextPayloadBytes;
+    batchUniforms_.push_back(
+        BatchUniform{std::move(buffer), std::move(retainedBytes), GeodeDevice::AllocateBufferId()});
+    cpuPayloadBytes_ += retainedCapacity;
     accountedBytes_ += size;
     return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
   }
@@ -344,6 +358,7 @@ public:
   uint64_t batchUniformMetadataBytesForTesting() const {
     return batchUniforms_.capacity() * sizeof(BatchUniform);
   }
+  uint64_t batchUniformPayloadBytesForTesting() const { return cpuPayloadBytes_; }
 
 private:
   struct Chunk {

--- a/donner/svg/renderer/geode/GeodeResourceBudget.h
+++ b/donner/svg/renderer/geode/GeodeResourceBudget.h
@@ -33,17 +33,24 @@ public:
     rejected_ = false;
   }
 
-  [[nodiscard]] bool reserve(std::size_t items, std::uint64_t retainedBytes) {
-    if (rejected_ || draws_ >= limits_.draws || items_ > limits_.items ||
-        items > limits_.items - items_ || retainedBytes_ > limits_.retainedBytes ||
+  [[nodiscard]] bool reserve(std::size_t draws, std::size_t items, std::uint64_t retainedBytes) {
+    if (rejected_ || draws_ > limits_.draws || draws > limits_.draws - draws_ ||
+        items_ > limits_.items || items > limits_.items - items_ ||
+        retainedBytes_ > limits_.retainedBytes ||
         retainedBytes > limits_.retainedBytes - retainedBytes_) {
       rejected_ = true;
       return false;
     }
-    ++draws_;
+    draws_ += draws;
     items_ += items;
     retainedBytes_ += retainedBytes;
     return true;
+  }
+
+  void release(std::size_t draws, std::size_t items, std::uint64_t retainedBytes) {
+    draws_ = draws > draws_ ? 0 : draws_ - draws;
+    items_ = items > items_ ? 0 : items_ - items;
+    retainedBytes_ = retainedBytes > retainedBytes_ ? 0 : retainedBytes_ - retainedBytes;
   }
 
   void reject() { rejected_ = true; }

--- a/donner/svg/renderer/geode/GeodeResourceBudget.h
+++ b/donner/svg/renderer/geode/GeodeResourceBudget.h
@@ -1,0 +1,227 @@
+#pragma once
+/// @file
+/// Aggregate CPU and GPU geometry admission for the Geode renderer.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "donner/svg/components/DocumentResourceFamilyBudget.h"
+
+namespace donner::geode {
+
+/** Aggregate encoded-geometry work retained by one renderer frame. */
+class GeodeFrameGeometryBudget {
+public:
+  static constexpr std::size_t kMaximumDraws = 64u * 1024u;
+  static constexpr std::size_t kMaximumItems = 1u << 20;
+  static constexpr std::uint64_t kMaximumRetainedBytes = 64u << 20;
+
+  struct Limits {
+    std::size_t draws = kMaximumDraws;
+    std::size_t items = kMaximumItems;
+    std::uint64_t retainedBytes = kMaximumRetainedBytes;
+  };
+
+  void reset() {
+    draws_ = 0;
+    items_ = 0;
+    retainedBytes_ = 0;
+    rejected_ = false;
+  }
+
+  [[nodiscard]] bool reserve(std::size_t items, std::uint64_t retainedBytes) {
+    if (rejected_ || draws_ >= limits_.draws || items_ > limits_.items ||
+        items > limits_.items - items_ || retainedBytes_ > limits_.retainedBytes ||
+        retainedBytes > limits_.retainedBytes - retainedBytes_) {
+      rejected_ = true;
+      return false;
+    }
+    ++draws_;
+    items_ += items;
+    retainedBytes_ += retainedBytes;
+    return true;
+  }
+
+  void reject() { rejected_ = true; }
+
+  void setLimitsForTesting(Limits limits) {
+    limits_.draws = std::min(limits_.draws, limits.draws);
+    limits_.items = std::min(limits_.items, limits.items);
+    limits_.retainedBytes = std::min(limits_.retainedBytes, limits.retainedBytes);
+  }
+
+  [[nodiscard]] std::size_t draws() const { return draws_; }
+  [[nodiscard]] std::size_t items() const { return items_; }
+  [[nodiscard]] std::uint64_t retainedBytes() const { return retainedBytes_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+private:
+  Limits limits_;
+  std::size_t draws_ = 0;
+  std::size_t items_ = 0;
+  std::uint64_t retainedBytes_ = 0;
+  bool rejected_ = false;
+};
+
+/** Live document geometry retained outside the frame-local arena. */
+class GeodeDocumentGeometryBudget {
+public:
+  static constexpr std::uint64_t kMaximumCacheBytes = 64u << 20;
+  static constexpr std::uint64_t kMaximumResidentBytes = 64u << 20;
+
+  struct Limits {
+    std::uint64_t cacheBytes = kMaximumCacheBytes;
+    std::uint64_t residentBytes = kMaximumResidentBytes;
+  };
+
+  explicit GeodeDocumentGeometryBudget(
+      std::shared_ptr<svg::components::DocumentResourceFamilyBudget> family = nullptr)
+      : family_(std::move(family)) {}
+
+  ~GeodeDocumentGeometryBudget() {
+    if (family_) {
+      family_->release(svg::components::DocumentResourceFamilyBudget::Kind::Geometry,
+                       cacheBytes_ + residentBytes_);
+    }
+  }
+
+  GeodeDocumentGeometryBudget(const GeodeDocumentGeometryBudget&) = delete;
+  GeodeDocumentGeometryBudget& operator=(const GeodeDocumentGeometryBudget&) = delete;
+
+  [[nodiscard]] bool replaceCacheBytes(std::uint64_t previous, std::uint64_t replacement) {
+    previous = std::min(previous, cacheBytes_);
+    if (replacement <= previous) {
+      const std::uint64_t released = previous - replacement;
+      cacheBytes_ -= released;
+      releaseFamily(released);
+      return true;
+    }
+
+    const std::uint64_t additional = replacement - previous;
+    if (cacheRejected_ || cacheBytes_ > limits_.cacheBytes ||
+        additional > limits_.cacheBytes - cacheBytes_ || !reserveFamily(additional)) {
+      cacheRejected_ = true;
+      return false;
+    }
+    cacheBytes_ += additional;
+    return true;
+  }
+
+  void releaseCacheBytes(std::uint64_t bytes) {
+    const std::uint64_t released = std::min(bytes, cacheBytes_);
+    cacheBytes_ -= released;
+    releaseFamily(released);
+  }
+
+  [[nodiscard]] bool reserveResidentBytes(std::uint64_t bytes) {
+    if (residentRejected_ || residentBytes_ > limits_.residentBytes ||
+        bytes > limits_.residentBytes - residentBytes_ || !reserveFamily(bytes)) {
+      residentRejected_ = true;
+      return false;
+    }
+    residentBytes_ += bytes;
+    return true;
+  }
+
+  void releaseResidentBytes(std::uint64_t bytes) {
+    const std::uint64_t released = std::min(bytes, residentBytes_);
+    residentBytes_ -= released;
+    releaseFamily(released);
+  }
+
+  void setLimitsForTesting(Limits limits) {
+    limits_.cacheBytes = std::min(limits_.cacheBytes, limits.cacheBytes);
+    limits_.residentBytes = std::min(limits_.residentBytes, limits.residentBytes);
+  }
+
+  [[nodiscard]] std::uint64_t cacheBytes() const { return cacheBytes_; }
+  [[nodiscard]] std::uint64_t residentBytes() const { return residentBytes_; }
+  [[nodiscard]] bool rejected() const { return cacheRejected_ || residentRejected_; }
+
+private:
+  [[nodiscard]] bool reserveFamily(std::uint64_t bytes) {
+    if (bytes > std::numeric_limits<std::size_t>::max()) {
+      return false;
+    }
+    return !family_ ||
+           family_->reserve(svg::components::DocumentResourceFamilyBudget::Kind::Geometry,
+                            static_cast<std::size_t>(bytes));
+  }
+
+  void releaseFamily(std::uint64_t bytes) {
+    if (family_) {
+      family_->release(svg::components::DocumentResourceFamilyBudget::Kind::Geometry,
+                       static_cast<std::size_t>(bytes));
+    }
+  }
+
+  std::shared_ptr<svg::components::DocumentResourceFamilyBudget> family_;
+  Limits limits_;
+  std::uint64_t cacheBytes_ = 0;
+  std::uint64_t residentBytes_ = 0;
+  bool cacheRejected_ = false;
+  bool residentRejected_ = false;
+};
+
+/** Movable ownership of one cached geometry reservation. */
+class GeodeGeometryCacheReservation {
+public:
+  GeodeGeometryCacheReservation() = default;
+  ~GeodeGeometryCacheReservation() { reset(); }
+
+  GeodeGeometryCacheReservation(const GeodeGeometryCacheReservation&) = delete;
+  GeodeGeometryCacheReservation& operator=(const GeodeGeometryCacheReservation&) = delete;
+
+  GeodeGeometryCacheReservation(GeodeGeometryCacheReservation&& other) noexcept
+      : budget_(std::move(other.budget_)), bytes_(other.bytes_) {
+    other.bytes_ = 0;
+  }
+
+  GeodeGeometryCacheReservation& operator=(GeodeGeometryCacheReservation&& other) noexcept {
+    if (this != &other) {
+      reset();
+      budget_ = std::move(other.budget_);
+      bytes_ = other.bytes_;
+      other.bytes_ = 0;
+    }
+    return *this;
+  }
+
+  [[nodiscard]] bool replace(std::shared_ptr<GeodeDocumentGeometryBudget> budget,
+                             std::uint64_t bytes) {
+    if (budget_.get() == budget.get()) {
+      if (!budget || !budget->replaceCacheBytes(bytes_, bytes)) {
+        return false;
+      }
+      bytes_ = bytes;
+      return true;
+    }
+    if (!budget || !budget->replaceCacheBytes(0, bytes)) {
+      return false;
+    }
+    reset();
+    budget_ = std::move(budget);
+    bytes_ = bytes;
+    return true;
+  }
+
+  void reset() {
+    if (budget_ && bytes_ != 0) {
+      budget_->releaseCacheBytes(bytes_);
+    }
+    budget_.reset();
+    bytes_ = 0;
+  }
+
+  [[nodiscard]] std::uint64_t bytes() const { return bytes_; }
+
+private:
+  std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
+  std::uint64_t bytes_ = 0;
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -20,6 +20,7 @@
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
+#include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeResourceBudget.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
@@ -409,13 +410,34 @@ TEST(GeodeResourceBudgetTest, ResidentRejectionPreservesCpuCacheFallback) {
   EXPECT_EQ(budget->residentBytes(), 0u);
 }
 
+TEST(GeodeResourceBudgetTest, StrokeCacheReplacementIncludesRetainedDashCapacity) {
+  GeodePathCacheComponent::StrokeSlot previous;
+  previous.strokeKey.dashArray.reserve(1u);
+  const std::optional<std::size_t> previousBytes = previous.retainedBytes();
+  ASSERT_TRUE(previousBytes.has_value());
+
+  GeodePathCacheComponent::StrokeSlot replacement;
+  replacement.strokeKey.dashArray.reserve(previous.strokeKey.dashArray.capacity() + 1u);
+  const std::optional<std::size_t> replacementBytes = replacement.retainedBytes();
+  ASSERT_TRUE(replacementBytes.has_value());
+  ASSERT_GT(*replacementBytes, *previousBytes);
+
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting({.cacheBytes = *previousBytes, .residentBytes = 64u << 20});
+  GeodeGeometryCacheReservation reservation;
+  ASSERT_TRUE(reservation.replace(budget, *previousBytes));
+  EXPECT_FALSE(reservation.replace(budget, *replacementBytes));
+  EXPECT_EQ(reservation.bytes(), *previousBytes);
+  EXPECT_EQ(budget->cacheBytes(), *previousBytes);
+}
+
 TEST(GeodeResourceBudgetTest, FrameGeometryStopsAtExactAggregateBoundary) {
   GeodeFrameGeometryBudget budget;
   budget.setLimitsForTesting({.draws = 2u, .items = 5u, .retainedBytes = 7u});
 
-  ASSERT_TRUE(budget.reserve(/*items=*/2u, /*retainedBytes=*/3u));
-  ASSERT_TRUE(budget.reserve(/*items=*/3u, /*retainedBytes=*/4u));
-  EXPECT_FALSE(budget.reserve(/*items=*/1u, /*retainedBytes=*/1u));
+  ASSERT_TRUE(budget.reserve(/*draws=*/1u, /*items=*/2u, /*retainedBytes=*/3u));
+  ASSERT_TRUE(budget.reserve(/*draws=*/1u, /*items=*/3u, /*retainedBytes=*/4u));
+  EXPECT_FALSE(budget.reserve(/*draws=*/1u, /*items=*/1u, /*retainedBytes=*/1u));
   EXPECT_EQ(budget.draws(), 2u);
   EXPECT_EQ(budget.items(), 5u);
   EXPECT_EQ(budget.retainedBytes(), 7u);

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -21,6 +21,7 @@
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
+#include "donner/svg/renderer/geode/GeodeResourceBudget.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
@@ -337,6 +338,89 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
   }
 }
 
+TEST_F(GeoEncoderTest, ResidentSlabRejectsGrowthPastExactDocumentBudget) {
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  constexpr uint64_t kInitialBytes = 1u << 20;
+  budget->setLimitsForTesting({.cacheBytes = 64u << 20, .residentBytes = kInitialBytes});
+
+  {
+    GeodeResidentSlab slab(device_->deviceId(), budget);
+    GeodeResidentSlab::Allocation exact;
+    ASSERT_TRUE(slab.allocate(*device_, kInitialBytes, /*alignment=*/256u, exact));
+    EXPECT_EQ(budget->residentBytes(), kInitialBytes);
+
+    GeodeResidentSlab::Allocation capPlusOne;
+    EXPECT_FALSE(slab.allocate(*device_, 1u, /*alignment=*/256u, capPlusOne));
+    EXPECT_EQ(budget->residentBytes(), kInitialBytes)
+        << "A rejected grow must not charge or allocate its next chunk.";
+  }
+
+  EXPECT_EQ(budget->residentBytes(), 0u)
+      << "Destroying the grow-only slab must release its persistent reservation.";
+}
+
+TEST_F(GeoEncoderTest, RecordSlabRejectsGrowthPastExactDocumentBudget) {
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  constexpr uint64_t kInitialBytes = 262144u;
+  constexpr std::size_t kInitialSlots = kInitialBytes / sizeof(InstanceRecord);
+  budget->setLimitsForTesting({.cacheBytes = 64u << 20, .residentBytes = kInitialBytes});
+
+  {
+    GeodeRecordSlab slab(device_->deviceId(), budget);
+    GeodeRecordSlab::Slot slot;
+    for (std::size_t i = 0; i < kInitialSlots; ++i) {
+      ASSERT_TRUE(slab.allocateSlot(*device_, slot)) << "slot " << i;
+    }
+    EXPECT_EQ(budget->residentBytes(), kInitialBytes);
+    EXPECT_FALSE(slab.allocateSlot(*device_, slot));
+    EXPECT_EQ(budget->residentBytes(), kInitialBytes);
+  }
+
+  EXPECT_EQ(budget->residentBytes(), 0u);
+}
+
+TEST(GeodeResourceBudgetTest, CacheReplacementIsAtomicAndReleasesAtOwnerDestruction) {
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting({.cacheBytes = 100u, .residentBytes = 100u});
+
+  {
+    GeodeGeometryCacheReservation reservation;
+    ASSERT_TRUE(reservation.replace(budget, 60u));
+    EXPECT_EQ(budget->cacheBytes(), 60u);
+    ASSERT_TRUE(reservation.replace(budget, 100u));
+    EXPECT_EQ(budget->cacheBytes(), 100u);
+    EXPECT_FALSE(reservation.replace(budget, 101u));
+    EXPECT_EQ(reservation.bytes(), 100u);
+    EXPECT_EQ(budget->cacheBytes(), 100u)
+        << "A cap+1 replacement must preserve the previously admitted entry.";
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
+TEST(GeodeResourceBudgetTest, ResidentRejectionPreservesCpuCacheFallback) {
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting({.cacheBytes = 100u, .residentBytes = 0u});
+
+  EXPECT_FALSE(budget->reserveResidentBytes(1u));
+  GeodeGeometryCacheReservation reservation;
+  EXPECT_TRUE(reservation.replace(budget, 100u));
+  EXPECT_EQ(budget->cacheBytes(), 100u);
+  EXPECT_EQ(budget->residentBytes(), 0u);
+}
+
+TEST(GeodeResourceBudgetTest, FrameGeometryStopsAtExactAggregateBoundary) {
+  GeodeFrameGeometryBudget budget;
+  budget.setLimitsForTesting({.draws = 2u, .items = 5u, .retainedBytes = 7u});
+
+  ASSERT_TRUE(budget.reserve(/*items=*/2u, /*retainedBytes=*/3u));
+  ASSERT_TRUE(budget.reserve(/*items=*/3u, /*retainedBytes=*/4u));
+  EXPECT_FALSE(budget.reserve(/*items=*/1u, /*retainedBytes=*/1u));
+  EXPECT_EQ(budget.draws(), 2u);
+  EXPECT_EQ(budget.items(), 5u);
+  EXPECT_EQ(budget.retainedBytes(), 7u);
+}
+
 /// The scene-batch bind-group cache lives on the device, which outlives the
 /// documents drawn through it (renderers lease devices from an idle pool).
 /// A destroyed document's slabs release their buffer handles, and those
@@ -481,8 +565,7 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
       const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
       std::memcpy(record.boundingVertices, quad, sizeof(quad));
       device_->queue().writeBuffer(generation.recordSlots[i].buffer,
-                                   generation.recordSlots[i].offset, &record,
-                                   sizeof(record));
+                                   generation.recordSlots[i].offset, &record, sizeof(record));
     }
     return generation;
   };
@@ -548,8 +631,7 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
            "bind-group lookup must miss. A hit means the cache matched a dead generation's "
            "entry and this batch drew the previous generation's records and geometry.";
     EXPECT_EQ(repeatBatchCreates, 0u)
-        << "Round " << round
-        << ": repeating the identical batch must reuse the cached bind group.";
+        << "Round " << round << ": repeating the identical batch must reuse the cached bind group.";
   }
 }
 

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -543,6 +543,50 @@ TEST_F(GeoEncoderTest, BatchUniformCpuMirrorStopsAtCapPlusOneAndReleases) {
   EXPECT_EQ(budget->residentBytes(), 0u);
 }
 
+TEST_F(GeoEncoderTest, BatchUniformCpuReservationIncludesVectorSpareCapacity) {
+  constexpr uint64_t kUniformBytes = 16u;
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+
+  {
+    GeodeRecordSlab slab(device_->deviceId(), budget);
+    for (uint32_t index = 0; index < 5u; ++index) {
+      const uint32_t value[4] = {index, index + 1u, index + 2u, index + 3u};
+      ASSERT_TRUE(slab.acquireBatchUniform(*device_, value, sizeof(value)).buffer);
+    }
+    EXPECT_EQ(budget->cacheBytes(), slab.batchUniformMetadataBytesForTesting() + 5u * kUniformBytes)
+        << "The family reservation must include spare vector slots, not only live entries.";
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
+TEST(GeodeResourceBudgetTest, ChargedResidentMirrorsMoveAndReleaseExactlyOnce) {
+  constexpr uint64_t kSolidBytes = 100u;
+  constexpr uint64_t kGradientBytes = 200u;
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  auto slab = std::make_shared<GeodeResidentSlab>(/*deviceId=*/1u, budget);
+
+  {
+    GeodeResidentSlot solid;
+    solid.slab = slab;
+    ASSERT_TRUE(solid.reserveUniformMirror(kSolidBytes));
+    GeodeResidentSlot movedSolid(std::move(solid));
+    GeodeResidentSlot assignedSolid;
+    assignedSolid = std::move(movedSolid);
+
+    GeodeResidentGradientSlot gradient;
+    gradient.slab = slab;
+    ASSERT_TRUE(gradient.reserveUniformMirror(kGradientBytes));
+    GeodeResidentGradientSlot movedGradient(std::move(gradient));
+    GeodeResidentGradientSlot assignedGradient;
+    assignedGradient = std::move(movedGradient);
+
+    EXPECT_EQ(budget->cacheBytes(), kSolidBytes + kGradientBytes);
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
 TEST(GeodeResourceBudgetTest, ResidentRejectionPreservesCpuCacheFallback) {
   auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
   budget->setLimitsForTesting({.cacheBytes = 100u, .residentBytes = 0u});

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -40,6 +40,22 @@ using svg::test::Near;
 using svg::test::Rgba;
 using svg::test::RgbaEq;
 
+class ProbeGeometryAdmission final : public GeometryAdmission {
+public:
+  bool admitGeometry(const EncodedPath& /*encoded*/, std::size_t logicalDraws) override {
+    admittedDraws += logicalDraws;
+    return allow;
+  }
+
+  void releaseGeometry(const EncodedPath& /*encoded*/, std::size_t logicalDraws) override {
+    releasedDraws += logicalDraws;
+  }
+
+  bool allow = true;
+  std::size_t admittedDraws = 0;
+  std::size_t releasedDraws = 0;
+};
+
 /// Test fixture: shares a process-wide device and creates per-test render
 /// targets + readback buffer.
 ///
@@ -193,6 +209,44 @@ TEST_F(GeoEncoderTest, FillRect) {
   // Top-left corner should be black (outside the rect).
   auto corner = pixelAt(pixels, 4, 4);
   EXPECT_THAT(corner, RgbaEq(0, 0, 0, 255)) << "Corner should be clear black";
+}
+
+TEST_F(GeoEncoderTest, RejectedPatternGeometryAllocatesNoPatternGpuState) {
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  ProbeGeometryAdmission admission;
+  admission.allow = false;
+
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  encoder.setGeometryAdmission(&admission);
+  GeoEncoder::PatternPaint paint;
+  paint.tile = target_;
+  paint.tileSize = Vector2d(8.0, 8.0);
+  encoder.fillPathPattern(path, FillRule::NonZero, paint, &encoded);
+
+  EXPECT_EQ(admission.admittedDraws, 1u);
+  EXPECT_EQ(encoder.patternGpuPreparationsForTesting(), 0u)
+      << "Pattern sampler/view creation must follow successful geometry admission.";
+  encoder.finish();
+}
+
+TEST_F(GeoEncoderTest, DegenerateResidentRadialDoesNotConsumeGeometryAdmission) {
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  ProbeGeometryAdmission admission;
+  RadialGradientParams::Stop stop;
+  RadialGradientParams params;
+  params.radius = 0.0;
+  params.stops = std::span<const RadialGradientParams::Stop>(&stop, 1u);
+  GeodeResidentGradientSlot slot;
+
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  encoder.setGeometryAdmission(&admission);
+  encoder.fillPathRadialGradientResident(slot, encoded, params, FillRule::NonZero, 1u);
+  EXPECT_EQ(admission.admittedDraws, 0u);
+  encoder.finish();
 }
 
 TEST_F(GeoEncoderTest, TinyUniformScaleStillRasterizesHalfPixelHalo) {

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -249,6 +249,34 @@ TEST_F(GeoEncoderTest, DegenerateResidentRadialDoesNotConsumeGeometryAdmission) 
   encoder.finish();
 }
 
+TEST_F(GeoEncoderTest, PreparedSceneAdmissionCanBeRefundedBeforeSingletonFallback) {
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  ProbeGeometryAdmission admission;
+
+  auto geometry = std::make_shared<GeodeResidentSlab>(device_->deviceId());
+  auto records = std::make_shared<GeodeRecordSlab>(device_->deviceId());
+  GeodeResidentSlot slot;
+  slot.slab = geometry;
+  slot.recordSlab = records;
+  ASSERT_TRUE(records->allocateSlot(*device_, slot.recordSlot));
+
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  encoder.setGeometryAdmission(&admission);
+  GeoEncoder::SceneRecordState recordState;
+  ASSERT_TRUE(encoder.ensureResidentSceneRecord(
+      slot, encoded, GeoEncoder::ScenePaint{css::RGBA(255, 0, 0, 255)}, FillRule::NonZero,
+      Transform2d(), nullptr, nullptr, &recordState));
+  ASSERT_EQ(encoder.pendingSceneAdmissionsForTesting(), 1u);
+  ASSERT_EQ(admission.admittedDraws, 1u);
+
+  encoder.releasePreparedSceneAdmission(encoded);
+  EXPECT_EQ(encoder.pendingSceneAdmissionsForTesting(), 0u);
+  EXPECT_EQ(admission.releasedDraws, 1u);
+  encoder.finish();
+}
+
 TEST_F(GeoEncoderTest, TinyUniformScaleStillRasterizesHalfPixelHalo) {
   const Path path =
       PathBuilder().addRect(Box2d({264062.5, 264062.5}, {735937.5, 735937.5})).build();

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -526,7 +526,7 @@ TEST_F(GeoEncoderTest, BatchUniformCpuMirrorStopsAtCapPlusOneAndReleases) {
   ASSERT_TRUE(entryBytes.has_value());
   auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
   budget->setLimitsForTesting(
-      {.cacheBytes = *entryBytes * 2u - 1u, .residentBytes = kUniformBytes * 2u});
+      {.cacheBytes = *entryBytes + kUniformBytes - 1u, .residentBytes = kUniformBytes * 2u});
 
   {
     GeodeRecordSlab slab(device_->deviceId(), budget);

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -484,6 +484,65 @@ TEST(GeodeResourceBudgetTest, CacheReplacementIsAtomicAndReleasesAtOwnerDestruct
   EXPECT_EQ(budget->cacheBytes(), 0u);
 }
 
+TEST(GeodeResourceBudgetTest, ResidentSlotMirrorReplacementPreservesExactReservation) {
+  constexpr uint64_t kUniformBytes = 100u;
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting({.cacheBytes = kUniformBytes, .residentBytes = 64u << 20});
+  auto slab = std::make_shared<GeodeResidentSlab>(/*deviceId=*/1u, budget);
+
+  {
+    GeodeResidentSlot slot;
+    slot.slab = slab;
+    ASSERT_TRUE(slot.reserveUniformMirror(kUniformBytes));
+    EXPECT_FALSE(slot.reservePaintMirror(1u));
+    EXPECT_EQ(budget->cacheBytes(), kUniformBytes)
+        << "A cap+1 mirror must preserve the previously admitted reservation.";
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
+TEST(GeodeResourceBudgetTest, ResidentGradientMirrorReleasesAtOwnerDestruction) {
+  constexpr uint64_t kUniformBytes = 672u;
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting({.cacheBytes = kUniformBytes, .residentBytes = 64u << 20});
+  auto slab = std::make_shared<GeodeResidentSlab>(/*deviceId=*/1u, budget);
+
+  {
+    GeodeResidentGradientSlot slot;
+    slot.slab = slab;
+    ASSERT_TRUE(slot.reserveUniformMirror(kUniformBytes));
+    EXPECT_FALSE(slot.reserveUniformMirror(kUniformBytes + 1u));
+    EXPECT_EQ(budget->cacheBytes(), kUniformBytes);
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
+TEST_F(GeoEncoderTest, BatchUniformCpuMirrorStopsAtCapPlusOneAndReleases) {
+  constexpr uint64_t kUniformBytes = 16u;
+  const std::optional<uint64_t> entryBytes =
+      GeodeRecordSlab::batchUniformRetainedBytes(kUniformBytes);
+  ASSERT_TRUE(entryBytes.has_value());
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+  budget->setLimitsForTesting(
+      {.cacheBytes = *entryBytes * 2u - 1u, .residentBytes = kUniformBytes * 2u});
+
+  {
+    GeodeRecordSlab slab(device_->deviceId(), budget);
+    const uint32_t first[4] = {1u, 2u, 3u, 4u};
+    const uint32_t second[4] = {5u, 6u, 7u, 8u};
+    ASSERT_TRUE(slab.acquireBatchUniform(*device_, first, sizeof(first)).buffer);
+    EXPECT_FALSE(slab.acquireBatchUniform(*device_, second, sizeof(second)).buffer);
+    EXPECT_EQ(budget->cacheBytes(), *entryBytes);
+    EXPECT_EQ(budget->residentBytes(), kUniformBytes)
+        << "The rejected CPU mirror must roll back its tentative GPU reservation.";
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+  EXPECT_EQ(budget->residentBytes(), 0u);
+}
+
 TEST(GeodeResourceBudgetTest, ResidentRejectionPreservesCpuCacheFallback) {
   auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
   budget->setLimitsForTesting({.cacheBytes = 100u, .residentBytes = 0u});

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -47,11 +47,14 @@ public:
     return allow;
   }
 
+  bool canEncodeGeometry() const override { return encodeOpen; }
+
   void releaseGeometry(const EncodedPath& /*encoded*/, std::size_t logicalDraws) override {
     releasedDraws += logicalDraws;
   }
 
   bool allow = true;
+  bool encodeOpen = true;
   std::size_t admittedDraws = 0;
   std::size_t releasedDraws = 0;
 };

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -521,20 +521,19 @@ TEST(GeodeResourceBudgetTest, ResidentGradientMirrorReleasesAtOwnerDestruction) 
 
 TEST_F(GeoEncoderTest, BatchUniformCpuMirrorStopsAtCapPlusOneAndReleases) {
   constexpr uint64_t kUniformBytes = 16u;
-  const std::optional<uint64_t> entryBytes =
-      GeodeRecordSlab::batchUniformRetainedBytes(kUniformBytes);
-  ASSERT_TRUE(entryBytes.has_value());
   auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
-  budget->setLimitsForTesting(
-      {.cacheBytes = *entryBytes + kUniformBytes - 1u, .residentBytes = kUniformBytes * 2u});
 
   {
     GeodeRecordSlab slab(device_->deviceId(), budget);
     const uint32_t first[4] = {1u, 2u, 3u, 4u};
     const uint32_t second[4] = {5u, 6u, 7u, 8u};
     ASSERT_TRUE(slab.acquireBatchUniform(*device_, first, sizeof(first)).buffer);
+    const uint64_t entryBytes = budget->cacheBytes();
+    const uint64_t payloadBytes = slab.batchUniformPayloadBytesForTesting();
+    budget->setLimitsForTesting(
+        {.cacheBytes = entryBytes + payloadBytes - 1u, .residentBytes = kUniformBytes * 2u});
     EXPECT_FALSE(slab.acquireBatchUniform(*device_, second, sizeof(second)).buffer);
-    EXPECT_EQ(budget->cacheBytes(), *entryBytes);
+    EXPECT_EQ(budget->cacheBytes(), entryBytes);
     EXPECT_EQ(budget->residentBytes(), kUniformBytes)
         << "The rejected CPU mirror must roll back its tentative GPU reservation.";
   }
@@ -553,7 +552,9 @@ TEST_F(GeoEncoderTest, BatchUniformCpuReservationIncludesVectorSpareCapacity) {
       const uint32_t value[4] = {index, index + 1u, index + 2u, index + 3u};
       ASSERT_TRUE(slab.acquireBatchUniform(*device_, value, sizeof(value)).buffer);
     }
-    EXPECT_EQ(budget->cacheBytes(), slab.batchUniformMetadataBytesForTesting() + 5u * kUniformBytes)
+    EXPECT_GE(slab.batchUniformPayloadBytesForTesting(), 5u * kUniformBytes);
+    EXPECT_EQ(budget->cacheBytes(), slab.batchUniformMetadataBytesForTesting() +
+                                        slab.batchUniformPayloadBytesForTesting())
         << "The family reservation must include spare vector slots, not only live entries.";
   }
 

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -354,6 +354,35 @@ TEST_F(GeodeGlyphInstancingTest, ResidentGlyphHitsStillRequireGeometrySubmission
       << "A resident hit must not bypass a rejected geometry submission.";
 }
 
+TEST_F(GeodeGlyphInstancingTest, SceneBatchChargesEachLogicalGlyphExactlyOnce) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="48">
+        <text x="10" y="80" fill="black">eeee</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/4u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  const Frame exact = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(exact.bitmap), 0u);
+  EXPECT_EQ(renderer.resourceStats().geometryDraws, 4u);
+  EXPECT_FALSE(renderer.resourceStats().geometryBudgetRejected)
+      << "The final batch draw must consume the four append-time reservations, not charge again.";
+
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/3u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  const Frame capPlusOne = render(renderer, document);
+  EXPECT_EQ(renderer.resourceStats().geometryDraws, 3u);
+  EXPECT_TRUE(renderer.resourceStats().geometryBudgetRejected);
+  EXPECT_GT(nonTransparentPixels(capPlusOne.bitmap), 0u)
+      << "Accepted glyphs must remain drawable when the cap+1 occurrence is rejected.";
+}
+
 /// The cache key carries every parameter that changes the outline. A font-size
 /// change alters the scale the outline is built at, so it must mint new entries
 /// and draw the new size rather than serving the old geometry.

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -214,8 +214,8 @@ TEST_F(GeodeGlyphInstancingTest, OverlappingTextElementsCompositeInPaintOrder) {
 }
 
 /// Residency is budgeted. Under a budget smaller than the working set the
-/// oldest unused entries are dropped, the dropped glyphs are re-uploaded when
-/// they come back, and the text keeps rendering identically throughout.
+/// oldest unused entries are dropped, misses that cannot be admitted use
+/// frame-scoped geometry, and the text keeps rendering identically throughout.
 TEST_F(GeodeGlyphInstancingTest, EvictionUnderPressureKeepsRenderingCorrect) {
   SVGDocument document = parse(R"svg(
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
@@ -237,8 +237,8 @@ TEST_F(GeodeGlyphInstancingTest, EvictionUnderPressureKeepsRenderingCorrect) {
   const Frame squeezed = render(renderer, document);
   EXPECT_GT(squeezed.counters.glyphResidencyEvictions, 0u)
       << "A budget below the working set must drop entries.";
-  EXPECT_GT(squeezed.counters.glyphResidencyUploads, 0u)
-      << "Glyphs dropped by the trim must be re-uploaded when they are drawn again.";
+  EXPECT_LE(renderer.residentGlyphCountForTesting(document), 2u)
+      << "The current frame must not repopulate the cache past its admission limit.";
   EXPECT_EQ(nonTransparentPixels(squeezed.bitmap), covered)
       << "Eviction must not change what the frame draws.";
 

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -294,6 +294,42 @@ TEST_F(GeodeGlyphInstancingTest, MaterializationBudgetRejectsBeforeSecondOutline
   EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
 }
 
+TEST_F(GeodeGlyphInstancingTest, MaterializationBudgetIsSharedAcrossOffscreenRenderers) {
+  SVGDocument firstDocument = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="48">
+        <text x="10" y="80" fill="black">a</text>
+      </svg>)svg");
+  SVGDocument secondDocument = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="48">
+        <text x="10" y="80" fill="black">b</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  renderer.setTextMaterializationBudgetForTesting(
+      {.uniqueOutlines = 1u,
+       .commands = RendererTextMaterializationBudget::kMaximumCommands,
+       .points = RendererTextMaterializationBudget::kMaximumPoints,
+       .bytes = RendererTextMaterializationBudget::kMaximumBytes,
+       .decodeWork = RendererTextMaterializationBudget::kMaximumDecodeWork},
+      /*maximumGlyphOccurrences=*/2u);
+  std::unique_ptr<RendererInterface> offscreen = renderer.createOffscreenInstance();
+  ASSERT_NE(offscreen, nullptr);
+
+  const Frame first = render(renderer, firstDocument);
+  ASSERT_GT(nonTransparentPixels(first.bitmap), 0u);
+  offscreen->draw(secondDocument);
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.textUniqueOutlines, 1u);
+  EXPECT_EQ(stats.textGlyphOccurrences, 2u);
+  EXPECT_TRUE(stats.textMaterializationBudgetRejected);
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(firstDocument), 1u);
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(secondDocument), 0u)
+      << "The offscreen cap+1 miss must not decode or populate its document cache.";
+}
+
 /// The cache key carries every parameter that changes the outline. A font-size
 /// change alters the scale the outline is built at, so it must mint new entries
 /// and draw the new size rather than serving the old geometry.

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -249,6 +249,24 @@ TEST_F(GeodeGlyphInstancingTest, EvictionUnderPressureKeepsRenderingCorrect) {
   EXPECT_EQ(nonTransparentPixels(restored.bitmap), covered);
 }
 
+TEST_F(GeodeGlyphInstancingTest, FirstFrameAdmissionHonorsResidencyEntryBudget) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="24">
+        <text x="10" y="60" fill="black">abcdefghij</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  constexpr size_t kMaximumEntries = 2u;
+  renderer.setGlyphResidencyBudgetForTesting(kMaximumEntries,
+                                             /*maxEncodedBytes=*/1u << 30);
+
+  const Frame frame = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(frame.bitmap), 0u) << "Text did not render at all.";
+  EXPECT_LE(renderer.residentGlyphCountForTesting(document), kMaximumEntries)
+      << "A single frame must not retain more glyph entries than the configured admission cap.";
+}
+
 /// The cache key carries every parameter that changes the outline. A font-size
 /// change alters the scale the outline is built at, so it must mint new entries
 /// and draw the new size rather than serving the old geometry.

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -267,6 +267,33 @@ TEST_F(GeodeGlyphInstancingTest, FirstFrameAdmissionHonorsResidencyEntryBudget) 
       << "A single frame must not retain more glyph entries than the configured admission cap.";
 }
 
+TEST_F(GeodeGlyphInstancingTest, MaterializationBudgetRejectsBeforeSecondOutlineDecode) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="48">
+        <text x="10" y="80" fill="black">ab</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  renderer.setTextMaterializationBudgetForTesting(
+      {.uniqueOutlines = 1u,
+       .commands = RendererTextMaterializationBudget::kMaximumCommands,
+       .points = RendererTextMaterializationBudget::kMaximumPoints,
+       .bytes = RendererTextMaterializationBudget::kMaximumBytes,
+       .decodeWork = RendererTextMaterializationBudget::kMaximumDecodeWork},
+      /*maximumGlyphOccurrences=*/2u);
+
+  const Frame frame = render(renderer, document);
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_TRUE(stats.textMaterializationBudgetSupported);
+  EXPECT_EQ(stats.textUniqueOutlines, 1u);
+  EXPECT_EQ(stats.textGlyphOccurrences, 2u);
+  EXPECT_TRUE(stats.textMaterializationBudgetRejected);
+  EXPECT_EQ(frame.counters.glyphResidencyUploads, 1u)
+      << "The cap+1 glyph must be rejected before its outline reaches the cache miss builder.";
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+}
+
 /// The cache key carries every parameter that changes the outline. A font-size
 /// change alters the scale the outline is built at, so it must mint new entries
 /// and draw the new size rather than serving the old geometry.

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -330,6 +330,30 @@ TEST_F(GeodeGlyphInstancingTest, MaterializationBudgetIsSharedAcrossOffscreenRen
       << "The offscreen cap+1 miss must not decode or populate its document cache.";
 }
 
+TEST_F(GeodeGlyphInstancingTest, ResidentGlyphHitsStillRequireGeometrySubmissionAdmission) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="48">
+        <text x="10" y="80" fill="black">a</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame first = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(first.bitmap), 0u);
+  ASSERT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/0u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  const Frame rejected = render(renderer, document);
+  EXPECT_EQ(rejected.counters.glyphResidencyHits, 1u)
+      << "The second frame must exercise the resident-cache hit path.";
+  EXPECT_TRUE(renderer.resourceStats().geometryBudgetRejected);
+  EXPECT_EQ(nonTransparentPixels(rejected.bitmap), 0u)
+      << "A resident hit must not bypass a rejected geometry submission.";
+}
+
 /// The cache key carries every parameter that changes the outline. A font-size
 /// change alters the scale the outline is built at, so it must mint new entries
 /// and draw the new size rather than serving the old geometry.

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -9,6 +9,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+
 #include "donner/base/Path.h"
 
 namespace donner::geode {
@@ -30,6 +32,15 @@ EncodedPath MakeEncodeWithCurves(size_t curveCount) {
   EncodedPath encoded;
   encoded.curves.resize(curveCount);
   return encoded;
+}
+
+Path MakeOutlineWithPoints(size_t pointCount) {
+  PathBuilder builder;
+  builder.moveTo(Vector2d(0.0, 0.0));
+  for (size_t index = 1; index < pointCount; ++index) {
+    builder.lineTo(Vector2d(static_cast<double>(index), static_cast<double>(index & 1u)));
+  }
+  return builder.build();
 }
 
 /// Insert `key` and immediately mark it used in `frame`, which is what the
@@ -93,6 +104,28 @@ TEST(GeodeGlyphCacheTest, MissingEntryReportsAMiss) {
   GeodeGlyphCache cache(/*deviceId=*/1u);
   EXPECT_EQ(cache.find(MakeKey(/*glyphIndex=*/1)), nullptr);
   EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(GeodeGlyphCacheTest, RetainedBytesIncludeOutlineCapacity) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  Path outline = MakeOutlineWithPoints(128u);
+  const std::optional<std::size_t> outlineBytes = outline.retainedBytes();
+  ASSERT_TRUE(outlineBytes.has_value());
+
+  ASSERT_NE(cache.insert(MakeKey(/*glyphIndex=*/1), std::move(outline), EncodedPath()), nullptr);
+  EXPECT_GE(cache.retainedBytes(), *outlineBytes);
+}
+
+TEST(GeodeGlyphCacheTest, RetainedByteAdmissionRejectsBeforeTakingOutlineOwnership) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  Path outline = MakeOutlineWithPoints(128u);
+
+  EXPECT_EQ(cache.insertWithinBudget(MakeKey(/*glyphIndex=*/1), std::move(outline), EncodedPath(),
+                                     /*oldestOpenFrame=*/1, /*maxEntries=*/100,
+                                     /*maxRetainedBytes=*/1),
+            nullptr);
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(cache.retainedBytes(), 0u);
 }
 
 TEST(GeodeGlyphCacheTest, EntryCountBudgetDropsTheLeastRecentlyUsedFirst) {

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -128,6 +128,39 @@ TEST(GeodeGlyphCacheTest, RetainedByteAdmissionRejectsBeforeTakingOutlineOwnersh
   EXPECT_EQ(cache.retainedBytes(), 0u);
 }
 
+TEST(GeodeGlyphCacheTest, SharedDocumentFamilyRejectsSecondSubdocumentBeforeInsertion) {
+  Path firstOutline = MakeOutlineWithPoints(128u);
+  const std::optional<std::size_t> entryBytes = firstOutline.retainedBytes();
+  ASSERT_TRUE(entryBytes.has_value());
+
+  svg::components::DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.geometryBytes = *entryBytes;
+  familyLimits.maximumTotalRetainedBytes = *entryBytes;
+  auto family = std::make_shared<svg::components::DocumentResourceFamilyBudget>(familyLimits);
+  auto firstDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
+  auto secondDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
+
+  {
+    GeodeGlyphCache firstCache(/*deviceId=*/1u, firstDocument);
+    GeodeGlyphCache secondCache(/*deviceId=*/1u, secondDocument);
+    ASSERT_NE(firstCache.insert(MakeKey(/*glyphIndex=*/1), std::move(firstOutline), EncodedPath()),
+              nullptr);
+    EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
+              *entryBytes);
+
+    Path secondOutline = MakeOutlineWithPoints(128u);
+    EXPECT_EQ(
+        secondCache.insert(MakeKey(/*glyphIndex=*/2), std::move(secondOutline), EncodedPath()),
+        nullptr)
+        << "The shared family cap must reject the cap+1 subdocument before cache insertion.";
+    EXPECT_EQ(secondCache.size(), 0u);
+  }
+
+  EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
+            0u)
+      << "Destroying every subdocument cache must release the exact family reservation.";
+}
+
 TEST(GeodeGlyphCacheTest, EntryCountBudgetDropsTheLeastRecentlyUsedFirst) {
   GeodeGlyphCache cache(/*deviceId=*/1u);
   const GlyphGeometryKey oldest = MakeKey(/*glyphIndex=*/1);

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -128,14 +128,16 @@ TEST(GeodeGlyphCacheTest, RetainedByteAdmissionRejectsBeforeTakingOutlineOwnersh
   EXPECT_EQ(cache.retainedBytes(), 0u);
 }
 
-TEST(GeodeGlyphCacheTest, SharedDocumentFamilyRejectsSecondSubdocumentBeforeInsertion) {
+TEST(GeodeGlyphCacheTest, SharedDocumentFamilyRejectsSecondSubdocumentAtCapPlusOne) {
   Path firstOutline = MakeOutlineWithPoints(128u);
   const std::optional<std::size_t> entryBytes = firstOutline.retainedBytes();
   ASSERT_TRUE(entryBytes.has_value());
+  Path secondOutline = MakeOutlineWithPoints(128u);
+  ASSERT_EQ(secondOutline.retainedBytes(), entryBytes);
 
   svg::components::DocumentResourceFamilyBudget::Limits familyLimits;
-  familyLimits.geometryBytes = *entryBytes;
-  familyLimits.maximumTotalRetainedBytes = *entryBytes;
+  familyLimits.geometryBytes = *entryBytes * 2u - 1u;
+  familyLimits.maximumTotalRetainedBytes = *entryBytes * 2u - 1u;
   auto family = std::make_shared<svg::components::DocumentResourceFamilyBudget>(familyLimits);
   auto firstDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
   auto secondDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
@@ -148,7 +150,6 @@ TEST(GeodeGlyphCacheTest, SharedDocumentFamilyRejectsSecondSubdocumentBeforeInse
     EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
               *entryBytes);
 
-    Path secondOutline = MakeOutlineWithPoints(128u);
     EXPECT_EQ(
         secondCache.insert(MakeKey(/*glyphIndex=*/2), std::move(secondOutline), EncodedPath()),
         nullptr)
@@ -159,6 +160,45 @@ TEST(GeodeGlyphCacheTest, SharedDocumentFamilyRejectsSecondSubdocumentBeforeInse
   EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
             0u)
       << "Destroying every subdocument cache must release the exact family reservation.";
+}
+
+TEST(GeodeGlyphCacheTest, FamilyReservationTracksDuplicateAndEvictionExactly) {
+  svg::components::DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.geometryBytes = 1u << 20;
+  familyLimits.maximumTotalRetainedBytes = 1u << 20;
+  auto family = std::make_shared<svg::components::DocumentResourceFamilyBudget>(familyLimits);
+  auto document = std::make_shared<GeodeDocumentGeometryBudget>(family);
+
+  {
+    GeodeGlyphCache cache(/*deviceId=*/1u, document);
+    const GlyphGeometryKey firstKey = MakeKey(/*glyphIndex=*/1);
+    GeodeGlyphResidentEntry* first =
+        cache.insert(firstKey, Path(), MakeEncodeWithCurves(/*curveCount=*/4u));
+    ASSERT_NE(first, nullptr);
+    first->lastUsedFrame = 1u;
+    const uint64_t firstBytes = cache.retainedBytes();
+    ASSERT_GT(firstBytes, 0u);
+    EXPECT_EQ(document->cacheBytes(), firstBytes);
+
+    EXPECT_EQ(cache.insert(firstKey, Path(), MakeEncodeWithCurves(/*curveCount=*/8u)), first);
+    EXPECT_EQ(document->cacheBytes(), firstBytes)
+        << "A duplicate key must not acquire a second family reservation.";
+
+    GeodeGlyphResidentEntry* second =
+        cache.insert(MakeKey(/*glyphIndex=*/2), Path(), MakeEncodeWithCurves(/*curveCount=*/6u));
+    ASSERT_NE(second, nullptr);
+    second->lastUsedFrame = 2u;
+    EXPECT_EQ(document->cacheBytes(), cache.retainedBytes());
+
+    ASSERT_EQ(cache.evictToBudget(/*oldestOpenFrame=*/3u, /*maxEntries=*/1u,
+                                  /*maxRetainedBytes=*/1u << 20),
+              1u);
+    EXPECT_EQ(document->cacheBytes(), cache.retainedBytes());
+  }
+
+  EXPECT_EQ(document->cacheBytes(), 0u);
+  EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
+            0u);
 }
 
 TEST(GeodeGlyphCacheTest, EntryCountBudgetDropsTheLeastRecentlyUsedFirst) {
@@ -255,6 +295,28 @@ TEST(GeodeTextInstanceRecordComponentTest, OccurrenceAddressesSurviveGrowth) {
   }
 
   EXPECT_EQ(&component.occurrences.front(), first);
+}
+
+TEST(GeodeTextInstanceRecordComponentTest, SharedFamilyBoundsProjectedOccurrenceStorage) {
+  const uint64_t occurrenceBytes = GeodeTextInstanceRecordComponent::kProjectedBytesPerOccurrence;
+  svg::components::DocumentResourceFamilyBudget::Limits familyLimits;
+  familyLimits.geometryBytes = occurrenceBytes;
+  familyLimits.maximumTotalRetainedBytes = occurrenceBytes;
+  auto family = std::make_shared<svg::components::DocumentResourceFamilyBudget>(familyLimits);
+  auto firstDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
+  auto secondDocument = std::make_shared<GeodeDocumentGeometryBudget>(family);
+
+  {
+    GeodeTextInstanceRecordComponent first;
+    GeodeTextInstanceRecordComponent second;
+    ASSERT_TRUE(first.reserveOccurrence(firstDocument));
+    EXPECT_FALSE(second.reserveOccurrence(secondDocument));
+    EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
+              occurrenceBytes);
+  }
+
+  EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
+            0u);
 }
 
 TEST(GeodeTextInstanceRecordComponentTest, MoveLeavesTheSourceWithNoSlotsToRelease) {

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -287,18 +287,26 @@ TEST(GeodeTextInstanceRecordComponentTest, OccurrenceAddressesSurviveGrowth) {
   // are still appending; a reallocating container would leave the batch
   // writing through dangling pointers at flush.
   GeodeTextInstanceRecordComponent component;
-  component.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
-  const GeodeTextInstanceRecordComponent::Occurrence* first = &component.occurrences.front();
+  component.occurrences.push_back(std::make_unique<GeodeTextInstanceRecordComponent::Occurrence>());
+  const GeodeTextInstanceRecordComponent::Occurrence* first = component.occurrences.front().get();
 
   for (int i = 0; i < 512; ++i) {
-    component.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
+    component.occurrences.push_back(
+        std::make_unique<GeodeTextInstanceRecordComponent::Occurrence>());
   }
 
-  EXPECT_EQ(&component.occurrences.front(), first);
+  EXPECT_EQ(component.occurrences.front().get(), first);
 }
 
 TEST(GeodeTextInstanceRecordComponentTest, SharedFamilyBoundsProjectedOccurrenceStorage) {
-  const uint64_t occurrenceBytes = GeodeTextInstanceRecordComponent::kProjectedBytesPerOccurrence;
+  uint64_t occurrenceBytes = 0;
+  {
+    auto probeBudget = std::make_shared<GeodeDocumentGeometryBudget>();
+    GeodeTextInstanceRecordComponent probe;
+    ASSERT_TRUE(probe.reserveOccurrence(probeBudget));
+    ASSERT_TRUE(probe.appendReservedOccurrence(GeodeRecordSlab::Slot{}));
+    occurrenceBytes = probe.cpuRetainedBytesForTesting();
+  }
   svg::components::DocumentResourceFamilyBudget::Limits familyLimits;
   familyLimits.geometryBytes = occurrenceBytes;
   familyLimits.maximumTotalRetainedBytes = occurrenceBytes;
@@ -310,6 +318,7 @@ TEST(GeodeTextInstanceRecordComponentTest, SharedFamilyBoundsProjectedOccurrence
     GeodeTextInstanceRecordComponent first;
     GeodeTextInstanceRecordComponent second;
     ASSERT_TRUE(first.reserveOccurrence(firstDocument));
+    ASSERT_TRUE(first.appendReservedOccurrence(GeodeRecordSlab::Slot{}));
     EXPECT_FALSE(second.reserveOccurrence(secondDocument));
     EXPECT_EQ(family->retainedBytes(svg::components::DocumentResourceFamilyBudget::Kind::Geometry),
               occurrenceBytes);
@@ -320,13 +329,13 @@ TEST(GeodeTextInstanceRecordComponentTest, SharedFamilyBoundsProjectedOccurrence
 }
 
 TEST(GeodeTextInstanceRecordComponentTest, ChargedOccurrenceMovesAndReleasesExactlyOnce) {
-  const uint64_t occurrenceBytes = GeodeTextInstanceRecordComponent::kProjectedBytesPerOccurrence;
   auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
 
   {
     GeodeTextInstanceRecordComponent source;
     ASSERT_TRUE(source.reserveOccurrence(budget));
-    source.occurrences.emplace_back();
+    ASSERT_TRUE(source.appendReservedOccurrence(GeodeRecordSlab::Slot{}));
+    const uint64_t occurrenceBytes = source.cpuRetainedBytesForTesting();
     GeodeTextInstanceRecordComponent moved(std::move(source));
     GeodeTextInstanceRecordComponent assigned;
     assigned = std::move(moved);
@@ -341,7 +350,7 @@ TEST(GeodeTextInstanceRecordComponentTest, MoveLeavesTheSourceWithNoSlotsToRelea
   // removed one; a source that kept its slots would free the survivor's
   // records from its own destructor.
   GeodeTextInstanceRecordComponent source;
-  source.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
+  source.occurrences.push_back(std::make_unique<GeodeTextInstanceRecordComponent::Occurrence>());
   source.lastFrame = 5u;
 
   GeodeTextInstanceRecordComponent moved = std::move(source);

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -319,6 +319,23 @@ TEST(GeodeTextInstanceRecordComponentTest, SharedFamilyBoundsProjectedOccurrence
             0u);
 }
 
+TEST(GeodeTextInstanceRecordComponentTest, ChargedOccurrenceMovesAndReleasesExactlyOnce) {
+  const uint64_t occurrenceBytes = GeodeTextInstanceRecordComponent::kProjectedBytesPerOccurrence;
+  auto budget = std::make_shared<GeodeDocumentGeometryBudget>();
+
+  {
+    GeodeTextInstanceRecordComponent source;
+    ASSERT_TRUE(source.reserveOccurrence(budget));
+    source.occurrences.emplace_back();
+    GeodeTextInstanceRecordComponent moved(std::move(source));
+    GeodeTextInstanceRecordComponent assigned;
+    assigned = std::move(moved);
+    EXPECT_EQ(budget->cacheBytes(), occurrenceBytes);
+  }
+
+  EXPECT_EQ(budget->cacheBytes(), 0u);
+}
+
 TEST(GeodeTextInstanceRecordComponentTest, MoveLeavesTheSourceWithNoSlotsToRelease) {
   // entt's swap-and-pop removal move-assigns the surviving component over the
   // removed one; a source that kept its slots would free the survivor's

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -437,6 +437,16 @@ TEST(GeodePathEncoder, NonRepresentableCoordinatesReportRejectedOutcome) {
   EXPECT_TRUE(encoded.rejected());
 }
 
+TEST(GeodePathEncoder, EncodedGeometryItemLimitRejectsBeforeRetainingVectors) {
+  const Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
+  const EncodedPath encoded =
+      GeodePathEncoder::encode(path, FillRule::NonZero, /*tolerance=*/0.1,
+                               GeodePathEncoder::Limits{.maximumEncodedGeometryItems = 1u});
+
+  EXPECT_TRUE(encoded.empty());
+  EXPECT_TRUE(encoded.rejected());
+}
+
 TEST(GeodePathEncoder, BoundingPolygonIsSmallAndCounterClockwise) {
   Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
 

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -404,6 +404,28 @@ TEST(GeodePathEncoder, DegeneratePath) {
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
   EXPECT_TRUE(encoded.empty());
+  EXPECT_FALSE(encoded.rejected());
+}
+
+TEST(GeodePathEncoder, OrdinaryPathReportsReadyOutcome) {
+  const Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+
+  ASSERT_FALSE(encoded.empty());
+  EXPECT_EQ(encoded.outcome, EncodedPath::Outcome::Ready);
+}
+
+TEST(GeodePathEncoder, ConvertedCommandLimitRejectsBeforeExpansion) {
+  PathBuilder builder;
+  builder.moveTo({0.0, 0.0});
+  builder.curveTo({0.25, 1.0e12}, {0.75, -1.0e12}, {1.0, 0.0});
+  builder.curveTo({1.25, 1.0e12}, {1.75, -1.0e12}, {2.0, 0.0});
+
+  const EncodedPath encoded =
+      GeodePathEncoder::encode(builder.build(), FillRule::NonZero, /*tolerance=*/0.0,
+                               GeodePathEncoder::Limits{.maximumConvertedCommands = 1u});
+  EXPECT_TRUE(encoded.empty());
+  EXPECT_TRUE(encoded.rejected());
 }
 
 TEST(GeodePathEncoder, BoundingPolygonIsSmallAndCounterClockwise) {

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -428,6 +428,15 @@ TEST(GeodePathEncoder, ConvertedCommandLimitRejectsBeforeExpansion) {
   EXPECT_TRUE(encoded.rejected());
 }
 
+TEST(GeodePathEncoder, NonRepresentableCoordinatesReportRejectedOutcome) {
+  const Path path =
+      PathBuilder().moveTo({0.0, 0.0}).lineTo({1.0e300, 1.0e300}).lineTo({0.0, 1.0}).build();
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+
+  EXPECT_TRUE(encoded.empty());
+  EXPECT_TRUE(encoded.rejected());
+}
+
 TEST(GeodePathEncoder, BoundingPolygonIsSmallAndCounterClockwise) {
   Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
 

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -318,6 +318,10 @@ donner_cc_test(
     srcs = [
         "RendererPublicApi_tests.cc",
     ],
+    defines = select({
+        "//donner/svg/renderer:text_enabled": ["DONNER_TEXT_ENABLED"],
+        "//conditions:default": [],
+    }),
     opens_gpu_device = True,
     # Variant lanes (doc 0031 M2.3): tiny / text_full / geode wrappers run
     # automatically under `bazel test //...`. The base test still runs at

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -590,6 +590,7 @@ donner_cc_test(
         "//donner/svg/renderer:renderer_utils",
         "//donner/svg/renderer:stroke_params",
         "//donner/svg/renderer/geode:geode_device",
+        "//donner/svg/renderer/geode:geode_path_cache_component",
         "//donner/svg/renderer/tests:rgba_test_matchers",
         "//donner/svg/resources:image_resource",
         "@tiny-skia-cpp//src:tiny_skia_lib",

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -350,6 +350,31 @@ TEST_F(RendererDriverTest, ClipGeometryAdmissionPersistsAcrossCurrentFrameSubTra
                                          Transform2d());
 }
 
+TEST_F(RendererDriverTest, RepeatedOverCapClipStopsPreflightAfterFirstRejection) {
+  constexpr std::size_t kMaximumClipShapes =
+      RendererTextMaterializationBudget::kMaximumUniqueOutlines;
+  std::string svg = R"svg(<defs><clipPath id="over">)svg";
+  for (std::size_t i = 0; i < kMaximumClipShapes + 1u; ++i) {
+    svg += R"svg(<path d="M0 0L1 1"/>)svg";
+  }
+  svg += R"svg(</clipPath></defs>
+              <rect width="1" height="1" clip-path="url(#over)"/>
+              <rect width="1" height="1" clip-path="url(#over)"/>)svg";
+  SVGDocument document = makeDocument(svg, Vector2i(1, 1));
+  RendererDriver::SecurityStats stats;
+  RendererDriver boundedDriver(renderer, /*verbose=*/false, &stats);
+
+  EXPECT_CALL(renderer, pushClip(_)).Times(2).WillRepeatedly([](const ResolvedClip& clip) {
+    ASSERT_THAT(clip.clipPaths, SizeIs(1));
+    EXPECT_TRUE(clip.clipPaths.front().path.empty());
+  });
+
+  boundedDriver.draw(document);
+
+  EXPECT_TRUE(stats.clipGeometryCopyRejected);
+  EXPECT_EQ(stats.clipGeometryPathsPreflighted, kMaximumClipShapes + 1u);
+}
+
 TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
   SVGDocument document = makeDocument(R"svg(
     <text x="2" y="3" fill="#00FF00">hi</text>

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -274,6 +274,30 @@ TEST_F(RendererDriverTest, ClipGeometryAdmissionStopsBeforeCopyingTheFirstOverCa
   driver.draw(overDocument);
 }
 
+TEST_F(RendererDriverTest, ClipGeometryAdmissionAggregatesAcrossTheTraversal) {
+  constexpr std::size_t kMaximumClipShapes =
+      RendererTextMaterializationBudget::kMaximumUniqueOutlines;
+  std::string svg = R"svg(<defs><clipPath id="exact">)svg";
+  for (std::size_t i = 0; i < kMaximumClipShapes; ++i) {
+    svg += R"svg(<path d="M0 0L1 1"/>)svg";
+  }
+  svg += R"svg(</clipPath><clipPath id="extra"><path d="M0 0L1 1"/></clipPath></defs>
+              <rect width="1" height="1" clip-path="url(#exact)"/>
+              <rect width="1" height="1" clip-path="url(#extra)"/>)svg";
+  SVGDocument document = makeDocument(svg, Vector2i(1, 1));
+
+  EXPECT_CALL(renderer, pushClip(_))
+      .WillOnce([=](const ResolvedClip& clip) {
+        EXPECT_THAT(clip.clipPaths, SizeIs(kMaximumClipShapes));
+      })
+      .WillOnce([](const ResolvedClip& clip) {
+        ASSERT_THAT(clip.clipPaths, SizeIs(1));
+        EXPECT_TRUE(clip.clipPaths.front().path.empty());
+      });
+
+  driver.draw(document);
+}
+
 TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
   SVGDocument document = makeDocument(R"svg(
     <text x="2" y="3" fill="#00FF00">hi</text>

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -298,6 +298,58 @@ TEST_F(RendererDriverTest, ClipGeometryAdmissionAggregatesAcrossTheTraversal) {
   driver.draw(document);
 }
 
+TEST_F(RendererDriverTest, ClipGeometryAdmissionPersistsAcrossCurrentFrameSubTraversals) {
+  constexpr std::size_t kMaximumClipShapes =
+      RendererTextMaterializationBudget::kMaximumUniqueOutlines;
+  std::string svg = R"svg(<defs><clipPath id="exact">)svg";
+  for (std::size_t i = 0; i < kMaximumClipShapes; ++i) {
+    svg += R"svg(<path d="M0 0L1 1"/>)svg";
+  }
+  svg += R"svg(</clipPath><clipPath id="extra"><path d="M0 0L1 1"/></clipPath></defs>
+              <rect width="1" height="1" clip-path="url(#exact)"/>
+              <rect width="1" height="1" clip-path="url(#extra)"/>)svg";
+  SVGDocument document = makeDocument(svg, Vector2i(1, 1));
+
+  ParseWarningSink warnings;
+  RendererUtils::prepareDocumentForRendering(document, false, warnings);
+  ASSERT_FALSE(warnings.hasWarnings());
+
+  Entity exactEntity = entt::null;
+  Entity extraEntity = entt::null;
+  Registry& registry = document.registry();
+  for (auto view = registry.view<components::RenderingInstanceComponent>();
+       const Entity entity : view) {
+    const auto& instance = view.get<components::RenderingInstanceComponent>(entity);
+    const auto* clipPaths =
+        instance.styleHandle(registry).try_get<components::ComputedClipPathsComponent>();
+    if (clipPaths == nullptr) {
+      continue;
+    }
+    if (clipPaths->clipPaths.size() == kMaximumClipShapes) {
+      exactEntity = entity;
+    } else if (clipPaths->clipPaths.size() == 1u) {
+      extraEntity = entity;
+    }
+  }
+  ASSERT_TRUE(exactEntity != entt::null);
+  ASSERT_TRUE(extraEntity != entt::null);
+
+  EXPECT_CALL(renderer, pushClip(_))
+      .WillOnce([=](const ResolvedClip& clip) {
+        EXPECT_THAT(clip.clipPaths, SizeIs(kMaximumClipShapes));
+      })
+      .WillOnce([](const ResolvedClip& clip) {
+        ASSERT_THAT(clip.clipPaths, SizeIs(1));
+        EXPECT_TRUE(clip.clipPaths.front().path.empty());
+      });
+
+  const RenderViewport viewport{.size = Vector2d(1.0, 1.0), .devicePixelRatio = 1.0};
+  driver.drawEntityRangeIntoCurrentFrame(registry, exactEntity, exactEntity, viewport,
+                                         Transform2d());
+  driver.drawEntityRangeIntoCurrentFrame(registry, extraEntity, extraEntity, viewport,
+                                         Transform2d());
+}
+
 TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
   SVGDocument document = makeDocument(R"svg(
     <text x="2" y="3" fill="#00FF00">hi</text>

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -246,6 +246,34 @@ TEST_F(RendererDriverTest, EmitsClipPathsWhenPresent) {
   }
 }
 
+TEST_F(RendererDriverTest, ClipGeometryAdmissionStopsBeforeCopyingTheFirstOverCapShape) {
+  constexpr std::size_t kMaximumClipShapes =
+      RendererTextMaterializationBudget::kMaximumUniqueOutlines;
+  const auto makeManyShapeClipDocument = [&](std::size_t shapeCount) {
+    std::string svg = R"svg(<defs><clipPath id="clip">)svg";
+    for (std::size_t i = 0; i < shapeCount; ++i) {
+      svg += R"svg(<path d="M0 0L1 1"/>)svg";
+    }
+    svg += R"svg(</clipPath></defs><rect width="1" height="1" clip-path="url(#clip)"/>)svg";
+    return makeDocument(svg, Vector2i(1, 1));
+  };
+
+  SVGDocument exactDocument = makeManyShapeClipDocument(kMaximumClipShapes);
+  SVGDocument overDocument = makeManyShapeClipDocument(kMaximumClipShapes + 1u);
+
+  EXPECT_CALL(renderer, pushClip(_))
+      .WillOnce([=](const ResolvedClip& clip) {
+        EXPECT_THAT(clip.clipPaths, SizeIs(kMaximumClipShapes));
+      })
+      .WillOnce([](const ResolvedClip& clip) {
+        ASSERT_THAT(clip.clipPaths, SizeIs(1));
+        EXPECT_TRUE(clip.clipPaths.front().path.empty());
+      });
+
+  driver.draw(exactDocument);
+  driver.draw(overDocument);
+}
+
 TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
   SVGDocument document = makeDocument(R"svg(
     <text x="2" y="3" fill="#00FF00">hi</text>

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -193,6 +194,19 @@ TEST_F(RendererDriverTest, ConcurrentDomDrawReplaysBackendCallbacksOutsideWriteA
 
   EXPECT_FALSE(document.handle()->currentThreadHasWriteAccess());
   EXPECT_EQ(document.handle()->revision(), initialRevision);
+}
+
+TEST_F(RendererDriverTest, NonFiniteViewportDoesNotCastBeforeBackendValidation) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect width="8" height="6" fill="red" />
+  )svg");
+  RenderViewport viewport;
+  viewport.size = Vector2d(std::numeric_limits<double>::infinity(), 16.0);
+  viewport.devicePixelRatio = 1.0;
+
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  driver.draw(document, viewport, Transform2d());
 }
 
 TEST_F(RendererDriverTest, EmitsClipPathsWhenPresent) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -31,6 +31,7 @@
 #include "donner/svg/renderer/StrokeParams.h"
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
 #include "tiny_skia/Pixmap.h"
@@ -780,6 +781,58 @@ TEST_F(RendererGeodeTest, SurfaceBudgetCountsPoolReuseAndNestedOffscreensBeforeA
   renderer.endFrame();
 }
 
+TEST_F(RendererGeodeTest, SurfaceBudgetCoversClipMaskBlendSnapshotMaskAndPatternTargets) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+  RenderViewport viewport;
+  viewport.size = Vector2d(8.0, 8.0);
+
+  {
+    RendererGeode renderer = createRenderer();
+    renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/2u, /*maximumBytes=*/4096u);
+    renderer.beginFrame(viewport);
+    ResolvedClip clip;
+    clip.clipPaths.push_back(
+        {.path = PathBuilder().addRect(Box2d({0.0, 0.0}, {4.0, 4.0})).build()});
+    renderer.pushClip(clip);
+    EXPECT_EQ(renderer.resourceStats().surfaceCount, 2u);
+    renderer.popClip();
+    renderer.endFrame();
+  }
+
+  {
+    RendererGeode renderer = createRenderer();
+    renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/3u, /*maximumBytes=*/4096u);
+    renderer.beginFrame(viewport);
+    renderer.pushIsolatedLayer(1.0, MixBlendMode::Multiply);
+    renderer.popIsolatedLayer();
+    EXPECT_EQ(renderer.resourceStats().surfaceCount, 3u)
+        << "The layer and its destination snapshot must both be admitted.";
+    renderer.endFrame();
+  }
+
+  {
+    RendererGeode renderer = createRenderer();
+    renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/3u, /*maximumBytes=*/4096u);
+    renderer.beginFrame(viewport);
+    renderer.pushMask(std::nullopt, MaskType::Alpha);
+    renderer.transitionMaskToContent();
+    EXPECT_EQ(renderer.resourceStats().surfaceCount, 3u)
+        << "Mask capture and content surfaces must be charged independently.";
+    renderer.popMask();
+    renderer.endFrame();
+  }
+
+  {
+    RendererGeode renderer = createRenderer();
+    renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/2u, /*maximumBytes=*/4096u);
+    renderer.beginFrame(viewport);
+    ASSERT_TRUE(renderer.beginPatternTile(Box2d::FromXYWH(0.0, 0.0, 4.0, 4.0), Transform2d()));
+    EXPECT_EQ(renderer.resourceStats().surfaceCount, 2u);
+    renderer.endPatternTile(/*forStroke=*/false);
+    renderer.endFrame();
+  }
+}
+
 TEST_F(RendererGeodeTest, GeometryBudgetIsSharedAcrossOffscreensAtExactDrawBoundary) {
   ASSERT_TRUE(sharedDevice() != nullptr);
 
@@ -808,6 +861,67 @@ TEST_F(RendererGeodeTest, GeometryBudgetIsSharedAcrossOffscreensAtExactDrawBound
 
   offscreen->endFrame();
   renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, GeometryBudgetChargesFillAndStrokeVariantsBeforeUpload) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/2u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  renderer.setPaint(solidFillAndStroke(css::RGBA(255, 0, 0, 255), css::RGBA(0, 0, 255, 255)));
+  StrokeParams stroke;
+  stroke.strokeWidth = 1.0;
+  renderer.drawRect(Box2d({1.0, 1.0}, {8.0, 8.0}), stroke);
+
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 2u);
+  EXPECT_FALSE(stats.geometryBudgetRejected);
+
+  renderer.drawRect(Box2d({10.0, 1.0}, {18.0, 8.0}), stroke);
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 2u);
+  EXPECT_TRUE(stats.geometryBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, CacheBudgetRejectsBeforeInsertionAndUsesTransientFallback) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  ParseWarningSink warnings = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+           <path id="bounded" d="M 1 1 H 12 V 12 H 1 Z" fill="red"/>
+         </svg>)",
+      warnings);
+  ASSERT_FALSE(parsed.hasError());
+  SVGDocument document = std::move(parsed.result());
+  const auto element = document.querySelector("#bounded");
+  ASSERT_TRUE(element.has_value());
+  const Entity entity = element->unsafeEntityHandle().entity();
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/4u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/0u,
+                                       /*maximumResidentBytes=*/64u << 20);
+  renderer.draw(document);
+
+  const auto* cache = document.registry().try_get<geode::GeodePathCacheComponent>(entity);
+  ASSERT_NE(cache, nullptr);
+  EXPECT_FALSE(cache->fillEncode.has_value())
+      << "Rejected retained geometry must not enter the document cache.";
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_TRUE(stats.geometryBudgetRejected);
+  EXPECT_EQ(stats.geometryDraws, 1u);
+
+  const RendererBitmap bitmap = renderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+  EXPECT_THAT(pixelAt(bitmap, 4, 4), RgbaEq(255, 0, 0, 255))
+      << "A cache rejection must retain the admitted frame-local draw fallback.";
 }
 
 TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -996,6 +996,42 @@ TEST_F(RendererGeodeTest, ResourceStatsAggregateEveryDocumentTouchedInTheFrame) 
   renderer.endFrame();
 }
 
+TEST_F(RendererGeodeTest, SingletonConversionFailureRefundsCurrentSceneAdmission) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  Registry firstRegistry;
+  const Entity firstEntity = firstRegistry.create();
+  Registry secondRegistry;
+  const Entity secondEntity = secondRegistry.create();
+  const Path firstPath = PathBuilder().addRect(Box2d({1.0, 1.0}, {6.0, 6.0})).build();
+  const Path secondPath = PathBuilder().addRect(Box2d({10.0, 1.0}, {15.0, 6.0})).build();
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/2u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawPath(
+      PathShape{.path = &firstPath, .sourceEntity = EntityHandle(firstRegistry, firstEntity)},
+      StrokeParams{});
+  renderer.injectScenePreparationFailureAfterForTesting(/*successfulPreparations=*/1u);
+  renderer.drawPath(
+      PathShape{.path = &secondPath, .sourceEntity = EntityHandle(secondRegistry, secondEntity)},
+      StrokeParams{});
+  renderer.endFrame();
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 2u);
+  EXPECT_FALSE(stats.geometryBudgetRejected)
+      << "Demoting the prepared current draw must refund its scene token before solo replay.";
+  const RendererBitmap bitmap = renderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+  EXPECT_THAT(pixelAt(bitmap, 3, 3), RgbaEq(255, 0, 0, 255));
+  EXPECT_THAT(pixelAt(bitmap, 12, 3), RgbaEq(255, 0, 0, 255));
+}
+
 TEST_F(RendererGeodeTest, CacheBudgetRejectsBeforeInsertionAndUsesTransientFallback) {
   ASSERT_TRUE(sharedDevice() != nullptr);
 

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -946,13 +946,48 @@ TEST_F(RendererGeodeTest, ClipMaskGeometryUsesTheSharedSubmissionBudget) {
       {.path = PathBuilder().addRect(Box2d({0.0, 0.0}, {8.0, 8.0})).build(), .layer = 0});
   clip.clipPaths.push_back(
       {.path = PathBuilder().addRect(Box2d({8.0, 8.0}, {16.0, 16.0})).build(), .layer = 0});
+  clip.clipPaths.push_back(
+      {.path = PathBuilder().addRect(Box2d({4.0, 4.0}, {12.0, 12.0})).build(), .layer = 0});
   renderer.pushClip(clip);
 
   const RendererResourceStats stats = renderer.resourceStats();
   EXPECT_EQ(stats.geometryDraws, 1u);
   EXPECT_TRUE(stats.geometryBudgetRejected);
+  EXPECT_EQ(renderer.lastFrameTimings().counters.pathEncodes, 2u)
+      << "Once cap+1 latches rejection, later mask shapes must skip CPU encoding.";
   renderer.popClip();
   renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, NestedClipSurfaceRejectionSuppressesTheWholeInnerSubtree) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/2u, /*maximumBytes=*/4096u);
+  RenderViewport viewport;
+  viewport.size = Vector2d(16.0, 16.0);
+  renderer.beginFrame(viewport);
+
+  ResolvedClip outer;
+  outer.clipPaths.push_back(
+      {.path = PathBuilder().addRect(Box2d({0.0, 0.0}, {16.0, 16.0})).build(), .layer = 0});
+  renderer.pushClip(outer);
+  ResolvedClip rejectedInner;
+  rejectedInner.clipPaths.push_back(
+      {.path = PathBuilder().addRect(Box2d({4.0, 4.0}, {12.0, 12.0})).build(), .layer = 0});
+  renderer.pushClip(rejectedInner);
+
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawRect(Box2d({0.0, 0.0}, {16.0, 16.0}), StrokeParams{});
+  EXPECT_TRUE(renderer.resourceStats().surfaceBudgetRejected);
+  renderer.popClip();
+  renderer.popClip();
+  renderer.endFrame();
+
+  const RendererBitmap bitmap = renderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+  EXPECT_THAT(bitmap.pixels, testing::Each(0u))
+      << "A clip whose required mask could not be allocated must fail closed.";
 }
 
 TEST_F(RendererGeodeTest, ResourceStatsAggregateEveryDocumentTouchedInTheFrame) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -753,6 +753,63 @@ TEST_F(RendererGeodeTest, TransientTexturePoolStaysWithinGlobalMemoryBudgetAcros
       << "Unique texture sizes must not bypass the global pool budget";
 }
 
+TEST_F(RendererGeodeTest, SurfaceBudgetCountsPoolReuseAndNestedOffscreensBeforeAllocation) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setSurfaceBudgetForTesting(/*maximumSurfaces=*/3u, /*maximumBytes=*/4096u);
+  std::unique_ptr<RendererInterface> offscreen = renderer.createOffscreenInstance();
+  ASSERT_NE(offscreen, nullptr);
+
+  RenderViewport viewport;
+  viewport.size = Vector2d(8.0, 8.0);
+  renderer.beginFrame(viewport);
+  offscreen->beginFrame(viewport);
+  renderer.pushIsolatedLayer(1.0, MixBlendMode::Normal);
+  offscreen->pushIsolatedLayer(1.0, MixBlendMode::Normal);
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_TRUE(stats.surfaceBudgetSupported);
+  EXPECT_EQ(stats.surfaceCount, 3u);
+  EXPECT_EQ(stats.surfaceBytes, 3u * 8u * 8u * 4u);
+  EXPECT_TRUE(stats.surfaceBudgetRejected);
+
+  offscreen->popIsolatedLayer();
+  renderer.popIsolatedLayer();
+  offscreen->endFrame();
+  renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, GeometryBudgetIsSharedAcrossOffscreensAtExactDrawBoundary) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/2u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  std::unique_ptr<RendererInterface> offscreen = renderer.createOffscreenInstance();
+  ASSERT_NE(offscreen, nullptr);
+
+  RenderViewport viewport;
+  viewport.size = Vector2d(16.0, 16.0);
+  renderer.beginFrame(viewport);
+  offscreen->beginFrame(viewport);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  offscreen->setPaint(solidFill(css::RGBA(0, 255, 0, 255)));
+  renderer.drawRect(Box2d({0.0, 0.0}, {4.0, 4.0}), StrokeParams{});
+  offscreen->drawRect(Box2d({4.0, 0.0}, {8.0, 4.0}), StrokeParams{});
+  renderer.drawRect(Box2d({8.0, 0.0}, {12.0, 4.0}), StrokeParams{});
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_TRUE(stats.geometryBudgetSupported);
+  EXPECT_EQ(stats.geometryDraws, 2u);
+  EXPECT_TRUE(stats.geometryBudgetRejected);
+
+  offscreen->endFrame();
+  renderer.endFrame();
+}
+
 TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {
   ASSERT_TRUE(sharedDevice() != nullptr);
 

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -888,6 +888,114 @@ TEST_F(RendererGeodeTest, GeometryBudgetChargesFillAndStrokeVariantsBeforeUpload
   renderer.endFrame();
 }
 
+TEST_F(RendererGeodeTest, StrokeOnlyDrawDoesNotPayForANonexistentFill) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/1u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  renderer.setPaint(solidStroke(css::RGBA(0, 0, 255, 255)));
+  StrokeParams stroke;
+  stroke.strokeWidth = 2.0;
+  renderer.drawRect(Box2d({2.0, 2.0}, {12.0, 12.0}), stroke);
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 1u);
+  EXPECT_FALSE(stats.geometryBudgetRejected);
+  renderer.endFrame();
+
+  const RendererBitmap bitmap = renderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+  EXPECT_THAT(pixelAt(bitmap, 2, 2), testing::Not(IsTransparent()));
+}
+
+TEST_F(RendererGeodeTest, DegenerateEmptyGeometryDoesNotConsumeFrameBudget) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/1u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawRect(Box2d({1.0, 1.0}, {4.0, 4.0}), StrokeParams{});
+  const Path empty;
+  renderer.drawPath(PathShape{.path = &empty}, StrokeParams{});
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 1u);
+  EXPECT_FALSE(stats.geometryBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, ClipMaskGeometryUsesTheSharedSubmissionBudget) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/1u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/64u << 20,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  ResolvedClip clip;
+  clip.clipPaths.push_back(
+      {.path = PathBuilder().addRect(Box2d({0.0, 0.0}, {8.0, 8.0})).build(), .layer = 0});
+  clip.clipPaths.push_back(
+      {.path = PathBuilder().addRect(Box2d({8.0, 8.0}, {16.0, 16.0})).build(), .layer = 0});
+  renderer.pushClip(clip);
+
+  const RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.geometryDraws, 1u);
+  EXPECT_TRUE(stats.geometryBudgetRejected);
+  renderer.popClip();
+  renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, ResourceStatsAggregateEveryDocumentTouchedInTheFrame) {
+  ASSERT_TRUE(sharedDevice() != nullptr);
+
+  Registry firstRegistry;
+  const Entity firstEntity = firstRegistry.create();
+  PathBuilder largeBuilder;
+  largeBuilder.moveTo({0.0, 0.0});
+  for (int i = 1; i <= 512; ++i) {
+    largeBuilder.lineTo({static_cast<double>(i % 16), static_cast<double>(i / 16)});
+  }
+  const Path largePath = largeBuilder.build();
+
+  Registry secondRegistry;
+  const Entity secondEntity = secondRegistry.create();
+  const Path smallPath = PathBuilder().addRect(Box2d({1.0, 1.0}, {4.0, 4.0})).build();
+
+  RendererGeode renderer = createRenderer();
+  renderer.setGeometryBudgetForTesting(/*maximumDraws=*/4u, /*maximumItems=*/1u << 20,
+                                       /*maximumFrameBytes=*/64u << 20,
+                                       /*maximumCacheBytes=*/4096u,
+                                       /*maximumResidentBytes=*/64u << 20);
+  beginFrame(renderer);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawPath(
+      PathShape{.path = &largePath, .sourceEntity = EntityHandle(firstRegistry, firstEntity)},
+      StrokeParams{});
+  renderer.drawPath(
+      PathShape{.path = &smallPath, .sourceEntity = EntityHandle(secondRegistry, secondEntity)},
+      StrokeParams{});
+
+  const auto* firstCache = firstRegistry.try_get<geode::GeodePathCacheComponent>(firstEntity);
+  const auto* secondCache = secondRegistry.try_get<geode::GeodePathCacheComponent>(secondEntity);
+  ASSERT_NE(firstCache, nullptr);
+  ASSERT_NE(secondCache, nullptr);
+  ASSERT_FALSE(firstCache->fillEncode.has_value()) << "Fixture must reject the first document.";
+  ASSERT_TRUE(secondCache->fillEncode.has_value()) << "Fixture must admit the second document.";
+  EXPECT_TRUE(renderer.resourceStats().geometryBudgetRejected)
+      << "Touching a clean second document must not erase the first document's rejection.";
+  renderer.endFrame();
+}
+
 TEST_F(RendererGeodeTest, CacheBudgetRejectsBeforeInsertionAndUsesTransientFallback) {
   ASSERT_TRUE(sharedDevice() != nullptr);
 

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -541,6 +541,24 @@ TEST(RendererPublicApiTest, RejectedFilterSuppressesItsSubtreeAndRestoresParent)
   EXPECT_THAT(PixelAt(snapshot, 12, 4), IsBlueish());
 }
 
+TEST(RendererPublicApiTest, FacadeRejectsNonFiniteAndOutOfRangeFrameDimensionsBeforeCasting) {
+  Renderer renderer;
+  constexpr double kInfinity = std::numeric_limits<double>::infinity();
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+  for (const RenderViewport viewport : {
+           RenderViewport{.size = Vector2d(kInfinity, 16.0), .devicePixelRatio = 1.0},
+           RenderViewport{.size = Vector2d(kNaN, 16.0), .devicePixelRatio = 1.0},
+           RenderViewport{.size = Vector2d(1.0e300, 16.0), .devicePixelRatio = 1.0},
+           RenderViewport{.size = Vector2d(16.0, 16.0), .devicePixelRatio = kInfinity},
+       }) {
+    renderer.beginFrame(viewport);
+    renderer.endFrame();
+    EXPECT_EQ(renderer.width(), 0);
+    EXPECT_EQ(renderer.height(), 0);
+  }
+}
+
 TEST(RendererPublicApiTest, PatternTileRejectsUnsafeDimensionsWithoutChangingFrameState) {
   Renderer renderer;
   renderer.beginFrame(RenderViewport{

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -14,6 +14,7 @@
 #include "donner/svg/SVGTextElement.h"
 #include "donner/svg/SVGUseElement.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
 #include "donner/svg/resources/FontManager.h"
@@ -62,6 +63,121 @@ RendererBitmap NormalizeSnapshot(RendererBitmap snapshot) {
   }
 
   return normalized;
+}
+
+TEST(RendererSurfaceBudgetTest, RejectsAggregateBytesAndSurfaceCountWithoutOvershoot) {
+  RendererSurfaceBudget byteBudget;
+  EXPECT_TRUE(byteBudget.reserve(4096, 4096, 4));
+  EXPECT_FALSE(byteBudget.reserve(1, 1));
+  EXPECT_EQ(byteBudget.bytes(), RendererSurfaceBudget::kMaximumBytes);
+  EXPECT_TRUE(byteBudget.rejected());
+
+  RendererSurfaceBudget countBudget;
+  EXPECT_TRUE(countBudget.reserve(1, 1, RendererSurfaceBudget::kMaximumSurfaces));
+  EXPECT_FALSE(countBudget.reserve(1, 1));
+  EXPECT_EQ(countBudget.surfaces(), RendererSurfaceBudget::kMaximumSurfaces);
+  EXPECT_LE(countBudget.bytes(), RendererSurfaceBudget::kMaximumBytes);
+}
+
+TEST(RendererDrawBudgetTest, RejectsEveryAggregateDimensionWithoutOvershoot) {
+  RendererDrawBudget budget;
+  EXPECT_TRUE(budget.reserve(
+      {.drawCalls = RendererDrawBudget::kMaximumDrawCalls,
+       .pathCommands = RendererDrawBudget::kMaximumPathCommands,
+       .pathMeasurementWorkUnits = RendererDrawBudget::kMaximumPathMeasurementWorkUnits,
+       .gradientStops = RendererDrawBudget::kMaximumGradientStops,
+       .imageDraws = RendererDrawBudget::kMaximumImageDraws,
+       .imageBytes = RendererDrawBudget::kMaximumImageBytes}));
+  EXPECT_FALSE(budget.reserve({.drawCalls = 1}));
+  EXPECT_TRUE(budget.rejected());
+  EXPECT_EQ(budget.drawCalls(), RendererDrawBudget::kMaximumDrawCalls);
+  EXPECT_EQ(budget.pathCommands(), RendererDrawBudget::kMaximumPathCommands);
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(),
+            RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_EQ(budget.gradientStops(), RendererDrawBudget::kMaximumGradientStops);
+  EXPECT_EQ(budget.imageDraws(), RendererDrawBudget::kMaximumImageDraws);
+  EXPECT_EQ(budget.imageBytes(), RendererDrawBudget::kMaximumImageBytes);
+}
+
+#ifdef DONNER_TEXT_ENABLED
+TEST(RendererTinySkiaSecurityTest, TextGlyphCapRejectsNextRenderableGlyphBeforeMaterialization) {
+  SVGDocument limitedDocument = ParseDocument(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="48" height="20">
+           <text x="2" y="14">A</text><text x="24" y="14">A</text>
+         </svg>)");
+  RendererTinySkia limitedRenderer;
+  limitedRenderer.setTextGlyphBudgetForTesting(1);
+  limitedRenderer.draw(limitedDocument);
+
+  const RendererResourceStats limitedStats = limitedRenderer.resourceStats();
+  EXPECT_EQ(limitedStats.drawCalls, 2u);
+  EXPECT_TRUE(limitedStats.drawBudgetRejected);
+  EXPECT_EQ(limitedRenderer.frameCounters().textGlyphMaterializations, 1u);
+
+  SVGDocument referenceDocument = ParseDocument(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="48" height="20">
+           <text x="2" y="14">A</text>
+         </svg>)");
+  RendererTinySkia referenceRenderer;
+  referenceRenderer.setTextGlyphBudgetForTesting(1);
+  referenceRenderer.draw(referenceDocument);
+  EXPECT_EQ(referenceRenderer.frameCounters().textGlyphMaterializations, 1u);
+
+  const RendererBitmap limitedSnapshot = limitedRenderer.takeSnapshot();
+  const RendererBitmap referenceSnapshot = referenceRenderer.takeSnapshot();
+  ASSERT_FALSE(limitedSnapshot.empty());
+  ASSERT_FALSE(referenceSnapshot.empty());
+  EXPECT_EQ(limitedSnapshot.dimensions, referenceSnapshot.dimensions);
+  EXPECT_THAT(limitedSnapshot.pixels, testing::ContainerEq(referenceSnapshot.pixels));
+}
+#endif
+
+void SetStrokePaint(RendererInterface& renderer) {
+  PaintParams paint;
+  paint.fill = PaintServer::None{};
+  paint.stroke = PaintServer::Solid{css::Color(css::RGBA(0, 0, 0, 255))};
+  renderer.setPaint(paint);
+}
+
+TEST(RendererPublicApiTest, TinyDashWorkCountsContoursAndZeroLengthPhaseBeforeRasterizing) {
+  RendererTinySkia renderer;
+  renderer.setDashWorkBudgetForTesting(8);
+  std::unique_ptr<RendererInterface> offscreen = renderer.createOffscreenInstance();
+  ASSERT_NE(offscreen, nullptr);
+  renderer.beginFrame(RenderViewport{.size = Vector2d(16.0, 16.0), .devicePixelRatio = 1.0});
+  offscreen->beginFrame(RenderViewport{.size = Vector2d(16.0, 16.0), .devicePixelRatio = 1.0});
+  SetStrokePaint(renderer);
+  SetStrokePaint(*offscreen);
+  renderer.setTransform(Transform2d::Scale(8.0));
+  offscreen->setTransform(Transform2d::Scale(8.0));
+
+  const Path acceptedPath = PathBuilder()
+                                .moveTo({0.25, 0.5})
+                                .lineTo({0.75, 0.5})
+                                .moveTo({0.25, 1.5})
+                                .lineTo({0.75, 1.5})
+                                .build();
+  const Path rejectedPath = PathBuilder().moveTo({0.25, 1.0}).lineTo({0.75, 1.0}).build();
+  const StrokeParams stroke{.strokeWidth = 0.25, .dashArray = {0.0, 0.0, 0.0, 0.0, 1.0, 1.0}};
+  renderer.drawPath(PathShape{.path = &acceptedPath}, stroke);
+
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.drawCalls, 1u);
+  EXPECT_FALSE(stats.drawBudgetRejected);
+
+  offscreen->drawPath(PathShape{.path = &rejectedPath}, stroke);
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.drawCalls, 2u);
+  EXPECT_TRUE(stats.drawBudgetRejected);
+
+  const RendererBitmap acceptedSnapshot = renderer.takeSnapshot();
+  const RendererBitmap rejectedSnapshot = offscreen->takeSnapshot();
+  ASSERT_FALSE(acceptedSnapshot.empty());
+  ASSERT_FALSE(rejectedSnapshot.empty());
+  EXPECT_THAT(acceptedSnapshot.pixels, testing::Not(testing::Each(0)));
+  EXPECT_THAT(rejectedSnapshot.pixels, testing::Each(0));
+  offscreen->endFrame();
+  renderer.endFrame();
 }
 
 // -- Pixel access and custom matchers --

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -180,27 +180,29 @@ TEST(RendererPublicApiTest, TinyDashWorkCountsContoursAndZeroLengthPhaseBeforeRa
   renderer.endFrame();
 }
 
-TEST(RendererTinySkiaSecurityTest, PathMeasurementWorkStopsAtTheFrameCapBeforeNextQuery) {
+TEST(RendererTinySkiaSecurityTest, PathMeasurementWorkTracksActualAggregateAcrossCurves) {
   RendererTinySkia renderer;
   renderer.beginFrame(RenderViewport{.size = Vector2d(2.0, 2.0), .devicePixelRatio = 1.0});
   SetStrokePaint(renderer);
 
   const Path maximumWorkPath =
       PathBuilder().moveTo({0.0, 0.0}).curveTo({0.0, 1.0}, {1.0, 0.0}, {1.0, 1.0}).build();
+  const std::size_t actualWork = maximumWorkPath.measure().measurementWorkUnits();
+  ASSERT_GT(actualWork, 0u);
+  ASSERT_LE(actualWork, RendererDrawBudget::kMaximumPathMeasurementWorkUnits / 2u);
   const StrokeParams measuredStroke{
       .strokeWidth = 0.25, .dashArray = {0.5, 0.5}, .pathLength = 1.0};
   renderer.drawPath(PathShape{.path = &maximumWorkPath}, measuredStroke);
 
   RendererResourceStats stats = renderer.resourceStats();
-  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, actualWork);
   EXPECT_FALSE(stats.drawBudgetRejected);
 
-  const Path nextPath = PathBuilder().moveTo({0.0, 0.0}).lineTo({1.0, 1.0}).build();
-  renderer.drawPath(PathShape{.path = &nextPath}, measuredStroke);
+  renderer.drawPath(PathShape{.path = &maximumWorkPath}, measuredStroke);
 
   stats = renderer.resourceStats();
-  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
-  EXPECT_TRUE(stats.drawBudgetRejected);
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, actualWork * 2u);
+  EXPECT_FALSE(stats.drawBudgetRejected);
   renderer.endFrame();
 }
 

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -79,6 +79,46 @@ TEST(RendererSurfaceBudgetTest, RejectsAggregateBytesAndSurfaceCountWithoutOvers
   EXPECT_LE(countBudget.bytes(), RendererSurfaceBudget::kMaximumBytes);
 }
 
+TEST(RendererSurfaceBudgetTest, ReleasedSurfacesRestoreActiveCapacity) {
+  RendererSurfaceBudget budget;
+  EXPECT_TRUE(budget.reserve(4096, 4096, 4));
+  EXPECT_EQ(budget.bytes(), RendererSurfaceBudget::kMaximumBytes);
+  EXPECT_EQ(budget.surfaces(), 4u);
+
+  EXPECT_TRUE(budget.release(4096, 4096));
+  EXPECT_EQ(budget.bytes(), RendererSurfaceBudget::kMaximumBytes * 3u / 4u);
+  EXPECT_EQ(budget.surfaces(), 3u);
+
+  EXPECT_TRUE(budget.reserve(4096, 4096));
+  EXPECT_EQ(budget.bytes(), RendererSurfaceBudget::kMaximumBytes);
+  EXPECT_EQ(budget.surfaces(), 4u);
+  EXPECT_FALSE(budget.rejected());
+}
+
+TEST(RendererPublicApiTest, FrameResourceScopeKeepsOffscreenAndRootSurfaceCharges) {
+  std::unique_ptr<RendererInterface> renderer = CreateActiveRendererInstance();
+  ASSERT_NE(renderer, nullptr);
+  std::unique_ptr<RendererInterface> offscreen = renderer->createOffscreenInstance();
+  ASSERT_NE(offscreen, nullptr);
+  const RenderViewport viewport{.size = Vector2d(1.0, 1.0), .devicePixelRatio = 1.0};
+
+  renderer->beginFrameResourceScope();
+  offscreen->beginFrame(viewport);
+  offscreen->endFrame();
+  EXPECT_EQ(renderer->resourceStats().surfaceCount, 1u);
+
+  renderer->beginFrame(viewport);
+  renderer->endFrame();
+  EXPECT_EQ(renderer->resourceStats().surfaceCount, 2u)
+      << "the root pass must not erase an earlier offscreen charge in the same outer frame";
+  renderer->endFrameResourceScope();
+
+  renderer->beginFrame(viewport);
+  renderer->endFrame();
+  EXPECT_EQ(renderer->resourceStats().surfaceCount, 1u)
+      << "the next standalone frame starts a fresh budget epoch";
+}
+
 TEST(RendererDrawBudgetTest, RejectsEveryAggregateDimensionWithoutOvershoot) {
   RendererDrawBudget budget;
   EXPECT_TRUE(budget.reserve(

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -180,6 +180,118 @@ TEST(RendererPublicApiTest, TinyDashWorkCountsContoursAndZeroLengthPhaseBeforeRa
   renderer.endFrame();
 }
 
+TEST(RendererTinySkiaSecurityTest, PathMeasurementWorkStopsAtTheFrameCapBeforeNextQuery) {
+  RendererTinySkia renderer;
+  renderer.beginFrame(RenderViewport{.size = Vector2d(2.0, 2.0), .devicePixelRatio = 1.0});
+  SetStrokePaint(renderer);
+
+  const Path maximumWorkPath =
+      PathBuilder().moveTo({0.0, 0.0}).curveTo({0.0, 1.0}, {1.0, 0.0}, {1.0, 1.0}).build();
+  const StrokeParams measuredStroke{
+      .strokeWidth = 0.25, .dashArray = {0.5, 0.5}, .pathLength = 1.0};
+  renderer.drawPath(PathShape{.path = &maximumWorkPath}, measuredStroke);
+
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_FALSE(stats.drawBudgetRejected);
+
+  const Path nextPath = PathBuilder().moveTo({0.0, 0.0}).lineTo({1.0, 1.0}).build();
+  renderer.drawPath(PathShape{.path = &nextPath}, measuredStroke);
+
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_TRUE(stats.drawBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST(RendererTinySkiaSecurityTest, ClipMaskAllocationsStopAtTheSurfaceCountCap) {
+  RendererTinySkia renderer;
+  renderer.beginFrame(RenderViewport{.size = Vector2d(1.0, 1.0), .devicePixelRatio = 1.0});
+
+  ResolvedClip clip;
+  clip.clipRect = Box2d::FromXYWH(0.0, 0.0, 1.0, 1.0);
+  for (std::size_t i = 1; i < RendererSurfaceBudget::kMaximumSurfaces; ++i) {
+    renderer.pushClip(clip);
+    renderer.popClip();
+  }
+
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.surfaceCount, RendererSurfaceBudget::kMaximumSurfaces);
+  EXPECT_EQ(stats.surfaceBytes, 4u + RendererSurfaceBudget::kMaximumSurfaces - 1u);
+  EXPECT_FALSE(stats.surfaceBudgetRejected);
+
+  renderer.pushClip(clip);
+  renderer.popClip();
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.surfaceCount, RendererSurfaceBudget::kMaximumSurfaces);
+  EXPECT_TRUE(stats.surfaceBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST(RendererTinySkiaSecurityTest, NestedClipShapeMasksStopAtTheSurfaceCountCap) {
+  RendererTinySkia renderer;
+  renderer.beginFrame(RenderViewport{.size = Vector2d(1.0, 1.0), .devicePixelRatio = 1.0});
+
+  const Path shapePath =
+      PathBuilder().moveTo({0.0, 0.0}).lineTo({1.0, 0.0}).lineTo({1.0, 1.0}).closePath().build();
+  ResolvedClip clip;
+  clip.clipRect = Box2d::FromXYWH(0.0, 0.0, 1.0, 1.0);
+  clip.clipPaths.reserve(RendererSurfaceBudget::kMaximumSurfaces - 2u);
+  for (std::size_t i = RendererSurfaceBudget::kMaximumSurfaces - 2u; i > 0; --i) {
+    ClipPathShape shape;
+    shape.path = shapePath;
+    shape.layer = static_cast<int>(i);
+    clip.clipPaths.push_back(std::move(shape));
+  }
+
+  renderer.pushClip(clip);
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.surfaceCount, RendererSurfaceBudget::kMaximumSurfaces);
+  EXPECT_FALSE(stats.surfaceBudgetRejected);
+  renderer.popClip();
+
+  ResolvedClip extraClip;
+  extraClip.clipRect = Box2d::FromXYWH(0.0, 0.0, 1.0, 1.0);
+  renderer.pushClip(extraClip);
+  renderer.popClip();
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.surfaceCount, RendererSurfaceBudget::kMaximumSurfaces);
+  EXPECT_TRUE(stats.surfaceBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST(RendererTinySkiaSecurityTest, RetainedClipEpochMasksHaveAFrameSurfaceEnvelope) {
+  constexpr std::size_t kRetainedClipMasks = 8;
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+
+  const auto beginAndCheckEnvelope = [&]() {
+    renderer.beginFrame(RenderViewport{.size = Vector2d(1.0, 1.0), .devicePixelRatio = 1.0});
+    const RendererResourceStats stats = renderer.resourceStats();
+    EXPECT_EQ(stats.surfaceCount, 1u + kRetainedClipMasks);
+    EXPECT_EQ(stats.surfaceBytes, 4u + kRetainedClipMasks);
+    EXPECT_FALSE(stats.surfaceBudgetRejected);
+  };
+
+  beginAndCheckEnvelope();
+  ResolvedClip clip;
+  clip.clipRect = Box2d::FromXYWH(0.0, 0.0, 1.0, 1.0);
+  const std::size_t admittedClipMasks =
+      RendererSurfaceBudget::kMaximumSurfaces - 1u - kRetainedClipMasks;
+  for (std::size_t i = 0; i < admittedClipMasks; ++i) {
+    renderer.pushClip(clip);
+    renderer.popClip();
+  }
+  EXPECT_EQ(renderer.resourceStats().surfaceCount, RendererSurfaceBudget::kMaximumSurfaces);
+  renderer.pushClip(clip);
+  renderer.popClip();
+  EXPECT_TRUE(renderer.resourceStats().surfaceBudgetRejected);
+  renderer.endFrame();
+
+  beginAndCheckEnvelope();
+  renderer.endFrame();
+}
+
 // -- Pixel access and custom matchers --
 
 /// Return RGBA pixel at (x,y) from a normalized snapshot.

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -99,6 +99,44 @@ TEST(RendererDrawBudgetTest, RejectsEveryAggregateDimensionWithoutOvershoot) {
   EXPECT_EQ(budget.imageBytes(), RendererDrawBudget::kMaximumImageBytes);
 }
 
+TEST(RendererDrawBudgetTest, ReconcilesBoundedPathQueriesAtTheExactAggregateCap) {
+  RendererDrawBudget budget;
+  const std::optional<RendererDrawBudget::PathMeasurementReservation> first =
+      budget.reservePathMeasurement();
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->maximumWorkUnits(), RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(),
+            RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+
+  ASSERT_TRUE(budget.reconcilePathMeasurement(
+      *first, RendererDrawBudget::kMaximumPathMeasurementWorkUnits - 1u, /*completed=*/true));
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(),
+            RendererDrawBudget::kMaximumPathMeasurementWorkUnits - 1u);
+  EXPECT_FALSE(budget.rejected());
+
+  const std::optional<RendererDrawBudget::PathMeasurementReservation> last =
+      budget.reservePathMeasurement();
+  ASSERT_TRUE(last.has_value());
+  EXPECT_EQ(last->maximumWorkUnits(), 1u);
+  ASSERT_TRUE(budget.reconcilePathMeasurement(*last, 1u, /*completed=*/true));
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(),
+            RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_FALSE(budget.rejected());
+
+  EXPECT_FALSE(budget.reservePathMeasurement().has_value());
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(),
+            RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_TRUE(budget.rejected());
+
+  budget.reset();
+  const std::optional<RendererDrawBudget::PathMeasurementReservation> incomplete =
+      budget.reservePathMeasurement();
+  ASSERT_TRUE(incomplete.has_value());
+  EXPECT_FALSE(budget.reconcilePathMeasurement(*incomplete, 5u, /*completed=*/false));
+  EXPECT_EQ(budget.pathMeasurementWorkUnits(), 5u);
+  EXPECT_TRUE(budget.rejected());
+}
+
 #ifdef DONNER_TEXT_ENABLED
 TEST(RendererTinySkiaSecurityTest, TextGlyphCapRejectsNextRenderableGlyphBeforeMaterialization) {
   SVGDocument limitedDocument = ParseDocument(
@@ -203,6 +241,41 @@ TEST(RendererTinySkiaSecurityTest, PathMeasurementWorkTracksActualAggregateAcros
   stats = renderer.resourceStats();
   EXPECT_EQ(stats.pathMeasurementWorkUnits, actualWork * 2u);
   EXPECT_FALSE(stats.drawBudgetRejected);
+  renderer.endFrame();
+}
+
+TEST(RendererTinySkiaSecurityTest, PathMeasurementQueriesStopAtExactAggregateCapPlusOne) {
+  PathBuilder builder;
+  for (int i = 0; i < 10; ++i) {
+    builder.moveTo({0.0, 0.0}).curveTo({0.0, 1.0}, {1.0, 0.0}, {1.0, 1.0});
+  }
+  for (int i = 0; i < 54; ++i) {
+    builder.lineTo({1.0, 1.0});
+  }
+  const Path exactWorkPath = builder.build();
+  const std::size_t workPerQuery = exactWorkPath.measure().measurementWorkUnits();
+  ASSERT_EQ(workPerQuery, 1024u);
+  ASSERT_EQ(RendererDrawBudget::kMaximumPathMeasurementWorkUnits % workPerQuery, 0u);
+
+  RendererTinySkia renderer;
+  renderer.beginFrame(RenderViewport{.size = Vector2d(2.0, 2.0), .devicePixelRatio = 1.0});
+  SetStrokePaint(renderer);
+  const StrokeParams measuredStroke{
+      .strokeWidth = 0.25, .dashArray = {1000.0, 1000.0}, .pathLength = 1.0};
+  const std::size_t admittedQueries =
+      RendererDrawBudget::kMaximumPathMeasurementWorkUnits / workPerQuery;
+  for (std::size_t i = 0; i < admittedQueries; ++i) {
+    renderer.drawPath(PathShape{.path = &exactWorkPath}, measuredStroke);
+  }
+
+  RendererResourceStats stats = renderer.resourceStats();
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_FALSE(stats.drawBudgetRejected);
+
+  renderer.drawPath(PathShape{.path = &exactWorkPath}, measuredStroke);
+  stats = renderer.resourceStats();
+  EXPECT_EQ(stats.pathMeasurementWorkUnits, RendererDrawBudget::kMaximumPathMeasurementWorkUnits);
+  EXPECT_TRUE(stats.drawBudgetRejected);
   renderer.endFrame();
 }
 

--- a/donner/svg/renderer/tests/TextBackend_tests.cc
+++ b/donner/svg/renderer/tests/TextBackend_tests.cc
@@ -152,6 +152,37 @@ std::vector<uint8_t> AddEmptyBitmapTables(std::span<const uint8_t> input) {
   return result;
 }
 
+std::vector<uint8_t> AddEmptyGlyfTable(std::span<const uint8_t> input) {
+  if (input.size() < 12) {
+    return {};
+  }
+  const uint16_t oldTableCount = ReadBe16(input, 4);
+  const size_t oldDirectorySize = 12u + static_cast<size_t>(oldTableCount) * 16u;
+  if (oldDirectorySize > input.size() || oldTableCount == UINT16_MAX) {
+    return {};
+  }
+
+  constexpr size_t kAddedDirectoryBytes = 16;
+  const uint16_t newTableCount = static_cast<uint16_t>(oldTableCount + 1u);
+  const size_t newDirectorySize = oldDirectorySize + kAddedDirectoryBytes;
+  std::vector<uint8_t> result(newDirectorySize + input.size() - oldDirectorySize, 0);
+  std::copy_n(input.begin(), 12, result.begin());
+  WriteBe16(&result, 4, newTableCount);
+  for (uint16_t table = 0; table < oldTableCount; ++table) {
+    const size_t recordOffset = 12u + static_cast<size_t>(table) * 16u;
+    std::copy_n(input.begin() + recordOffset, 16, result.begin() + recordOffset);
+    WriteBe32(&result, recordOffset + 8u,
+              ReadBe32(input, recordOffset + 8u) + kAddedDirectoryBytes);
+  }
+  std::copy(input.begin() + oldDirectorySize, input.end(), result.begin() + newDirectorySize);
+
+  const size_t glyfRecord = oldDirectorySize;
+  constexpr std::string_view kGlyf = "glyf";
+  std::copy(kGlyf.begin(), kGlyf.end(), result.begin() + glyfRecord);
+  WriteBe32(&result, glyfRecord + 8u, static_cast<uint32_t>(result.size()));
+  return result;
+}
+
 auto GlyphIndexIs(auto matcher) {
   return Field("glyphIndex", &TextBackend::ShapedGlyph::glyphIndex, matcher);
 }
@@ -610,6 +641,27 @@ TEST(TextBackendFullCapabilities, UntrustedBitmapFontIsRejectedBeforeFreeTypeSha
           .glyphs,
       IsEmpty());
   EXPECT_FALSE(backend.bitmapGlyph(font, 1, 1.0f).has_value());
+}
+
+TEST(TextBackendFullCapabilities, UntrustedOutlineDecodeRequiresValidatedComplexity) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextBackendFull backend(fontManager, registry);
+
+  const FontHandle fallback = fontManager.fallbackFont();
+  ASSERT_TRUE(static_cast<bool>(fallback));
+  const std::vector<uint8_t> data = AddEmptyGlyfTable(fontManager.fontData(fallback));
+  ASSERT_FALSE(data.empty());
+  const FontHandle untrusted = fontManager.loadFontData(data);
+  ASSERT_TRUE(static_cast<bool>(untrusted));
+  EXPECT_FALSE(fontManager.isTrustedFont(untrusted));
+  EXPECT_FALSE(fontManager.glyphOutlineComplexity(untrusted, 1).has_value());
+
+  const auto shaped =
+      backend.shapeRun(untrusted, 32.0f, "O", 0, 1, false, FontVariant::Normal, false);
+  ASSERT_THAT(shaped.glyphs, ElementsAre(GlyphIndexIs(Gt(0))));
+  const float scale = backend.scaleForEmToPixels(untrusted, 32.0f);
+  EXPECT_TRUE(backend.glyphOutline(untrusted, shaped.glyphs.front().glyphIndex, scale).empty());
 }
 
 TEST(TextBackendFullCapabilities, UntrustedOutlineFontDisablesEmbeddedBitmapLoading) {

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -189,6 +189,7 @@ donner_cc_test(
     data = [
         "//donner/base/fonts:testdata/valid-001.woff",
         "//donner/base/fonts:testdata/valid-001.woff2",
+        "//third_party/roboto:Roboto-Regular.ttf",
     ],
     defines = select({
         "//donner/svg/renderer:text_full_enabled": ["DONNER_TEXT_WOFF2_ENABLED"],

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -176,6 +176,7 @@ struct FontManager::FontBudgetState {
   size_t usedBytes = 0;
   size_t usedFonts = 0;
   size_t usedValidationWork = 0;
+  size_t compressedFontDecompressionAttempts = 0;
   std::unordered_map<const std::vector<uint8_t>*, std::weak_ptr<const std::vector<uint8_t>>>
       validationRejectedSources;
 };
@@ -630,6 +631,10 @@ size_t FontManager::fontValidationWork() const {
   return budgetStateForRead()->usedValidationWork;
 }
 
+size_t FontManager::compressedFontDecompressionAttempts() const {
+  return budgetStateForRead()->compressedFontDecompressionAttempts;
+}
+
 size_t FontManager::numValidationRejectedSources() const {
   return budgetStateForRead()->validationRejectedSources.size();
 }
@@ -791,6 +796,7 @@ bool FontManager::canStoreLoadedFont(Entity entity, size_t rawBytes, size_t inde
 bool FontManager::loadWoff1(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
                             bool* validationWorkLimitExceeded) {
   const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  ++budgetState->compressedFontDecompressionAttempts;
   fonts::WoffParser::Options options;
   options.maximumSfntSize = std::min(options.maximumSfntSize, budgetState->maximumBytes);
   auto maybeFont = fonts::WoffParser::Parse(data, options);
@@ -852,6 +858,7 @@ bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t>
 bool FontManager::loadWoff2(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
                             bool* validationWorkLimitExceeded) {
   const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  ++budgetState->compressedFontDecompressionAttempts;
   fonts::Woff2Parser::Options options;
   options.maximumOutputSize = std::min(options.maximumOutputSize, budgetState->maximumBytes);
   auto result = fonts::Woff2Parser::Decompress(data, options);

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -69,12 +69,12 @@ uint32_t readBE32(const uint8_t* p) {
          (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
 }
 
-bool HasCffFlavor(std::span<const uint8_t> data) {
+/// WOFF flavor fields cannot prove that decompressed tables omit CFF, so compressed inputs share
+/// the exhausted-budget path regardless of their advertised flavor.
+bool IsCompressedOrCffFont(std::span<const uint8_t> data) {
   if (data.size() < 4) return false;
   const uint32_t magic = readBE32(data.data());
-  if (magic == kSfntCff) return true;
-  return (magic == kWoffMagic || magic == kWoff2Magic) && data.size() >= 8 &&
-         readBE32(data.data() + 4) == kSfntCff;
+  return magic == kSfntCff || magic == kWoffMagic || magic == kWoff2Magic;
 }
 
 bool IsSupportedFontMagic(uint32_t magic) {
@@ -557,7 +557,7 @@ bool FontManager::exhaustedValidationBudgetRejects(
     const std::shared_ptr<FontBudgetState>& budgetState) const {
   return trust == FontDataTrust::Untrusted &&
          budgetState->usedValidationWork >= budgetState->maximumValidationWork &&
-         HasCffFlavor(data);
+         IsCompressedOrCffFont(data);
 }
 
 void FontManager::rememberValidationRejectedSource(

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -533,8 +533,22 @@ bool FontManager::isTrustedFont(FontHandle handle) const {
 }
 
 std::optional<FontManager::GlyphOutlineComplexity> FontManager::glyphOutlineComplexity(
-    FontHandle /*handle*/, int /*glyphIndex*/) const {
-  return std::nullopt;
+    FontHandle handle, int glyphIndex) const {
+  if (!isValidHandle(handle) || glyphIndex < 0) {
+    return std::nullopt;
+  }
+  const auto* font = registry_.try_get<LoadedFontComponent>(handle.entity());
+  if (!font) {
+    return std::nullopt;
+  }
+  const auto complexity = font->sfnt.glyphOutlineComplexity(static_cast<std::size_t>(glyphIndex));
+  if (!complexity) {
+    return std::nullopt;
+  }
+  return GlyphOutlineComplexity{
+      .maximumVertices = complexity->maximumVertices,
+      .work = complexity->work,
+  };
 }
 
 std::optional<std::span<const uint8_t>> FontManager::sfntTable(FontHandle handle,

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -159,8 +159,10 @@ struct FontManager::FontFaceComponent {
 struct FontManager::FontBudgetState {
   size_t maximumBytes = 0;
   size_t maximumFonts = 0;
+  size_t maximumValidationWork = 0;
   size_t usedBytes = 0;
   size_t usedFonts = 0;
+  size_t usedValidationWork = 0;
 };
 
 struct FontManager::FontBudgetContext {
@@ -244,11 +246,11 @@ const FontFamilyProvider* FontManager::DefaultFontProvider() {
 }
 
 FontManager::FontManager(Registry& registry, size_t maximumLoadedFontBytes,
-                         size_t maximumLoadedFonts)
+                         size_t maximumLoadedFonts, size_t maximumFontValidationWork)
     : registry_(registry),
       provider_(g_defaultFontProvider.load(std::memory_order_acquire)),
-      candidateBudgetState_(std::make_shared<FontBudgetState>(
-          FontBudgetState{maximumLoadedFontBytes, maximumLoadedFonts, 0, 0})) {}
+      candidateBudgetState_(std::make_shared<FontBudgetState>(FontBudgetState{
+          maximumLoadedFontBytes, maximumLoadedFonts, maximumFontValidationWork, 0, 0, 0})) {}
 FontManager::~FontManager() = default;
 
 size_t FontManager::ProviderFontKeyHash::operator()(const ProviderFontKey& key) const noexcept {
@@ -570,6 +572,10 @@ size_t FontManager::loadedFontBytes() const {
 
 size_t FontManager::numLoadedFonts() const {
   return budgetStateForRead()->usedFonts;
+}
+
+size_t FontManager::fontValidationWork() const {
+  return budgetStateForRead()->usedValidationWork;
 }
 
 FontHandle FontManager::fallbackFont() {

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -532,6 +532,11 @@ bool FontManager::isTrustedFont(FontHandle handle) const {
   return font != nullptr && font->trust == FontDataTrust::Trusted;
 }
 
+std::optional<FontManager::GlyphOutlineComplexity> FontManager::glyphOutlineComplexity(
+    FontHandle /*handle*/, int /*glyphIndex*/) const {
+  return std::nullopt;
+}
+
 std::optional<std::span<const uint8_t>> FontManager::sfntTable(FontHandle handle,
                                                                std::string_view tag) const {
   if (!isValidHandle(handle)) {

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -578,6 +578,10 @@ size_t FontManager::fontValidationWork() const {
   return budgetStateForRead()->usedValidationWork;
 }
 
+size_t FontManager::numValidationRejectedSources() const {
+  return 0u;
+}
+
 FontHandle FontManager::fallbackFont() {
   if (isValidHandle(fallbackHandle_)) {
     return fallbackHandle_;

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -69,6 +69,19 @@ uint32_t readBE32(const uint8_t* p) {
          (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
 }
 
+bool HasCffFlavor(std::span<const uint8_t> data) {
+  if (data.size() < 4) return false;
+  const uint32_t magic = readBE32(data.data());
+  if (magic == kSfntCff) return true;
+  return (magic == kWoffMagic || magic == kWoff2Magic) && data.size() >= 8 &&
+         readBE32(data.data() + 4) == kSfntCff;
+}
+
+bool IsSupportedFontMagic(uint32_t magic) {
+  return magic == kWoffMagic || magic == kWoff2Magic || magic == kSfntTrueType ||
+         magic == kSfntCff || magic == kSfntApple || magic == kSfntType1;
+}
+
 /**
  * Reconstruct a flat sfnt byte stream from a WoffFont's decompressed tables.
  *
@@ -163,7 +176,8 @@ struct FontManager::FontBudgetState {
   size_t usedBytes = 0;
   size_t usedFonts = 0;
   size_t usedValidationWork = 0;
-  std::vector<std::weak_ptr<const std::vector<uint8_t>>> validationRejectedSources;
+  std::unordered_map<const std::vector<uint8_t>*, std::weak_ptr<const std::vector<uint8_t>>>
+      validationRejectedSources;
 };
 
 struct FontManager::FontBudgetContext {
@@ -492,15 +506,21 @@ bool FontManager::loadFontDataSharedIntoEntity(
     return false;
   }
 
+  const uint32_t magic = readBE32(data->data());
+  if (!IsSupportedFontMagic(magic)) {
+    return false;
+  }
+
   const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
-  if (isValidationRejectedSource(data, budgetState)) return false;
+  if (exhaustedValidationBudgetRejects(*data, trust, budgetState) ||
+      isValidationRejectedSource(data, budgetState)) {
+    return false;
+  }
   bool workLimitExceeded = false;
   const auto finishLoad = [&](bool loaded) {
     rememberValidationRejectedSource(data, workLimitExceeded, budgetState);
     return loaded;
   };
-
-  const uint32_t magic = readBE32(data->data());
 
   // WOFF fonts need decompression/reconstruction, so they create new owned buffers.
   if (magic == kWoffMagic) {
@@ -517,10 +537,6 @@ bool FontManager::loadFontDataSharedIntoEntity(
 #endif
   }
 
-  if (magic != kSfntTrueType && magic != kSfntCff && magic != kSfntApple && magic != kSfntType1) {
-    return false;
-  }
-
   // Raw TTF/OTF: share the data via shared_ptr (no copy).
   return finishLoad(setRawFontData(entity, data, trust, &workLimitExceeded));
 }
@@ -528,18 +544,27 @@ bool FontManager::loadFontDataSharedIntoEntity(
 bool FontManager::isValidationRejectedSource(
     const std::shared_ptr<const std::vector<uint8_t>>& data,
     const std::shared_ptr<FontBudgetState>& budgetState) const {
-  std::erase_if(budgetState->validationRejectedSources,
-                [](const auto& source) { return source.expired(); });
-  return std::any_of(budgetState->validationRejectedSources.begin(),
-                     budgetState->validationRejectedSources.end(),
-                     [&](const auto& source) { return source.lock() == data; });
+  const auto found = budgetState->validationRejectedSources.find(data.get());
+  if (found == budgetState->validationRejectedSources.end()) return false;
+  if (found->second.lock() == data) return true;
+  budgetState->validationRejectedSources.erase(found);
+  return false;
+}
+
+bool FontManager::exhaustedValidationBudgetRejects(
+    std::span<const uint8_t> data, FontDataTrust trust,
+    const std::shared_ptr<FontBudgetState>& budgetState) const {
+  return trust == FontDataTrust::Untrusted &&
+         budgetState->usedValidationWork >= budgetState->maximumValidationWork &&
+         HasCffFlavor(data);
 }
 
 void FontManager::rememberValidationRejectedSource(
     const std::shared_ptr<const std::vector<uint8_t>>& data, bool workLimitExceeded,
     const std::shared_ptr<FontBudgetState>& budgetState) {
-  if (workLimitExceeded) {
-    budgetState->validationRejectedSources.push_back(data);
+  if (workLimitExceeded &&
+      budgetState->validationRejectedSources.size() < budgetState->maximumFonts) {
+    budgetState->validationRejectedSources.insert_or_assign(data.get(), data);
   }
 }
 
@@ -606,11 +631,7 @@ size_t FontManager::fontValidationWork() const {
 }
 
 size_t FontManager::numValidationRejectedSources() const {
-  size_t count = 0;
-  for (const auto& source : budgetStateForRead()->validationRejectedSources) {
-    count += source.expired() ? 0u : 1u;
-  }
-  return count;
+  return budgetStateForRead()->validationRejectedSources.size();
 }
 
 FontHandle FontManager::fallbackFont() {
@@ -640,6 +661,12 @@ std::optional<fonts::SfntFont> FontManager::validateSfntForLoad(
     *validationWorkLimitExceeded = false;
   }
   if (!canStoreLoadedFont(entity, data.size(), 0, budgetState)) {
+    return std::nullopt;
+  }
+  if (exhaustedValidationBudgetRejects(data, trust, budgetState)) {
+    if (validationWorkLimitExceeded) {
+      *validationWorkLimitExceeded = true;
+    }
     return std::nullopt;
   }
 
@@ -785,6 +812,13 @@ bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t>
 
   const uint32_t magic = readBE32(data.data());
 
+  if (!IsSupportedFontMagic(magic)) {
+    return false;
+  }
+
+  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  if (exhaustedValidationBudgetRejects(data, trust, budgetState)) return false;
+
   if (magic == kWoffMagic) {
     return loadWoff1(entity, data, trust);
   }
@@ -799,12 +833,7 @@ bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t>
 #endif
   }
 
-  if (magic != kSfntTrueType && magic != kSfntCff && magic != kSfntApple && magic != kSfntType1) {
-    return false;
-  }
-
   // Validate and budget the retained index before copying the untrusted byte stream.
-  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
   auto sfnt = validateSfntForLoad(entity, data, trust, budgetState);
   if (!sfnt) {
     return false;

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -163,6 +163,7 @@ struct FontManager::FontBudgetState {
   size_t usedBytes = 0;
   size_t usedFonts = 0;
   size_t usedValidationWork = 0;
+  std::vector<std::weak_ptr<const std::vector<uint8_t>>> validationRejectedSources;
 };
 
 struct FontManager::FontBudgetContext {
@@ -250,7 +251,7 @@ FontManager::FontManager(Registry& registry, size_t maximumLoadedFontBytes,
     : registry_(registry),
       provider_(g_defaultFontProvider.load(std::memory_order_acquire)),
       candidateBudgetState_(std::make_shared<FontBudgetState>(FontBudgetState{
-          maximumLoadedFontBytes, maximumLoadedFonts, maximumFontValidationWork, 0, 0, 0})) {}
+          maximumLoadedFontBytes, maximumLoadedFonts, maximumFontValidationWork, 0, 0, 0, {}})) {}
 FontManager::~FontManager() = default;
 
 size_t FontManager::ProviderFontKeyHash::operator()(const ProviderFontKey& key) const noexcept {
@@ -491,16 +492,24 @@ bool FontManager::loadFontDataSharedIntoEntity(
     return false;
   }
 
+  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  if (isValidationRejectedSource(data, budgetState)) return false;
+  bool workLimitExceeded = false;
+  const auto finishLoad = [&](bool loaded) {
+    rememberValidationRejectedSource(data, workLimitExceeded, budgetState);
+    return loaded;
+  };
+
   const uint32_t magic = readBE32(data->data());
 
   // WOFF fonts need decompression/reconstruction, so they create new owned buffers.
   if (magic == kWoffMagic) {
-    return loadWoff1(entity, *data, trust);
+    return finishLoad(loadWoff1(entity, *data, trust, &workLimitExceeded));
   }
 
   if (magic == kWoff2Magic) {
 #ifdef DONNER_TEXT_WOFF2_ENABLED
-    return loadWoff2(entity, *data, trust);
+    return finishLoad(loadWoff2(entity, *data, trust, &workLimitExceeded));
 #else
     std::cerr << "FontManager: WOFF2 font encountered but WOFF2 support not enabled. "
                  "Build with --config=text-full to enable.\n";
@@ -513,7 +522,25 @@ bool FontManager::loadFontDataSharedIntoEntity(
   }
 
   // Raw TTF/OTF: share the data via shared_ptr (no copy).
-  return setRawFontData(entity, data, trust);
+  return finishLoad(setRawFontData(entity, data, trust, &workLimitExceeded));
+}
+
+bool FontManager::isValidationRejectedSource(
+    const std::shared_ptr<const std::vector<uint8_t>>& data,
+    const std::shared_ptr<FontBudgetState>& budgetState) const {
+  std::erase_if(budgetState->validationRejectedSources,
+                [](const auto& source) { return source.expired(); });
+  return std::any_of(budgetState->validationRejectedSources.begin(),
+                     budgetState->validationRejectedSources.end(),
+                     [&](const auto& source) { return source.lock() == data; });
+}
+
+void FontManager::rememberValidationRejectedSource(
+    const std::shared_ptr<const std::vector<uint8_t>>& data, bool workLimitExceeded,
+    const std::shared_ptr<FontBudgetState>& budgetState) {
+  if (workLimitExceeded) {
+    budgetState->validationRejectedSources.push_back(data);
+  }
 }
 
 std::span<const uint8_t> FontManager::fontData(FontHandle handle) const {
@@ -579,7 +606,11 @@ size_t FontManager::fontValidationWork() const {
 }
 
 size_t FontManager::numValidationRejectedSources() const {
-  return 0u;
+  size_t count = 0;
+  for (const auto& source : budgetStateForRead()->validationRejectedSources) {
+    count += source.expired() ? 0u : 1u;
+  }
+  return count;
 }
 
 FontHandle FontManager::fallbackFont() {
@@ -602,8 +633,43 @@ FontHandle FontManager::fallbackFont() {
   return fallbackHandle_;
 }
 
-bool FontManager::setRawFontData(Entity entity, std::vector<uint8_t> data, FontDataTrust trust) {
-  auto sfnt = fonts::SfntFont::Validate(data);
+std::optional<fonts::SfntFont> FontManager::validateSfntForLoad(
+    Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+    const std::shared_ptr<FontBudgetState>& budgetState, bool* validationWorkLimitExceeded) {
+  if (validationWorkLimitExceeded) {
+    *validationWorkLimitExceeded = false;
+  }
+  if (!canStoreLoadedFont(entity, data.size(), 0, budgetState)) {
+    return std::nullopt;
+  }
+
+  assert(budgetState->usedValidationWork <= budgetState->maximumValidationWork);
+  const size_t remainingValidationWork =
+      budgetState->maximumValidationWork - budgetState->usedValidationWork;
+  const size_t perCallValidationWork =
+      trust == FontDataTrust::Trusted
+          ? fonts::kMaximumCffOutlineValidationWork
+          : std::min(remainingValidationWork, fonts::kMaximumCffOutlineValidationWork);
+  fonts::SfntValidationMetrics metrics;
+  auto sfnt = fonts::SfntFont::Validate(data, {.maximumCffValidationWork = perCallValidationWork},
+                                        &metrics);
+  if (trust == FontDataTrust::Untrusted) {
+    assert(metrics.cffValidationWork <= remainingValidationWork);
+    budgetState->usedValidationWork += metrics.cffValidationWork;
+  }
+  if (metrics.cffWorkLimitExceeded) {
+    if (validationWorkLimitExceeded) {
+      *validationWorkLimitExceeded = true;
+    }
+    return std::nullopt;
+  }
+  return sfnt;
+}
+
+bool FontManager::setRawFontData(Entity entity, std::vector<uint8_t> data, FontDataTrust trust,
+                                 bool* validationWorkLimitExceeded) {
+  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  auto sfnt = validateSfntForLoad(entity, data, trust, budgetState, validationWorkLimitExceeded);
   if (!sfnt) {
     return false;
   }
@@ -617,11 +683,13 @@ bool FontManager::setRawFontData(Entity entity, std::vector<uint8_t> data, FontD
 
 bool FontManager::setRawFontData(Entity entity,
                                  std::shared_ptr<const std::vector<uint8_t>> sharedData,
-                                 FontDataTrust trust) {
+                                 FontDataTrust trust, bool* validationWorkLimitExceeded) {
   if (!sharedData) {
     return false;
   }
-  auto sfnt = fonts::SfntFont::Validate(*sharedData);
+  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  auto sfnt =
+      validateSfntForLoad(entity, *sharedData, trust, budgetState, validationWorkLimitExceeded);
   if (!sfnt) {
     return false;
   }
@@ -693,7 +761,8 @@ bool FontManager::canStoreLoadedFont(Entity entity, size_t rawBytes, size_t inde
   return true;
 }
 
-bool FontManager::loadWoff1(Entity entity, std::span<const uint8_t> data, FontDataTrust trust) {
+bool FontManager::loadWoff1(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+                            bool* validationWorkLimitExceeded) {
   const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
   fonts::WoffParser::Options options;
   options.maximumSfntSize = std::min(options.maximumSfntSize, budgetState->maximumBytes);
@@ -705,7 +774,7 @@ bool FontManager::loadWoff1(Entity entity, std::span<const uint8_t> data, FontDa
 
   // Reconstruct sfnt byte stream from decompressed WOFF tables.
   std::vector<uint8_t> sfntData = reconstructSfnt(maybeFont.result());
-  return setRawFontData(entity, std::move(sfntData), trust);
+  return setRawFontData(entity, std::move(sfntData), trust, validationWorkLimitExceeded);
 }
 
 bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t> data,
@@ -735,11 +804,11 @@ bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t>
   }
 
   // Validate and budget the retained index before copying the untrusted byte stream.
-  auto sfnt = fonts::SfntFont::Validate(data);
+  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
+  auto sfnt = validateSfntForLoad(entity, data, trust, budgetState);
   if (!sfnt) {
     return false;
   }
-  const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
   if (!canStoreLoadedFont(entity, data.size(), sfnt->retainedBytes(), budgetState)) {
     return false;
   }
@@ -751,7 +820,8 @@ bool FontManager::loadFontDataIntoEntity(Entity entity, std::span<const uint8_t>
 }
 
 #ifdef DONNER_TEXT_WOFF2_ENABLED
-bool FontManager::loadWoff2(Entity entity, std::span<const uint8_t> data, FontDataTrust trust) {
+bool FontManager::loadWoff2(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+                            bool* validationWorkLimitExceeded) {
   const std::shared_ptr<FontBudgetState> budgetState = budgetStateForWrite();
   fonts::Woff2Parser::Options options;
   options.maximumOutputSize = std::min(options.maximumOutputSize, budgetState->maximumBytes);
@@ -761,7 +831,7 @@ bool FontManager::loadWoff2(Entity entity, std::span<const uint8_t> data, FontDa
     return false;
   }
 
-  return setRawFontData(entity, std::move(result.result()), trust);
+  return setRawFontData(entity, std::move(result.result()), trust, validationWorkLimitExceeded);
 }
 #endif
 

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -345,6 +345,8 @@ private:
                                     FontDataTrust trust);
   bool isValidationRejectedSource(const std::shared_ptr<const std::vector<uint8_t>>& data,
                                   const std::shared_ptr<FontBudgetState>& budgetState) const;
+  bool exhaustedValidationBudgetRejects(std::span<const uint8_t> data, FontDataTrust trust,
+                                        const std::shared_ptr<FontBudgetState>& budgetState) const;
   void rememberValidationRejectedSource(const std::shared_ptr<const std::vector<uint8_t>>& data,
                                         bool workLimitExceeded,
                                         const std::shared_ptr<FontBudgetState>& budgetState);

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -372,6 +372,9 @@ private:
    */
   bool loadFontDataIntoEntity(Entity entity, std::span<const uint8_t> data, FontDataTrust trust);
 
+  /// Number of immutable @font-face sources memoized after permanent validation rejection.
+  size_t numValidationRejectedSources() const;
+
   /// Returns true if \p handle refers to a live font entity in the registry.
   bool isValidHandle(FontHandle handle) const;
 

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -84,6 +84,12 @@ namespace donner::svg {
  */
 class FontManager {
 public:
+  /// Validation-time allocation/work bound for one font outline.
+  struct GlyphOutlineComplexity {
+    std::size_t maximumVertices = 0;
+    std::size_t work = 0;
+  };
+
   /// Default aggregate byte budget for font data loaded into one registry.
   static constexpr size_t kDefaultMaximumLoadedFontBytes = 64 * 1024 * 1024;
 
@@ -209,6 +215,10 @@ public:
 
   /// Returns whether @p handle was loaded from an explicitly trusted source.
   bool isTrustedFont(FontHandle handle) const;
+
+  /// Return a lifetime-safe O(1) pre-decode bound for a validated glyph.
+  std::optional<GlyphOutlineComplexity> glyphOutlineComplexity(FontHandle handle,
+                                                               int glyphIndex) const;
 
   /**
    * Get a table from the cached, validated sfnt directory for a handle.

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -247,6 +247,9 @@ public:
   /// CFF validation work permanently consumed by load attempts in this registry.
   size_t fontValidationWork() const;
 
+  /// Compressed-font decompression attempts performed for this registry.
+  size_t compressedFontDecompressionAttempts() const;
+
   /**
    * Get the number of registered `@font-face` rules.
    */

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "donner/base/EcsRegistry.h"
+#include "donner/base/fonts/SfntUtils.h"
 #include "donner/css/FontFace.h"
 #include "donner/svg/resources/FontCatalogTypes.h"
 
@@ -97,15 +98,16 @@ public:
   static constexpr size_t kDefaultMaximumLoadedFonts = 1024;
 
   /// Default aggregate CFF validation work admitted for one registry.
-  static constexpr size_t kDefaultMaximumFontValidationWork = 64 * 1024 * 1024;
+  static constexpr size_t kDefaultMaximumFontValidationWork =
+      fonts::kMaximumCffOutlineValidationWork;
 
   /**
    * Construct a FontManager tied to the provided ECS @p registry.
    *
    * The first manager to perform a serialized font load for a registry establishes its aggregate
-   * byte and item limits. Read-only queries never establish or replace that state. Later manager
-   * instances for the same registry share it so loaded components remain accounted across manager
-   * lifetimes.
+   * byte, item, and untrusted CFF-validation limits. Read-only queries never establish or replace
+   * that state. Later manager instances for the same registry share it so loaded components and
+   * validation attempts remain accounted across manager lifetimes.
    *
    * Construction does not access the registry context, so a FontManager can itself be safely
    * constructed by `registry.ctx().emplace<FontManager>(registry)`.
@@ -319,9 +321,10 @@ private:
    * @param data Owned font data buffer. Must remain valid for the lifetime of the FontManager.
    * @return True on success.
    */
-  bool setRawFontData(Entity entity, std::vector<uint8_t> data, FontDataTrust trust);
+  bool setRawFontData(Entity entity, std::vector<uint8_t> data, FontDataTrust trust,
+                      bool* validationWorkLimitExceeded = nullptr);
   bool setRawFontData(Entity entity, std::shared_ptr<const std::vector<uint8_t>> sharedData,
-                      FontDataTrust trust);
+                      FontDataTrust trust, bool* validationWorkLimitExceeded = nullptr);
 
   /** Return the registry budget when installed, otherwise this manager's private candidate. */
   std::shared_ptr<const FontBudgetState> budgetStateForRead() const;
@@ -340,6 +343,15 @@ private:
   bool loadFontDataSharedIntoEntity(Entity entity,
                                     const std::shared_ptr<const std::vector<uint8_t>>& data,
                                     FontDataTrust trust);
+  bool isValidationRejectedSource(const std::shared_ptr<const std::vector<uint8_t>>& data,
+                                  const std::shared_ptr<FontBudgetState>& budgetState) const;
+  void rememberValidationRejectedSource(const std::shared_ptr<const std::vector<uint8_t>>& data,
+                                        bool workLimitExceeded,
+                                        const std::shared_ptr<FontBudgetState>& budgetState);
+  std::optional<fonts::SfntFont> validateSfntForLoad(
+      Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+      const std::shared_ptr<FontBudgetState>& budgetState,
+      bool* validationWorkLimitExceeded = nullptr);
 
   /**
    * Internal: load a WOFF 1.0 font by parsing and reconstructing the sfnt byte stream.
@@ -348,7 +360,8 @@ private:
    * @param data Raw WOFF data.
    * @return True on success.
    */
-  bool loadWoff1(Entity entity, std::span<const uint8_t> data, FontDataTrust trust);
+  bool loadWoff1(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+                 bool* validationWorkLimitExceeded = nullptr);
 
 #ifdef DONNER_TEXT_WOFF2_ENABLED
   /**
@@ -360,7 +373,8 @@ private:
    * @param data Raw WOFF2 data.
    * @return True on success.
    */
-  bool loadWoff2(Entity entity, std::span<const uint8_t> data, FontDataTrust trust);
+  bool loadWoff2(Entity entity, std::span<const uint8_t> data, FontDataTrust trust,
+                 bool* validationWorkLimitExceeded = nullptr);
 #endif
 
   /**

--- a/donner/svg/resources/FontManager.h
+++ b/donner/svg/resources/FontManager.h
@@ -96,6 +96,9 @@ public:
   /// Default maximum number of font byte streams retained in one registry.
   static constexpr size_t kDefaultMaximumLoadedFonts = 1024;
 
+  /// Default aggregate CFF validation work admitted for one registry.
+  static constexpr size_t kDefaultMaximumFontValidationWork = 64 * 1024 * 1024;
+
   /**
    * Construct a FontManager tied to the provided ECS @p registry.
    *
@@ -109,7 +112,8 @@ public:
    */
   explicit FontManager(Registry& registry,
                        size_t maximumLoadedFontBytes = kDefaultMaximumLoadedFontBytes,
-                       size_t maximumLoadedFonts = kDefaultMaximumLoadedFonts);
+                       size_t maximumLoadedFonts = kDefaultMaximumLoadedFonts,
+                       size_t maximumFontValidationWork = kDefaultMaximumFontValidationWork);
   /// Destructor.
   ~FontManager();
 
@@ -237,6 +241,9 @@ public:
 
   /// Number of loaded font components currently charged to this registry's budget.
   size_t numLoadedFonts() const;
+
+  /// CFF validation work permanently consumed by load attempts in this registry.
+  size_t fontValidationWork() const;
 
   /**
    * Get the number of registered `@font-face` rules.

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -220,6 +220,56 @@ TEST(FontManagerTest, RejectedFontDoesNotConsumeAggregateBudget) {
   EXPECT_EQ(mgr.numLoadedFonts(), 0u);
 }
 
+TEST(FontManagerTest, CffValidationWorkIsAggregateAcrossManagersAndAttempts) {
+  Registry registry;
+  const std::vector<uint8_t> cff(embedded::kPublicSansMediumOtf.begin(),
+                                 embedded::kPublicSansMediumOtf.end());
+  FontManager first(registry, FontManager::kDefaultMaximumLoadedFontBytes,
+                    FontManager::kDefaultMaximumLoadedFonts, 1);
+
+  EXPECT_FALSE(static_cast<bool>(first.loadFontData(cff)));
+  EXPECT_EQ(first.fontValidationWork(), 1u);
+
+  FontManager peer(registry, FontManager::kDefaultMaximumLoadedFontBytes,
+                   FontManager::kDefaultMaximumLoadedFonts,
+                   FontManager::kDefaultMaximumFontValidationWork);
+  EXPECT_EQ(peer.fontValidationWork(), 1u);
+  EXPECT_FALSE(static_cast<bool>(peer.loadFontData(cff)));
+  EXPECT_EQ(peer.fontValidationWork(), 1u);
+}
+
+TEST(FontManagerTest, ExhaustedCffWorkBudgetPreservesReplacementAndAllowsTrueType) {
+  Registry registry;
+  const std::vector<uint8_t> trueType = readFile("donner/base/fonts/testdata/valid-001.woff");
+  const std::vector<uint8_t> cff(embedded::kPublicSansMediumOtf.begin(),
+                                 embedded::kPublicSansMediumOtf.end());
+  ASSERT_FALSE(trueType.empty());
+  FontManager manager(registry, FontManager::kDefaultMaximumLoadedFontBytes,
+                      FontManager::kDefaultMaximumLoadedFonts, 0);
+
+  const FontHandle handle = manager.loadFontData(trueType);
+  ASSERT_TRUE(static_cast<bool>(handle));
+  const std::vector<uint8_t> original(manager.fontData(handle).begin(),
+                                      manager.fontData(handle).end());
+  EXPECT_FALSE(FontManagerTestAccess::ReplaceFontData(manager, handle, cff));
+  ASSERT_EQ(manager.fontData(handle).size(), original.size());
+  EXPECT_THAT(manager.fontData(handle), testing::ElementsAreArray(original));
+  EXPECT_EQ(manager.fontValidationWork(), 0u);
+
+  EXPECT_TRUE(FontManagerTestAccess::ReplaceFontData(manager, handle, trueType));
+  EXPECT_TRUE(static_cast<bool>(manager.glyphOutlineComplexity(handle, 1)));
+}
+
+TEST(FontManagerTest, SuccessfulCffLoadChargesMeasuredValidationWork) {
+  Registry registry;
+  FontManager manager(registry);
+  const std::vector<uint8_t> cff(embedded::kPublicSansMediumOtf.begin(),
+                                 embedded::kPublicSansMediumOtf.end());
+
+  ASSERT_TRUE(static_cast<bool>(manager.loadFontData(cff)));
+  EXPECT_GT(manager.fontValidationWork(), 0u);
+}
+
 TEST(FontManagerTest, ReplacementUpdatesExactAggregateCharge) {
   Registry registry;
   const std::vector<uint8_t> original(embedded::kPublicSansMediumOtf.begin(),

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -29,6 +29,10 @@ struct FontManagerTestAccess {
   static bool HasPersistentBudgetState(const Registry& registry) {
     return registry.ctx().contains<FontManager::FontBudgetContext>();
   }
+
+  static size_t NumValidationRejectedSources(const FontManager& manager) {
+    return manager.numValidationRejectedSources();
+  }
 };
 
 namespace {
@@ -178,7 +182,10 @@ TEST(FontManagerTest, EnforcesAggregateLoadedFontBudget) {
   FontManager mgr(registry, RetainedCharge(data));
 
   EXPECT_TRUE(static_cast<bool>(mgr.loadFontData(data)));
+  const size_t validationWorkAfterAdmission = mgr.fontValidationWork();
+  EXPECT_GT(validationWorkAfterAdmission, 0u);
   EXPECT_FALSE(static_cast<bool>(mgr.loadFontData(data)));
+  EXPECT_EQ(mgr.fontValidationWork(), validationWorkAfterAdmission);
 }
 
 TEST(FontManagerTest, AccountsExactFontAndCachedIndexBytes) {
@@ -240,7 +247,7 @@ TEST(FontManagerTest, CffValidationWorkIsAggregateAcrossManagersAndAttempts) {
 
 TEST(FontManagerTest, ExhaustedCffWorkBudgetPreservesReplacementAndAllowsTrueType) {
   Registry registry;
-  const std::vector<uint8_t> trueType = readFile("donner/base/fonts/testdata/valid-001.woff");
+  const std::vector<uint8_t> trueType = readFile("third_party/roboto/Roboto-Regular.ttf");
   const std::vector<uint8_t> cff(embedded::kPublicSansMediumOtf.begin(),
                                  embedded::kPublicSansMediumOtf.end());
   ASSERT_FALSE(trueType.empty());
@@ -268,6 +275,29 @@ TEST(FontManagerTest, SuccessfulCffLoadChargesMeasuredValidationWork) {
 
   ASSERT_TRUE(static_cast<bool>(manager.loadFontData(cff)));
   EXPECT_GT(manager.fontValidationWork(), 0u);
+}
+
+TEST(FontManagerTest, PermanentlyRejectedFontFaceSourceIsNotRevalidated) {
+  Registry registry;
+  FontManager manager(registry, FontManager::kDefaultMaximumLoadedFontBytes,
+                      FontManager::kDefaultMaximumLoadedFonts, 1);
+  css::FontFace face;
+  face.familyName = RcString("RejectedCff");
+  css::FontFaceSource source;
+  source.kind = css::FontFaceSource::Kind::Data;
+  source.payload = std::make_shared<const std::vector<uint8_t>>(
+      embedded::kPublicSansMediumOtf.begin(), embedded::kPublicSansMediumOtf.end());
+  face.sources.push_back(std::move(source));
+  manager.addFontFace(face);
+
+  const FontHandle first = manager.findFont("RejectedCff");
+  ASSERT_TRUE(static_cast<bool>(first));
+  EXPECT_EQ(manager.fontValidationWork(), 1u);
+  EXPECT_EQ(FontManagerTestAccess::NumValidationRejectedSources(manager), 1u);
+
+  EXPECT_EQ(manager.findFont("RejectedCff"), first);
+  EXPECT_EQ(manager.fontValidationWork(), 1u);
+  EXPECT_EQ(FontManagerTestAccess::NumValidationRejectedSources(manager), 1u);
 }
 
 TEST(FontManagerTest, ReplacementUpdatesExactAggregateCharge) {

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -33,6 +33,10 @@ struct FontManagerTestAccess {
   static size_t NumValidationRejectedSources(const FontManager& manager) {
     return manager.numValidationRejectedSources();
   }
+
+  static size_t CompressedFontDecompressionAttempts(const FontManager& manager) {
+    return manager.compressedFontDecompressionAttempts();
+  }
 };
 
 namespace {
@@ -46,6 +50,16 @@ std::vector<uint8_t> readFile(const std::string& path) {
   std::ifstream file(path, std::ios::binary);
   return std::vector<uint8_t>(std::istreambuf_iterator<char>(file),
                               std::istreambuf_iterator<char>());
+}
+
+std::vector<uint8_t> WithCompressedFlavor(std::vector<uint8_t> data, uint32_t flavor) {
+  EXPECT_GE(data.size(), 8u);
+  if (data.size() < 8) return {};
+  data[4] = static_cast<uint8_t>(flavor >> 24);
+  data[5] = static_cast<uint8_t>(flavor >> 16);
+  data[6] = static_cast<uint8_t>(flavor >> 8);
+  data[7] = static_cast<uint8_t>(flavor);
+  return data;
 }
 
 /// A FontFamilyProvider that serves a fixed set of family names (Public Sans bytes for all) and
@@ -487,6 +501,51 @@ TEST(FontManagerTest, LoadWoff1Data) {
   FontHandle trustedHandle = mgr.loadFontData(woffData, FontDataTrust::Trusted);
   EXPECT_TRUE(static_cast<bool>(trustedHandle));
   EXPECT_TRUE(mgr.isTrustedFont(trustedHandle));
+}
+
+TEST(FontManagerTest, CffWorkExhaustionRejectsMislabeledCompressedFontsBeforeDecompression) {
+  Registry registry;
+  FontManager manager(registry, FontManager::kDefaultMaximumLoadedFontBytes,
+                      FontManager::kDefaultMaximumLoadedFonts, 1);
+  const std::vector<uint8_t> cff(embedded::kPublicSansMediumOtf.begin(),
+                                 embedded::kPublicSansMediumOtf.end());
+  EXPECT_FALSE(static_cast<bool>(manager.loadFontData(cff)));
+  ASSERT_EQ(manager.fontValidationWork(), 1u);
+
+  const std::vector<uint8_t> mislabeledWoff =
+      WithCompressedFlavor(readFile("donner/base/fonts/testdata/valid-001.woff"), 0x00010000);
+  ASSERT_FALSE(mislabeledWoff.empty());
+  EXPECT_FALSE(static_cast<bool>(manager.loadFontData(mislabeledWoff)));
+  EXPECT_FALSE(static_cast<bool>(manager.loadFontData(std::vector<uint8_t>(mislabeledWoff))));
+
+#ifdef DONNER_TEXT_WOFF2_ENABLED
+  const std::vector<uint8_t> mislabeledWoff2 =
+      WithCompressedFlavor(readFile("donner/base/fonts/testdata/valid-001.woff2"), 0x00010000);
+  ASSERT_FALSE(mislabeledWoff2.empty());
+  EXPECT_FALSE(static_cast<bool>(manager.loadFontData(mislabeledWoff2)));
+#endif
+
+  EXPECT_EQ(FontManagerTestAccess::CompressedFontDecompressionAttempts(manager), 0u);
+
+  const std::vector<uint8_t> trueType = readFile("third_party/roboto/Roboto-Regular.ttf");
+  ASSERT_FALSE(trueType.empty());
+  EXPECT_TRUE(static_cast<bool>(manager.loadFontData(trueType)));
+  EXPECT_EQ(FontManagerTestAccess::CompressedFontDecompressionAttempts(manager), 0u);
+}
+
+TEST(FontManagerTest, MislabeledCompressedCffStillLoadsBeforeValidationBudgetExhaustion) {
+  Registry registry;
+  FontManager manager(registry);
+  const std::vector<uint8_t> mislabeledWoff =
+      WithCompressedFlavor(readFile("donner/base/fonts/testdata/valid-001.woff"), 0x00010000);
+  ASSERT_FALSE(mislabeledWoff.empty());
+
+  const FontHandle handle = manager.loadFontData(mislabeledWoff);
+  ASSERT_TRUE(static_cast<bool>(handle));
+  EXPECT_GT(manager.fontValidationWork(), 0u);
+  EXPECT_EQ(FontManagerTestAccess::CompressedFontDecompressionAttempts(manager), 1u);
+  EXPECT_TRUE(FontManagerTestAccess::ReplaceFontData(manager, handle, mislabeledWoff));
+  EXPECT_EQ(FontManagerTestAccess::CompressedFontDecompressionAttempts(manager), 2u);
 }
 
 TEST(FontManagerTest, ReplacementUsesNewTrustAndRejectedReplacementPreservesOldTrust) {

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -373,6 +373,8 @@ TEST(FontManagerTest, LoadWoff1Data) {
   EXPECT_TRUE(static_cast<bool>(handle));
   EXPECT_FALSE(mgr.isTrustedFont(handle));
   EXPECT_FALSE(mgr.fontData(handle).empty());
+  const auto complexity = mgr.glyphOutlineComplexity(handle, 1);
+  ASSERT_TRUE(complexity.has_value());
 
   FontHandle trustedHandle = mgr.loadFontData(woffData, FontDataTrust::Trusted);
   EXPECT_TRUE(static_cast<bool>(trustedHandle));

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -300,6 +300,34 @@ TEST(FontManagerTest, PermanentlyRejectedFontFaceSourceIsNotRevalidated) {
   EXPECT_EQ(FontManagerTestAccess::NumValidationRejectedSources(manager), 1u);
 }
 
+TEST(FontManagerTest, ExhaustedCffWorkDoesNotGrowRejectionMetadataForDistinctSources) {
+  Registry registry;
+  FontManager manager(registry, FontManager::kDefaultMaximumLoadedFontBytes, 256, 1);
+  FontHandle fallback;
+
+  for (int sourceIndex = 0; sourceIndex < 128; ++sourceIndex) {
+    css::FontFace face;
+    face.familyName = RcString("RejectedCff" + std::to_string(sourceIndex));
+    css::FontFaceSource source;
+    source.kind = css::FontFaceSource::Kind::Data;
+    source.payload = std::make_shared<const std::vector<uint8_t>>(
+        embedded::kPublicSansMediumOtf.begin(), embedded::kPublicSansMediumOtf.end());
+    face.sources.push_back(std::move(source));
+    manager.addFontFace(face);
+
+    const FontHandle resolved = manager.findFont(face.familyName);
+    ASSERT_TRUE(static_cast<bool>(resolved));
+    if (sourceIndex == 0) {
+      fallback = resolved;
+    } else {
+      EXPECT_EQ(resolved, fallback);
+    }
+  }
+
+  EXPECT_EQ(manager.fontValidationWork(), 1u);
+  EXPECT_EQ(FontManagerTestAccess::NumValidationRejectedSources(manager), 1u);
+}
+
 TEST(FontManagerTest, ReplacementUpdatesExactAggregateCharge) {
   Registry registry;
   const std::vector<uint8_t> original(embedded::kPublicSansMediumOtf.begin(),

--- a/donner/svg/text/TextBackendFull.cc
+++ b/donner/svg/text/TextBackendFull.cc
@@ -73,6 +73,22 @@ bool HasCachedOutlineTables(const FontManager& fontManager, FontHandle font) {
          fontManager.sfntTable(font, "CFF2").has_value();
 }
 
+bool CanDecodeGlyphOutline(const FontManager& fontManager, FontHandle font, int glyphIndex,
+                           float scale) {
+  return glyphIndex >= 0 && std::isfinite(scale) && scale >= 0.0f &&
+         (fontManager.isTrustedFont(font) ||
+          fontManager.glyphOutlineComplexity(font, glyphIndex).has_value());
+}
+
+std::optional<float> CheckedFontSizePx(float scale, unsigned int unitsPerEm) {
+  const float fontSizePx = scale * static_cast<float>(unitsPerEm);
+  constexpr float kMaximumFontSizePx =
+      static_cast<float>(std::numeric_limits<FT_F26Dot6>::max() / 64);
+  return std::isfinite(fontSizePx) && fontSizePx <= kMaximumFontSizePx
+             ? std::optional<float>(fontSizePx)
+             : std::nullopt;
+}
+
 /// Small-caps synthesis scale factor.
 constexpr float kSmallCapScale = 0.8f;
 
@@ -375,6 +391,9 @@ std::optional<SubSuperMetrics> TextBackendFull::subSuperMetrics(FontHandle font)
 // ---------------------------------------------------------------------------
 
 Path TextBackendFull::glyphOutline(FontHandle font, int glyphIndex, float scale) const {
+  if (!CanDecodeGlyphOutline(fontManager_, font, glyphIndex, scale)) {
+    return {};
+  }
   hb_font_t* hbFont = getOrCreateHbFont(font);
   if (!hbFont) {
     return {};
@@ -383,14 +402,17 @@ Path TextBackendFull::glyphOutline(FontHandle font, int glyphIndex, float scale)
   // The `scale` parameter is fontSizePx / upem (same as stbtt_ScaleForMappingEmToPixels).
   // Convert back to fontSizePx for FreeType.
   const unsigned int upem = hb_face_get_upem(hb_font_get_face(hbFont));
-  const float fontSizePx = scale * static_cast<float>(upem);
+  const std::optional<float> fontSizePx = CheckedFontSizePx(scale, upem);
+  if (!fontSizePx.has_value()) {
+    return {};
+  }
 
   // Get the FreeType face and set it to the correct size.
   FT_Face ftFace = hb_ft_font_get_ft_face(hbFont);
   if (!ftFace) {
     return {};
   }
-  FT_Set_Char_Size(ftFace, 0, static_cast<FT_F26Dot6>(fontSizePx * 64.0f), 72, 72);
+  FT_Set_Char_Size(ftFace, 0, static_cast<FT_F26Dot6>(*fontSizePx * 64.0f), 72, 72);
 
   // Use NO_HINTING to match the HarfBuzz font configuration (set in getOrCreateHbFont).
   // Hinted outlines differ from unhinted metrics, causing shape/position mismatches
@@ -409,8 +431,8 @@ Path TextBackendFull::glyphOutline(FontHandle font, int glyphIndex, float scale)
   // Dividing by 64 gives the pixel coordinates, which match the caller's expected scale
   // because we set FreeType's size to `scale * upem`.
   PathBuilder builder;
-  const double ftScaleX = pixelScaleForPpem(ftFace, fontSizePx, true);
-  const double ftScaleY = pixelScaleForPpem(ftFace, fontSizePx, false);
+  const double ftScaleX = pixelScaleForPpem(ftFace, *fontSizePx, true);
+  const double ftScaleY = pixelScaleForPpem(ftFace, *fontSizePx, false);
 
   FT_Outline_Funcs funcs{};
   struct FtCtx {


### PR DESCRIPTION
Bounds renderer geometry, surface, text, and font-outline materialization before attacker-controlled work can expand or persist.

- Distinguishes benign empty geometry from explicit rejection and bounds cubic-to-quadratic expansion before temporary output grows.
- Enforces shared Geode frame, document, and resource-family budgets across ordinary fill/stroke encodes, common submission paths, resident slabs, clip/layer/mask/pattern textures, glyph caches, text records, transient fallbacks, and offscreen renderers.
- Charges TinySkia path measurement, dash work, clip geometry and masks, gradient stops, text outlines, and retained clip epochs with checked cap and cap-plus-one behavior.
- Validates CFF1 and static CFF2 Type 2 charstrings before outline decode, including subroutines, hint masks, bounded legacy composites, stack/depth/point/work limits, and aggregate multi-font admission. Variable CFF2 remains fail-closed.
- Preserves valid Bravura and legacy CFF rendering, checked viewport conversion, and valid stroke-only, scene-demotion, and cache-fallback behavior.

This is the final renderer layer above #1047 in stack #1050.

Validation:

- `bazelisk test //... --test_tag_filters=-manual,-perf --test_output=errors` (356 passed, 129 configuration skips)
- UBSan text-full SFNT, FontManager, renderer public API, and embedded-font tests
- ASan-fuzzer SFNT, font-decoder, and SVG-render corpora
- Default, TinySkia, Geode, text-full, and no-text focused renderer suites
- Native Geode Wasm build and editor Wasm package-size ratchets
- `tools/lint.sh`
- `python3 tools/cmake/gen_cmakelists.py --check`
- Independent exact-range security, code, history, privacy, and build-boundary review
