### PR TITLE
Account retained complex-property capacity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -760,6 +760,9 @@ jobs:
           stall_limit="${BAZEL_STALL_LIMIT_SECONDS:-900}"
           heartbeat_interval="${BAZEL_HEARTBEAT_INTERVAL_SECONDS:-60}"
           stall_report="$(dirname "$log_path")/stall.txt"
+          heartbeat_control="${log_path}.heartbeat-control.$$"
+          mkfifo "$heartbeat_control"
+          exec 9<> "$heartbeat_control"
 
           # Killing only the launcher is not enough: bazelisk forks the Bazel
           # client, which keeps the write end of this pipeline open, so `tee`
@@ -793,40 +796,20 @@ jobs:
             kill "-$signal" "$root" 2>/dev/null || true
           }
 
+          set +e
           {
+            set -e
             "$@" &
             command_pid=$!
 
             (
               last_progress=""
               last_change=$SECONDS
-              sleep_pid=""
-              stop_requested=false
-
-              request_heartbeat_stop() {
-                stop_requested=true
-              }
-
-              stop_heartbeat() {
-                if [[ -n "$sleep_pid" ]]; then
-                  kill "$sleep_pid" 2>/dev/null || true
-                  wait "$sleep_pid" 2>/dev/null || true
-                fi
-                exit 0
-              }
-              trap request_heartbeat_stop TERM INT
 
               while kill -0 "$command_pid" 2>/dev/null; do
-                # Defer exit until the newly forked sleeper's PID is published below.
-                trap request_heartbeat_stop TERM INT
-                sleep "$heartbeat_interval" &
-                sleep_pid=$!
-                trap stop_heartbeat TERM INT
-                if [[ "$stop_requested" == true ]]; then
-                  stop_heartbeat
+                if IFS= read -r -t "$heartbeat_interval" _ <&9; then
+                  exit 0
                 fi
-                wait "$sleep_pid" || exit 0
-                sleep_pid=""
                 kill -0 "$command_pid" 2>/dev/null || break
 
                 # Ignore our own annotations so the watchdog cannot see its own
@@ -864,13 +847,15 @@ jobs:
             status=$?
             set -e
 
-            # The watcher owns and traps its sleeper, so terminating it cannot
-            # leave an orphan holding this pipeline until the interval expires.
-            kill -TERM "$heartbeat_pid" 2>/dev/null || true
+            printf 'stop\n' >&9
             wait "$heartbeat_pid" 2>/dev/null || true
             exit "$status"
           } 2>&1 | tee "$log_path"
-          exit "${PIPESTATUS[0]}"
+          status="${PIPESTATUS[0]}"
+          set -e
+          exec 9>&-
+          rm -f "$heartbeat_control"
+          exit "$status"
           EOF
           chmod +x "$DIAG_DIR/run_bazel_with_heartbeat.sh"
 

--- a/donner/svg/components/style/tests/StyleSystem_tests.cc
+++ b/donner/svg/components/style/tests/StyleSystem_tests.cc
@@ -677,6 +677,29 @@ TEST(StyleResourceBudgetTest, SharesRetainedBytesAcrossDocumentFamily) {
   EXPECT_EQ(family->retainedBytes(DocumentResourceFamilyBudget::Kind::ComputedStyle), 0u);
 }
 
+TEST(StyleResourceBudgetTest, SpareVectorCapacityReachesExactCapThenRejectsPlusOne) {
+  StrokeDasharray dasharray;
+  dasharray.reserve(8);
+  dasharray.emplace_back(1.0, Lengthd::Unit::Px);
+  const std::size_t retainedCapacityBytes = dasharray.capacity() * sizeof(Lengthd);
+
+  PropertyRegistry properties;
+  properties.strokeDasharray.set(std::move(dasharray), css::Specificity());
+
+  StyleResourceBudget::Limits limits;
+  limits.complexPropertyBytes = retainedCapacityBytes;
+  StyleResourceBudget budget(limits);
+  Registry registry;
+  const Entity atCap = registry.create();
+  const Entity plusOne = registry.create();
+
+  EXPECT_TRUE(budget.reserveComplexPropertyBytes(atCap, properties.complexPropertyBytes()));
+  EXPECT_EQ(budget.complexPropertyBytes(), retainedCapacityBytes);
+  EXPECT_FALSE(budget.reserveComplexPropertyBytes(plusOne, 1));
+  EXPECT_EQ(budget.complexPropertyBytes(), retainedCapacityBytes);
+  EXPECT_TRUE(budget.rejected());
+}
+
 TEST(StyleResourceBudgetTest, ChargesDeclarationSourceBytesPerApplication) {
   StyleResourceBudget::Limits limits;
   limits.declarationByteWork = 1024;

--- a/donner/svg/properties/PropertyRegistry.cc
+++ b/donner/svg/properties/PropertyRegistry.cc
@@ -33,22 +33,30 @@ void SaturatingAdd(std::size_t& destination, std::size_t value) {
                     : destination + value;
 }
 
-void AddComponentValueBytes(std::size_t& destination, const css::ComponentValue& component) {
-  const auto addValues = [&](std::span<const css::ComponentValue> values) {
-    if (values.size() > std::numeric_limits<std::size_t>::max() / sizeof(css::ComponentValue)) {
-      destination = std::numeric_limits<std::size_t>::max();
-      return;
-    }
-    SaturatingAdd(destination, values.size() * sizeof(css::ComponentValue));
-    for (const css::ComponentValue& value : values) {
-      AddComponentValueBytes(destination, value);
-    }
-  };
+void SaturatingAddArrayBytes(std::size_t& destination, std::size_t capacity,
+                             std::size_t elementSize) {
+  if (elementSize != 0 && capacity > std::numeric_limits<std::size_t>::max() / elementSize) {
+    destination = std::numeric_limits<std::size_t>::max();
+    return;
+  }
+  SaturatingAdd(destination, capacity * elementSize);
+}
 
+void AddComponentValueBytes(std::size_t& destination, const css::ComponentValue& component);
+
+void AddComponentValuesBytes(std::size_t& destination,
+                             const std::vector<css::ComponentValue>& values) {
+  SaturatingAddArrayBytes(destination, values.capacity(), sizeof(css::ComponentValue));
+  for (const css::ComponentValue& value : values) {
+    AddComponentValueBytes(destination, value);
+  }
+}
+
+void AddComponentValueBytes(std::size_t& destination, const css::ComponentValue& component) {
   if (component.is<css::Function>()) {
-    addValues(component.get<css::Function>().values);
+    AddComponentValuesBytes(destination, component.get<css::Function>().values);
   } else if (component.is<css::SimpleBlock>()) {
-    addValues(component.get<css::SimpleBlock>().values);
+    AddComponentValuesBytes(destination, component.get<css::SimpleBlock>().values);
   }
 }
 
@@ -2351,30 +2359,23 @@ size_t PropertyRegistry::numPropertiesSet() const {
 std::size_t PropertyRegistry::complexPropertyBytes() const {
   std::size_t result = 0;
   if (const StrokeDasharray* dasharray = strokeDasharray.getStoredValue()) {
-    result += dasharray->size() * sizeof(Lengthd);
+    SaturatingAddArrayBytes(result, dasharray->capacity(), sizeof(Lengthd));
   }
   if (const SmallVector<RcString, 1>* families = fontFamily.getStoredValue()) {
-    result += families->size() * sizeof(RcString);
+    SaturatingAddArrayBytes(result, families->capacity(), sizeof(RcString));
     for (const RcString& family : *families) {
-      result += family.size();
+      SaturatingAdd(result, family.size());
     }
   }
   if (const std::vector<FilterEffect>* effects = filter.getStoredValue()) {
-    SaturatingAdd(result, effects->size() * sizeof(FilterEffect));
+    SaturatingAddArrayBytes(result, effects->capacity(), sizeof(FilterEffect));
   }
   for (const auto& entry : unparsedProperties) {
     const parser::UnparsedProperty& property = entry.second;
     using MapValue = decltype(unparsedProperties)::value_type;
     SaturatingAdd(result, sizeof(MapValue) + 3 * sizeof(void*));
 
-    const std::span<const css::ComponentValue> values(property.declaration.values);
-    if (values.size() > std::numeric_limits<std::size_t>::max() / sizeof(css::ComponentValue)) {
-      return std::numeric_limits<std::size_t>::max();
-    }
-    SaturatingAdd(result, values.size() * sizeof(css::ComponentValue));
-    for (const css::ComponentValue& component : values) {
-      AddComponentValueBytes(result, component);
-    }
+    AddComponentValuesBytes(result, property.declaration.values);
   }
   return result;
 }

--- a/donner/svg/properties/tests/PropertyRegistry_tests.cc
+++ b/donner/svg/properties/tests/PropertyRegistry_tests.cc
@@ -282,6 +282,53 @@ TEST(PropertyRegistry, ComplexPropertyBytesIncludesUnparsedComponentTrees) {
   EXPECT_GT(registry.complexPropertyBytes(), 1024 * sizeof(ComponentValue));
 }
 
+TEST(PropertyRegistry, ComplexPropertyBytesChargesRetainedVectorCapacity) {
+  PropertyRegistry dashRegistry;
+  StrokeDasharray dasharray;
+  dasharray.reserve(8);
+  dasharray.emplace_back(1.0, Lengthd::Unit::Px);
+  const std::size_t dashCapacity = dasharray.capacity();
+  dashRegistry.strokeDasharray.set(std::move(dasharray), Specificity());
+  EXPECT_EQ(dashRegistry.complexPropertyBytes(), dashCapacity * sizeof(Lengthd));
+
+  PropertyRegistry familyRegistry;
+  SmallVector<RcString, 1> families;
+  families.emplace_back(RcString("Alpha"));
+  families.emplace_back(RcString("Beta"));
+  families.emplace_back(RcString("Gamma"));
+  families.emplace_back(RcString("Delta"));
+  families.resize(1);
+  const std::size_t familyCapacity = families.capacity();
+  const std::size_t retainedFamilyStringBytes = families.front().size();
+  familyRegistry.fontFamily.set(std::move(families), Specificity());
+  EXPECT_EQ(familyRegistry.complexPropertyBytes(),
+            familyCapacity * sizeof(RcString) + retainedFamilyStringBytes);
+
+  PropertyRegistry filterRegistry;
+  std::vector<FilterEffect> effects;
+  effects.reserve(8);
+  effects.emplace_back(FilterEffect::None{});
+  const std::size_t filterCapacity = effects.capacity();
+  filterRegistry.filter.set(std::move(effects), Specificity());
+  EXPECT_EQ(filterRegistry.complexPropertyBytes(), filterCapacity * sizeof(FilterEffect));
+
+  css::Function function(RcString("translate"), FileOffset::Offset(0));
+  function.values.reserve(8);
+  function.values.emplace_back(Token(Token::Ident("value"), 0));
+  const std::size_t nestedCapacity = function.values.capacity();
+  std::vector<ComponentValue> topLevelValues;
+  topLevelValues.reserve(8);
+  topLevelValues.emplace_back(std::move(function));
+  const std::size_t topLevelCapacity = topLevelValues.capacity();
+  css::Declaration declaration("transform", std::move(topLevelValues));
+
+  PropertyRegistry unparsedRegistry;
+  unparsedRegistry.unparsedProperties.emplace(
+      RcString("transform"), parser::UnparsedProperty{std::move(declaration), Specificity()});
+  EXPECT_GE(unparsedRegistry.complexPropertyBytes(),
+            (topLevelCapacity + nestedCapacity) * sizeof(ComponentValue));
+}
+
 TEST(PropertyRegistry, ParseDeclarationError) {
   std::optional<ParseDiagnostic> parseProperty(const css::Declaration& declaration);
 

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -326,6 +326,14 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 self.assertEqual("x" * (iteration + 1), hook_count.read_text())
                 self._assert_sleepers_reaped(hook_pids, iteration + 1)
 
+    def test_progress_watchers_use_interruptible_control_channels(self):
+        """Command completion must wake progress waits without a sleeper race."""
+        script = self._heartbeat_script()
+        self.assertNotIn('sleep "$heartbeat_interval" &', script)
+        self.assertIn('read -r -t "$heartbeat_interval"', script)
+        self.assertNotIn('sleep "$progress_interval" &', self.coverage_script)
+        self.assertIn('read -r -t "$progress_interval"', self.coverage_script)
+
     def test_coverage_cleanup_is_portable_and_prompt_without_ps(self):
         """Coverage remains portable to macOS and owns its heartbeat sleeper."""
         self.assertNotIn("awk -v p=", self.coverage_script)

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -75,38 +75,6 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 timeout=timeout,
             )
 
-    def _inject_pre_publish_signal(self, script, sleep_command, hook):
-        """Signal the watcher after sleep forks but before it publishes the PID."""
-        self.assertEqual(1, script.count(sleep_command))
-        return script.replace(sleep_command, f'{sleep_command}\n"{hook}" "$!"', 1)
-
-    def _write_parent_signal_hook(self, directory):
-        hook = directory / "signal-parent.sh"
-        release = Path(f"{hook}.release")
-        os.mkfifo(release)
-        hook.write_text(
-            '#!/bin/sh\nprintf x >> "$0.count"\nprintf "%s\\n" "$1" >> "$0.pids"\n'
-            'printf "go\\n" > "$0.release"\nkill -TERM "$PPID"\n'
-        )
-        hook.chmod(0o755)
-        return hook, Path(f"{hook}.count"), Path(f"{hook}.pids"), release
-
-    def _write_blocking_sleep(self, directory):
-        """Install a sleep whose PID stays alive until the watcher explicitly stops it."""
-        fake_bin = directory / "bin"
-        fake_bin.mkdir()
-        fake_sleep = fake_bin / "sleep"
-        fake_sleep.write_text("#!/bin/sh\nexec /bin/sleep 300\n")
-        fake_sleep.chmod(0o755)
-        return fake_bin
-
-    def _assert_sleepers_reaped(self, pid_file, expected_count):
-        pids = [int(pid) for pid in pid_file.read_text().splitlines()]
-        self.assertEqual(expected_count, len(pids))
-        for pid in pids:
-            with self.assertRaises(ProcessLookupError):
-                os.kill(pid, 0)
-
     def test_coverage_does_not_expand_ci_config_twice(self):
         """The coverage command inherits its CI config from the runner rc."""
         flag_line = re.search(
@@ -287,44 +255,24 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            hook, hook_count, hook_pids, hook_release = self._write_parent_signal_hook(temp_path)
-            script = self._inject_pre_publish_signal(
-                script, 'sleep "$heartbeat_interval" &', hook
-            )
-            fake_bin = self._write_blocking_sleep(temp_path)
-            fake_ps = fake_bin / "ps"
-            fake_ps.write_text("#!/bin/sh\nexit 127\n")
-            fake_ps.chmod(0o755)
             log = Path(temp_dir) / "command.log"
             wrapper = Path(temp_dir) / "wrapper.sh"
             wrapper.write_text(script)
             wrapper.chmod(0o755)
             env = os.environ.copy()
-            env["BAZEL_HEARTBEAT_INTERVAL_SECONDS"] = "5"
-            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            env["BAZEL_HEARTBEAT_INTERVAL_SECONDS"] = "300"
 
-            for iteration in range(4):
-                result = subprocess.run(
-                    [
-                        str(wrapper),
-                        str(log),
-                        "bash",
-                        "-c",
-                        'read -r _ < "$1"; exit 17',
-                        "_",
-                        str(hook_release),
-                    ],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    env=env,
-                    timeout=10,
-                )
+            result = subprocess.run(
+                [str(wrapper), str(log), "bash", "-c", "exit 17"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=5,
+            )
 
-                self.assertEqual(17, result.returncode, f"iteration {iteration}: {result.stderr}")
-                self.assertEqual("x" * (iteration + 1), hook_count.read_text())
-                self._assert_sleepers_reaped(hook_pids, iteration + 1)
+            self.assertEqual(17, result.returncode, result.stderr)
+            self.assertEqual([], list(Path(temp_dir).glob("*.heartbeat-control.*")))
 
     def test_progress_watchers_use_interruptible_control_channels(self):
         """Command completion must wake progress waits without a sleeper race."""
@@ -335,35 +283,24 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         self.assertIn('read -r -t "$progress_interval"', self.coverage_script)
 
     def test_coverage_cleanup_is_portable_and_prompt_without_ps(self):
-        """Coverage remains portable to macOS and owns its heartbeat sleeper."""
+        """Coverage remains portable and wakes its progress watcher promptly."""
         self.assertNotIn("awk -v p=", self.coverage_script)
         self.assertNotIn('ps -o pid= --ppid "$root"', self.coverage_script)
         self.assertIn("ps -A -o pid=,ppid=", self.coverage_script)
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            hook, hook_count, hook_pids, hook_release = self._write_parent_signal_hook(temp_path)
-            functions = self._inject_pre_publish_signal(
-                self.coverage_script.split("\nTARGETS=()", 1)[0],
-                'sleep "$progress_interval" &',
-                hook,
-            )
+            functions = self.coverage_script.split("\nTARGETS=()", 1)[0]
             fixture = functions + """
 
 ps() { return 127; }
-DONNER_COVERAGE_PROGRESS_INTERVAL_SECONDS=5
+DONNER_COVERAGE_PROGRESS_INTERVAL_SECONDS=300
 export DONNER_COVERAGE_PROGRESS_INTERVAL_SECONDS
-run_quiet_with_progress "fixture" "$1" bash -c 'read -r _ < "$1"; exit 23' _ "$2"
+run_quiet_with_progress "fixture" "$1" bash -c 'exit 23'
 """
-            log = str(temp_path / "coverage.log")
-            fake_bin = self._write_blocking_sleep(temp_path)
-            env = os.environ.copy()
-            env["PATH"] = f"{fake_bin}:{env['PATH']}"
-            for iteration in range(4):
-                result = self._run_script(fixture, [log, str(hook_release)], env=env)
-                self.assertEqual(23, result.returncode, f"iteration {iteration}: {result.stderr}")
-                self.assertEqual("x" * (iteration + 1), hook_count.read_text())
-                self._assert_sleepers_reaped(hook_pids, iteration + 1)
+            log = str(Path(temp_dir) / "coverage.log")
+            result = self._run_script(fixture, [log], timeout=5)
+            self.assertEqual(23, result.returncode, result.stderr)
+            self.assertEqual([], list(Path(temp_dir).glob("*.progress-control.*")))
 
 
 if __name__ == "__main__":

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -81,38 +81,19 @@ function run_quiet_with_progress() {
   # names the target, and kill so the job fails fast instead of running out its
   # backstop.
   local stall_limit="${DONNER_COVERAGE_STALL_LIMIT_SECONDS:-900}"
+  local progress_control="${log_file}.progress-control.$$"
+  mkfifo "$progress_control"
+  exec 9<> "$progress_control"
 
   (
     local last_line=""
     local last_change
-    local sleep_pid=""
-    local stop_requested=false
-
-    request_progress_stop() {
-      stop_requested=true
-    }
-
-    stop_progress_watcher() {
-      if [[ -n "$sleep_pid" ]]; then
-        kill "$sleep_pid" 2> /dev/null || true
-        wait "$sleep_pid" 2> /dev/null || true
-      fi
-      exit 0
-    }
-    trap request_progress_stop TERM INT
 
     last_change=$(date +%s)
     while true; do
-      # Defer exit until the newly forked sleeper's PID is published below.
-      trap request_progress_stop TERM INT
-      sleep "$progress_interval" &
-      sleep_pid=$!
-      trap stop_progress_watcher TERM INT
-      if [[ "$stop_requested" == true ]]; then
-        stop_progress_watcher
+      if IFS= read -r -t "$progress_interval" _ <&9; then
+        exit 0
       fi
-      wait "$sleep_pid" || exit 0
-      sleep_pid=""
 
       if ! kill -0 "$command_pid" 2> /dev/null; then
         exit 0
@@ -158,10 +139,10 @@ function run_quiet_with_progress() {
 
   local status=0
   wait "$command_pid" || status=$?
-  # The watcher owns and traps its sleeper, so terminating it cannot leave an
-  # orphan holding the caller's output pipe until the interval expires.
-  kill -TERM "$progress_pid" 2> /dev/null || true
+  printf 'stop\n' >&9
   wait "$progress_pid" 2> /dev/null || true
+  exec 9>&-
+  rm -f "$progress_control"
 
   local end_time
   end_time=$(date +%s)


### PR DESCRIPTION
Charges retained vector capacity, rather than logical size, before computed-style admission.

- Covers dash arrays, font families, filter vectors, and nested CSS component trees.
- Uses saturating multiplication and addition so oversized accounting fails closed.
- Preserves transactional per-entity replacement and document-family release behavior.

Validation:
- Properties and StyleSystem suites
- UBSan variants
- Lint, diff, privacy, and independent exact-range review

Fixes #1041