### PR TITLE
Handle negative-pitch bitmap glyph rows safely

### DIFF
--- a/donner/svg/text/BitmapGlyphUtils.h
+++ b/donner/svg/text/BitmapGlyphUtils.h
@@ -90,9 +90,20 @@ inline std::optional<BgraBitmapLayout> ValidateBgraBitmapLayout(unsigned int wid
 }
 
 /// Convert one validated BGRA bitmap into tightly packed logical-row-order RGBA pixels.
-inline std::vector<uint8_t> ConvertValidatedBgraToRgba(const uint8_t* /*buffer*/,
-                                                       const BgraBitmapLayout& /*layout*/) {
-  return {};
+inline std::vector<uint8_t> ConvertValidatedBgraToRgba(const uint8_t* buffer,
+                                                       const BgraBitmapLayout& layout) {
+  std::vector<uint8_t> rgba(layout.rgbaBytes);
+  for (int row = 0; row < layout.height; ++row) {
+    const uint8_t* source = buffer + static_cast<std::ptrdiff_t>(row) * layout.pitch;
+    uint8_t* destination = rgba.data() + static_cast<std::size_t>(row) * layout.rowBytes;
+    for (int column = 0; column < layout.width; ++column) {
+      destination[column * 4 + 0] = source[column * 4 + 2];
+      destination[column * 4 + 1] = source[column * 4 + 1];
+      destination[column * 4 + 2] = source[column * 4 + 0];
+      destination[column * 4 + 3] = source[column * 4 + 3];
+    }
+  }
+  return rgba;
 }
 
 }  // namespace donner::svg::details

--- a/donner/svg/text/BitmapGlyphUtils.h
+++ b/donner/svg/text/BitmapGlyphUtils.h
@@ -93,8 +93,13 @@ inline std::optional<BgraBitmapLayout> ValidateBgraBitmapLayout(unsigned int wid
 inline std::vector<uint8_t> ConvertValidatedBgraToRgba(const uint8_t* buffer,
                                                        const BgraBitmapLayout& layout) {
   std::vector<uint8_t> rgba(layout.rgbaBytes);
+  // FreeType stores the first bytes of a negative-pitch buffer in the lower row. Rebase to the
+  // logical upper row, then the signed pitch advances toward each following lower scanline.
+  // https://freetype.org/freetype2/docs/glyphs/glyphs-7.html
+  const uint8_t* logicalFirstRow =
+      layout.pitch < 0 ? buffer + (layout.sourceSpanBytes - layout.rowBytes) : buffer;
   for (int row = 0; row < layout.height; ++row) {
-    const uint8_t* source = buffer + static_cast<std::ptrdiff_t>(row) * layout.pitch;
+    const uint8_t* source = logicalFirstRow + static_cast<std::ptrdiff_t>(row) * layout.pitch;
     uint8_t* destination = rgba.data() + static_cast<std::size_t>(row) * layout.rowBytes;
     for (int column = 0; column < layout.width; ++column) {
       destination[column * 4 + 0] = source[column * 4 + 2];

--- a/donner/svg/text/BitmapGlyphUtils.h
+++ b/donner/svg/text/BitmapGlyphUtils.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 namespace donner::svg::details {
 
@@ -86,6 +87,12 @@ inline std::optional<BgraBitmapLayout> ValidateBgraBitmapLayout(unsigned int wid
       .sourceSpanBytes = sourceSpanBytes,
       .rgbaBytes = *rgbaBytes,
   };
+}
+
+/// Convert one validated BGRA bitmap into tightly packed logical-row-order RGBA pixels.
+inline std::vector<uint8_t> ConvertValidatedBgraToRgba(const uint8_t* /*buffer*/,
+                                                       const BgraBitmapLayout& /*layout*/) {
+  return {};
 }
 
 }  // namespace donner::svg::details

--- a/donner/svg/text/TextBackendFull.cc
+++ b/donner/svg/text/TextBackendFull.cc
@@ -577,22 +577,6 @@ std::optional<double> BitmapPixelScale(hb_font_t* hbFont, FT_Face face, float re
   return fontSizePx / strikePpem;
 }
 
-std::vector<uint8_t> ConvertBgraToRgba(const FT_Bitmap& bitmap,
-                                       const details::BgraBitmapLayout& layout) {
-  std::vector<uint8_t> rgba(layout.rgbaBytes);
-  for (int row = 0; row < layout.height; ++row) {
-    const uint8_t* source = bitmap.buffer + static_cast<std::ptrdiff_t>(row) * layout.pitch;
-    uint8_t* destination = rgba.data() + static_cast<std::size_t>(row) * layout.rowBytes;
-    for (int column = 0; column < layout.width; ++column) {
-      destination[column * 4 + 0] = source[column * 4 + 2];
-      destination[column * 4 + 1] = source[column * 4 + 1];
-      destination[column * 4 + 2] = source[column * 4 + 0];
-      destination[column * 4 + 3] = source[column * 4 + 3];
-    }
-  }
-  return rgba;
-}
-
 }  // namespace
 
 std::optional<TextBackend::BitmapGlyph> TextBackendFull::bitmapGlyph(FontHandle font,
@@ -630,7 +614,7 @@ std::optional<TextBackend::BitmapGlyph> TextBackendFull::bitmapGlyph(FontHandle 
   }
 
   BitmapGlyph result;
-  result.rgbaPixels = ConvertBgraToRgba(bitmap, *layout);
+  result.rgbaPixels = details::ConvertValidatedBgraToRgba(bitmap.buffer, *layout);
   result.width = layout->width;
   result.height = layout->height;
   result.bearingX = static_cast<double>(ftFace->glyph->bitmap_left) * *pixelScale;

--- a/donner/svg/text/tests/TextBackendFullBitmap_tests.cc
+++ b/donner/svg/text/tests/TextBackendFullBitmap_tests.cc
@@ -83,6 +83,19 @@ TEST(BitmapGlyphUtils, RejectsMalformedAndUnreasonableLayouts) {
             std::nullopt);
 }
 
+TEST(BitmapGlyphUtils, ConvertsNegativePitchRowsInLogicalOrder) {
+  std::array<uint8_t, 20> storage{
+      9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+  };
+  const uint8_t* logicalFirstRow = storage.data() + 12;
+  const auto layout = details::ValidateBgraBitmapLayout(
+      /*width=*/2, /*rows=*/2, /*pitch=*/-12, logicalFirstRow);
+  ASSERT_TRUE(layout.has_value());
+
+  EXPECT_THAT(details::ConvertValidatedBgraToRgba(logicalFirstRow, *layout),
+              ElementsAre(3, 2, 1, 4, 7, 6, 5, 8, 11, 10, 9, 12, 15, 14, 13, 16));
+}
+
 TEST(TextBackendFullBitmap, DecodesBoundedTrustedBitmapFontSeed) {
   const std::vector<uint8_t> fontBytes = LoadBitmapFontSeed();
   ASSERT_THAT(fontBytes, Not(SizeIs(0)));

--- a/donner/svg/text/tests/TextBackendFullBitmap_tests.cc
+++ b/donner/svg/text/tests/TextBackendFullBitmap_tests.cc
@@ -87,12 +87,12 @@ TEST(BitmapGlyphUtils, ConvertsNegativePitchRowsInLogicalOrder) {
   std::array<uint8_t, 20> storage{
       9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8,
   };
-  const uint8_t* logicalFirstRow = storage.data() + 12;
-  const auto layout = details::ValidateBgraBitmapLayout(
-      /*width=*/2, /*rows=*/2, /*pitch=*/-12, logicalFirstRow);
+  const uint8_t* rawBuffer = storage.data();
+  const auto layout =
+      details::ValidateBgraBitmapLayout(/*width=*/2, /*rows=*/2, /*pitch=*/-12, rawBuffer);
   ASSERT_TRUE(layout.has_value());
 
-  EXPECT_THAT(details::ConvertValidatedBgraToRgba(logicalFirstRow, *layout),
+  EXPECT_THAT(details::ConvertValidatedBgraToRgba(rawBuffer, *layout),
               ElementsAre(3, 2, 1, 4, 7, 6, 5, 8, 11, 10, 9, 12, 15, 14, 13, 16));
 }
 


### PR DESCRIPTION
Exercises and fixes the production BGRA-to-RGBA path for raw negative-pitch FreeType bitmap buffers.

- Reproduces the original stack-buffer underflow under ASan.
- Rebases raw lower-row-first storage to the logical top row before signed stepping.
- Keeps all pointer arithmetic inside the previously validated 16 MiB source span.

Validation:
- Text-full bitmap suites
- ASan and UBSan
- Lint, diff, privacy, and independent exact-range review

Fixes #1043