### PR TITLE
Share filter preparation budgets across frame passes

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -262,6 +262,21 @@ SampleThumbnailRenderResult RenderSampleThumbnail(
   return result;
 }
 
+class ScopedFrameResourceScope {
+public:
+  explicit ScopedFrameResourceScope(svg::RendererInterface& renderer) : renderer_(renderer) {
+    renderer_.beginFrameResourceScope();
+  }
+
+  ~ScopedFrameResourceScope() { renderer_.endFrameResourceScope(); }
+
+  ScopedFrameResourceScope(const ScopedFrameResourceScope&) = delete;
+  ScopedFrameResourceScope& operator=(const ScopedFrameResourceScope&) = delete;
+
+private:
+  svg::RendererInterface& renderer_;
+};
+
 }  // namespace
 
 PresentationSnapshotPlan ChoosePresentationSnapshotPlan(bool hasCompositedPreview,
@@ -883,6 +898,7 @@ void AsyncRenderer::workerLoop() {
       } else {
         const std::chrono::milliseconds delay(
             sampleThumbnailRenderDelayMsForTesting_.load(std::memory_order_acquire));
+        const ScopedFrameResourceScope resourceScope(*sampleThumbnailRendererRoot);
         result = RenderSampleThumbnail(std::move(*sampleThumbnailStorage), *offscreenRenderer,
                                        cancelSampleThumbnail_, delay);
       }

--- a/donner/editor/tests/SampleThumbnailAsync_tests.cc
+++ b/donner/editor/tests/SampleThumbnailAsync_tests.cc
@@ -92,6 +92,13 @@ constexpr std::string_view kBlueSvg = R"svg(
 </svg>
 )svg";
 
+constexpr std::string_view kFilteredSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 24">
+  <defs><filter id="f"><feFlood flood-color="#20e080"/></filter></defs>
+  <rect width="32" height="24" fill="#e02020" filter="url(#f)"/>
+</svg>
+)svg";
+
 std::optional<SampleThumbnailRenderResult> WaitForThumbnailResult(
     AsyncRenderer& renderer, std::chrono::seconds timeout = 5s) {
   const auto deadline = std::chrono::steady_clock::now() + timeout;
@@ -351,6 +358,30 @@ TEST(SampleThumbnailAsyncTest, RendersSourceDependentBitmapsThroughOneBoundedWor
   EXPECT_FALSE(stats.pending);
   EXPECT_FALSE(stats.active);
   EXPECT_FALSE(stats.resultReady);
+}
+
+TEST(SampleThumbnailAsyncTest, ReusedOffscreenRendererStartsFreshFilterPreparationFrames) {
+  svg::Renderer thumbnailRoot;
+  svg::RendererFilterPreparationBudget* budget = thumbnailRoot.filterPreparationBudget();
+  ASSERT_NE(budget, nullptr);
+  svg::RendererFilterPreparationBudget::Limits limits;
+  limits.graphs = 1u;
+  budget->setLimitsForTesting(limits);
+
+  AsyncRenderer renderer;
+  ASSERT_TRUE(renderer.requestSampleThumbnail(ThumbnailRequest(21u, kFilteredSvg, thumbnailRoot)));
+  std::optional<SampleThumbnailRenderResult> first = WaitForThumbnailResult(renderer);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_EQ(first->outcome, SampleThumbnailRenderOutcome::Rendered);
+  EXPECT_EQ(budget->attempts(), 1u);
+  EXPECT_FALSE(budget->rejected());
+
+  ASSERT_TRUE(renderer.requestSampleThumbnail(ThumbnailRequest(22u, kFilteredSvg, thumbnailRoot)));
+  std::optional<SampleThumbnailRenderResult> second = WaitForThumbnailResult(renderer);
+  ASSERT_TRUE(second.has_value());
+  ASSERT_EQ(second->outcome, SampleThumbnailRenderOutcome::Rendered);
+  EXPECT_EQ(budget->attempts(), 1u);
+  EXPECT_FALSE(budget->rejected());
 }
 
 TEST(SampleThumbnailAsyncTest, TextAndStyleThumbnailContainsDonnerRenderedGlyphPixels) {

--- a/donner/svg/renderer/RenderSnapshot.cc
+++ b/donner/svg/renderer/RenderSnapshot.cc
@@ -571,6 +571,10 @@ RendererBitmap RenderSnapshotRecorder::takeSnapshot() const {
   return RendererBitmap();
 }
 
+RendererFilterPreparationBudget* RenderSnapshotRecorder::filterPreparationBudget() {
+  return offscreenFactory_.filterPreparationBudget();
+}
+
 std::unique_ptr<RendererInterface> RenderSnapshotRecorder::createOffscreenInstance() const {
   return offscreenFactory_.createOffscreenInstance();
 }

--- a/donner/svg/renderer/RenderSnapshot.h
+++ b/donner/svg/renderer/RenderSnapshot.h
@@ -124,6 +124,7 @@ public:
   void drawText(Registry& registry, const components::ComputedTextComponent& text,
                 const TextParams& params) override;
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
+  [[nodiscard]] RendererFilterPreparationBudget* filterPreparationBudget() override;
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
 private:

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -646,6 +646,10 @@ bool Renderer::requiresTextureSnapshotPresentation() const {
   return impl_->requiresTextureSnapshotPresentation();
 }
 
+RendererFilterPreparationBudget* Renderer::filterPreparationBudget() {
+  return impl_->filterPreparationBudget();
+}
+
 std::unique_ptr<RendererInterface> Renderer::createOffscreenInstance() const {
   return impl_->createOffscreenInstance();
 }

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -30,6 +30,18 @@ namespace donner::svg {
 
 namespace {
 
+class ScopedFrameResourceScope {
+public:
+  explicit ScopedFrameResourceScope(RendererInterface& renderer) : renderer_(renderer) {
+    renderer_.beginFrameResourceScope();
+  }
+
+  ~ScopedFrameResourceScope() { renderer_.endFrameResourceScope(); }
+
+private:
+  RendererInterface& renderer_;
+};
+
 void CollectSubtreeEntities(const SVGElement& element, std::unordered_set<Entity>& out) {
   out.insert(element.entityHandle().entity());
   for (std::optional<SVGElement> child = element.firstChild(); child.has_value();
@@ -496,6 +508,7 @@ RendererBitmap RenderDocumentsToAtlasBitmap(RendererInterface& renderer,
 }
 
 RendererImage Renderer::renderElement(SVGElement element, Vector2i sizePx) {
+  const ScopedFrameResourceScope resourceScope(*impl_);
   if (elementThumbnailRenderer_ == nullptr) {
     elementThumbnailRenderer_ = impl_->createOffscreenInstance();
   }

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -336,6 +336,8 @@ public:
   /// Returns true when this backend requires direct texture presentation.
   [[nodiscard]] bool requiresTextureSnapshotPresentation() const override;
 
+  [[nodiscard]] RendererFilterPreparationBudget* filterPreparationBudget() override;
+
   /// Creates an offscreen renderer of the active backend type.
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -1109,90 +1109,26 @@ std::optional<ImageParams> toImageParams(const components::RenderingInstanceComp
 
 }  // namespace
 
-bool RendererDriver::FilterPreparationBudget::beginGraph(SecurityStats* stats) {
-  if (rejected || attempts >= kMaximumPreparedFilterGraphs) {
-    rejected = true;
-    if (stats) {
-      stats->filterPreparationRejected = true;
-    }
-    return false;
-  }
-  ++attempts;
-  if (stats) {
-    stats->filterPreparationAttempts = attempts;
-  }
-  return true;
-}
-
-bool RendererDriver::FilterPreparationBudget::reserveNodes(std::size_t nodeCount,
-                                                           SecurityStats* stats) {
-  if (rejected || nodeCount > kMaximumPreparedFilterNodes - nodes) {
-    rejected = true;
-    if (stats) {
-      stats->filterPreparationRejected = true;
-    }
-    return false;
-  }
-  ++graphs;
-  nodes += nodeCount;
-  if (stats) {
-    stats->preparedFilterGraphs = graphs;
-    stats->preparedFilterNodes = nodes;
-  }
-  return true;
-}
-
-bool RendererDriver::FilterPreparationBudget::reserveImageBytes(std::uint64_t byteCount,
-                                                                SecurityStats* stats) {
-  if (rejected || byteCount > kMaximumPreparedFilterImageBytes - imageBytes) {
-    rejected = true;
-    if (stats) {
-      stats->filterPreparationRejected = true;
-    }
-    return false;
-  }
-  imageBytes += byteCount;
-  if (stats) {
-    stats->preparedFilterImageBytes = imageBytes;
-  }
-  return true;
-}
-
-bool RendererDriver::FilterPreparationBudget::reservePayloadBytes(std::uint64_t byteCount,
-                                                                  SecurityStats* stats) {
-  if (rejected || byteCount > kMaximumPreparedFilterPayloadBytes - payloadBytes) {
-    rejected = true;
-    if (stats) {
-      stats->filterPreparationRejected = true;
-    }
-    return false;
-  }
-  payloadBytes += byteCount;
-  if (stats) {
-    stats->preparedFilterPayloadBytes = payloadBytes;
-  }
-  return true;
-}
-
-bool RendererDriver::FilterPreparationBudget::reserveShadowEntities(std::size_t entityCount,
-                                                                    SecurityStats* stats) {
-  if (rejected || entityCount > kMaximumPreparedFilterShadowEntities - shadowEntities) {
-    rejected = true;
-    if (stats) {
-      stats->filterPreparationRejected = true;
-    }
-    return false;
-  }
-  shadowEntities += entityCount;
-  if (stats) {
-    stats->preparedFilterShadowEntities = shadowEntities;
-  }
-  return true;
+void RendererDriver::syncFilterPreparationStats() {
+  if (!securityStats_) return;
+  securityStats_->filterPreparationAttempts = filterPreparationBudget_->attempts();
+  securityStats_->preparedFilterGraphs = filterPreparationBudget_->graphs();
+  securityStats_->preparedFilterNodes = filterPreparationBudget_->nodes();
+  securityStats_->preparedFilterImageBytes = filterPreparationBudget_->imageBytes();
+  securityStats_->preparedFilterMaterializationBytes =
+      filterPreparationBudget_->materializationBytes();
+  securityStats_->preparedFilterPayloadBytes = filterPreparationBudget_->payloadBytes();
+  securityStats_->preparedFilterShadowEntities = filterPreparationBudget_->shadowEntities();
+  securityStats_->filterPreparationRejected = filterPreparationBudget_->rejected();
 }
 
 RendererDriver::RendererDriver(RendererInterface& renderer, bool verbose,
                                SecurityStats* securityStats)
-    : renderer_(renderer), verbose_(verbose), securityStats_(securityStats) {}
+    : renderer_(renderer), verbose_(verbose), securityStats_(securityStats) {
+  if (RendererFilterPreparationBudget* shared = renderer_.filterPreparationBudget()) {
+    filterPreparationBudget_ = shared;
+  }
+}
 
 void RendererDriver::resetOwnedSecurityBudgets() {
   if (filterPreparationBudget_ == &ownedFilterPreparationBudget_) {
@@ -1291,6 +1227,7 @@ bool RendererDriver::drawInterruptibly(SVGDocument& document, const RenderViewpo
 
   if (mainEntities.empty()) {
     renderer_.beginFrame(viewport);
+    syncFilterPreparationStats();
     renderer_.endFrame();
     return true;
   }
@@ -1342,6 +1279,7 @@ void RendererDriver::drawPreparedDocument(SVGDocument& document, const RenderVie
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
+  syncFilterPreparationStats();
 
   // Snapshot the entities we intend to traverse BEFORE the filter-graph pre-pass, so that shadow
   // entities created by feImage pre-rendering don't get picked up by the main traversal view.
@@ -1389,6 +1327,7 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
+  syncFilterPreparationStats();
   (void)drawPreparedEntityRange(registry, firstEntity, lastEntity, {});
   renderer_.endFrame();
   surfaceFromCanvasTransform_ = Transform2d();
@@ -1405,6 +1344,7 @@ bool RendererDriver::drawEntityRangeInterruptibly(Registry& registry, Entity fir
   surfaceFromCanvasTransform_ = surfaceFromCanvas;
 
   renderer_.beginFrame(viewport);
+  syncFilterPreparationStats();
   const bool completed = drawPreparedEntityRange(registry, firstEntity, lastEntity, shouldCancel);
   renderer_.endFrame();
   surfaceFromCanvasTransform_ = Transform2d();
@@ -1910,35 +1850,57 @@ bool RendererDriver::reservePreparedFilterGraph(const components::FilterGraph& f
   for (const components::FilterNode& node : filterGraph.nodes) {
     const std::uint64_t nodeBytes = components::FilterPrimitivePayloadBytes(node.primitive);
     if (nodeBytes > kMaximumPreparedFilterPayloadBytes - payloadBytes) {
-      return filterPreparationBudget_->reservePayloadBytes(kMaximumPreparedFilterPayloadBytes + 1,
-                                                           securityStats_);
+      const bool accepted =
+          filterPreparationBudget_->reservePayloadBytes(kMaximumPreparedFilterPayloadBytes + 1);
+      syncFilterPreparationStats();
+      return accepted;
     }
     payloadBytes += nodeBytes;
   }
-  if (!filterPreparationBudget_->reservePayloadBytes(payloadBytes, securityStats_)) {
+  if (!filterPreparationBudget_->reservePayloadBytes(payloadBytes)) {
+    syncFilterPreparationStats();
     return false;
   }
   const std::optional<std::uint64_t> decodedImageBytes = ExistingFilterImageBytes(filterGraph);
   if (!decodedImageBytes.has_value() ||
-      !filterPreparationBudget_->reserveImageBytes(*decodedImageBytes, securityStats_)) {
+      !filterPreparationBudget_->reserveImageBytes(*decodedImageBytes)) {
+    syncFilterPreparationStats();
     return false;
   }
-  return filterPreparationBudget_->reserveNodes(filterGraph.nodes.size(), securityStats_);
+  const bool accepted = filterPreparationBudget_->reserveNodes(filterGraph.nodes.size());
+  syncFilterPreparationStats();
+  return accepted;
+}
+
+bool RendererDriver::reservePreparedFilterMaterialization(
+    const components::FilterGraph& filterGraph) {
+  const std::optional<std::uint64_t> imageBytes = ExistingFilterImageBytes(filterGraph);
+  const std::uint64_t materializationBytes =
+      !imageBytes.has_value() || *imageBytes > kMaximumPreparedFilterMaterializationBytes / 2u
+          ? kMaximumPreparedFilterMaterializationBytes + 1u
+          : *imageBytes * 2u;
+  const bool accepted = filterPreparationBudget_->reserveMaterializationBytes(materializationBytes);
+  syncFilterPreparationStats();
+  return accepted;
 }
 
 std::optional<std::uint64_t> RendererDriver::reservePreparedFilterImage(Vector2i size) {
   const std::optional<std::uint64_t> bytes = BoundedRgbaBytes(size);
-  if (!bytes.has_value() || !filterPreparationBudget_->reserveImageBytes(*bytes, securityStats_)) {
+  if (!bytes.has_value() || !filterPreparationBudget_->reserveImageBytes(*bytes)) {
+    syncFilterPreparationStats();
     return std::nullopt;
   }
+  syncFilterPreparationStats();
   return bytes;
 }
 
 bool RendererDriver::reservePreparedFilterShadowTree(Registry& registry, Entity targetEntity) {
   const std::optional<std::size_t> entityCount =
       BoundedShadowTreeEntityCount(registry, targetEntity, kMaximumPreparedFilterShadowEntities);
-  return entityCount.has_value() &&
-         filterPreparationBudget_->reserveShadowEntities(*entityCount, securityStats_);
+  if (!entityCount.has_value()) return false;
+  const bool accepted = filterPreparationBudget_->reserveShadowEntities(*entityCount);
+  syncFilterPreparationStats();
+  return accepted;
 }
 
 std::shared_ptr<const std::vector<std::uint8_t>> RendererDriver::adoptPreparedFilterSnapshot(
@@ -1966,9 +1928,11 @@ const components::RenderingInstanceComponent* RendererDriver::beginPreparingFilt
   if (!instance || !instance->resolvedFilter.has_value()) {
     return nullptr;
   }
-  if (!filterPreparationBudget_->beginGraph(securityStats_)) {
+  if (!filterPreparationBudget_->beginGraph()) {
+    syncFilterPreparationStats();
     return nullptr;
   }
+  syncFilterPreparationStats();
   const auto& style = instance->styleHandle(registry).get<components::ComputedStyleComponent>();
   return style.properties.has_value() ? instance : nullptr;
 }
@@ -2018,6 +1982,9 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
         // across them - the next iteration of this loop re-fetches via `storage.get(entity)`.
         preRenderSvgFeImages(*filterGraph, registry);
         preRenderFeImageFragments(*filterGraph, registry, entity, filterRegion);
+      }
+      if (!reservePreparedFilterMaterialization(*filterGraph)) {
+        continue;
       }
     }
 

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -81,6 +81,18 @@ inline constexpr int kMaxFeImageFragmentDepth = 32;
 /// - we'd rather do a little extra work than cull content the user should see.
 inline constexpr double kViewportCullSlackDevicePx = 1.0;
 
+class ScopedFrameResourceScope {
+public:
+  explicit ScopedFrameResourceScope(RendererInterface& renderer) : renderer_(renderer) {
+    renderer_.beginFrameResourceScope();
+  }
+
+  ~ScopedFrameResourceScope() { renderer_.endFrameResourceScope(); }
+
+private:
+  RendererInterface& renderer_;
+};
+
 Vector2i CheckedRenderingSize(const RenderViewport& viewport) {
   constexpr double kMaximumDimension = static_cast<double>(std::numeric_limits<int>::max());
   if (!std::isfinite(viewport.size.x) || !std::isfinite(viewport.size.y) || viewport.size.x < 0.0 ||
@@ -1139,11 +1151,16 @@ void RendererDriver::resetOwnedSecurityBudgets() {
   }
   if (clipGeometryCopyBudget_ == &ownedClipGeometryCopyBudget_) {
     ownedClipGeometryCopyBudget_.reset();
+    if (securityStats_) {
+      securityStats_->clipGeometryPathsPreflighted = 0;
+      securityStats_->clipGeometryCopyRejected = false;
+    }
   }
 }
 
 void RendererDriver::draw(SVGDocument& document) {
   if (document.threadingMode() == ThreadingMode::ConcurrentDom) {
+    const ScopedFrameResourceScope resourceScope(renderer_);
     RenderSnapshot snapshot = captureRenderSnapshot(document);
     draw(snapshot);
     return;
@@ -1166,6 +1183,7 @@ void RendererDriver::draw(SVGDocument& document) {
 void RendererDriver::draw(SVGDocument& document, const RenderViewport& viewport,
                           const Transform2d& surfaceFromCanvas) {
   if (document.threadingMode() == ThreadingMode::ConcurrentDom) {
+    const ScopedFrameResourceScope resourceScope(renderer_);
     RenderSnapshot snapshot;
     {
       DocumentWriteAccess access = document.writeAccess();
@@ -1238,6 +1256,7 @@ bool RendererDriver::drawInterruptibly(SVGDocument& document, const RenderViewpo
 }
 
 RenderSnapshot RendererDriver::captureRenderSnapshot(SVGDocument& document) {
+  const ScopedFrameResourceScope resourceScope(renderer_);
   RenderSnapshot snapshot;
   DocumentWriteAccess access = document.writeAccess();
 

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -45,6 +45,7 @@ public:
     std::size_t preparedFilterGraphs = 0;
     std::size_t preparedFilterNodes = 0;
     std::uint64_t preparedFilterImageBytes = 0;
+    std::uint64_t preparedFilterMaterializationBytes = 0;
     std::uint64_t preparedFilterPayloadBytes = 0;
     std::size_t preparedFilterShadowEntities = 0;
     bool filterPreparationRejected = false;

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -28,14 +28,19 @@ namespace donner::svg {
  */
 class RendererDriver {
 public:
-  /// Aggregate limits for per-instance filter graph preparation and feImage snapshots.
+  /// Aggregate limits for frame-wide filter graph preparation and feImage snapshots.
   static constexpr std::size_t kMaximumPreparedFilterGraphs =
-      components::FilterExecutionBudget::kMaximumExecutions;
+      RendererFilterPreparationBudget::kMaximumGraphs;
   static constexpr std::size_t kMaximumPreparedFilterNodes =
-      kMaximumPreparedFilterGraphs * components::kMaximumFilterGraphNodes;
-  static constexpr std::uint64_t kMaximumPreparedFilterImageBytes = 4ULL * 1024 * 1024;
-  static constexpr std::uint64_t kMaximumPreparedFilterPayloadBytes = 16ULL * 1024 * 1024;
-  static constexpr std::size_t kMaximumPreparedFilterShadowEntities = 4096;
+      RendererFilterPreparationBudget::kMaximumNodes;
+  static constexpr std::uint64_t kMaximumPreparedFilterImageBytes =
+      RendererFilterPreparationBudget::kMaximumImageBytes;
+  static constexpr std::uint64_t kMaximumPreparedFilterMaterializationBytes =
+      RendererFilterPreparationBudget::kMaximumMaterializationBytes;
+  static constexpr std::uint64_t kMaximumPreparedFilterPayloadBytes =
+      RendererFilterPreparationBudget::kMaximumPayloadBytes;
+  static constexpr std::size_t kMaximumPreparedFilterShadowEntities =
+      RendererFilterPreparationBudget::kMaximumShadowEntities;
 
   /// Optional diagnostics for structured fuzzers and embedders auditing rejected preparation.
   struct SecurityStats {
@@ -221,22 +226,6 @@ public:
   [[nodiscard]] RendererBitmap takeSnapshot() const;
 
 private:
-  struct FilterPreparationBudget {
-    std::size_t attempts = 0;
-    std::size_t graphs = 0;
-    std::size_t nodes = 0;
-    std::uint64_t imageBytes = 0;
-    std::uint64_t payloadBytes = 0;
-    std::size_t shadowEntities = 0;
-    bool rejected = false;
-
-    bool beginGraph(SecurityStats* stats);
-    bool reserveNodes(std::size_t nodeCount, SecurityStats* stats);
-    bool reserveImageBytes(std::uint64_t byteCount, SecurityStats* stats);
-    bool reservePayloadBytes(std::uint64_t byteCount, SecurityStats* stats);
-    bool reserveShadowEntities(std::size_t entityCount, SecurityStats* stats);
-  };
-
   /**
    * Resolve and pre-render the filter graph for every entity with a resolved filter in `entities`,
    * caching each result in \ref preparedFilterGraphs_. Must be called BEFORE any `traverse` pass
@@ -252,6 +241,7 @@ private:
   const components::RenderingInstanceComponent* beginPreparingFilterEntity(Registry& registry,
                                                                            Entity entity);
   bool reservePreparedFilterGraph(const components::FilterGraph& filterGraph);
+  bool reservePreparedFilterMaterialization(const components::FilterGraph& filterGraph);
   std::optional<std::uint64_t> reservePreparedFilterImage(Vector2i size);
   bool reservePreparedFilterShadowTree(Registry& registry, Entity targetEntity);
   std::shared_ptr<const std::vector<std::uint8_t>> adoptPreparedFilterSnapshot(
@@ -405,11 +395,13 @@ private:
   /// the sub-driver (see `preRenderFeImageFragments`).
   int feImageFragmentDepth_ = 0;
 
-  FilterPreparationBudget ownedFilterPreparationBudget_;
-  FilterPreparationBudget* filterPreparationBudget_ = &ownedFilterPreparationBudget_;
+  RendererFilterPreparationBudget ownedFilterPreparationBudget_;
+  RendererFilterPreparationBudget* filterPreparationBudget_ = &ownedFilterPreparationBudget_;
   RendererTextMaterializationBudget ownedClipGeometryCopyBudget_;
   RendererTextMaterializationBudget* clipGeometryCopyBudget_ = &ownedClipGeometryCopyBudget_;
   SecurityStats* securityStats_ = nullptr;
+
+  void syncFilterPreparationStats();
 
   /// Filter graphs resolved and pre-rendered by \ref prepareFilterGraphs. Keyed by the entity
   /// whose filter produced the graph. Populated in a pre-pass before \ref traverse so the main

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1272,6 +1272,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget =
       std::make_shared<components::FilterExecutionBudget>();
   bool ownsFilterExecutionBudget = true;
+  std::shared_ptr<RendererFilterPreparationBudget> filterPreparationBudget =
+      std::make_shared<RendererFilterPreparationBudget>();
+  bool ownsFilterPreparationBudget = true;
   std::shared_ptr<geode::GeodeFrameGeometryBudget> geometryBudget =
       std::make_shared<geode::GeodeFrameGeometryBudget>();
   bool ownsGeometryBudget = true;
@@ -4212,6 +4215,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (ownsFilterExecutionBudget) {
       filterExecutionBudget->reset();
     }
+    if (ownsFilterPreparationBudget) {
+      filterPreparationBudget->reset();
+    }
     if (ownsGeometryBudget) {
       geometryBudget->reset();
       documentGeometryFrameState->reset();
@@ -6671,6 +6677,8 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
       new RendererGeode(impl_->device, impl_->verbose, impl_->offscreenCreationHookForTesting));
   renderer->impl_->filterExecutionBudget = impl_->filterExecutionBudget;
   renderer->impl_->ownsFilterExecutionBudget = false;
+  renderer->impl_->filterPreparationBudget = impl_->filterPreparationBudget;
+  renderer->impl_->ownsFilterPreparationBudget = false;
   renderer->impl_->geometryBudget = impl_->geometryBudget;
   renderer->impl_->ownsGeometryBudget = false;
   renderer->impl_->surfaceBudget = impl_->surfaceBudget;
@@ -6680,6 +6688,10 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
   renderer->impl_->documentGeometryLimits = impl_->documentGeometryLimits;
   renderer->impl_->documentGeometryFrameState = impl_->documentGeometryFrameState;
   return renderer;
+}
+
+RendererFilterPreparationBudget* RendererGeode::filterPreparationBudget() {
+  return impl_->filterPreparationBudget.get();
 }
 
 void RendererGeode::setOffscreenCreationHookForTesting(std::function<void()> hook) {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -322,6 +322,7 @@ public:
   void drawText(Registry& registry, const components::ComputedTextComponent& text,
                 const TextParams& params) override;
 
+  [[nodiscard]] RendererFilterPreparationBudget* filterPreparationBudget() override;
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
   /// Install a zero-default hook entered after the new renderer owns its device.

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -216,6 +216,110 @@ private:
   bool rejected_ = false;
 };
 
+/** Aggregate filter-graph preparation and source-image materialization budget for one frame. */
+class RendererFilterPreparationBudget {
+public:
+  static constexpr std::size_t kMaximumGraphs =
+      components::FilterExecutionBudget::kMaximumExecutions;
+  static constexpr std::size_t kMaximumNodes =
+      kMaximumGraphs * components::kMaximumFilterGraphNodes;
+  static constexpr std::uint64_t kMaximumImageBytes = 4ULL * 1024 * 1024;
+  static constexpr std::uint64_t kMaximumMaterializationBytes = 2 * kMaximumImageBytes;
+  static constexpr std::uint64_t kMaximumPayloadBytes = 16ULL * 1024 * 1024;
+  static constexpr std::size_t kMaximumShadowEntities = 4096;
+
+  struct Limits {
+    std::size_t graphs = kMaximumGraphs;
+    std::size_t nodes = kMaximumNodes;
+    std::uint64_t imageBytes = kMaximumImageBytes;
+    std::uint64_t materializationBytes = kMaximumMaterializationBytes;
+    std::uint64_t payloadBytes = kMaximumPayloadBytes;
+    std::size_t shadowEntities = kMaximumShadowEntities;
+  };
+
+  void reset() {
+    attempts_ = 0;
+    graphs_ = 0;
+    nodes_ = 0;
+    imageBytes_ = 0;
+    materializationBytes_ = 0;
+    payloadBytes_ = 0;
+    shadowEntities_ = 0;
+    rejected_ = false;
+  }
+
+  [[nodiscard]] bool beginGraph() {
+    if (rejected_ || attempts_ >= limits_.graphs) {
+      rejected_ = true;
+      return false;
+    }
+    ++attempts_;
+    return true;
+  }
+
+  [[nodiscard]] bool reserveNodes(std::size_t count) {
+    if (!reserveCounter(nodes_, count, limits_.nodes)) return false;
+    ++graphs_;
+    return true;
+  }
+
+  [[nodiscard]] bool reserveImageBytes(std::uint64_t count) {
+    return reserveCounter(imageBytes_, count, limits_.imageBytes);
+  }
+
+  [[nodiscard]] bool reserveMaterializationBytes(std::uint64_t count) {
+    return reserveCounter(materializationBytes_, count, limits_.materializationBytes);
+  }
+
+  [[nodiscard]] bool reservePayloadBytes(std::uint64_t count) {
+    return reserveCounter(payloadBytes_, count, limits_.payloadBytes);
+  }
+
+  [[nodiscard]] bool reserveShadowEntities(std::size_t count) {
+    return reserveCounter(shadowEntities_, count, limits_.shadowEntities);
+  }
+
+  [[nodiscard]] std::size_t attempts() const { return attempts_; }
+  [[nodiscard]] std::size_t graphs() const { return graphs_; }
+  [[nodiscard]] std::size_t nodes() const { return nodes_; }
+  [[nodiscard]] std::uint64_t imageBytes() const { return imageBytes_; }
+  [[nodiscard]] std::uint64_t materializationBytes() const { return materializationBytes_; }
+  [[nodiscard]] std::uint64_t payloadBytes() const { return payloadBytes_; }
+  [[nodiscard]] std::size_t shadowEntities() const { return shadowEntities_; }
+  [[nodiscard]] bool rejected() const { return rejected_; }
+
+  void setLimitsForTesting(Limits limits) {
+    limits_.graphs = std::min(limits_.graphs, limits.graphs);
+    limits_.nodes = std::min(limits_.nodes, limits.nodes);
+    limits_.imageBytes = std::min(limits_.imageBytes, limits.imageBytes);
+    limits_.materializationBytes =
+        std::min(limits_.materializationBytes, limits.materializationBytes);
+    limits_.payloadBytes = std::min(limits_.payloadBytes, limits.payloadBytes);
+    limits_.shadowEntities = std::min(limits_.shadowEntities, limits.shadowEntities);
+  }
+
+private:
+  template <typename T>
+  [[nodiscard]] bool reserveCounter(T& consumed, T count, T limit) {
+    if (rejected_ || consumed > limit || count > limit - consumed) {
+      rejected_ = true;
+      return false;
+    }
+    consumed += count;
+    return true;
+  }
+
+  Limits limits_;
+  std::size_t attempts_ = 0;
+  std::size_t graphs_ = 0;
+  std::size_t nodes_ = 0;
+  std::uint64_t imageBytes_ = 0;
+  std::uint64_t materializationBytes_ = 0;
+  std::uint64_t payloadBytes_ = 0;
+  std::size_t shadowEntities_ = 0;
+  bool rejected_ = false;
+};
+
 /** Aggregate conversion, rasterization, and upload work shared by a render frame. */
 class RendererDrawBudget {
 public:
@@ -1054,6 +1158,11 @@ public:
 
   /// Return resource-admission diagnostics for the current frame.
   [[nodiscard]] virtual RendererResourceStats resourceStats() const { return {}; }
+
+  /// Shared driver-side filter preparation budget for this renderer family, when supported.
+  [[nodiscard]] virtual RendererFilterPreparationBudget* filterPreparationBudget() {
+    return nullptr;
+  }
 
   /// Cause the next local filter raster allocation to fail in a boundary test.
   virtual void injectFilterLocalRasterAllocationFailureForTesting() {}

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -1483,6 +1483,9 @@ void RendererTinySkia::resetOwnedFrameBudgets() {
   if (ownsFilterExecutionBudget_) {
     filterExecutionBudget_->reset();
   }
+  if (ownsFilterPreparationBudget_) {
+    filterPreparationBudget_->reset();
+  }
 }
 
 void RendererTinySkia::beginFrameResourceScope() {
@@ -3408,6 +3411,8 @@ std::unique_ptr<RendererInterface> RendererTinySkia::createOffscreenInstance() c
   auto renderer = std::make_unique<RendererTinySkia>(verbose_);
   renderer->filterExecutionBudget_ = filterExecutionBudget_;
   renderer->ownsFilterExecutionBudget_ = false;
+  renderer->filterPreparationBudget_ = filterPreparationBudget_;
+  renderer->ownsFilterPreparationBudget_ = false;
   renderer->drawBudget_ = drawBudget_;
   renderer->ownsDrawBudget_ = false;
   renderer->surfaceBudget_ = surfaceBudget_;
@@ -3417,6 +3422,10 @@ std::unique_ptr<RendererInterface> RendererTinySkia::createOffscreenInstance() c
   renderer->textMaterializationBudget_ = textMaterializationBudget_;
   renderer->ownsTextMaterializationBudget_ = false;
   return renderer;
+}
+
+RendererFilterPreparationBudget* RendererTinySkia::filterPreparationBudget() {
+  return filterPreparationBudget_.get();
 }
 
 void RendererTinySkia::setDashWorkBudgetForTesting(std::size_t maximumWorkUnits) {

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -251,6 +251,7 @@ public:
   [[nodiscard]] RendererBitmap takeSnapshot() const override;
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
   [[nodiscard]] RendererResourceStats resourceStats() const override;
+  [[nodiscard]] RendererFilterPreparationBudget* filterPreparationBudget() override;
 
   /// Reduce generated-dash work for a boundary test.
   void setDashWorkBudgetForTesting(std::size_t maximumWorkUnits);
@@ -509,6 +510,9 @@ private:
   std::shared_ptr<components::FilterExecutionBudget> filterExecutionBudget_ =
       std::make_shared<components::FilterExecutionBudget>();
   bool ownsFilterExecutionBudget_ = true;
+  std::shared_ptr<RendererFilterPreparationBudget> filterPreparationBudget_ =
+      std::make_shared<RendererFilterPreparationBudget>();
+  bool ownsFilterPreparationBudget_ = true;
   std::shared_ptr<RendererDrawBudget> drawBudget_ = std::make_shared<RendererDrawBudget>();
   bool ownsDrawBudget_ = true;
   std::shared_ptr<RendererSurfaceBudget> surfaceBudget_ = std::make_shared<RendererSurfaceBudget>();

--- a/donner/svg/renderer/tests/MockRendererInterface.h
+++ b/donner/svg/renderer/tests/MockRendererInterface.h
@@ -57,6 +57,7 @@ public:
               (const std::function<bool()>& shouldCancel), (const, override));
   MOCK_METHOD(std::shared_ptr<const RendererTextureSnapshot>, takeTextureSnapshot, (), (override));
   MOCK_METHOD(bool, requiresTextureSnapshotPresentation, (), (const, override));
+  MOCK_METHOD(RendererFilterPreparationBudget*, filterPreparationBudget, (), (override));
   MOCK_METHOD(std::unique_ptr<RendererInterface>, createOffscreenInstance, (), (const, override));
   MOCK_METHOD(void, setDebugGeometryOverlay, (bool enabled), (override));
   MOCK_METHOD(bool, debugGeometryOverlay, (), (const, override));

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -1137,10 +1137,14 @@ TEST_F(RendererDriverTest, PreparedFragmentImageKeepsFamilyReservationWithShared
         retainedPixels = image->imageData;
       });
 
-  driver.draw(document);
+  RendererDriver::SecurityStats stats;
+  RendererDriver boundedDriver(renderer, /*verbose=*/false, &stats);
+  boundedDriver.draw(document);
 
   ASSERT_THAT(retainedPixels, testing::NotNull());
   const std::size_t pixelBytes = retainedPixels->size();
+  EXPECT_EQ(stats.preparedFilterImageBytes, pixelBytes);
+  EXPECT_EQ(stats.preparedFilterMaterializationBytes, pixelBytes * 2u);
   const std::size_t retainedWithPixels =
       family->retainedBytes(components::DocumentResourceFamilyBudget::Kind::ComputedFilter);
   retainedPixels.reset();

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -375,6 +375,32 @@ TEST_F(RendererDriverTest, RepeatedOverCapClipStopsPreflightAfterFirstRejection)
   EXPECT_EQ(stats.clipGeometryPathsPreflighted, kMaximumClipShapes + 1u);
 }
 
+TEST_F(RendererDriverTest, SharedFilterBudgetStillResetsClipDiagnosticsPerDriverFrame) {
+  RendererFilterPreparationBudget sharedFilterBudget;
+  ON_CALL(renderer, filterPreparationBudget()).WillByDefault(testing::Return(&sharedFilterBudget));
+
+  constexpr std::size_t kMaximumClipShapes =
+      RendererTextMaterializationBudget::kMaximumUniqueOutlines;
+  std::string overSvg = R"svg(<defs><clipPath id="over">)svg";
+  for (std::size_t i = 0; i < kMaximumClipShapes + 1u; ++i) {
+    overSvg += R"svg(<path d="M0 0L1 1"/>)svg";
+  }
+  overSvg += R"svg(</clipPath></defs><rect width="1" height="1" clip-path="url(#over)"/>)svg";
+  SVGDocument overDocument = makeDocument(overSvg, Vector2i(1, 1));
+  SVGDocument cleanDocument = makeDocument(R"svg(<rect width="1" height="1"/>)svg", Vector2i(1, 1));
+
+  RendererDriver::SecurityStats stats;
+  RendererDriver overDriver(renderer, /*verbose=*/false, &stats);
+  RendererDriver cleanDriver(renderer, /*verbose=*/false, &stats);
+  overDriver.draw(overDocument);
+  ASSERT_TRUE(stats.clipGeometryCopyRejected);
+  ASSERT_EQ(stats.clipGeometryPathsPreflighted, kMaximumClipShapes + 1u);
+
+  cleanDriver.draw(cleanDocument);
+  EXPECT_FALSE(stats.clipGeometryCopyRejected);
+  EXPECT_EQ(stats.clipGeometryPathsPreflighted, 0u);
+}
+
 TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
   SVGDocument document = makeDocument(R"svg(
     <text x="2" y="3" fill="#00FF00">hi</text>

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -152,6 +152,65 @@ TEST(RendererPublicApiTest, FrameResourceScopeSharesFilterPreparationAcrossIndep
   EXPECT_TRUE(stats.filterPreparationRejected);
 }
 
+TEST(RendererPublicApiTest, ConcurrentSnapshotCaptureSharesOuterFilterPreparationBudget) {
+  std::string firstSource = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+      <defs><filter id="f"><feFlood/></filter></defs>
+  )svg";
+  for (std::size_t i = 0; i < RendererDriver::kMaximumPreparedFilterGraphs; ++i) {
+    firstSource += R"svg(<rect width="1" height="1" filter="url(#f)"/>)svg";
+  }
+  firstSource += "</svg>";
+  SVGDocument firstDocument = ParseDocument(firstSource);
+  SVGDocument plusOneDocument = ParseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+      <defs><filter id="f"><feFlood/></filter></defs>
+      <rect width="1" height="1" filter="url(#f)"/>
+    </svg>
+  )svg");
+  firstDocument.setThreadingMode(ThreadingMode::ConcurrentDom);
+  plusOneDocument.setThreadingMode(ThreadingMode::ConcurrentDom);
+
+  RendererTinySkia renderer;
+  RendererDriver firstDriver(renderer);
+  RendererDriver plusOneDriver(renderer);
+  renderer.beginFrameResourceScope();
+  firstDriver.draw(firstDocument);
+  plusOneDriver.draw(plusOneDocument);
+  renderer.endFrameResourceScope();
+
+  RendererFilterPreparationBudget* budget = renderer.filterPreparationBudget();
+  ASSERT_NE(budget, nullptr);
+  EXPECT_EQ(budget->attempts(), RendererDriver::kMaximumPreparedFilterGraphs);
+  EXPECT_TRUE(budget->rejected());
+}
+
+TEST(RendererPublicApiTest, ReusedElementRendererStartsFreshFilterPreparationFrames) {
+  SVGDocument document = ParseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="8" height="8">
+      <defs><filter id="f"><feFlood flood-color="red"/></filter></defs>
+      <rect id="target" width="8" height="8" filter="url(#f)"/>
+    </svg>
+  )svg");
+  std::optional<SVGElement> target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  Renderer renderer;
+  RendererFilterPreparationBudget* budget = renderer.filterPreparationBudget();
+  ASSERT_NE(budget, nullptr);
+  RendererFilterPreparationBudget::Limits limits;
+  limits.graphs = 1;
+  budget->setLimitsForTesting(limits);
+
+  EXPECT_FALSE(renderer.renderElement(*target, Vector2i(8, 8)).empty());
+  EXPECT_EQ(budget->attempts(), 1u);
+  EXPECT_FALSE(budget->rejected());
+
+  EXPECT_FALSE(renderer.renderElement(*target, Vector2i(8, 8)).empty());
+  EXPECT_EQ(budget->attempts(), 1u);
+  EXPECT_FALSE(budget->rejected());
+}
+
 TEST(RendererDrawBudgetTest, RejectsEveryAggregateDimensionWithoutOvershoot) {
   RendererDrawBudget budget;
   EXPECT_TRUE(budget.reserve(

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -14,6 +14,7 @@
 #include "donner/svg/SVGTextElement.h"
 #include "donner/svg/SVGUseElement.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
@@ -117,6 +118,38 @@ TEST(RendererPublicApiTest, FrameResourceScopeKeepsOffscreenAndRootSurfaceCharge
   renderer->endFrame();
   EXPECT_EQ(renderer->resourceStats().surfaceCount, 1u)
       << "the next standalone frame starts a fresh budget epoch";
+}
+
+TEST(RendererPublicApiTest, FrameResourceScopeSharesFilterPreparationAcrossIndependentDrivers) {
+  std::string firstSource = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+      <defs><filter id="f"><feFlood/></filter></defs>
+  )svg";
+  for (std::size_t i = 0; i < RendererDriver::kMaximumPreparedFilterGraphs; ++i) {
+    firstSource += R"svg(<rect width="1" height="1" filter="url(#f)"/>)svg";
+  }
+  firstSource += "</svg>";
+  SVGDocument firstDocument = ParseDocument(firstSource);
+  SVGDocument plusOneDocument = ParseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+      <defs><filter id="f"><feFlood/></filter></defs>
+      <rect width="1" height="1" filter="url(#f)"/>
+    </svg>
+  )svg");
+
+  RendererTinySkia renderer;
+  RendererDriver::SecurityStats stats;
+  RendererDriver firstDriver(renderer, /*verbose=*/false, &stats);
+  RendererDriver plusOneDriver(renderer, /*verbose=*/false, &stats);
+
+  renderer.beginFrameResourceScope();
+  firstDriver.draw(firstDocument);
+  plusOneDriver.draw(plusOneDocument);
+  renderer.endFrameResourceScope();
+
+  EXPECT_EQ(stats.filterPreparationAttempts, RendererDriver::kMaximumPreparedFilterGraphs);
+  EXPECT_EQ(stats.preparedFilterGraphs, RendererDriver::kMaximumPreparedFilterGraphs);
+  EXPECT_TRUE(stats.filterPreparationRejected);
 }
 
 TEST(RendererDrawBudgetTest, RejectsEveryAggregateDimensionWithoutOvershoot) {


### PR DESCRIPTION
Shares filter preparation and image materialization admission across compositor, offscreen, snapshot, and thumbnail passes in one renderer frame.

- Preserves the 4 MiB decoded-image ceiling and adds an 8 MiB two-copy materialization envelope.
- Covers TinySkia, Geode, ConcurrentDom snapshot replay, nested drivers, reused element renderers, and reused standalone thumbnail offscreens.
- Opens each standalone thumbnail frame on the owning root so non-owning offscreen children cannot carry sticky rejection into the next request.
- Resets clip diagnostics independently while keeping in-frame rejection sticky.

Validation:
- Driver, public API, compositor, render-element, and sample-thumbnail suites
- Default, TinySkia, Geode, and UBSan variants
- CMake, lint, diff, privacy, and independent exact-range review

Fixes #1045