### PR TITLE
Restore full-suite reliability

### DIFF
--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -6281,7 +6281,7 @@ void EditorShell::refreshAfterToolDrivenFlush() {
   app_.flushFrame();
   renderCoordinator_.invalidatePresentationAfterDocumentFlush(app_,
                                                               app_.document().lastFlushResult());
-  documentSyncController_.applyPendingWritebacks(app_, selectTool_, textEditor_);
+  applyPendingWritebacksWhenRendererIdle(renderCoordinator_.asyncRenderer().isBusy());
   renderCoordinator_.refreshSelectionBoundsCache(app_);
   updatePenLivePreviewTarget();
   renderCoordinator_.rasterizeOverlayForCurrentSelection(
@@ -6324,6 +6324,17 @@ bool EditorShell::flushQueuedMutationAndRefreshOverlay() {
   requestRenderAtEndOfFrame_ = true;
   window_.wakeEventLoop();
   return true;
+}
+
+void EditorShell::applyPendingWritebacksWhenRendererIdle(bool rendererBusy) {
+  if (rendererBusy) {
+    // The writebacks remain queued in the app/tool/controller until this helper reaches an idle
+    // frame. AsyncRenderer's completion callback wakes the event loop for that transition; waking
+    // here would recursively schedule every busy frame and defeat the completion-driven wait.
+    return;
+  }
+
+  documentSyncController_.applyPendingWritebacks(app_, selectTool_, textEditor_);
 }
 
 bool EditorShell::flushInteractiveDragMutationAndRequestRender() {
@@ -7184,7 +7195,7 @@ void EditorShell::runFrame() {
   markPhase(mainFrameCost.overlayRefreshMs);
 
   documentSyncController_.syncParseErrorMarkers(app_, textEditor_);
-  documentSyncController_.applyPendingWritebacks(app_, selectTool_, textEditor_);
+  applyPendingWritebacksWhenRendererIdle(documentUiSnapshotRendererBusy);
   markPhase(mainFrameCost.documentSyncMs);
 
   if (!app_.hasDocument()) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -521,6 +521,7 @@ private:
   void renderTextToolHint();
   [[nodiscard]] SelectionChromeDetail selectionChromeDetailForActiveTool() const;
   bool flushQueuedMutationAndRefreshOverlay();
+  void applyPendingWritebacksWhenRendererIdle(bool rendererBusy);
   bool flushInteractiveDragMutationAndRequestRender();
   /// Re-run the post-flush presentation refresh after a tool that flushes the
   /// document internally (the text tool's wrap measurement).

--- a/donner/svg/components/filter/ComputedFilterResourceBudget.h
+++ b/donner/svg/components/filter/ComputedFilterResourceBudget.h
@@ -210,9 +210,10 @@ private:
     auto familyReservation = std::make_shared<FamilyReservation>(family_, bytes);
     auto pixels = std::shared_ptr<const std::vector<std::uint8_t>>(
         new std::vector<std::uint8_t>(std::move(sourcePixels)),
-        [reservation = std::move(familyReservation)](const std::vector<std::uint8_t>* value) {
-          (void)reservation;
+        [reservation =
+             std::move(familyReservation)](const std::vector<std::uint8_t>* value) mutable {
           delete value;
+          reservation.reset();
         });
     sharedImageBytes_ += bytes;
     ++sharedImageMaterializations_;

--- a/tools/generate_build_report_tests.py
+++ b/tools/generate_build_report_tests.py
@@ -776,7 +776,9 @@ class GenerateBuildReportTests(unittest.TestCase):
             progress_interval_sec=0.01,
             status_stream=io.StringIO(),
         )
-        result = runner.run("python-sleep", ["python3", "-c", "import time; time.sleep(0.03)"])
+        result = runner.run(
+            "python-sleep", [sys.executable, "-c", "import time; time.sleep(0.03)"]
+        )
 
         self.assertTrue(result.success)
         self.assertGreaterEqual(result.duration_sec, 0.02)


### PR DESCRIPTION
This restores reliable execution of Donner's required full test suite by fixing three failures exposed by the complete pre-PR gate.

## Summary

- launch the build-report progress fixture with the current Python interpreter so the test remains hermetic under Bazel
- release a shared filter image's family reservation when the last strong owner goes away, even while weak cache entries retain the control block
- defer source writebacks while the asynchronous renderer owns the document, then drain them on the first idle frame

## Verification

- `bazel test //...`
- `bazel test --jobs=48 --runs_per_test=20 //donner/editor/tests:editor_shell_tests --cache_test_results=no --test_output=errors` (80/80 candidate runs passed; the parent reproduced the race in 1/80 runs)
- all four configured renderer-driver variants covering the family-reservation regression
- `bazel test //tools:generate_build_report_tests`
- `tools/lint.sh`
- `python3 tools/cmake/gen_cmakelists.py --check`

## Security

The changes do not expand inputs, interfaces, permissions, or resource limits. They tighten ownership timing and preserve pending writebacks until the document is safe to update.
