### PR TITLE
Run incremental coverage on affected test variants

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -306,7 +306,7 @@ build --test_env=DONNER_RENDERER_TEST_VERBOSE
 coverage --config=coverage
 coverage --combined_report=lcov
 coverage --instrumentation_filter="-test_utils$,//donner[:/]"
-coverage --test_tag_filters=-fuzz_target,-lint
+coverage --test_tag_filters=-fuzz_target,-lint,-manual,-perf
 # Continue past build/analysis failures so coverage is collected from all tests
 # that can run.
 coverage --keep_going

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -523,6 +523,7 @@ jobs:
           # The alias-resolved affected set, shared by the kind query below and
           # by the test-presence query after it. Keep it single-quoted: `$a` is
           # a bazel query variable, not a shell one.
+          # shellcheck disable=SC2016
           resolved_expr="$(printf 'let a = set(%s) in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))' "$(tr '\n' ' ' < "$work_dir/affected.txt")")"
           kind_query_file="$work_dir/affected-query.txt"
           printf '%s\n' "$resolved_expr" > "$kind_query_file"
@@ -588,7 +589,9 @@ jobs:
               # test_suite expansion and rule kinds this workflow does not
               # enumerate are handled by definition rather than by a name
               # heuristic, and subtract the tags the coverage command itself
-              # filters out (--test_tag_filters=-fuzz_target,-lint in .bazelrc),
+              # filters out
+              # (--test_tag_filters=-fuzz_target,-lint,-manual,-perf in
+              # .bazelrc),
               # because a subset whose only tests carry those tags leaves the
               # coverage run with the very empty test set this gate exists to
               # keep it out of. `attr` matches its pattern against the string
@@ -597,7 +600,7 @@ jobs:
               # punctuation rather than anchored with ^$. Fail closed: a query
               # failure keeps the coverage run.
               test_query_file="$work_dir/affected-tests-query.txt"
-              printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint)[,\]]", tests(%s))\n' \
+              printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint|manual|perf)[,\]]", tests(%s))\n' \
                 "$resolved_expr" "$resolved_expr" > "$test_query_file"
               affected_tests_file="$work_dir/affected-tests.txt"
               if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
@@ -608,6 +611,9 @@ jobs:
                   emit_targets true no_test_targets ""
                   exit 0
                 fi
+                affected="$(
+                  python3 -c 'import pathlib, sys; labels = [line.strip() for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]; print(" ".join(labels))' "$affected_tests_file"
+                )"
               else
                 echo "Test-presence query failed; running coverage on affected subset (guard intact)."
                 cat "$diagnostics_dir/test-query.log" || true
@@ -636,6 +642,8 @@ jobs:
           # untrimmed set / target; variant-only targets (no base sibling)
           # are never dropped. See tools/coverage_variant_trim.py and
           # docs/design_docs/0029-2.
+          # Intentional word splitting: each Bazel label becomes one line.
+          # shellcheck disable=SC2086
           printf '%s\n' $affected > "$work_dir/affected-pretrim.txt"
           if trimmed="$(python3 tools/coverage_variant_trim.py \
               --affected-file "$work_dir/affected-pretrim.txt" \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -426,8 +426,8 @@ jobs:
           # workspace checkout, refs/pull/N/merge), not against HEAD_SHA.
           # Hashing base-tip vs HEAD_SHA attributes post-fork drift on main to
           # the PR, inflating the affected set on any branch that has not
-          # rebased (measured up to 126x over-inclusion; see
-          # docs/design_docs/0029-2). In the tip-vs-merge comparison, drift is
+          # rebased (measured up to 126x over-inclusion). In the
+          # tip-vs-merge comparison, drift is
           # present on BOTH sides, so unchanged-by-the-PR targets hash
           # identically and drop out; and because the merge graph is the one
           # hashed, reverse dependencies that exist ONLY in the merge (a dep
@@ -626,10 +626,11 @@ jobs:
             cat "$diagnostics_dir/kind-query.log" || true
           fi
 
-          # Representative-variant trim (operator-approved policy, 2026-07-11):
-          # PR PATCH coverage runs one representative variant per test - the
-          # base/default target - and drops `_tiny`/`_text_full`/`_geode`
-          # variant wrappers whose base sibling is in the set. The wrappers
+          # Representative-variant trim:
+          # PR patch coverage runs one representative variant per test - the
+          # base/default target - and drops generated variant wrappers only
+          # when their ordinary base or named representative is in the set.
+          # The wrappers
           # compile the SAME sources under different backend/feature flags, so
           # for patch coverage they are redundant parameterizations whose
           # unique signal (backend/feature-gated lines) stays covered by the
@@ -639,9 +640,9 @@ jobs:
           # handwritten targets that merely share the suffix (e.g. a
           # cc_library named renderer_geode) are untouched. Fail closed: tool
           # failure, a failed kind query, or an unknown kind keeps the
-          # untrimmed set / target; variant-only targets (no base sibling)
-          # are never dropped. See tools/coverage_variant_trim.py and
-          # docs/design_docs/0029-2.
+          # untrimmed set / target; variant-only targets (no base or named
+          # representative sibling) are never dropped. The full contract is in
+          # tools/coverage_variant_trim.py.
           # Intentional word splitting: each Bazel label becomes one line.
           # shellcheck disable=SC2086
           printf '%s\n' $affected > "$work_dir/affected-pretrim.txt"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -635,7 +635,7 @@ jobs:
           # unique signal (backend/feature-gated lines) stays covered by the
           # main-push FULL multi-variant baseline. Only targets whose rule
           # kind (from the label_kind query above) is the generated
-          # donner_multi_transitioned_test wrapper are ever dropped, so
+          # _donner_multi_transitioned_test wrapper are ever dropped, so
           # handwritten targets that merely share the suffix (e.g. a
           # cc_library named renderer_geode) are untouched. Fail closed: tool
           # failure, a failed kind query, or an unknown kind keeps the

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -135,6 +135,14 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
             {"-fuzz_target", "-lint", "-manual", "-perf"},
             set(match.group(1).split(",")),
         )
+        query_match = re.search(
+            r'attr\("tags", "[^"]*\(([^)]+)\)[^"]*"', self.coverage
+        )
+        self.assertIsNotNone(query_match)
+        self.assertEqual(
+            {tag.removeprefix("-") for tag in match.group(1).split(",")},
+            set(query_match.group(1).split("|")),
+        )
 
     def test_every_change_based_test_step_handles_an_empty_selection(self):
         """A selection with no test targets must not fail a change-based lane.

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -125,6 +125,17 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 job = self._job_body(job_name)
                 self.assertEqual(1, job.count("--test_tag_filters=-manual,-perf"))
 
+    def test_coverage_excludes_all_opt_in_test_tags(self):
+        """Coverage must not run manual/perf tests through its own override."""
+        match = re.search(
+            r"^coverage --test_tag_filters=([^\n]+)$", self.bazelrc, re.MULTILINE
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(
+            {"-fuzz_target", "-lint", "-manual", "-perf"},
+            set(match.group(1).split(",")),
+        )
+
     def test_every_change_based_test_step_handles_an_empty_selection(self):
         """A selection with no test targets must not fail a change-based lane.
 

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -193,6 +193,26 @@ class CoverageLaneRoutingTest(unittest.TestCase):
         self.assertNotIn("build_defs/*", case_line)
         self.assertNotIn(".bazelrc", case_line)
 
+    def test_successful_test_query_becomes_the_coverage_target_set(self):
+        """Coverage must run the affected tests, not every affected rule.
+
+        The affected graph contains libraries, binaries, fuzzers, benchmarks,
+        packaging rules, and private implementation targets. The workflow
+        already computes the runnable affected-test set; retaining the broader
+        graph after that query turns a small code change into a near-full build.
+        """
+        test_query = self.text.index('affected_tests_file="$work_dir/affected-tests.txt"')
+        final_assignment = self.text.index('affected="$(', test_query)
+        variant_trim = self.text.index("# Representative-variant trim", test_query)
+        emit = self.text.index('emit_targets false bazel_diff "$affected"', variant_trim)
+
+        self.assertLess(test_query, final_assignment)
+        self.assertLess(final_assignment, variant_trim)
+        self.assertLess(variant_trim, emit)
+        assignment = self.text[final_assignment:variant_trim]
+        self.assertIn('"$affected_tests_file"', assignment)
+        self.assertNotIn('"$work_dir/affected.txt"', assignment)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/coverage_variant_trim.py
+++ b/tools/coverage_variant_trim.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Trim redundant variant-wrapper targets from the PR coverage target set.
 
-Policy (operator-approved, 2026-07-11): PR PATCH coverage instruments and runs
-ONE representative variant per test - the base/default target - and the full
-multi-variant matrix stays on the main-push coverage baseline. Rationale: the
+PR patch coverage instruments and runs one representative variant per test,
+using the base/default target, while the full multi-variant matrix stays on the
+main-push coverage baseline. Rationale: the
 `donner_variant_cc_test` wrappers (`{name}_tiny`, `{name}_text_full`,
 `{name}_geode`; see build_defs/rules.bzl `_VARIANT_SPECS`) compile the SAME
 source files under different backend/feature flags, so for Codecov patch
@@ -22,16 +22,16 @@ Named product matrices use `_default_text` as that representative when no
 unsuffixed wrapper exists; sibling `_max` and `_geode` wrappers are redundant
 for PR patch coverage under the same policy.
 
-Fail-safe contract: a target is dropped ONLY when ALL of the following hold:
-(1) its label carries a variant suffix, (2) its base sibling (the label with
-the suffix stripped) is itself present in the affected set, and (3) its rule
-kind, per the caller-provided `bazel query --output label_kind` result, is the
-generated wrapper kind (`_donner_multi_transitioned_test`). The kind gate keeps
-handwritten targets that merely share the naming convention (e.g. a
-`cc_library` named `renderer_geode` beside `renderer`) out of the trim. A
-label missing from the kind file, an unreadable kind file, or any error in
-this tool must be treated as "keep the target" / "keep the full set" (fail
-closed toward more coverage).
+Fail-safe contract: a target is dropped only when its rule kind is the generated
+wrapper kind (`_donner_multi_transitioned_test`) and one of two representatives
+is present in the affected set: ordinary suffix variants require the
+suffix-stripped base sibling; named `_max`/`_geode` product variants require a
+`_default_text` sibling whose kind is also the generated wrapper kind. The kind
+gate keeps handwritten targets that merely share the naming convention (e.g. a
+`cc_library` named `renderer_geode` beside `renderer`) out of the trim. A label
+missing from the kind file, an unreadable kind file, or any error in this tool
+must be treated as "keep the target" / "keep the full set" (fail closed toward
+more coverage).
 
 Reads one label per line, writes the trimmed set (one per line) to stdout and
 a summary line to stderr.
@@ -57,7 +57,7 @@ WRAPPER_KIND = "_donner_multi_transitioned_test"
 def parse_label_kinds(label_kind_text):
     """Parse `bazel query --output label_kind` text into {label: kind}.
 
-    Lines look like `donner_multi_transitioned_test rule //pkg:name`. Lines
+    Lines look like `_donner_multi_transitioned_test rule //pkg:name`. Lines
     that do not match are skipped (fail-safe: unknown labels are not trimmed).
     """
     kinds = {}

--- a/tools/coverage_variant_trim.py
+++ b/tools/coverage_variant_trim.py
@@ -11,18 +11,22 @@ coverage of a PR's changed lines they are redundant parameterizations - their
 unique coverage is limited to backend/feature-gated lines, which the main-push
 full run keeps covering. The measured cost of the redundancy on the coverage
 lane is a ~7x instrumented compile multiplier on SVG element translation units
-and 90 of 296 test executions (docs/design_docs/0029-2, PR #829 exemplar).
+and 90 of 296 test executions in a representative broad change.
 
 The base variant is the representative because it is the default build graph
 (what `bazel test` and the CI lanes exercise by default), it already accounts
 for the majority of coverage test executions (206 of 296 on the exemplar), and
 its instrumented surface is the broadest default-feature surface.
 
+Named product matrices use `_default_text` as that representative when no
+unsuffixed wrapper exists; sibling `_max` and `_geode` wrappers are redundant
+for PR patch coverage under the same policy.
+
 Fail-safe contract: a target is dropped ONLY when ALL of the following hold:
 (1) its label carries a variant suffix, (2) its base sibling (the label with
 the suffix stripped) is itself present in the affected set, and (3) its rule
 kind, per the caller-provided `bazel query --output label_kind` result, is the
-generated wrapper kind (`donner_multi_transitioned_test`). The kind gate keeps
+generated wrapper kind (`_donner_multi_transitioned_test`). The kind gate keeps
 handwritten targets that merely share the naming convention (e.g. a
 `cc_library` named `renderer_geode` beside `renderer`) out of the trim. A
 label missing from the kind file, an unreadable kind file, or any error in
@@ -41,6 +45,8 @@ import sys
 # for readability; suffixes are tested longest-first to keep `_text_full`
 # from being misread as a `_full` variant of `..._text`.
 VARIANT_SUFFIXES = ("_text_full", "_tiny", "_geode")
+NAMED_REPRESENTATIVE_SUFFIX = "_default_text"
+NAMED_REDUNDANT_SUFFIXES = ("_max", "_geode")
 
 # The private rule kind donner_cc_test's `variants` attr generates for each
 # `{name}_{variant}` wrapper (build_defs/rules.bzl). Only this kind is ever
@@ -74,6 +80,21 @@ def trim_variants(labels, label_kinds=None):
     dropped = []
     for label in labels:
         drop = False
+        if kinds.get(label) == WRAPPER_KIND:
+            for suffix in NAMED_REDUNDANT_SUFFIXES:
+                if label.endswith(suffix):
+                    representative = (
+                        label[: -len(suffix)] + NAMED_REPRESENTATIVE_SUFFIX
+                    )
+                    if (
+                        representative in label_set
+                        and kinds.get(representative) == WRAPPER_KIND
+                    ):
+                        drop = True
+                    break
+        if drop:
+            dropped.append(label)
+            continue
         for suffix in VARIANT_SUFFIXES:
             if label.endswith(suffix):
                 base = label[: -len(suffix)]

--- a/tools/coverage_variant_trim.py
+++ b/tools/coverage_variant_trim.py
@@ -42,10 +42,10 @@ import sys
 # from being misread as a `_full` variant of `..._text`.
 VARIANT_SUFFIXES = ("_text_full", "_tiny", "_geode")
 
-# The rule kind donner_cc_test's `variants` attr generates for each
+# The private rule kind donner_cc_test's `variants` attr generates for each
 # `{name}_{variant}` wrapper (build_defs/rules.bzl). Only this kind is ever
 # trimmed.
-WRAPPER_KIND = "donner_multi_transitioned_test"
+WRAPPER_KIND = "_donner_multi_transitioned_test"
 
 
 def parse_label_kinds(label_kind_text):

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -102,6 +102,35 @@ class TrimVariantsTest(unittest.TestCase):
         self.assertEqual(kept, labels[:1])
         self.assertEqual(dropped, labels[1:])
 
+    def test_named_product_variant_without_representative_is_kept(self):
+        labels = [
+            "//donner/svg/renderer/tests:resvg_test_suite_max",
+            "//donner/svg/renderer/tests:resvg_test_suite_geode",
+        ]
+        kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_named_product_variant_with_nonwrapper_kind_is_kept(self):
+        labels = [
+            "//donner/svg/renderer/tests:resvg_test_suite_default_text",
+            "//donner/svg/renderer/tests:resvg_test_suite_max",
+        ]
+        kinds = kinds_for(wrappers=labels[:1], others=labels[1:])
+        kept, dropped = trim_variants(labels, kinds)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_named_product_variant_with_nonwrapper_representative_is_kept(self):
+        labels = [
+            "//donner/svg/renderer/tests:resvg_test_suite_default_text",
+            "//donner/svg/renderer/tests:resvg_test_suite_max",
+        ]
+        kinds = kinds_for(wrappers=labels[1:], others=labels[:1])
+        kept, dropped = trim_variants(labels, kinds)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
     def test_suffix_only_name_is_kept(self):
         labels = ["//pkg:_geode", "//pkg:_tiny"]
         kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -116,6 +116,13 @@ class TrimVariantsTest(unittest.TestCase):
 
 
 class ParseLabelKindsTest(unittest.TestCase):
+    def test_wrapper_kind_matches_bazel_label_kind_output(self):
+        """Private Starlark rules include their leading underscore in query output."""
+        label = "//donner/svg/compositor:compositor_tests_geode"
+        kinds = parse_label_kinds(f"_donner_multi_transitioned_test rule {label}\n")
+        self.assertEqual(WRAPPER_KIND, "_donner_multi_transitioned_test")
+        self.assertEqual(kinds[label], WRAPPER_KIND)
+
     def test_parses_label_kind_lines(self):
         text = (
             "cc_test rule //donner/svg/compositor:compositor_tests\n"

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -126,7 +126,7 @@ class ParseLabelKindsTest(unittest.TestCase):
     def test_parses_label_kind_lines(self):
         text = (
             "cc_test rule //donner/svg/compositor:compositor_tests\n"
-            "donner_multi_transitioned_test rule //donner/svg/compositor:compositor_tests_geode\n"
+            "_donner_multi_transitioned_test rule //donner/svg/compositor:compositor_tests_geode\n"
             "cc_library rule //donner/svg/renderer:renderer_geode\n"
         )
         kinds = parse_label_kinds(text)

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -92,6 +92,16 @@ class TrimVariantsTest(unittest.TestCase):
             ["//donner/svg/components/paint:paint_component_tests_text_full"],
         )
 
+    def test_named_product_variants_keep_default_text_representative(self):
+        labels = [
+            "//donner/svg/renderer/tests:resvg_test_suite_default_text",
+            "//donner/svg/renderer/tests:resvg_test_suite_max",
+            "//donner/svg/renderer/tests:resvg_test_suite_geode",
+        ]
+        kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))
+        self.assertEqual(kept, labels[:1])
+        self.assertEqual(dropped, labels[1:])
+
     def test_suffix_only_name_is_kept(self):
         labels = ["//pkg:_geode", "//pkg:_tiny"]
         kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))


### PR DESCRIPTION
Incremental PR coverage currently passes every impacted build rule to Bazel and does not consistently recognize generated test-variant wrappers. This can turn a small change into an unnecessarily broad coverage build. The final filtered affected-test set should be the coverage root set, with one representative configuration retained per test family.

## What changed

- use the successful affected-test query as the final incremental coverage target set
- exclude manual, performance, fuzz, and lint targets consistently in both selection and execution
- recognize Bazel's private transitioned-wrapper rule kind
- retain the base variant for ordinary test matrices
- retain `_default_text` while dropping redundant `_max` and `_geode` wrappers for named product matrices
- preserve the broader target set whenever selection or trimming fails
- leave LCOV generation and report validation behavior unchanged

## Verification

- `bazel test //tools:coverage_variant_trim_tests //tools:coverage_lane_routing_tests //tools:ci_runtime_workflow_tests`
- `actionlint .github/workflows/coverage.yml`
- `tools/lint.sh`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `bazel test //...` (465 passed, 21 skipped)

## Security

No workflow permissions, credentials, external actions, or trust gates change. Target queries are read-only, and failure paths continue toward broader coverage rather than silently reducing it.
