### PR TITLE
geode: migrate the clip, layer-composite, and checkerboard paths onto the GPU runtime

### DIFF
--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -2,13 +2,13 @@ load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
 load("//build_defs:visibility.bzl", "donner_internal_visibility")
 load("//build_defs:package.bzl", "donner_package")
 
-# donner::gpu - the Donner-owned GPU runtime (design doc 0053).
+# donner::gpu - the Donner-owned GPU runtime.
 #
-# Packets 2 and 3 of the design's change sequence: typed immutable descriptors, explicit
-# Result/Status errors, move-only RAII generation-checked handles, deferred destruction by
-# submission serial, submit-time re-validation of recorded commands, fail-closed validation
-# shared by every backend, and the deterministic recording backend. Production rendering stays
-# on the existing Geode path until each family is migrated.
+# What the runtime guarantees: typed immutable descriptors, explicit Result/Status errors,
+# move-only RAII generation-checked handles, deferred destruction by submission serial,
+# submit-time re-validation of recorded commands, fail-closed validation shared by every
+# backend, and a deterministic recording backend. Production rendering stays on the existing
+# Geode path until each family is migrated.
 
 donner_cc_library(
     name = "gpu",

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -8,7 +8,7 @@ load("//build_defs:package.bzl", "donner_package")
 # Result/Status errors, move-only RAII generation-checked handles, deferred destruction by
 # submission serial, submit-time re-validation of recorded commands, fail-closed validation
 # shared by every backend, and the deterministic recording backend. Production rendering stays
-# on the existing Geode path until the migration packets.
+# on the existing Geode path until each family is migrated.
 
 donner_cc_library(
     name = "gpu",

--- a/donner/gpu/Descriptors.cc
+++ b/donner/gpu/Descriptors.cc
@@ -135,6 +135,7 @@ std::ostream& operator<<(std::ostream& os, BlendFactor value) {
     case BlendFactor::One: return os << "One";
     case BlendFactor::SrcAlpha: return os << "SrcAlpha";
     case BlendFactor::OneMinusSrcAlpha: return os << "OneMinusSrcAlpha";
+    case BlendFactor::OneMinusDstAlpha: return os << "OneMinusDstAlpha";
   }
   return os << "Unknown";
 }
@@ -246,7 +247,8 @@ bool IsKnownEnumValue(BlendFactor value) {
     case BlendFactor::Zero:
     case BlendFactor::One:
     case BlendFactor::SrcAlpha:
-    case BlendFactor::OneMinusSrcAlpha: return true;
+    case BlendFactor::OneMinusSrcAlpha:
+    case BlendFactor::OneMinusDstAlpha: return true;
   }
   return false;
 }

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -179,6 +179,7 @@ enum class BlendFactor : uint8_t {
   One,               //!< Factor 1.
   SrcAlpha,          //!< Factor (source alpha).
   OneMinusSrcAlpha,  //!< Factor (1 - source alpha).
+  OneMinusDstAlpha,  //!< Factor (1 - destination alpha); destination-over compositing.
 };
 
 /// Blend operations used by Donner pipelines.

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -336,8 +336,8 @@ struct TextureDescriptor {
   Extent2d size;                                     //!< Extent in texels. Must be nonzero.
   TextureFormat format = TextureFormat::RGBA8Unorm;  //!< Texel format.
   TextureUsage usage = TextureUsage::None;           //!< Usage flags. Must not be empty.
-  uint32_t sampleCount = 1;  //!< Samples per texel. Must be 1: the runtime is single-sample by
-                             //!< design (analytical coverage, design 0041).
+  uint32_t sampleCount = 1;  //!< Samples per texel. Must be 1: the runtime resolves coverage
+                             //!< analytically instead of by multisampling.
 };
 
 /// Descriptor for `Device::createTextureView`. Views cover the whole texture.
@@ -504,8 +504,8 @@ struct RenderPipelineDescriptor {
   FragmentState fragment;                                        //!< Fragment stage.
   PrimitiveTopology topology = PrimitiveTopology::TriangleList;  //!< Primitive topology.
   CullMode cullMode = CullMode::None;                            //!< Face culling mode.
-  uint32_t multisampleCount = 1;  //!< Samples per pixel. Must be 1: the runtime is single-sample
-                                  //!< by design (analytical coverage, design 0041).
+  uint32_t multisampleCount = 1;  //!< Samples per pixel. Must be 1: the runtime resolves
+                                  //!< coverage analytically instead of by multisampling.
 };
 
 /// One color attachment of a \ref RenderPassDescriptor.

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -178,7 +178,7 @@ Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
  *
  * The public API is non-virtual and validates every descriptor, handle, and byte range before
  * delegating to protected `on*` virtuals (template-method pattern), so every backend - the
- * deterministic \ref RecordingDevice today, platform backends in later packets - inherits
+ * deterministic \ref RecordingDevice and the platform backends - inherits
  * identical fail-closed behavior. Validation runs in release builds too: invalid input returns
  * a \ref GpuError, never asserts.
  *

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -119,6 +119,7 @@ MTLBlendFactor ToMtlBlendFactor(BlendFactor factor) {
     case BlendFactor::One: return MTLBlendFactorOne;
     case BlendFactor::SrcAlpha: return MTLBlendFactorSourceAlpha;
     case BlendFactor::OneMinusSrcAlpha: return MTLBlendFactorOneMinusSourceAlpha;
+    case BlendFactor::OneMinusDstAlpha: return MTLBlendFactorOneMinusDestinationAlpha;
   }
   UTILS_RELEASE_ASSERT_MSG(false, "validated BlendFactor out of range");
   return MTLBlendFactorZero;

--- a/donner/gpu/tests/RecordingDevice_tests.cc
+++ b/donner/gpu/tests/RecordingDevice_tests.cc
@@ -306,6 +306,37 @@ TEST(RecordingDeviceTests, SpirvShaderModuleSerializationIsDeterministic) {
   EXPECT_THAT(first.serialize(), Eq(second.serialize()));
 }
 
+TEST(RecordingDeviceTests, DestinationOverBlendStateRoundTrips) {
+  RecordingDevice device;
+  const BindGroupLayout bindGroupLayout =
+      GetResultOrFail(device.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "underlayBindings",
+          {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                                BindingType::UniformBuffer}}}));
+  const PipelineLayout pipelineLayout = GetResultOrFail(
+      device.createPipelineLayout(PipelineLayoutDescriptor{"underlayLayout", {bindGroupLayout}}));
+  const ShaderModule shader = GetResultOrFail(device.createShaderModule(ShaderModuleDescriptor{
+      "underlay", "@vertex fn vsMain() {}\n@fragment fn fsMain() {}", ShaderSourceKind::Wgsl}));
+
+  // `result = dst + src * (1 - dst.alpha)`: the destination-over term a background pass needs to
+  // land underneath premultiplied content already in the attachment.
+  const BlendComponent destinationOver{BlendFactor::OneMinusDstAlpha, BlendFactor::One,
+                                       BlendOperation::Add};
+  const RenderPipeline pipeline =
+      GetResultOrFail(device.createRenderPipeline(RenderPipelineDescriptor{
+          "underlay", pipelineLayout, VertexState{shader, "vsMain", {}},
+          FragmentState{shader,
+                        "fsMain",
+                        {ColorTargetState{TextureFormat::RGBA8Unorm,
+                                          BlendState{destinationOver, destinationOver}}}},
+          PrimitiveTopology::TriangleList, CullMode::None}));
+  EXPECT_TRUE(pipeline.isValid());
+
+  EXPECT_THAT(device.serialize(),
+              HasSubstr("blend={color={srcFactor=OneMinusDstAlpha dstFactor=One operation=Add} "
+                        "alpha={srcFactor=OneMinusDstAlpha dstFactor=One operation=Add}}"));
+}
+
 TEST(RecordingDeviceTests, SerializationContainsNoPointers) {
   RecordingDevice device;
   RecordRepresentativeStream(device);

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -164,6 +164,7 @@ VkBlendFactor ToVkBlendFactor(BlendFactor factor) {
     case BlendFactor::One: return VK_BLEND_FACTOR_ONE;
     case BlendFactor::SrcAlpha: return VK_BLEND_FACTOR_SRC_ALPHA;
     case BlendFactor::OneMinusSrcAlpha: return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    case BlendFactor::OneMinusDstAlpha: return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
   }
   UTILS_RELEASE_ASSERT_MSG(false, "validated BlendFactor out of range");
   return VK_BLEND_FACTOR_ZERO;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1732,7 +1732,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     wgpu::TextureDescriptor desc;
   };
   std::vector<PendingRelease> framePendingReleases;
-  std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>> framePendingTextureViewReleases;
 
   void releaseTextureAtFrameEnd(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
     if (!texture) {
@@ -1746,18 +1745,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     releaseTextureAtFrameEnd(std::move(texture), desc);
   }
 
-  void releaseTextureViewsAtFrameEnd(
-      std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>>& views) {
-    for (auto& view : views) {
-      if (view) {
-        framePendingTextureViewReleases.push_back(std::move(view));
-      }
-    }
-    views.clear();
-  }
-
   void drainPendingReleases() {
-    framePendingTextureViewReleases.clear();
     for (auto& pending : framePendingReleases) {
       releaseTexture(std::move(pending.texture), pending.desc);
     }
@@ -1786,7 +1774,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     closeFrameGpuEncoderAfterSubmit();
 
     frameFinishedEncoders.clear();
-    framePendingTextureViewReleases.clear();
     drainPendingReleases();
 
     wgpu::CommandEncoderDescriptor descriptor = {};
@@ -1893,28 +1880,19 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     bool hasPolygon = false;
     bool allocationRejected = false;
     Vector2d polygonCorners[4];
-    /// Path-clip mask. When non-null, `maskResolveView`
-    /// references a 1-sample R8Unorm texture sampled by the fill /
-    /// gradient pipelines through their clip-mask bindings. The
-    /// texture is allocated per `pushClip` call - the Impl owns the
-    /// wgpu::Texture to keep the resolve alive until `popClip`.
+    /// Path-clip mask. When non-null these name a 1-sample texture sampled
+    /// by the fill / gradient pipelines through their clip-mask bindings.
+    /// The texture is allocated per `pushClip` call and parked in
+    /// `maskLayerTextures`, which keeps it alive until `popClip`.
     ///
     /// For nested `<clipPath>` references, the pushClip code builds
     /// one mask per clip-path layer (deepest first); each outer
     /// layer's mask is rendered with the previous layer's mask as an
     /// input clip mask so every outer shape is intersected with the
-    /// deeper union. The final (outermost) layer's resolve lives in
-    /// `maskResolveView`; the intermediate layer textures are parked
-    /// in `maskLayerTextures` so their wgpu::Texture ownership
-    /// persists until `popClip`.
-    wgpu::Texture maskResolveTexture;
-    /// Owned texture views created for each nested mask layer. Released after
-    /// the frame command buffer is submitted because recorded bind groups may
-    /// still reference them after `popClip`.
-    std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>> maskLayerViews;
-    wgpu::TextureView maskResolveView;
-    /// Runtime aliases for `maskResolveTexture` / `maskResolveView`, owned by the frame's import
-    /// lists. Null exactly when `maskResolveView` is null.
+    /// deeper union. The outermost layer's resolve is the one named here.
+    ///
+    /// Both are aliases owned by the frame's import lists, so they are valid
+    /// for the rest of the frame and are null together.
     const gpu::Texture* maskResolveTextureHandle = nullptr;
     const gpu::TextureView* maskResolveViewHandle = nullptr;
     /// Paired (texture, descriptor) entries. Every clip-mask texture
@@ -2170,7 +2148,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
         // intersection in the shader (see ClipStackEntry docs).
         polygonEntry = &entry;
       }
-      if (entry.maskResolveView) {
+      if (entry.maskResolveViewHandle != nullptr) {
         // Same deal for the path-clip mask - we always bind the
         // topmost one, and nested path-clip intersections are a
         // TODO (would need multiple clip-mask bindings in the
@@ -4345,13 +4323,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
 
   static void releaseClipStackTextures(std::vector<ClipStackEntry>& entries) {
     for (ClipStackEntry& entry : entries) {
-      entry.maskLayerViews.clear();
       for (PendingRelease& release : entry.maskLayerTextures) {
         releasePendingTexture(release);
       }
       entry.maskLayerTextures.clear();
-      entry.maskResolveTexture = wgpu::Texture();
-      entry.maskResolveView = wgpu::TextureView();
       entry.maskResolveTextureHandle = nullptr;
       entry.maskResolveViewHandle = nullptr;
     }
@@ -4496,7 +4471,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       device->waitForQueueIdle();
     }
 
-    framePendingTextureViewReleases.clear();
     for (PendingRelease& release : framePendingReleases) {
       releasePendingTexture(release);
     }
@@ -5089,8 +5063,6 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
   // binding the previously-rendered deeper mask as the input clip.
   if (!clip.clipPaths.empty() && impl_->device && impl_->encoder && impl_->pixelWidth > 0 &&
       impl_->pixelHeight > 0) {
-    const wgpu::Device& dev = impl_->device->device();
-
     const auto makeMaskTexture = [&](const char* label, wgpu::TextureDescriptor& outDesc) {
       outDesc = wgpu::TextureDescriptor{};
       outDesc.label = wgpuLabel(label);
@@ -5140,24 +5112,17 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
     // with it as it's being rendered. Without this seed the outer
     // ancestor clip would be lost the moment the inner clip lands
     // because `updateEncoderScissor` only binds the topmost entry.
-    wgpu::Texture nestedMaskTexture;
-    wgpu::TextureView nestedMaskView;
-    // Runtime aliases tracking `nestedMaskTexture` / `nestedMaskView`, owned by the frame's
-    // import lists.
+    // Aliases owned by the frame's import lists, so they stay valid for the rest of the frame.
     const gpu::Texture* nestedMaskTextureHandle = nullptr;
     const gpu::TextureView* nestedMaskViewHandle = nullptr;
     for (auto rit = impl_->clipStack.rbegin(); rit != impl_->clipStack.rend(); ++rit) {
-      if (rit->maskResolveView) {
-        nestedMaskTexture = rit->maskResolveTexture;
-        nestedMaskView = rit->maskResolveView;
+      if (rit->maskResolveViewHandle != nullptr) {
         nestedMaskTextureHandle = rit->maskResolveTextureHandle;
         nestedMaskViewHandle = rit->maskResolveViewHandle;
         break;
       }
     }
 
-    (void)dev;  // Kept for potential future use; texture allocation
-                // routes through `impl_->acquireTexture` now.
     for (auto it = runs.rbegin(); it != runs.rend(); ++it) {
       wgpu::TextureDescriptor maskDesc = {};
       wgpu::Texture maskTexture = makeMaskTexture("RendererGeodeClipMask", maskDesc);
@@ -5168,7 +5133,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 
       // Bind the previously-rendered nested mask (if any) so this
       // layer's fragment shader samples it and intersects.
-      if (nestedMaskView) {
+      if (nestedMaskViewHandle != nullptr) {
         impl_->encoder->setClipMask(*nestedMaskTextureHandle, *nestedMaskViewHandle);
       } else {
         impl_->encoder->clearClipMask();
@@ -5185,14 +5150,8 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       }
       impl_->encoder->endMaskPass();
 
-      nestedMaskTexture = maskTexture;
       nestedMaskTextureHandle = &maskTextureHandle;
       nestedMaskViewHandle = &impl_->importTextureView(maskTextureHandle);
-      geode::ScopedWgpuHandle<wgpu::TextureView> maskView(maskTexture.createView());
-      nestedMaskView = maskView.get();
-      if (maskView) {
-        entry.maskLayerViews.push_back(std::move(maskView));
-      }
 
       // Keep the intermediate textures alive until popClip, paired
       // with their descs for texture-pool release.
@@ -5201,8 +5160,6 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       // The outermost layer (the LAST one processed by this loop,
       // i.e. the FIRST run in `runs`) provides the mask view the
       // main draws sample as their clip.
-      entry.maskResolveTexture = nestedMaskTexture;
-      entry.maskResolveView = nestedMaskView;
       entry.maskResolveTextureHandle = nestedMaskTextureHandle;
       entry.maskResolveViewHandle = nestedMaskViewHandle;
     }
@@ -5225,11 +5182,10 @@ void RendererGeode::popClip() {
   if (!impl_->clipStack.empty()) {
     // Defer release of the mask textures to endFrame - the main
     // encoder that was just drawing under this clip may have recorded
-    // samples from `maskResolveTexture` into the frame encoder, and
+    // samples from the resolved mask texture into the frame encoder, and
     // recycling mid-frame could hand the texture to a later acquire
     // before the submit.
     Impl::ClipStackEntry& entry = impl_->clipStack.back();
-    impl_->releaseTextureViewsAtFrameEnd(entry.maskLayerViews);
     for (auto& release : entry.maskLayerTextures) {
       impl_->releaseTextureAtFrameEnd(std::move(release.texture), release.desc);
     }

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5280,14 +5280,11 @@ void RendererGeode::popIsolatedLayer() {
   impl_->target = frame.savedTarget;
 
   if (frame.blendMode != MixBlendMode::Normal) {
-    // SVG `mix-blend-mode`. The fragment shader needs the
-    // parent's current pixels as a backdrop, but WebGPU forbids
-    // reading from the render pass's own color attachment. Snapshot
-    // the parent's 1-sample resolve target into a separate texture
-    // via a CopyTextureToTexture command, then open a fresh parent
-    // encoder with `LoadOp::Clear` (NOT Load - the blend shader
-    // outputs the final pixel directly, incorporating the snapshot
-    // backdrop, so preserving the old contents would double-apply).
+    // SVG `mix-blend-mode`. The fragment shader needs the parent's current pixels as a
+    // backdrop, but a render pass may not read from its own color attachment. Snapshot the
+    // parent's 1-sample resolve target into a separate texture with a texture-to-texture copy,
+    // then open a fresh parent encoder over the parent target; the load-op note further down
+    // covers why that encoder preserves the target's contents.
     wgpu::TextureDescriptor snapDesc = {};
     snapDesc.label = wgpuLabel("RendererGeodeBlendDstSnapshot");
     snapDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
@@ -5300,21 +5297,18 @@ void RendererGeode::popIsolatedLayer() {
     wgpu::Texture snapshot = impl_->acquireTexture(snapDesc);
 
     if (snapshot) {
-      // Record the snapshot copy into the shared frame CommandEncoder
-      // `impl_->encoder->finish()` above already
-      // ended the layer's render pass, so it's safe to record a
-      // CommandEncoder-level copyTextureToTexture here - no separate
-      // CommandEncoder + submit required.
-      wgpu::TexelCopyTextureInfo src = {};
-      src.texture = frame.savedTarget;
-      wgpu::TexelCopyTextureInfo dst = {};
-      dst.texture = snapshot;
-      const wgpu::Extent3D extent = {static_cast<uint32_t>(impl_->pixelWidth),
-                                     static_cast<uint32_t>(impl_->pixelHeight), 1u};
-      // Everything recorded before this point has already been replayed into the frame command
-      // encoder by the encoder retire above, so the copy lands after those draws and before the
-      // composite recorded below.
-      impl_->frameCommandEncoder.get().copyTextureToTexture(src, dst, extent);
+      const gpu::Texture& savedTargetHandle = impl_->importTarget(frame.savedTarget);
+      const gpu::Texture& snapshotHandle = impl_->importTexture(snapshot, snapDesc);
+
+      // The layer's render pass ended when its encoder was retired above, so the copy can be
+      // recorded outside a pass. It joins the frame's recorded stream after those draws and
+      // before the composite recorded below, which is the order the backdrop has to be frozen in.
+      const gpu::Status copied = impl_->frameGpuEncoder->copyTextureToTexture(
+          savedTargetHandle, snapshotHandle,
+          gpu::Extent2d{static_cast<uint32_t>(impl_->pixelWidth),
+                        static_cast<uint32_t>(impl_->pixelHeight)});
+      UTILS_RELEASE_ASSERT_MSG(!copied.hasError(),
+                               "Failed to record the mix-blend-mode backdrop snapshot copy");
 
       // Open a fresh parent encoder that PRESERVES the target's existing
       // contents (the backdrop pre-push - identical to `snapshot` at
@@ -5332,15 +5326,14 @@ void RendererGeode::popIsolatedLayer() {
       // safe.
       auto newEncoder = std::make_unique<geode::GeoEncoder>(
           *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-          impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
+          savedTargetHandle, impl_->targetExtent(), *impl_->frameGpuEncoder);
       impl_->configurePathEncoder(*newEncoder);
       newEncoder->setLoadPreserve();
       impl_->encoder = std::move(newEncoder);
       impl_->updateEncoderScissor();
       impl_->encoder->blitFullTargetBlended(
-          impl_->importTexture(frame.layerTexture, frame.layerDesc),
-          impl_->importTexture(snapshot, snapDesc), static_cast<uint32_t>(frame.blendMode),
-          frame.opacity);
+          impl_->importTexture(frame.layerTexture, frame.layerDesc), snapshotHandle,
+          static_cast<uint32_t>(frame.blendMode), frame.opacity);
       // Defer release: `blitFullTargetBlended` recorded samples from
       // both `frame.layerTexture` and `snapshot` into the shared
       // frameCommandEncoder; they must stay alive until that buffer

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -76,9 +76,9 @@ donner_cc_library(
     name = "geode_path_encoder",
     srcs = ["GeodePathEncoder.cc"],
     hdrs = ["GeodePathEncoder.h"],
-    # //donner/gpu: the design 0053 vertical slice tests (Metal, Vulkan)
-    # encode the frozen-baseline paths with the same banding the production
-    # path uses. GeodePathEncoder is pure CPU path math with no GPU dependency.
+    # //donner/gpu: the GPU vertical slice tests (Metal, Vulkan) encode the
+    # frozen-baseline paths with the same banding the production path uses.
+    # GeodePathEncoder is pure CPU path math with no GPU dependency.
     visibility = [
         "//donner/gpu:__subpackages__",
         "//donner/svg/renderer:__subpackages__",
@@ -273,10 +273,10 @@ donner_cc_library(
         "GeodeFilterEngine.cc",
         "GeodeImagePipeline.cc",
         "GeodePipeline.cc",
-        # TEMPORARY design-0053 Phase 1 adapter (see GeodeWgpuAdapterDevice.h
-        # for the removal gates). Folded into geode_device like the pipelines
-        # so GeodeDevice can own the adapter alongside the shared pipelines
-        # it constructs (packet 8a+) without a circular dependency.
+        # TEMPORARY transition adapter (see GeodeWgpuAdapterDevice.h for the
+        # removal gates). Folded into geode_device like the pipelines so
+        # GeodeDevice can own the adapter alongside the shared pipelines it
+        # constructs, without a circular dependency.
         "GeodeWgpuAdapterDevice.cc",
     ],
     hdrs = [
@@ -308,7 +308,7 @@ donner_cc_library(
         "//donner/editor/gui:__pkg__",
         "//donner/editor/tests:__pkg__",
         # The donner::gpu shader IR validation fixture compiles emitted WGSL
-        # through GeodeDevice as a black box (design 0053 transition baseline).
+        # through GeodeDevice as a black box, the transition baseline.
         "//donner/gpu:__subpackages__",
         "//donner/svg/renderer:__subpackages__",
         "//examples:__pkg__",
@@ -707,8 +707,8 @@ donner_cc_library(
         "GeodeBufferPool.h",
     ],
     target_compatible_with = _GEODE_ONLY,
-    # //donner/gpu: the design 0053 frozen-baseline capture tool and the
-    # Vulkan vertical slice test render through GeoEncoder as a black box.
+    # //donner/gpu: the frozen-baseline capture tool and the Vulkan vertical
+    # slice test render through GeoEncoder as a black box.
     visibility = [
         "//donner/gpu:__subpackages__",
         "//donner/svg/renderer:__subpackages__",

--- a/donner/svg/renderer/geode/GeodeCheckerboardPipeline.cc
+++ b/donner/svg/renderer/geode/GeodeCheckerboardPipeline.cc
@@ -1,6 +1,7 @@
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <optional>
 #include <span>
@@ -79,6 +80,27 @@ bool CheckerboardRequestIsDrawable(const wgpu::Texture& target, Vector2i targetS
   }
   return !params.scissorPx.has_value() ||
          (params.scissorPx->width != 0 && params.scissorPx->height != 0);
+}
+
+/// True when the device's command stream is free for a submission of our own.
+///
+/// While a renderer has a frame open it owns that stream: the runtime device replays every
+/// submission into the frame's command buffer so the whole frame keeps one recording order.
+/// A checkerboard submitted there would be spliced into a command buffer it does not own, at a
+/// point in that buffer it cannot reason about, and would not reach the target when its caller
+/// expects it to. There is also no ordering it could pick instead: it cannot know whether the
+/// open frame draws to the same target, so queueing itself ahead of that frame would be right
+/// for an overwriting checkerboard and wrong for one that goes underneath. Declining is the
+/// only answer that stays true to `draw`'s contract, and no caller needs the overlap - the
+/// presentation path draws the checkerboard before it opens its frame.
+bool DeviceCommandStreamIsFree(GeodeDevice& device) {
+  if (!device.adapterDevice().hasHostCommandEncoder()) {
+    return true;
+  }
+  std::fprintf(stderr,
+               "[Geode] checkerboard skipped: another frame owns the device's command stream. "
+               "Draw it outside that frame.\n");
+  return false;
 }
 
 /// A surface-owned render target named for the runtime, plus the view a pass attaches.
@@ -236,7 +258,8 @@ bool GeodeCheckerboardPass::ensureResources(GeodeDevice& device,
 bool GeodeCheckerboardPass::draw(GeodeDevice& device, const wgpu::Texture& target,
                                  Vector2i targetSizePx, const CheckerboardUnderlayParams& params,
                                  GeodeCheckerboardPipeline::BlendMode blendMode) {
-  if (!CheckerboardRequestIsDrawable(target, targetSizePx, params)) {
+  if (!CheckerboardRequestIsDrawable(target, targetSizePx, params) ||
+      !DeviceCommandStreamIsFree(device)) {
     return false;
   }
 

--- a/donner/svg/renderer/geode/GeodeCheckerboardPipeline.cc
+++ b/donner/svg/renderer/geode/GeodeCheckerboardPipeline.cc
@@ -1,9 +1,16 @@
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
 #include <string_view>
+#include <utility>
 
+#include "donner/base/RcString.h"
+#include "donner/gpu/CommandEncoder.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
-#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 
 namespace donner::geode {
 
@@ -60,126 +67,167 @@ GeodeCheckerboardPipeline& PipelineForBlendMode(GeodeDevice& device,
              : device.checkerboardPipeline();
 }
 
+/// True when the requested pass has a target to draw into and an appearance that produces
+/// visible cells. A degenerate request is not an error; the caller simply draws nothing.
+bool CheckerboardRequestIsDrawable(const wgpu::Texture& target, Vector2i targetSizePx,
+                                   const CheckerboardUnderlayParams& params) {
+  if (!target || targetSizePx.x <= 0 || targetSizePx.y <= 0) {
+    return false;
+  }
+  if (!(params.devicePixelRatio > 0.0) || !(params.cellSizeLogicalPx > 0.0)) {
+    return false;
+  }
+  return !params.scissorPx.has_value() ||
+         (params.scissorPx->width != 0 && params.scissorPx->height != 0);
+}
+
+/// A surface-owned render target named for the runtime, plus the view a pass attaches.
+struct NamedTarget {
+  gpu::Texture texture;   //!< Runtime name for the borrowed target; owns no backing.
+  gpu::TextureView view;  //!< Whole-texture view used as the pass attachment.
+};
+
+/// Names @p target for the runtime so a pass can attach it. The target belongs to the embedding
+/// surface, so its capabilities are read from the texture itself and cannot be described wrongly.
+/// Returns nothing when the runtime refuses either handle.
+std::optional<NamedTarget> NameTargetForPass(GeodeWgpuAdapterDevice& adapterDevice,
+                                             const wgpu::Texture& target) {
+  gpu::Result<gpu::Texture> texture = adapterDevice.importExternalTexture(
+      target, gpu::Extent2d{target.getWidth(), target.getHeight()},
+      GpuTextureFormatFromWgpu(target.getFormat()), GpuTextureUsageFromWgpu(target.getUsage()));
+  if (texture.hasError()) {
+    return std::nullopt;
+  }
+  gpu::Result<gpu::TextureView> view = adapterDevice.createTextureView(
+      texture.result(), gpu::TextureViewDescriptor{"GeodeCheckerboardTargetView"});
+  if (view.hasError()) {
+    return std::nullopt;
+  }
+  return NamedTarget{std::move(texture).result(), std::move(view).result()};
+}
+
+/// Records the fullscreen-triangle pass into its own command buffer and submits it. The pass
+/// encoder latches its first error and reports it from `finish`, so the individual pass
+/// operations are checked once there rather than one at a time.
+bool RecordAndSubmitCheckerboardPass(GeodeDevice& device,
+                                     const GeodeCheckerboardPipeline& checkerboard,
+                                     const gpu::TextureView& targetView,
+                                     const gpu::BindGroup& bindGroup,
+                                     const std::optional<CheckerboardScissorPx>& scissorPx) {
+  GeodeWgpuAdapterDevice& adapterDevice = device.adapterDevice();
+  gpu::Result<std::unique_ptr<gpu::CommandEncoder>> encoder = adapterDevice.createCommandEncoder();
+  if (encoder.hasError()) {
+    return false;
+  }
+  gpu::CommandEncoder& commands = *encoder.result();
+
+  gpu::Result<gpu::RenderPassEncoder*> pass = commands.beginRenderPass(gpu::RenderPassDescriptor{
+      "GeodeCheckerboardPass",
+      {gpu::RenderPassColorAttachment{targetView, gpu::LoadOp::Load, gpu::StoreOp::Store}}});
+  if (pass.hasError()) {
+    return false;
+  }
+
+  gpu::RenderPassEncoder& renderPass = *pass.result();
+  if (scissorPx.has_value()) {
+    (void)renderPass.setScissorRect(scissorPx->x, scissorPx->y, scissorPx->width,
+                                    scissorPx->height);
+  }
+  (void)renderPass.setPipeline(checkerboard.pipeline());
+  device.countPipelineSwitch();
+  (void)renderPass.setBindGroup(0, bindGroup);
+  (void)renderPass.draw(3, 1, 0, 0);
+  (void)renderPass.end();
+
+  gpu::Result<gpu::CommandBuffer> commandBuffer = commands.finish();
+  if (commandBuffer.hasError()) {
+    return false;
+  }
+  return !adapterDevice.submit(std::move(commandBuffer).result()).hasError();
+}
+
 }  // namespace
 
-GeodeCheckerboardPipeline::GeodeCheckerboardPipeline(const wgpu::Device& device,
-                                                     wgpu::TextureFormat colorFormat,
+GeodeCheckerboardPipeline::GeodeCheckerboardPipeline(GeodeWgpuAdapterDevice& adapterDevice,
+                                                     gpu::TextureFormat colorFormat,
                                                      BlendMode blendMode) {
-  wgpu::BindGroupLayoutEntry layoutEntry = {};
-  layoutEntry.binding = 0;
-  layoutEntry.visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
-  layoutEntry.buffer.type = wgpu::BufferBindingType::Uniform;
-  layoutEntry.buffer.minBindingSize = sizeof(Uniforms);
-
-  wgpu::BindGroupLayoutDescriptor layoutDesc = {};
-  layoutDesc.label = wgpuLabel("GeodeCheckerboardBGL");
-  layoutDesc.entryCount = 1;
-  layoutDesc.entries = &layoutEntry;
-  bindGroupLayout_ = device.createBindGroupLayout(layoutDesc);
-  if (!bindGroupLayout_) {
+  gpu::Result<gpu::BindGroupLayout> bindGroupLayout =
+      adapterDevice.createBindGroupLayout(gpu::BindGroupLayoutDescriptor{
+          "GeodeCheckerboardBGL",
+          {gpu::BindGroupLayoutEntry{0, gpu::ShaderStage::Vertex | gpu::ShaderStage::Fragment,
+                                     gpu::BindingType::UniformBuffer}}});
+  if (bindGroupLayout.hasError()) {
     return;
   }
+  bindGroupLayout_ = std::move(bindGroupLayout).result();
 
-  wgpu::ShaderSourceWGSL wgslSource{wgpu::Default};
-  wgslSource.code.data = kCheckerboardWgsl.data();
-  wgslSource.code.length = kCheckerboardWgsl.size();
-
-  wgpu::ShaderModuleDescriptor shaderDesc{wgpu::Default};
-  shaderDesc.label = wgpuLabel("GeodeCheckerboard");
-  shaderDesc.nextInChain = &wgslSource.chain;
-  ScopedWgpuHandle<wgpu::ShaderModule> shader(device.createShaderModule(shaderDesc));
-  if (!shader) {
+  gpu::Result<gpu::PipelineLayout> pipelineLayout = adapterDevice.createPipelineLayout(
+      gpu::PipelineLayoutDescriptor{"GeodeCheckerboardPL", {bindGroupLayout_}});
+  if (pipelineLayout.hasError()) {
     return;
   }
+  pipelineLayout_ = std::move(pipelineLayout).result();
 
-  wgpu::PipelineLayoutDescriptor pipelineLayoutDesc = {};
-  pipelineLayoutDesc.label = wgpuLabel("GeodeCheckerboardPL");
-  pipelineLayoutDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout bindGroupLayouts[1] = {bindGroupLayout_};
-  pipelineLayoutDesc.bindGroupLayouts = bindGroupLayouts;
-  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(
-      device.createPipelineLayout(pipelineLayoutDesc));
-  if (!pipelineLayout) {
+  gpu::Result<gpu::ShaderModule> shaderModule =
+      adapterDevice.createShaderModule(gpu::ShaderModuleDescriptor{
+          "GeodeCheckerboard", RcString(kCheckerboardWgsl), gpu::ShaderSourceKind::Wgsl});
+  if (shaderModule.hasError()) {
     return;
   }
+  shaderModule_ = std::move(shaderModule).result();
 
   // `result = dst + src * (1 - dst.alpha)` on both color and alpha. The shader
   // emits an opaque checker color, so fully-transparent destination pixels take
   // the checker outright, fully-opaque ones are untouched, and partially
   // transparent premultiplied content blends over it exactly as `destination-
   // over` does in Canvas2D / Skia.
-  wgpu::BlendState destinationOver = {};
-  destinationOver.color.operation = wgpu::BlendOperation::Add;
-  destinationOver.color.srcFactor = wgpu::BlendFactor::OneMinusDstAlpha;
-  destinationOver.color.dstFactor = wgpu::BlendFactor::One;
-  destinationOver.alpha.operation = wgpu::BlendOperation::Add;
-  destinationOver.alpha.srcFactor = wgpu::BlendFactor::OneMinusDstAlpha;
-  destinationOver.alpha.dstFactor = wgpu::BlendFactor::One;
+  const gpu::BlendComponent destinationOver{gpu::BlendFactor::OneMinusDstAlpha,
+                                            gpu::BlendFactor::One, gpu::BlendOperation::Add};
 
-  wgpu::ColorTargetState colorTarget = {};
-  colorTarget.format = colorFormat;
-  colorTarget.writeMask = wgpu::ColorWriteMask::All;
+  gpu::ColorTargetState colorTarget{colorFormat};
   if (blendMode == BlendMode::DestinationOver) {
-    colorTarget.blend = &destinationOver;
+    colorTarget.blend = gpu::BlendState{destinationOver, destinationOver};
   }
 
-  wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader.get();
-  fragmentState.entryPoint = wgpuLabel("fs_main");
-  fragmentState.targetCount = 1;
-  fragmentState.targets = &colorTarget;
-
-  wgpu::RenderPipelineDescriptor pipelineDesc = {};
-  pipelineDesc.label = wgpuLabel("GeodeCheckerboard");
-  pipelineDesc.layout = pipelineLayout.get();
-  pipelineDesc.vertex.module = shader.get();
-  pipelineDesc.vertex.entryPoint = wgpuLabel("vs_main");
-  pipelineDesc.vertex.bufferCount = 0;
-  pipelineDesc.vertex.buffers = nullptr;
-  pipelineDesc.primitive.topology = wgpu::PrimitiveTopology::TriangleList;
-  pipelineDesc.primitive.cullMode = wgpu::CullMode::None;
-  pipelineDesc.fragment = &fragmentState;
-  pipelineDesc.multisample.count = 1;
-  pipelineDesc.multisample.mask = 0xFFFFFFFF;
-  pipeline_ = device.createRenderPipeline(pipelineDesc);
+  gpu::Result<gpu::RenderPipeline> pipeline =
+      adapterDevice.createRenderPipeline(gpu::RenderPipelineDescriptor{
+          "GeodeCheckerboard", pipelineLayout_, gpu::VertexState{shaderModule_, "vs_main", {}},
+          gpu::FragmentState{shaderModule_, "fs_main", {colorTarget}},
+          gpu::PrimitiveTopology::TriangleList, gpu::CullMode::None});
+  if (pipeline.hasError()) {
+    return;
+  }
+  pipeline_ = std::move(pipeline).result();
 }
 
 bool GeodeCheckerboardPass::ensureResources(GeodeDevice& device,
                                             const GeodeCheckerboardPipeline& pipeline,
                                             GeodeCheckerboardPipeline::BlendMode blendMode) {
-  if (bindGroup_ && bindGroupBlendMode_ == blendMode) {
+  if (bindGroup_.isValid() && bindGroupBlendMode_ == blendMode) {
     return true;
   }
-  bindGroup_.reset();
+  bindGroup_ = gpu::BindGroup();
 
-  if (!uniformBuffer_) {
-    wgpu::BufferDescriptor bufferDesc = {};
-    bufferDesc.label = wgpuLabel("GeodeCheckerboardUniforms");
-    bufferDesc.size = sizeof(GeodeCheckerboardPipeline::Uniforms);
-    bufferDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-    uniformBuffer_.reset(device.device().createBuffer(bufferDesc));
-    device.countBuffer();
-    if (!uniformBuffer_) {
+  GeodeWgpuAdapterDevice& adapterDevice = device.adapterDevice();
+  if (!uniformBuffer_.isValid()) {
+    gpu::Result<gpu::Buffer> uniformBuffer = adapterDevice.createBuffer(gpu::BufferDescriptor{
+        "GeodeCheckerboardUniforms", sizeof(GeodeCheckerboardPipeline::Uniforms),
+        gpu::BufferUsage::Uniform | gpu::BufferUsage::CopyDst});
+    if (uniformBuffer.hasError()) {
       return false;
     }
+    uniformBuffer_ = std::move(uniformBuffer).result();
   }
 
-  wgpu::BindGroupEntry bindGroupEntry = {};
-  bindGroupEntry.binding = 0;
-  bindGroupEntry.buffer = uniformBuffer_.get();
-  bindGroupEntry.offset = 0;
-  bindGroupEntry.size = sizeof(GeodeCheckerboardPipeline::Uniforms);
-
-  wgpu::BindGroupDescriptor bindGroupDesc = {};
-  bindGroupDesc.label = wgpuLabel("GeodeCheckerboardBG");
-  bindGroupDesc.layout = pipeline.bindGroupLayout();
-  bindGroupDesc.entryCount = 1;
-  bindGroupDesc.entries = &bindGroupEntry;
-  bindGroup_.reset(device.device().createBindGroup(bindGroupDesc));
-  device.countBindGroup();
-  if (!bindGroup_) {
+  gpu::Result<gpu::BindGroup> bindGroup = adapterDevice.createBindGroup(gpu::BindGroupDescriptor{
+      "GeodeCheckerboardBG",
+      pipeline.bindGroupLayout(),
+      {gpu::BindGroupEntry{
+          0, gpu::BufferBinding{uniformBuffer_, 0, sizeof(GeodeCheckerboardPipeline::Uniforms)}}}});
+  if (bindGroup.hasError()) {
     return false;
   }
+  bindGroup_ = std::move(bindGroup).result();
 
   bindGroupBlendMode_ = blendMode;
   return true;
@@ -188,14 +236,7 @@ bool GeodeCheckerboardPass::ensureResources(GeodeDevice& device,
 bool GeodeCheckerboardPass::draw(GeodeDevice& device, const wgpu::Texture& target,
                                  Vector2i targetSizePx, const CheckerboardUnderlayParams& params,
                                  GeodeCheckerboardPipeline::BlendMode blendMode) {
-  if (!target || targetSizePx.x <= 0 || targetSizePx.y <= 0) {
-    return false;
-  }
-  if (!(params.devicePixelRatio > 0.0) || !(params.cellSizeLogicalPx > 0.0)) {
-    return false;
-  }
-  if (params.scissorPx.has_value() &&
-      (params.scissorPx->width == 0 || params.scissorPx->height == 0)) {
+  if (!CheckerboardRequestIsDrawable(target, targetSizePx, params)) {
     return false;
   }
 
@@ -216,56 +257,21 @@ bool GeodeCheckerboardPass::draw(GeodeDevice& device, const wgpu::Texture& targe
                          static_cast<float>(params.originOffsetPx.y)},
       .padding = {0.0f, 0.0f},
   };
-  device.queue().writeBuffer(uniformBuffer_.get(), 0, &uniforms, sizeof(uniforms));
-  device.countBufferWrite(sizeof(uniforms));
 
-  ScopedWgpuHandle<wgpu::TextureView> view(target.createView());
-  if (!view) {
+  GeodeWgpuAdapterDevice& adapterDevice = device.adapterDevice();
+  if (adapterDevice
+          .writeBuffer(uniformBuffer_, 0,
+                       std::span(reinterpret_cast<const uint8_t*>(&uniforms), sizeof(uniforms)))
+          .hasError()) {
     return false;
   }
 
-  wgpu::CommandEncoderDescriptor encoderDesc = {};
-  encoderDesc.label = wgpuLabel("GeodeCheckerboardEncoder");
-  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(device.device().createCommandEncoder(encoderDesc));
-  if (!encoder) {
+  const std::optional<NamedTarget> named = NameTargetForPass(adapterDevice, target);
+  if (!named.has_value()) {
     return false;
   }
-
-  wgpu::RenderPassColorAttachment color = {};
-  color.view = view.get();
-  color.loadOp = wgpu::LoadOp::Load;
-  color.storeOp = wgpu::StoreOp::Store;
-  color.clearValue = {0.0, 0.0, 0.0, 0.0};
-  color.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
-
-  wgpu::RenderPassDescriptor passDesc = {};
-  passDesc.label = wgpuLabel("GeodeCheckerboardPass");
-  passDesc.colorAttachmentCount = 1;
-  passDesc.colorAttachments = &color;
-  ScopedWgpuHandle<wgpu::RenderPassEncoder> pass(encoder.get().beginRenderPass(passDesc));
-  if (!pass) {
-    return false;
-  }
-
-  if (params.scissorPx.has_value()) {
-    pass.get().setScissorRect(params.scissorPx->x, params.scissorPx->y, params.scissorPx->width,
-                              params.scissorPx->height);
-  }
-  pass.get().setPipeline(checkerboard.pipeline());
-  pass.get().setBindGroup(0, bindGroup_.get(), 0, nullptr);
-  pass.get().draw(3, 1, 0, 0);
-  device.countPipelineSwitch();
-  device.countDraw();
-  pass.get().end();
-  pass.reset();
-
-  ScopedWgpuHandle<wgpu::CommandBuffer> commands(encoder.get().finish());
-  if (!commands) {
-    return false;
-  }
-  device.queue().submit(1, &commands.get());
-  device.countSubmit();
-  return true;
+  return RecordAndSubmitCheckerboardPass(device, checkerboard, named->view, bindGroup_,
+                                         params.scissorPx);
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeCheckerboardPipeline.h
+++ b/donner/svg/renderer/geode/GeodeCheckerboardPipeline.h
@@ -8,11 +8,12 @@
 #include <webgpu/webgpu.hpp>
 
 #include "donner/base/Vector2.h"
-#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+#include "donner/gpu/Device.h"
 
 namespace donner::geode {
 
 class GeodeDevice;
+class GeodeWgpuAdapterDevice;
 
 /**
  * Appearance of the transparency checkerboard drawn behind see-through
@@ -75,12 +76,12 @@ struct CheckerboardUnderlayParams {
 };
 
 /**
- * Caches the compiled `wgpu::RenderPipeline` that draws the transparency
- * checkerboard behind see-through document regions, plus its bind group layout.
+ * Caches the compiled render pipeline that draws the transparency checkerboard
+ * behind see-through document regions, plus its bind group layout.
  *
  * Owned by `GeodeDevice` (lazily, via `GeodeDevice::checkerboardPipeline()` and
  * `GeodeDevice::checkerboardUnderlayPipeline()`) so every consumer sharing the
- * device reuses one compiled pipeline per blend mode - wgpu-native retains every
+ * device reuses one compiled pipeline per blend mode - the backend retains every
  * pipeline ever constructed, so per-consumer construction leaks (issue #575).
  *
  * Bind group layout:
@@ -125,12 +126,12 @@ public:
   /**
    * Create the checkerboard pipeline for the given device and target format.
    *
-   * @param device The WebGPU device.
+   * @param adapterDevice The Donner GPU device owned by the GeodeDevice.
    * @param colorFormat The pixel format of the render target this pipeline
    *   will draw into. Must match the target texture's format at draw time.
    * @param blendMode How the emitted checkerboard combines with the target.
    */
-  GeodeCheckerboardPipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat,
+  GeodeCheckerboardPipeline(GeodeWgpuAdapterDevice& adapterDevice, gpu::TextureFormat colorFormat,
                             BlendMode blendMode = BlendMode::Replace);
 
   ~GeodeCheckerboardPipeline() = default;
@@ -142,17 +143,19 @@ public:
   GeodeCheckerboardPipeline& operator=(GeodeCheckerboardPipeline&&) noexcept = default;
 
   /// True when the shader, bind group layout, and pipeline all compiled.
-  bool valid() const { return static_cast<bool>(pipeline_) && static_cast<bool>(bindGroupLayout_); }
+  bool valid() const { return pipeline_.isValid() && bindGroupLayout_.isValid(); }
 
   /// The compiled render pipeline.
-  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
+  const gpu::RenderPipeline& pipeline() const { return pipeline_; }
 
   /// Bind group layout used by the pipeline.
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
 
 private:
-  wgpu::BindGroupLayout bindGroupLayout_;
-  wgpu::RenderPipeline pipeline_;
+  gpu::ShaderModule shaderModule_;
+  gpu::BindGroupLayout bindGroupLayout_;
+  gpu::PipelineLayout pipelineLayout_;
+  gpu::RenderPipeline pipeline_;
 };
 
 /**
@@ -192,8 +195,8 @@ public:
    * partial alpha blends as `destination-over` does.
    *
    * @param device Device that owns @p target and the shared pipeline.
-   * @param target Render target. Needs `RenderAttachment` usage and the
-   *   device's texture format.
+   * @param target Render target owned by the embedding surface. Needs
+   *   `RenderAttachment` usage and the device's texture format.
    * @param targetSizePx Target size in device pixels.
    * @param params Checkerboard placement and appearance.
    * @param blendMode How the checkerboard combines with the target's contents.
@@ -211,8 +214,8 @@ private:
   [[nodiscard]] bool ensureResources(GeodeDevice& device, const GeodeCheckerboardPipeline& pipeline,
                                      GeodeCheckerboardPipeline::BlendMode blendMode);
 
-  ScopedWgpuHandle<wgpu::Buffer> uniformBuffer_;
-  ScopedWgpuHandle<wgpu::BindGroup> bindGroup_;
+  gpu::Buffer uniformBuffer_;
+  gpu::BindGroup bindGroup_;
   /// Blend mode \ref bindGroup_ was built against; a different one rebuilds it
   /// because each blend mode has its own pipeline and bind group layout.
   std::optional<GeodeCheckerboardPipeline::BlendMode> bindGroupBlendMode_;

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -247,7 +247,7 @@ struct GeodeDevice::Impl {
   // Borrowed wgpu aliases of the shared bind-slot resources below, for the call sites that
   // still build wgpu bind groups. Non-owning: the runtime handles own the backing.
 
-  // TEMPORARY design-0053 Phase 1 adapter (see GeodeWgpuAdapterDevice.h for the removal
+  // TEMPORARY transition adapter (see GeodeWgpuAdapterDevice.h for the removal
   // gates). Declared ABOVE the pipelines: the pipeline classes hold donner::gpu RAII handles
   // whose destructors release through the adapter, so the adapter must destruct after them
   // (reverse-declaration order).

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -864,7 +864,8 @@ GeodeCheckerboardPipeline& GeodeDevice::checkerboardPipeline() const {
     // checkerboard; other consumers should not pay the pipeline-compile cost
     // at startup.
     impl_->checkerboardPipeline = std::make_unique<GeodeCheckerboardPipeline>(
-        device_, textureFormat_, GeodeCheckerboardPipeline::BlendMode::Replace);
+        *impl_->adapterDevice, GpuTextureFormatFromWgpu(textureFormat_),
+        GeodeCheckerboardPipeline::BlendMode::Replace);
   }
   return *impl_->checkerboardPipeline;
 }
@@ -874,7 +875,8 @@ GeodeCheckerboardPipeline& GeodeDevice::checkerboardUnderlayPipeline() const {
     // it because a consumer normally draws through exactly one of the two:
     // before the document pixels (replace) or after them (destination-over).
     impl_->checkerboardUnderlayPipeline = std::make_unique<GeodeCheckerboardPipeline>(
-        device_, textureFormat_, GeodeCheckerboardPipeline::BlendMode::DestinationOver);
+        *impl_->adapterDevice, GpuTextureFormatFromWgpu(textureFormat_),
+        GeodeCheckerboardPipeline::BlendMode::DestinationOver);
   }
   return *impl_->checkerboardUnderlayPipeline;
 }

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -721,7 +721,7 @@ public:
   GeodeCheckerboardPipeline& checkerboardUnderlayPipeline() const;
   /// @}
 
-  /// The TEMPORARY design-0053 Phase 1 adapter implementing \c donner::gpu::Device over this
+  /// The TEMPORARY transition adapter implementing \c donner::gpu::Device over this
   /// device's wgpu objects. Owned here alongside the shared pipelines (which are created
   /// through it); see GeodeWgpuAdapterDevice.h for the removal gates.
   GeodeWgpuAdapterDevice& adapterDevice() const UTILS_LIFETIME_BOUND;

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -129,9 +129,9 @@ public:
   /// Move assignment operator.
   GeodeGradientPipeline& operator=(GeodeGradientPipeline&&) noexcept = default;
 
-  /// The compiled render pipeline (TEMPORARY 8a wgpu alias for the still-wgpu GeoEncoder).
+  /// The compiled render pipeline.
   const gpu::RenderPipeline& pipeline() const { return pipeline_; }
-  /// The bind group layout used by the pipeline (TEMPORARY 8a wgpu alias).
+  /// The bind group layout used by the pipeline.
   const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
   /// Color format the pipeline was built for.
   gpu::TextureFormat colorFormat() const { return colorFormat_; }
@@ -180,9 +180,9 @@ public:
   GeodeMaskPipeline(GeodeMaskPipeline&&) noexcept = default;
   GeodeMaskPipeline& operator=(GeodeMaskPipeline&&) noexcept = default;
 
-  /// The compiled render pipeline (TEMPORARY 8a wgpu alias for the still-wgpu GeoEncoder).
+  /// The compiled render pipeline.
   const gpu::RenderPipeline& pipeline() const { return pipeline_; }
-  /// The bind group layout used by the pipeline (TEMPORARY 8a wgpu alias).
+  /// The bind group layout used by the pipeline.
   const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
   /// The color format the pipeline targets. Always `RGBA8Unorm`.
   gpu::TextureFormat colorFormat() const { return gpu::TextureFormat::RGBA8Unorm; }

--- a/donner/svg/renderer/geode/GeodeShaders.cc
+++ b/donner/svg/renderer/geode/GeodeShaders.cc
@@ -58,7 +58,7 @@ wgpu::ShaderModule createShaderFromWgsl(const wgpu::Device& device, const char* 
 }
 
 /// Build a `donner::gpu` WGSL shader module from an embedded source blob: the pipeline-family
-/// path through the Donner GPU runtime (design 0053 packet 8). The source bytes are identical
+/// path through the Donner GPU runtime. The source bytes are identical
 /// to what the raw-wgpu helper above fed the driver, so migrated pipelines compile
 /// byte-identical WGSL.
 gpu::Result<gpu::ShaderModule> createGpuShaderFromWgsl(gpu::Device& device, const char* label,

--- a/donner/svg/renderer/geode/GeodeShaders.h
+++ b/donner/svg/renderer/geode/GeodeShaders.h
@@ -8,9 +8,9 @@
 
 namespace donner::geode {
 
-// The four pipeline-family creators below build shader modules through the donner::gpu runtime
-// (design 0053 packet 8); the filter creators further down still compile through wgpu directly
-// and migrate with the filter packet.
+// The four pipeline-family creators below build shader modules through the donner::gpu runtime;
+// the filter creators further down still compile through wgpu directly, because the runtime
+// does not model the compute passes they feed.
 
 /**
  * Compile the Slug fill shader for the given device.

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -1083,6 +1083,10 @@ void GeodeWgpuAdapterDevice::clearHostCommandEncoder() {
   hostCommandEncoder_ = wgpu::CommandEncoder();
 }
 
+bool GeodeWgpuAdapterDevice::hasHostCommandEncoder() const {
+  return static_cast<bool>(hostCommandEncoder_);
+}
+
 void GeodeWgpuAdapterDevice::notifyHostSubmitted() {
   if (hostPendingSerial_ == 0) {
     return;

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -194,6 +194,7 @@ wgpu::BlendFactor ToWgpuBlendFactor(gpu::BlendFactor factor) {
     case gpu::BlendFactor::One: return wgpu::BlendFactor::One;
     case gpu::BlendFactor::SrcAlpha: return wgpu::BlendFactor::SrcAlpha;
     case gpu::BlendFactor::OneMinusSrcAlpha: return wgpu::BlendFactor::OneMinusSrcAlpha;
+    case gpu::BlendFactor::OneMinusDstAlpha: return wgpu::BlendFactor::OneMinusDstAlpha;
   }
   UTILS_RELEASE_ASSERT_MSG(false, "validated BlendFactor out of range");
   return wgpu::BlendFactor::Zero;

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -115,6 +115,17 @@ public:
   /// until \ref notifyHostSubmitted reports their submit.
   void clearHostCommandEncoder();
 
+  /// True while a host command encoder is installed, i.e. while submissions are replayed into
+  /// it instead of reaching the queue.
+  ///
+  /// This device is shared by everything drawing through one \ref GeodeDevice, but a host
+  /// encoder belongs to the single caller that installed it. Anything else submitting during
+  /// that window would be spliced into a command buffer it does not own, at a point in that
+  /// buffer it cannot reason about, and its \ref submit would report success for work that has
+  /// not reached the queue. A caller whose submission must stand on its own checks this first
+  /// and declines.
+  bool hasHostCommandEncoder() const;
+
   /**
    * Reports that the host submitted a command buffer carrying every stream replayed since the
    * previous report, so their completion can now be observed. Advances \ref completedSerial to

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -504,6 +504,42 @@ TEST_F(RendererGeodeTest, CheckerboardOriginOffsetShiftsTheAnchor) {
   EXPECT_THAT(shiftedNegative.second, RgbaEq(kCheckerLight, kCheckerLight, kCheckerLight, 255));
 }
 
+TEST_F(RendererGeodeTest, CheckerboardRefusesWhileAnotherFrameOwnsTheDeviceCommandStream) {
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+  renderer.endFrame();
+
+  const std::shared_ptr<const RendererTextureSnapshot> frame = takeFinishedFrame(renderer);
+  ASSERT_NE(frame, nullptr);
+
+  // A second renderer sharing the device opens a frame. From here until its `endFrame`, that
+  // frame owns the device's command stream: every submission through the shared runtime device
+  // is appended to the frame's command buffer instead of reaching the queue. A checkerboard
+  // spliced in there would neither reach the target now nor land where its caller asked for it.
+  RendererGeode other = createRenderer();
+  beginFrame(other);
+
+  EXPECT_FALSE(drawCheckerboard(*frame, geode::CheckerboardUnderlayParams{}))
+      << "Drawing while another frame owns the device's command stream must fail, not report "
+         "success for a pass that never reaches the queue";
+
+  const RendererBitmap duringOtherFrame = frame->takeSnapshot();
+  ASSERT_FALSE(duringOtherFrame.empty());
+  EXPECT_THAT(pixelAt(duringOtherFrame, kCheckerCell / 2, kCheckerCell / 2), RgbaEq(0, 0, 0, 0))
+      << "A refused pass must leave the target exactly as it was";
+
+  other.endFrame();
+
+  // With that frame closed the identical call succeeds and the pixels land, so the refusal is
+  // scoped to the overlap rather than disabling the pass for the rest of the device's life.
+  ASSERT_TRUE(drawCheckerboard(*frame, geode::CheckerboardUnderlayParams{}));
+  const RendererBitmap afterOtherFrame = frame->takeSnapshot();
+  ASSERT_FALSE(afterOtherFrame.empty());
+  EXPECT_THAT(pixelAt(afterOtherFrame, kCheckerCell / 2, kCheckerCell / 2),
+              RgbaEq(kCheckerLight, kCheckerLight, kCheckerLight, 255))
+      << "Once the device's command stream is free the checkerboard must reach the target";
+}
+
 TEST_F(RendererGeodeTest, CheckerboardCellsAreLogicalPixelsNotDevicePixels) {
   RendererGeode renderer = createRenderer();
   beginFrame(renderer);

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -498,7 +498,6 @@
         "createPipelineLayout",
         "createRenderPipeline",
         "createShaderModule",
-        "createView",
         "draw",
         "finish",
         "setBindGroup",
@@ -507,48 +506,8 @@
         "submit",
         "writeBuffer"
       ],
-      "wgpuCFunctions": [
-        "wgpuLabel"
-      ],
-      "wgpuCTypes": [
-        "WGPUBindGroupLayout"
-      ],
       "wgpuCppTokens": [
-        "BindGroupDescriptor",
-        "BindGroupEntry",
-        "BindGroupLayoutDescriptor",
-        "BindGroupLayoutEntry",
-        "BlendFactor",
-        "BlendOperation",
-        "BlendState",
-        "BufferBindingType",
-        "BufferDescriptor",
-        "BufferUsage",
-        "ColorTargetState",
-        "ColorWriteMask",
-        "CommandBuffer",
-        "CommandEncoder",
-        "CommandEncoderDescriptor",
-        "CullMode",
-        "Default",
-        "Device",
-        "FragmentState",
-        "LoadOp",
-        "PipelineLayout",
-        "PipelineLayoutDescriptor",
-        "PrimitiveTopology",
-        "RenderPassColorAttachment",
-        "RenderPassDescriptor",
-        "RenderPassEncoder",
-        "RenderPipelineDescriptor",
-        "ShaderModule",
-        "ShaderModuleDescriptor",
-        "ShaderSourceWGSL",
-        "ShaderStage",
-        "StoreOp",
-        "Texture",
-        "TextureFormat",
-        "TextureView"
+        "Texture"
       ]
     },
     "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h": {
@@ -556,13 +515,7 @@
         "draw"
       ],
       "wgpuCppTokens": [
-        "BindGroup",
-        "BindGroupLayout",
-        "Buffer",
-        "Device",
-        "RenderPipeline",
-        "Texture",
-        "TextureFormat"
+        "Texture"
       ]
     },
     "donner/svg/renderer/geode/GeodeCounters.h": {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -448,7 +448,6 @@
         "ComputePassDescriptor",
         "ComputePassEncoder",
         "Default",
-        "Device",
         "Extent3D",
         "Future",
         "FutureWaitInfo",


### PR DESCRIPTION
Finishes the render-pipeline side of Geode's move onto `donner::gpu`. The transparency checkerboard, the last render pipeline family that still built and recorded through the backend API directly, now goes through the runtime, and the two remaining backend calls in the clip and isolated-layer paths are deleted along with the bookkeeping they needed.

## What moved

- **Clip masks.** The clip stack already rendered every mask pass and bound every clip mask through runtime handles; the parallel backend texture and texture-view bookkeeping it still carried was only kept alive to be kept alive. It is gone, along with the frame-deferred backend view release list, whose last caller it was. The lifetime guarantee it provided is now the runtime's: an imported view stays valid for the rest of the frame, and its backing object is held until the submission that referenced it completes.
- **Isolated layers.** `popIsolatedLayer` freezes the parent target into a snapshot before compositing a blended layer. That copy was the family's last backend-recorded command; it is now a runtime texture-to-texture copy, recorded into the same stream as the composite draws around it, so its ordering comes from recording order rather than from two streams being interleaved by hand.
- **Transparency checkerboard.** Bind group layout, shader module, pipeline layout, pipeline, blend state, uniform buffer, bind group, command encoder, render pass and submit all move onto the runtime. The pass target still arrives as a backend texture because it belongs to the embedding surface, not to Geode; it is named for the runtime for the duration of the pass, with format and capabilities read from the texture itself. That external-texture handoff is the one backend type left in the family.
- **`gpu::BlendFactor::OneMinusDstAlpha`.** The runtime's blend set covered only source-alpha compositing. A pass that lands *underneath* content already in the attachment needs `result = dst + src * (1 - dst.alpha)`, so the destination-alpha factor is added and mapped in all three backends. It is the last factor Donner's compositing model uses.
- **Comment hygiene.** One dedicated comment-only commit makes the GPU runtime headers and the Geode transition surface stand on their own: comments that pointed at planning artifacts now carry the invariant or constraint inline. Four accessor comments were stale as well, describing a returned pipeline and bind group layout as temporary backend aliases, which they stopped being when the pipeline family moved onto the runtime.

## What did not move, and why

- **Mask layers** (`pushMask` / `transitionMaskToContent` / `popMask`) were already recording through the runtime; they had no backend commands left to migrate. Their remaining backend surface is texture allocation.
- **The snapshot-readback pipeline is a compute pipeline**, not a render pipeline. The runtime does not model compute passes, so it stays where the filter engine is: waiting on compute support.
- **The transient texture pool** still allocates through the backend. It is shared with the filter engine, whose allocate/release interface hands backend textures back and forth, so moving it is part of that migration rather than this one.
- **The filter-layer viewport copy** cannot be expressed yet: it copies from a non-zero source origin, and the runtime records whole-rect copies from texel (0, 0).

## Verification

- `bazel test //...`, the five-target Geode editor lane, lint (both halves), manifest freshness, the CMake generator check, the design-doc provenance check, and the no-Rust verifier all pass.
- On a Linux GPU host: the Vulkan solid-fill vertical slice and the ASan Geode resvg suite both pass.
- Behavior is covered by the existing Geode golden, replay, and checkerboard pixel suites. Counters are unchanged: the runtime device already counts buffers, bind groups, buffer writes, draws and submits, so the checkerboard's explicit counting is deleted except for the pipeline-switch counter, which the runtime does not model and which stays an explicit call at the point the pass binds its pipeline.
- The new blend factor is exercised end to end through the wgpu adapter by the checkerboard pixel tests, and at the descriptor layer by a new recording-device test. Its Metal and Vulkan mappings compile but have no execution coverage yet, because nothing builds a destination-over pipeline on a native device until the native cutover; that packet should carry the pixel test for them.
