### PR TITLE
geode: move the shared texture pool and the filter on-ramp onto the GPU runtime

### DIFF
--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -61,6 +61,16 @@ donner_cc_library(
     visibility = donner_internal_visibility(),
 )
 
+# The sub-rectangle texture-copy scene shared by the backend copy slices: the
+# same source pattern, destination fill, copy rectangle, origins, and expected
+# image.
+donner_cc_library(
+    name = "sub_rectangle_copy_scene",
+    testonly = 1,
+    hdrs = ["tests/SubRectangleCopyScene.h"],
+    visibility = donner_internal_visibility(),
+)
+
 # gmock matchers and unwrap helpers shared by the model tests here and by backend/adapter
 # conformance tests in other packages (e.g. the Geode wgpu adapter).
 donner_cc_library(

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -509,8 +509,11 @@ Status CommandEncoder::copyTextureToBuffer(const TexelCopyTextureInfo& source,
 Status CommandEncoder::validateCopyTexturePair(const Texture& source, const Texture& destination,
                                                const TextureDescriptor& sourceDescriptor,
                                                const TextureDescriptor& destinationDescriptor) {
-  // WebGPU forbids self-copy: source and destination must be different textures
-  // ("GPUCommandEncoder.copyTextureToTexture" validation; overlapping copies are undefined).
+  // Source and destination must be different textures. WebGPU allows one texture to be both
+  // operands when the two rectangles do not overlap, but deciding that needs an overlap test on
+  // the origins, and a copy whose rectangles do overlap is undefined rather than diagnosable.
+  // Rejecting every same-texture copy keeps the operation decidable from the handles alone; a
+  // caller that wants to move a region within one texture copies through a scratch texture.
   if (source.slotIndex() == destination.slotIndex() &&
       source.generation() == destination.generation()) {
     return fail(Err(GpuErrorType::InvalidDescriptor,
@@ -540,7 +543,26 @@ Status CommandEncoder::validateCopyTexturePair(const Texture& source, const Text
   return OkStatus();
 }
 
-Status CommandEncoder::validateCopyExtent(const Extent2d& copySize,
+Status CommandEncoder::validateCopyRectFits(std::string_view role, const Origin2d& origin,
+                                            const Extent2d& copySize,
+                                            const TextureDescriptor& descriptor) {
+  // The origin is caller-supplied, so the far edge is computed in 64 bits: a near-UINT32_MAX
+  // origin plus a large extent wraps in 32-bit arithmetic and would compare as in-bounds.
+  const std::optional<uint64_t> right = CheckedAdd(uint64_t{origin.x}, uint64_t{copySize.width});
+  const std::optional<uint64_t> bottom = CheckedAdd(uint64_t{origin.y}, uint64_t{copySize.height});
+  if (!right || !bottom || *right > descriptor.size.width || *bottom > descriptor.size.height) {
+    return fail(
+        Err(GpuErrorType::OutOfBounds,
+            std::format("copyTextureToTexture: {} rectangle {}x{} at ({}, {}) does not fit "
+                        "{} \"{}\" size {}x{}",
+                        role, copySize.width, copySize.height, origin.x, origin.y, role,
+                        descriptor.label.str(), descriptor.size.width, descriptor.size.height)));
+  }
+  return OkStatus();
+}
+
+Status CommandEncoder::validateCopyExtent(const Extent2d& copySize, const Origin2d& sourceOrigin,
+                                          const Origin2d& destinationOrigin,
                                           const TextureDescriptor& sourceDescriptor,
                                           const TextureDescriptor& destinationDescriptor) {
   if (copySize.width == 0 || copySize.height == 0) {
@@ -548,29 +570,17 @@ Status CommandEncoder::validateCopyExtent(const Extent2d& copySize,
                     std::format("copyTextureToTexture: copy size {}x{} has a zero dimension",
                                 copySize.width, copySize.height)));
   }
-  // Copies are whole-rect from texel (0, 0), so fitting reduces to per-axis extent comparisons
-  // (no origin addition to overflow-check).
-  if (copySize.width > sourceDescriptor.size.width ||
-      copySize.height > sourceDescriptor.size.height) {
-    return fail(
-        Err(GpuErrorType::OutOfBounds,
-            std::format("copyTextureToTexture: copy size {}x{} exceeds source \"{}\" size {}x{}",
-                        copySize.width, copySize.height, sourceDescriptor.label.str(),
-                        sourceDescriptor.size.width, sourceDescriptor.size.height)));
+  const Status sourceStatus =
+      validateCopyRectFits("source", sourceOrigin, copySize, sourceDescriptor);
+  if (sourceStatus.hasError()) {
+    return sourceStatus;
   }
-  if (copySize.width > destinationDescriptor.size.width ||
-      copySize.height > destinationDescriptor.size.height) {
-    return fail(Err(
-        GpuErrorType::OutOfBounds,
-        std::format("copyTextureToTexture: copy size {}x{} exceeds destination \"{}\" size {}x{}",
-                    copySize.width, copySize.height, destinationDescriptor.label.str(),
-                    destinationDescriptor.size.width, destinationDescriptor.size.height)));
-  }
-  return OkStatus();
+  return validateCopyRectFits("destination", destinationOrigin, copySize, destinationDescriptor);
 }
 
 Status CommandEncoder::copyTextureToTexture(const Texture& source, const Texture& destination,
-                                            const Extent2d& copySize) {
+                                            const Extent2d& copySize, const Origin2d& sourceOrigin,
+                                            const Origin2d& destinationOrigin) {
   if (std::optional<GpuError> error = checkRecordable(PassKind::None)) {
     return fail(std::move(*error));
   }
@@ -592,14 +602,16 @@ Status CommandEncoder::copyTextureToTexture(const Texture& source, const Texture
   if (pairStatus.hasError()) {
     return pairStatus;
   }
-  const Status extentStatus = validateCopyExtent(copySize, sourceDescriptor, destinationDescriptor);
+  const Status extentStatus = validateCopyExtent(copySize, sourceOrigin, destinationOrigin,
+                                                 sourceDescriptor, destinationDescriptor);
   if (extentStatus.hasError()) {
     return extentStatus;
   }
 
   commands_.push_back(CopyTextureToTextureCommand{
       ResourceIdentity{source.slotIndex(), source.generation()},
-      ResourceIdentity{destination.slotIndex(), destination.generation()}, copySize});
+      ResourceIdentity{destination.slotIndex(), destination.generation()}, copySize, sourceOrigin,
+      destinationOrigin});
   return OkStatus();
 }
 

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -226,18 +226,25 @@ public:
                              const Extent2d& copySize);
 
   /**
-   * Records a texture-to-texture copy starting at texel (0, 0) of both textures (the RHI's
-   * whole-rect copy convention). Not allowed inside a render pass. Both textures must be live
-   * handles of this device and share one \ref TextureFormat, \p source needs
-   * \ref TextureUsage::CopySrc, \p destination needs \ref TextureUsage::CopyDst, and
-   * \p copySize must be nonzero and fit inside both texture extents.
+   * Records a texture-to-texture copy of a \p copySize rectangle, read from \p sourceOrigin and
+   * written at \p destinationOrigin. Both origins default to texel (0, 0), which is the
+   * whole-rect copy convention this operation had before sub-rectangle copies existed, so an
+   * existing call keeps its meaning.
+   *
+   * Not allowed inside a pass. Both textures must be live handles of this device and share one
+   * \ref TextureFormat, \p source needs \ref TextureUsage::CopySrc, \p destination needs
+   * \ref TextureUsage::CopyDst, \p copySize must be nonzero, and each origin plus \p copySize
+   * must fit inside its texture's extent.
    *
    * @param source Source texture; needs \ref TextureUsage::CopySrc.
    * @param destination Destination texture; needs \ref TextureUsage::CopyDst.
    * @param copySize Copy extent in texels.
+   * @param sourceOrigin Top-left texel of the source rectangle.
+   * @param destinationOrigin Top-left texel of the destination rectangle.
    */
   Status copyTextureToTexture(const Texture& source, const Texture& destination,
-                              const Extent2d& copySize);
+                              const Extent2d& copySize, const Origin2d& sourceOrigin = {},
+                              const Origin2d& destinationOrigin = {});
 
   /**
    * Finishes recording and registers the command buffer with the device. Fails with the first
@@ -304,12 +311,26 @@ private:
                                  const TextureDescriptor& sourceDescriptor,
                                  const TextureDescriptor& destinationDescriptor);
 
-  /// Validates that a texture-to-texture copy's extent is non-degenerate and fits both operands.
+  /// Validates that a texture-to-texture copy's extent is non-degenerate and that each operand's
+  /// origin-plus-extent rectangle fits inside that operand.
   /// @param copySize Copy extent in texels.
+  /// @param sourceOrigin Top-left texel of the source rectangle.
+  /// @param destinationOrigin Top-left texel of the destination rectangle.
   /// @param sourceDescriptor Descriptor the source was created with.
   /// @param destinationDescriptor Descriptor the destination was created with.
-  Status validateCopyExtent(const Extent2d& copySize, const TextureDescriptor& sourceDescriptor,
+  Status validateCopyExtent(const Extent2d& copySize, const Origin2d& sourceOrigin,
+                            const Origin2d& destinationOrigin,
+                            const TextureDescriptor& sourceDescriptor,
                             const TextureDescriptor& destinationDescriptor);
+
+  /// Validates that one operand's origin-plus-extent rectangle fits inside its texture, reported
+  /// against \p role so a diagnostic names which side of the copy was out of bounds.
+  /// @param role Operand name for the diagnostic, "source" or "destination".
+  /// @param origin Top-left texel of that operand's rectangle.
+  /// @param copySize Copy extent in texels.
+  /// @param descriptor Descriptor that operand was created with.
+  Status validateCopyRectFits(std::string_view role, const Origin2d& origin,
+                              const Extent2d& copySize, const TextureDescriptor& descriptor);
 
   // RenderPassEncoder forwards to these.
   Status passSetPipeline(const RenderPipeline& pipeline);

--- a/donner/gpu/Commands.h
+++ b/donner/gpu/Commands.h
@@ -98,11 +98,14 @@ struct CopyTextureToBufferCommand {
   Extent2d copySize;             //!< Copy extent in texels.
 };
 
-/// Recorded `copyTextureToTexture` (whole-rect texture copy from texel (0, 0)).
+/// Recorded `copyTextureToTexture` (sub-rectangle texture copy; both origins default to texel
+/// (0, 0), which is the whole-rect copy every recorded stream used before origins existed).
 struct CopyTextureToTextureCommand {
   ResourceIdentity textureSrcId;  //!< Source texture identity.
   ResourceIdentity textureDstId;  //!< Destination texture identity.
   Extent2d copySize;              //!< Copy extent in texels.
+  Origin2d sourceOrigin;          //!< Top-left source texel the copy reads from.
+  Origin2d destinationOrigin;     //!< Top-left destination texel the copy writes to.
 };
 
 /// One recorded command.

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -433,6 +433,22 @@ struct Extent2d {
   }
 };
 
+/// A 2D texel coordinate, used as the corner a copy region starts at. The default (0, 0) is the
+/// whole-rect-from-the-origin convention every copy used before sub-rectangle copies existed.
+struct Origin2d {
+  uint32_t x = 0;  //!< Column of the first copied texel.
+  uint32_t y = 0;  //!< Row of the first copied texel.
+
+  /// Equality operator. @param other Origin to compare against.
+  bool operator==(const Origin2d& other) const = default;
+
+  /// Ostream output operator, e.g. `(4, 8)`. @param os Output stream. @param value Origin to
+  /// output.
+  friend std::ostream& operator<<(std::ostream& os, const Origin2d& value) {
+    return os << "(" << value.x << ", " << value.y << ")";
+  }
+};
+
 /// Descriptor for `Device::createBuffer`.
 struct BufferDescriptor {
   RcString label;                         //!< Debug label; also appears in recordings.

--- a/donner/gpu/RecordingDevice.cc
+++ b/donner/gpu/RecordingDevice.cc
@@ -155,9 +155,13 @@ struct CommandSerializer {
        << " rowsPerImage=" << command.layout.rowsPerImage << " copySize=" << command.copySize;
   }
   void operator()(const CopyTextureToTextureCommand& command) {
+    // The origins are serialized unconditionally, including the (0, 0) default: a stream is read
+    // to tell two recordings apart, and a field that disappears when it holds its default makes
+    // a whole-rect copy and a copy that was deliberately reset to the origin look identical.
     os << "copyTextureToTexture src=" << RefId(TextureTag::kName, command.textureSrcId.slotIndex)
+       << " srcOrigin=" << command.sourceOrigin
        << " dst=" << RefId(TextureTag::kName, command.textureDstId.slotIndex)
-       << " copySize=" << command.copySize;
+       << " dstOrigin=" << command.destinationOrigin << " copySize=" << command.copySize;
   }
 };
 

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -319,6 +319,7 @@ struct MetalDevice::Impl {
   /// @param state Encoding state.
   /// @param copy Recorded command.
   Status encodeCopyTextureToBuffer(EncodingState& state, const CopyTextureToBufferCommand& copy);
+  Status encodeCopyTextureToTexture(EncodingState& state, const CopyTextureToTextureCommand& copy);
 
   /// Encodes a render-pass command, or returns empty when \p command is not one.
   /// @param state Encoding state. @param command Recorded command.
@@ -1013,6 +1014,38 @@ Status MetalDevice::Impl::encodeCopyTextureToBuffer(EncodingState& state,
   return OkStatus();
 }
 
+Status MetalDevice::Impl::encodeCopyTextureToTexture(EncodingState& state,
+                                                     const CopyTextureToTextureCommand& copy) {
+  if (state.renderEncoder != nil) {
+    return GpuError{GpuErrorType::InvalidState, "copyTextureToTexture inside a render pass"};
+  }
+  if (state.computeEncoder != nil) {
+    return GpuError{GpuErrorType::InvalidState, "copyTextureToTexture inside a compute pass"};
+  }
+  id<MTLTexture> source = GetSlot(textures, copy.textureSrcId.slotIndex);
+  id<MTLTexture> destination = GetSlot(textures, copy.textureDstId.slotIndex);
+  if (source == nil || destination == nil) {
+    return GpuError{GpuErrorType::InvalidState,
+                    "copyTextureToTexture: source or destination texture is missing"};
+  }
+  id<MTLBlitCommandEncoder> blitEncoder = [state.commandBuffer blitCommandEncoder];
+  if (blitEncoder == nil) {
+    return GpuError{GpuErrorType::InvalidState, "Metal blit command encoder creation failed"};
+  }
+  [blitEncoder
+        copyFromTexture:source
+            sourceSlice:0
+            sourceLevel:0
+           sourceOrigin:MTLOriginMake(copy.sourceOrigin.x, copy.sourceOrigin.y, 0)
+             sourceSize:MTLSizeMake(copy.copySize.width, copy.copySize.height, 1)
+              toTexture:destination
+       destinationSlice:0
+       destinationLevel:0
+      destinationOrigin:MTLOriginMake(copy.destinationOrigin.x, copy.destinationOrigin.y, 0)];
+  [blitEncoder endEncoding];
+  return OkStatus();
+}
+
 std::optional<Status> MetalDevice::Impl::encodeRenderCommand(EncodingState& state,
                                                              const Command& command) {
   if (const auto* beginPass = std::get_if<BeginRenderPassCommand>(&command)) {
@@ -1098,9 +1131,8 @@ std::optional<Status> MetalDevice::Impl::encodeCopyCommand(EncodingState& state,
                                                            const Command& command) {
   if (const auto* copy = std::get_if<CopyTextureToBufferCommand>(&command)) {
     return encodeCopyTextureToBuffer(state, *copy);
-  } else if (std::get_if<CopyTextureToTextureCommand>(&command) != nullptr) {
-    return Status(GpuError{GpuErrorType::Unsupported,
-                           "the Metal backend does not implement copyTextureToTexture yet"});
+  } else if (const auto* textureCopy = std::get_if<CopyTextureToTextureCommand>(&command)) {
+    return encodeCopyTextureToTexture(state, *textureCopy);
   }
   return std::nullopt;
 }

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -89,4 +89,23 @@ donner_cc_test(
     ],
 )
 
+# The Metal texture-to-texture copy slice: a sub-rectangle copy between two
+# origins, executed and compared against the shared expected image. Metal API
+# validation is enabled so validation issues abort loudly.
+donner_cc_test(
+    name = "metal_sub_rectangle_copy_tests",
+    srcs = ["MetalSubRectangleCopy_tests.cc"],
+    env = {
+        "MTL_DEBUG_LAYER": "1",
+        "MTL_SHADER_VALIDATION": "1",
+    },
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        "//donner/gpu",
+        "//donner/gpu:sub_rectangle_copy_scene",
+        "//donner/gpu/metal:metal_device",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -207,30 +207,6 @@ TEST_F(MetalSolidFillTest, ReadBackBufferRejectsStaleHandleAfterSlotReuse) {
   EXPECT_EQ(stale.error().type, GpuErrorType::InvalidHandle) << stale.error();
 }
 
-TEST_F(MetalSolidFillTest, CopyTextureToTextureFailsClosedAsUnsupported) {
-  // The RHI records and validates the copy, but the Metal backend does not execute it yet: the
-  // submission must fail closed with Unsupported instead of silently dropping the copy.
-  const Texture source =
-      unwrap(device_->createTexture(TextureDescriptor{
-                 "copySource", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::CopySrc}),
-             "createTexture copySource");
-  const Texture destination = unwrap(
-      device_->createTexture(TextureDescriptor{"copyDestination", Extent2d{4, 4},
-                                               TextureFormat::RGBA8Unorm, TextureUsage::CopyDst}),
-      "createTexture copyDestination");
-
-  std::unique_ptr<CommandEncoder> encoder =
-      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
-  const Status copyStatus = encoder->copyTextureToTexture(source, destination, Extent2d{4, 4});
-  ASSERT_FALSE(copyStatus.hasError()) << copyStatus.error();
-  CommandBuffer commands = unwrap(encoder->finish(), "finish");
-
-  Result<uint64_t> submitted = device_->submit(std::move(commands));
-  ASSERT_TRUE(submitted.hasError()) << "copyTextureToTexture submission unexpectedly succeeded";
-  EXPECT_EQ(submitted.error().type, GpuErrorType::Unsupported) << submitted.error();
-  EXPECT_THAT(submitted.error().message, testing::HasSubstr("copyTextureToTexture"));
-}
-
 TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
   // ----- Shader module and pipeline from the emitted MSL -----
   shader::ShaderResult<shader::IrModule> irModule = shader::programs::BuildSolidFillModule();

--- a/donner/gpu/metal/tests/MetalSubRectangleCopy_tests.cc
+++ b/donner/gpu/metal/tests/MetalSubRectangleCopy_tests.cc
@@ -1,0 +1,113 @@
+/// @file
+/// The Metal texture-to-texture copy slice: copies a sub-rectangle between two textures through
+/// donner::gpu::metal::MetalDevice and compares the destination texels byte-for-byte against the
+/// shared expected image.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/tests/SubRectangleCopyScene.h"
+
+namespace donner::gpu::metal::tests {
+namespace {
+
+using gpu::tests::kSubRectCopyBytesPerRow;
+using gpu::tests::kSubRectCopyDestinationX;
+using gpu::tests::kSubRectCopyDestinationY;
+using gpu::tests::kSubRectCopyExtent;
+using gpu::tests::kSubRectCopyHeight;
+using gpu::tests::kSubRectCopySourceX;
+using gpu::tests::kSubRectCopySourceY;
+using gpu::tests::kSubRectCopyWidth;
+using gpu::tests::SubRectCopyDestinationUpload;
+using gpu::tests::SubRectCopyExpectedTexel;
+using gpu::tests::SubRectCopySourceUpload;
+
+class MetalSubRectangleCopyTest : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = MetalDevice::Create();
+    if (!device_) {
+      GTEST_SKIP() << "No Metal device available";
+    }
+  }
+
+  /// Unwraps an RHI result, failing the test on error.
+  template <typename T>
+  T unwrap(Result<T>&& result, const char* what) {
+    if (result.hasError()) {
+      ADD_FAILURE() << what << " failed: " << result.error();
+    }
+    return std::move(result).result();
+  }
+
+  std::unique_ptr<MetalDevice> device_;
+};
+
+TEST_F(MetalSubRectangleCopyTest, CopiesTheRectangleBetweenTheTwoOrigins) {
+  const Extent2d extent{kSubRectCopyExtent, kSubRectCopyExtent};
+  const TexelCopyBufferLayout layout{0, kSubRectCopyBytesPerRow, kSubRectCopyExtent};
+
+  Texture source = unwrap(
+      device_->createTexture(TextureDescriptor{"source", extent, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopySrc | TextureUsage::CopyDst}),
+      "createTexture source");
+  Texture destination = unwrap(
+      device_->createTexture(TextureDescriptor{"destination", extent, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopyDst | TextureUsage::CopySrc}),
+      "createTexture destination");
+  Buffer readback = unwrap(device_->createBuffer(BufferDescriptor{
+                               "readback", uint64_t{kSubRectCopyBytesPerRow} * kSubRectCopyExtent,
+                               BufferUsage::CopyDst | BufferUsage::MapRead}),
+                           "createBuffer readback");
+
+  ASSERT_FALSE(device_->writeTexture(source, SubRectCopySourceUpload(), layout, extent).hasError());
+  ASSERT_FALSE(device_->writeTexture(destination, SubRectCopyDestinationUpload(), layout, extent)
+                   .hasError());
+
+  std::unique_ptr<CommandEncoder> encoder =
+      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+  ASSERT_FALSE(encoder
+                   ->copyTextureToTexture(
+                       source, destination, Extent2d{kSubRectCopyWidth, kSubRectCopyHeight},
+                       Origin2d{kSubRectCopySourceX, kSubRectCopySourceY},
+                       Origin2d{kSubRectCopyDestinationX, kSubRectCopyDestinationY})
+                   .hasError());
+  ASSERT_FALSE(
+      encoder->copyTextureToBuffer(TexelCopyTextureInfo{destination}, readback, layout, extent)
+          .hasError());
+
+  Result<CommandBuffer> commands = encoder->finish();
+  ASSERT_FALSE(commands.hasError()) << commands.error();
+  Result<uint64_t> serial = device_->submit(std::move(commands).result());
+  ASSERT_FALSE(serial.hasError()) << serial.error();
+
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0))
+      << "Command buffer did not complete cleanly: " << device_->lastErrorForTest();
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+
+  Result<std::vector<uint8_t>> pixels = device_->readBackBuffer(readback);
+  ASSERT_FALSE(pixels.hasError()) << pixels.error();
+
+  for (uint32_t y = 0; y < kSubRectCopyExtent; ++y) {
+    for (uint32_t x = 0; x < kSubRectCopyExtent; ++x) {
+      const size_t offset = size_t{y} * kSubRectCopyBytesPerRow + size_t{x} * 4u;
+      const std::array<uint8_t, 4> actual = {
+          pixels.result()[offset + 0], pixels.result()[offset + 1], pixels.result()[offset + 2],
+          pixels.result()[offset + 3]};
+      EXPECT_THAT(actual, testing::ElementsAreArray(SubRectCopyExpectedTexel(x, y)))
+          << "texel (" << x << ", " << y << ")";
+    }
+  }
+}
+
+}  // namespace
+}  // namespace donner::gpu::metal::tests

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -490,13 +491,61 @@ TEST_F(CopyTextureToTextureTests, RejectsZeroCopySize) {
 TEST_F(CopyTextureToTextureTests, RejectsCopyBeyondSourceExtent) {
   const Texture destination = createDestination(Extent2d{8, 8});
   EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{8, 8}),
-              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("exceeds source")));
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds,
+                                    HasSubstr("source rectangle 8x8 at (0, 0) does not fit")));
 }
 
 TEST_F(CopyTextureToTextureTests, RejectsCopyBeyondDestinationExtent) {
   const Texture destination = createDestination(Extent2d{2, 2});
   EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{4, 4}),
-              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("exceeds destination")));
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds,
+                                    HasSubstr("destination rectangle 4x4 at (0, 0) does not fit")));
+}
+
+TEST_F(CopyTextureToTextureTests, SubRectangleCopyIsAcceptedAndSubmits) {
+  const Texture destination = createDestination(Extent2d{8, 8});
+  EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{2, 2}, Origin2d{2, 1},
+                                             Origin2d{5, 6}),
+              IsOk());
+
+  auto finished = encoder_->finish();
+  ASSERT_THAT(finished, HasResult());
+  EXPECT_THAT(device_.submit(std::move(finished).result()), HasResult());
+}
+
+TEST_F(CopyTextureToTextureTests, ACopyFlushWithTheSourceEdgeIsAccepted) {
+  // The far edge check is inclusive: a rectangle ending exactly on the texture edge is in bounds,
+  // and rejecting it would make the last row and column of every texture uncopyable.
+  const Texture destination = createDestination(Extent2d{8, 8});
+  EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{2, 2}, Origin2d{2, 2},
+                                             Origin2d{6, 6}),
+              IsOk());
+}
+
+TEST_F(CopyTextureToTextureTests, RejectsSourceOriginThatPushesTheRectPastTheEdge) {
+  const Texture destination = createDestination(Extent2d{8, 8});
+  EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{4, 4}, Origin2d{1, 0}),
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds,
+                                    HasSubstr("source rectangle 4x4 at (1, 0) does not fit "
+                                              "source \"target\" size 4x4")));
+}
+
+TEST_F(CopyTextureToTextureTests, RejectsDestinationOriginThatPushesTheRectPastTheEdge) {
+  const Texture destination = createDestination(Extent2d{4, 4});
+  EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{4, 4}, Origin2d{},
+                                             Origin2d{0, 1}),
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds,
+                                    HasSubstr("destination rectangle 4x4 at (0, 1) does not fit "
+                                              "destination \"copyDst\" size 4x4")));
+}
+
+TEST_F(CopyTextureToTextureTests, RejectsAnOriginThatWouldOverflowThirtyTwoBitArithmetic) {
+  // origin + extent is computed in 64 bits: in 32-bit arithmetic this pair wraps to a small
+  // in-bounds far edge, and the copy would be accepted and then read out of the texture.
+  const Texture destination = createDestination(Extent2d{8, 8});
+  EXPECT_THAT(encoder_->copyTextureToTexture(target_, destination, Extent2d{4, 4},
+                                             Origin2d{std::numeric_limits<uint32_t>::max() - 1, 0}),
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("does not fit source")));
 }
 
 TEST_F(CopyTextureToTextureTests, RejectsNullSourceHandle) {

--- a/donner/gpu/tests/RecordingDevice_tests.cc
+++ b/donner/gpu/tests/RecordingDevice_tests.cc
@@ -274,9 +274,33 @@ TEST(RecordingDeviceTests, CopyTextureToTextureSerializesSourceDestinationAndSiz
   ASSERT_THAT(commandBuffer, HasResult());
   ASSERT_THAT(device.submit(std::move(commandBuffer).result()), HasResult());
 
-  // Line format: labeled src and dst identities, then the copy extent.
+  // Line format: labeled src and dst identities each followed by their origin, then the copy
+  // extent. The default origins are spelled out rather than omitted.
   EXPECT_THAT(device.serialize(),
-              HasSubstr("  copyTextureToTexture src=texture#0 dst=texture#1 copySize=4x4\n"));
+              HasSubstr("  copyTextureToTexture src=texture#0 srcOrigin=(0, 0) dst=texture#1 "
+                        "dstOrigin=(0, 0) copySize=4x4\n"));
+}
+
+TEST(RecordingDeviceTests, CopyTextureToTextureSerializesSubRectangleOrigins) {
+  RecordingDevice device;
+  const Texture source = GetResultOrFail(device.createTexture(TextureDescriptor{
+      "source", Extent2d{8, 8}, TextureFormat::RGBA8Unorm, TextureUsage::CopySrc}));
+  const Texture destination = GetResultOrFail(device.createTexture(TextureDescriptor{
+      "destination", Extent2d{8, 8}, TextureFormat::RGBA8Unorm, TextureUsage::CopyDst}));
+
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device.createCommandEncoder());
+  ASSERT_THAT(encoder->copyTextureToTexture(source, destination, Extent2d{3, 2}, Origin2d{5, 1},
+                                            Origin2d{0, 6}),
+              IsOk());
+  auto commandBuffer = encoder->finish();
+  ASSERT_THAT(commandBuffer, HasResult());
+  ASSERT_THAT(device.submit(std::move(commandBuffer).result()), HasResult());
+
+  // Two copies that differ only in where they read and write must serialize differently, or a
+  // recorded stream cannot be used to tell them apart.
+  EXPECT_THAT(device.serialize(),
+              HasSubstr("  copyTextureToTexture src=texture#0 srcOrigin=(5, 1) dst=texture#1 "
+                        "dstOrigin=(0, 6) copySize=3x2\n"));
 }
 
 TEST(RecordingDeviceTests, SpirvShaderModuleSerializesWordCountAndHash) {

--- a/donner/gpu/tests/SubRectangleCopyScene.h
+++ b/donner/gpu/tests/SubRectangleCopyScene.h
@@ -1,0 +1,116 @@
+#pragma once
+/// @file
+/// Shared scene for the texture-to-texture sub-rectangle copy slices.
+///
+/// Every backend slice copies the same rectangle out of the same source into the same
+/// pre-filled destination and checks the same expected bytes, so a backend that ignores an
+/// origin, swaps the two origins, or clamps one of them shows up as a byte difference rather
+/// than as a test that agrees with itself.
+///
+/// The source texel values encode their own coordinates, and the copy rectangle is taken from an
+/// interior corner with a different destination corner. A backend that dropped either origin, or
+/// applied the source origin to the destination, would land different bytes in different places,
+/// so no single mistake reproduces the expected image.
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace donner::gpu::tests {
+
+/// Width and height of both the source and the destination texture, in texels.
+inline constexpr uint32_t kSubRectCopyExtent = 8;
+
+/// Bytes per row of the staging buffers, meeting the runtime's 256-byte row pitch.
+inline constexpr uint32_t kSubRectCopyBytesPerRow = 256;
+
+/// Width of the copied rectangle, in texels.
+inline constexpr uint32_t kSubRectCopyWidth = 3;
+
+/// Height of the copied rectangle, in texels. Different from the width so a backend that
+/// transposed the extent would not still produce the expected image.
+inline constexpr uint32_t kSubRectCopyHeight = 2;
+
+/// Column of the copy's top-left texel in the source.
+inline constexpr uint32_t kSubRectCopySourceX = 5;
+
+/// Row of the copy's top-left texel in the source. Different from \ref kSubRectCopySourceX so a
+/// backend that swapped the axes would be caught.
+inline constexpr uint32_t kSubRectCopySourceY = 1;
+
+/// Column of the copy's top-left texel in the destination. Disjoint from the source rectangle so
+/// a backend that applied the source origin to both sides would be caught.
+inline constexpr uint32_t kSubRectCopyDestinationX = 1;
+
+/// Row of the copy's top-left texel in the destination.
+inline constexpr uint32_t kSubRectCopyDestinationY = 5;
+
+/// Texel of the source pattern at (\p x, \p y), RGBA in texel units. Each texel encodes its own
+/// coordinates, so a texel that arrives from the wrong place names where it came from.
+/// @param x Column in the source texture.
+/// @param y Row in the source texture.
+inline std::array<uint8_t, 4> SubRectCopySourceTexel(uint32_t x, uint32_t y) {
+  return {static_cast<uint8_t>(0x10u + x * 0x11u), static_cast<uint8_t>(0x20u + y * 0x11u), 0x40,
+          0xFF};
+}
+
+/// The sentinel every destination texel starts at. Distinct from every source texel, so an
+/// untouched destination texel cannot be mistaken for a copied one.
+inline std::array<uint8_t, 4> SubRectCopyDestinationFill() {
+  return {0x01, 0x02, 0x03, 0xFF};
+}
+
+/// True if destination texel (\p x, \p y) lies inside the copied rectangle.
+/// @param x Column in the destination texture.
+/// @param y Row in the destination texture.
+inline bool SubRectCopyCoversDestination(uint32_t x, uint32_t y) {
+  return x >= kSubRectCopyDestinationX && x < kSubRectCopyDestinationX + kSubRectCopyWidth &&
+         y >= kSubRectCopyDestinationY && y < kSubRectCopyDestinationY + kSubRectCopyHeight;
+}
+
+/// Expected destination texel at (\p x, \p y) after the copy.
+/// @param x Column in the destination texture.
+/// @param y Row in the destination texture.
+inline std::array<uint8_t, 4> SubRectCopyExpectedTexel(uint32_t x, uint32_t y) {
+  if (!SubRectCopyCoversDestination(x, y)) {
+    return SubRectCopyDestinationFill();
+  }
+  return SubRectCopySourceTexel(x - kSubRectCopyDestinationX + kSubRectCopySourceX,
+                                y - kSubRectCopyDestinationY + kSubRectCopySourceY);
+}
+
+/// The source pattern packed into rows of \ref kSubRectCopyBytesPerRow, ready for
+/// `Device::writeTexture`.
+inline std::vector<uint8_t> SubRectCopySourceUpload() {
+  std::vector<uint8_t> rows(size_t{kSubRectCopyBytesPerRow} * kSubRectCopyExtent, 0);
+  for (uint32_t y = 0; y < kSubRectCopyExtent; ++y) {
+    for (uint32_t x = 0; x < kSubRectCopyExtent; ++x) {
+      const std::array<uint8_t, 4> texel = SubRectCopySourceTexel(x, y);
+      const size_t offset = size_t{y} * kSubRectCopyBytesPerRow + size_t{x} * 4u;
+      rows[offset + 0] = texel[0];
+      rows[offset + 1] = texel[1];
+      rows[offset + 2] = texel[2];
+      rows[offset + 3] = texel[3];
+    }
+  }
+  return rows;
+}
+
+/// The destination's starting fill packed into rows of \ref kSubRectCopyBytesPerRow, ready for
+/// `Device::writeTexture`.
+inline std::vector<uint8_t> SubRectCopyDestinationUpload() {
+  std::vector<uint8_t> rows(size_t{kSubRectCopyBytesPerRow} * kSubRectCopyExtent, 0);
+  const std::array<uint8_t, 4> fill = SubRectCopyDestinationFill();
+  for (uint32_t y = 0; y < kSubRectCopyExtent; ++y) {
+    for (uint32_t x = 0; x < kSubRectCopyExtent; ++x) {
+      const size_t offset = size_t{y} * kSubRectCopyBytesPerRow + size_t{x} * 4u;
+      rows[offset + 0] = fill[0];
+      rows[offset + 1] = fill[1];
+      rows[offset + 2] = fill[2];
+      rows[offset + 3] = fill[3];
+    }
+  }
+  return rows;
+}
+
+}  // namespace donner::gpu::tests

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -1163,6 +1163,7 @@ struct VulkanDevice::Impl {
   /// @param state Encoding state.
   /// @param copy Recorded command.
   Status encodeCopyTextureToBuffer(EncodingState& state, const CopyTextureToBufferCommand& copy);
+  Status encodeCopyTextureToTexture(EncodingState& state, const CopyTextureToTextureCommand& copy);
 
   /// Encodes a render-pass command, or returns empty when the command is not one.
   /// @param state Encoding state.
@@ -2794,13 +2795,49 @@ std::optional<Status> VulkanDevice::Impl::encodeComputeCommand(EncodingState& st
   return std::nullopt;
 }
 
+Status VulkanDevice::Impl::encodeCopyTextureToTexture(EncodingState& state,
+                                                      const CopyTextureToTextureCommand& copy) {
+  if (state.inRenderPass) {
+    return GpuError{GpuErrorType::InvalidState, "copyTextureToTexture inside a render pass"};
+  }
+  TextureRecord* source = FindRecord(textures, copy.textureSrcId.slotIndex);
+  TextureRecord* destination = FindRecord(textures, copy.textureDstId.slotIndex);
+  if (source == nullptr || destination == nullptr) {
+    return GpuError{GpuErrorType::InvalidState,
+                    "copyTextureToTexture: source or destination texture is missing"};
+  }
+
+  // Both operands move to their transfer layouts first. The staged layout is recorded for each so
+  // a later pass's transition prescan starts from what this copy actually left behind, rather
+  // than from the layout the texture was created in.
+  RecordImageBarrier(*api, state.commandBuffer, source->image,
+                     encodedLayoutOf(state, copy.textureSrcId.slotIndex, *source),
+                     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+  state.stagedLayouts[copy.textureSrcId.slotIndex] = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  RecordImageBarrier(*api, state.commandBuffer, destination->image,
+                     encodedLayoutOf(state, copy.textureDstId.slotIndex, *destination),
+                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+  state.stagedLayouts[copy.textureDstId.slotIndex] = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+
+  VkImageCopy copyRegion = {};
+  copyRegion.srcSubresource = VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+  copyRegion.srcOffset = VkOffset3D{static_cast<int32_t>(copy.sourceOrigin.x),
+                                    static_cast<int32_t>(copy.sourceOrigin.y), 0};
+  copyRegion.dstSubresource = VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+  copyRegion.dstOffset = VkOffset3D{static_cast<int32_t>(copy.destinationOrigin.x),
+                                    static_cast<int32_t>(copy.destinationOrigin.y), 0};
+  copyRegion.extent = VkExtent3D{copy.copySize.width, copy.copySize.height, 1};
+  api->vkCmdCopyImage(state.commandBuffer, source->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                      destination->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion);
+  return OkStatus();
+}
+
 std::optional<Status> VulkanDevice::Impl::encodeCopyCommand(EncodingState& state,
                                                             const Command& command) {
   if (const auto* copy = std::get_if<CopyTextureToBufferCommand>(&command)) {
     return encodeCopyTextureToBuffer(state, *copy);
-  } else if (std::get_if<CopyTextureToTextureCommand>(&command) != nullptr) {
-    return Status(GpuError{GpuErrorType::Unsupported,
-                           "the Vulkan backend does not implement copyTextureToTexture yet"});
+  } else if (const auto* textureCopy = std::get_if<CopyTextureToTextureCommand>(&command)) {
+    return encodeCopyTextureToTexture(state, *textureCopy);
   }
   return std::nullopt;
 }

--- a/donner/gpu/vulkan/VulkanLoader.cc
+++ b/donner/gpu/vulkan/VulkanLoader.cc
@@ -274,6 +274,7 @@ Status VulkanLoader::loadDevice(VkDevice device) {
                 resolve("vkCmdCopyBufferToImage"));
   missing.store(api_.vkCmdCopyImageToBuffer, "vkCmdCopyImageToBuffer",
                 resolve("vkCmdCopyImageToBuffer"));
+  missing.store(api_.vkCmdCopyImage, "vkCmdCopyImage", resolve("vkCmdCopyImage"));
   if (!missing.complete()) {
     return GpuError{GpuErrorType::Unsupported,
                     std::format("the Vulkan device does not provide {}", missing.name())};

--- a/donner/gpu/vulkan/VulkanLoader.h
+++ b/donner/gpu/vulkan/VulkanLoader.h
@@ -116,6 +116,7 @@ struct VulkanApi {
   PFN_vkCmdPipelineBarrier vkCmdPipelineBarrier = nullptr;
   PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage = nullptr;
   PFN_vkCmdCopyImageToBuffer vkCmdCopyImageToBuffer = nullptr;
+  PFN_vkCmdCopyImage vkCmdCopyImage = nullptr;
   /// @}
 };
 

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -113,4 +113,30 @@ donner_cc_test(
     ],
 )
 
+# The Vulkan texture-to-texture copy slice: a sub-rectangle copy between two
+# origins, executed and compared against the shared expected image. Like the
+# compute slice this is a plain Linux-gated test with no geode transition and no
+# pinned driver: the expected bytes are an exact copy of bytes the test itself
+# uploaded, so there is no cross-driver quantization freedom to control for, and
+# running on whatever driver the host exposes covers the real hardware path.
+#
+# Deliberately carries no executor-routing properties, for the reason spelled out
+# on the solid-fill wrapper above: a property naming a worker class the execution
+# pool does not offer queues the action forever instead of failing.
+donner_cc_test(
+    name = "vulkan_sub_rectangle_copy_tests",
+    srcs = ["VulkanSubRectangleCopy_tests.cc"],
+    env = {
+        "DONNER_REQUIRE_VULKAN": "1",
+        "XDG_RUNTIME_DIR": "/tmp",
+    },
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "//donner/gpu",
+        "//donner/gpu:sub_rectangle_copy_scene",
+        "//donner/gpu/vulkan:vulkan_device",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/vulkan/tests/VulkanSubRectangleCopy_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanSubRectangleCopy_tests.cc
@@ -1,0 +1,121 @@
+/// @file
+/// The Vulkan texture-to-texture copy slice: copies a sub-rectangle between two textures through
+/// donner::gpu::vulkan::VulkanDevice and compares the destination texels byte-for-byte against
+/// the shared expected image.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/tests/SubRectangleCopyScene.h"
+#include "donner/gpu/vulkan/VulkanDevice.h"
+
+namespace donner::gpu::vulkan::tests {
+namespace {
+
+using gpu::tests::kSubRectCopyBytesPerRow;
+using gpu::tests::kSubRectCopyDestinationX;
+using gpu::tests::kSubRectCopyDestinationY;
+using gpu::tests::kSubRectCopyExtent;
+using gpu::tests::kSubRectCopyHeight;
+using gpu::tests::kSubRectCopySourceX;
+using gpu::tests::kSubRectCopySourceY;
+using gpu::tests::kSubRectCopyWidth;
+using gpu::tests::SubRectCopyDestinationUpload;
+using gpu::tests::SubRectCopyExpectedTexel;
+using gpu::tests::SubRectCopySourceUpload;
+
+class VulkanSubRectangleCopyTest : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = VulkanDevice::Create();
+    if (!device_) {
+      // CI sets DONNER_REQUIRE_VULKAN=1 (see BUILD.bazel) so a missing driver is a red test
+      // instead of a silent skip; local runs without a Vulkan runtime still skip.
+      const char* requireVulkan = std::getenv("DONNER_REQUIRE_VULKAN");
+      if (requireVulkan != nullptr && std::string_view(requireVulkan) == "1") {
+        FAIL() << "DONNER_REQUIRE_VULKAN=1 is set but no Vulkan 1.1 device is available; the "
+                  "vertical-slice gate must not be skipped on this runner";
+      }
+      GTEST_SKIP() << "No Vulkan 1.1 device available";
+    }
+  }
+
+  /// Unwraps an RHI result, failing the test on error.
+  template <typename T>
+  T unwrap(Result<T>&& result, const char* what) {
+    if (result.hasError()) {
+      ADD_FAILURE() << what << " failed: " << result.error();
+    }
+    return std::move(result).result();
+  }
+
+  std::unique_ptr<VulkanDevice> device_;
+};
+
+TEST_F(VulkanSubRectangleCopyTest, CopiesTheRectangleBetweenTheTwoOrigins) {
+  const Extent2d extent{kSubRectCopyExtent, kSubRectCopyExtent};
+  const TexelCopyBufferLayout layout{0, kSubRectCopyBytesPerRow, kSubRectCopyExtent};
+
+  Texture source = unwrap(
+      device_->createTexture(TextureDescriptor{"source", extent, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopySrc | TextureUsage::CopyDst}),
+      "createTexture source");
+  Texture destination = unwrap(
+      device_->createTexture(TextureDescriptor{"destination", extent, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopyDst | TextureUsage::CopySrc}),
+      "createTexture destination");
+  Buffer readback = unwrap(device_->createBuffer(BufferDescriptor{
+                               "readback", uint64_t{kSubRectCopyBytesPerRow} * kSubRectCopyExtent,
+                               BufferUsage::CopyDst | BufferUsage::MapRead}),
+                           "createBuffer readback");
+
+  ASSERT_FALSE(device_->writeTexture(source, SubRectCopySourceUpload(), layout, extent).hasError());
+  ASSERT_FALSE(device_->writeTexture(destination, SubRectCopyDestinationUpload(), layout, extent)
+                   .hasError());
+
+  std::unique_ptr<CommandEncoder> encoder =
+      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+  ASSERT_FALSE(encoder
+                   ->copyTextureToTexture(
+                       source, destination, Extent2d{kSubRectCopyWidth, kSubRectCopyHeight},
+                       Origin2d{kSubRectCopySourceX, kSubRectCopySourceY},
+                       Origin2d{kSubRectCopyDestinationX, kSubRectCopyDestinationY})
+                   .hasError());
+  ASSERT_FALSE(
+      encoder->copyTextureToBuffer(TexelCopyTextureInfo{destination}, readback, layout, extent)
+          .hasError());
+
+  Result<CommandBuffer> commands = encoder->finish();
+  ASSERT_FALSE(commands.hasError()) << commands.error();
+  Result<uint64_t> serial = device_->submit(std::move(commands).result());
+  ASSERT_FALSE(serial.hasError()) << serial.error();
+
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0))
+      << "Command buffer did not complete cleanly";
+
+  Result<std::vector<uint8_t>> pixels = device_->readBackBuffer(readback);
+  ASSERT_FALSE(pixels.hasError()) << pixels.error();
+
+  for (uint32_t y = 0; y < kSubRectCopyExtent; ++y) {
+    for (uint32_t x = 0; x < kSubRectCopyExtent; ++x) {
+      const size_t offset = size_t{y} * kSubRectCopyBytesPerRow + size_t{x} * 4u;
+      const std::array<uint8_t, 4> actual = {
+          pixels.result()[offset + 0], pixels.result()[offset + 1], pixels.result()[offset + 2],
+          pixels.result()[offset + 3]};
+      EXPECT_THAT(actual, testing::ElementsAreArray(SubRectCopyExpectedTexel(x, y)))
+          << "texel (" << x << ", " << y << ")";
+    }
+  }
+}
+
+}  // namespace
+}  // namespace donner::gpu::vulkan::tests

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5563,19 +5563,20 @@ void RendererGeode::popFilterLayer() {
     wgpu::Texture viewportTexture = impl_->acquireTexture(vpDesc);
 
     if (viewportTexture) {
-      wgpu::TexelCopyTextureInfo src = {};
-      src.texture = filteredTexture;
-      src.origin = {static_cast<uint32_t>(frame.filterBufferOffsetX),
-                    static_cast<uint32_t>(frame.filterBufferOffsetY), 0u};
-      wgpu::TexelCopyTextureInfo dst = {};
-      dst.texture = viewportTexture;
-      const wgpu::Extent3D extent = {vpW, vpH, 1u};
+      const gpu::Texture& filteredHandle = impl_->importFilterResult(filteredTexture);
+      const gpu::Texture& viewportHandle = impl_->importTexture(viewportTexture, vpDesc);
+
       // Everything recorded before this point has already been replayed into the frame command
       // encoder by the encoder retire above, so the copy lands after those draws and before the
       // composite recorded below.
-      impl_->frameCommandEncoder.get().copyTextureToTexture(src, dst, extent);
+      const gpu::Status copied = impl_->frameGpuEncoder->copyTextureToTexture(
+          filteredHandle, viewportHandle, gpu::Extent2d{vpW, vpH},
+          gpu::Origin2d{static_cast<uint32_t>(frame.filterBufferOffsetX),
+                        static_cast<uint32_t>(frame.filterBufferOffsetY)});
+      UTILS_RELEASE_ASSERT_MSG(!copied.hasError(),
+                               "Failed to record the filter viewport extraction copy");
 
-      impl_->encoder->blitFullTarget(impl_->importTexture(viewportTexture, vpDesc), 1.0);
+      impl_->encoder->blitFullTarget(viewportHandle, 1.0);
       impl_->releaseTextureAtFrameEnd(std::move(viewportTexture), vpDesc);
     }
   } else {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1961,6 +1961,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   /// intersection with a previous polygon) - nested rotated clips are
   /// rare enough that we accept the over-coverage fallback.
   struct ClipStackEntry {
+    ClipStackEntry() = default;
+    ~ClipStackEntry() = default;
+
+    // Move-only, explicitly. The mask textures this entry owns are move-only runtime handles, so
+    // a copy could never have worked; saying so here matters because a standard library that
+    // instantiates a container's copy constructor eagerly (libstdc++ does, libc++ does not)
+    // fails to compile on the implicit copy rather than on a copy anyone wrote.
+    ClipStackEntry(const ClipStackEntry&) = delete;
+    ClipStackEntry& operator=(const ClipStackEntry&) = delete;
+    ClipStackEntry(ClipStackEntry&&) = default;
+    ClipStackEntry& operator=(ClipStackEntry&&) = default;
+
     Box2d pixelRect;
     bool valid = false;
     bool hasPolygon = false;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -894,25 +894,26 @@ std::optional<ResolvedRadialGradient> resolveRadialGradientParams(
 struct RendererGeodeTextureKey {
   uint32_t width = 0;
   uint32_t height = 0;
-  wgpu::TextureFormat format = wgpu::TextureFormat::Undefined;
-  wgpu::TextureUsage usage = wgpu::TextureUsage::None;
-  // Every current caller uses 1 mip / 1 sample / 2D, but key them anyway:
-  // a pooled single-sample texture handed to a future multisample or
-  // mipmapped request would validate and silently render wrong.
-  uint32_t mipLevelCount = 1;
+  gpu::TextureFormat format = gpu::TextureFormat::RGBA8Unorm;
+  gpu::TextureUsage usage = gpu::TextureUsage::None;
+  // Every current caller uses one sample, but key it anyway: a pooled single-sample texture
+  // handed to a future multisample request would validate and silently render wrong. Mip level
+  // count and dimension are not keyed because the runtime creates one-mip 2D textures only, so
+  // there is no second value for them to take.
   uint32_t sampleCount = 1;
-  wgpu::TextureDimension dimension = wgpu::TextureDimension::_2D;
 
   auto operator<=>(const RendererGeodeTextureKey& other) const = default;
 
-  static RendererGeodeTextureKey From(const wgpu::TextureDescriptor& desc) {
-    return RendererGeodeTextureKey{desc.size.width,    desc.size.height, desc.format,   desc.usage,
-                                   desc.mipLevelCount, desc.sampleCount, desc.dimension};
+  /// Key identifying the bucket \p desc allocates from.
+  /// @param desc Descriptor a texture was, or would be, created with.
+  static RendererGeodeTextureKey From(const gpu::TextureDescriptor& desc) {
+    return RendererGeodeTextureKey{desc.size.width, desc.size.height, desc.format, desc.usage,
+                                   desc.sampleCount};
   }
 };
 
 struct RendererGeodeTextureBucket {
-  std::vector<geode::ScopedWgpuHandle<wgpu::Texture>> free;
+  std::vector<gpu::Texture> free;
   uint64_t lastUsedFrame = 0;
 };
 
@@ -921,16 +922,25 @@ struct RendererGeodeTextureBucket {
  *
  * Exact-size reuse remains available across RendererGeode instances sharing one GeodeDevice, while
  * one retained-memory budget covers the editor's main, compositor, and thumbnail renderers.
+ *
+ * The pool's currency is the runtime's own \c gpu::Texture, so a pooled texture is already named
+ * to the runtime when it is handed out and needs no per-frame import. It holds the device it
+ * allocates from rather than taking one per call, because a texture must be destroyed through
+ * that device on eviction and in this pool's destructor, where no caller is present to supply
+ * one.
  */
 class RendererGeodeTexturePool {
 public:
+  /// Constructs a pool allocating from \p device.
+  /// @param device Device every pooled texture is created on and destroyed through.
+  explicit RendererGeodeTexturePool(std::shared_ptr<geode::GeodeDevice> device)
+      : device_(std::move(device)) {}
+
   ~RendererGeodeTexturePool() {
     for (auto& [unusedKey, bucket] : buckets_) {
       (void)unusedKey;
-      for (geode::ScopedWgpuHandle<wgpu::Texture>& texture : bucket.free) {
-        if (texture) {
-          texture.get().destroy();
-        }
+      for (gpu::Texture& texture : bucket.free) {
+        destroyPooledTexture(std::move(texture));
       }
     }
   }
@@ -956,14 +966,17 @@ public:
     return result;
   }
 
-  wgpu::Texture acquire(geode::GeodeDevice& device, const wgpu::TextureDescriptor& desc) {
+  /// Takes a pooled texture matching \p desc, or creates one on a miss. The runtime counts the
+  /// creation itself, so a hit ticks no counter and a miss ticks exactly one.
+  /// @param desc Descriptor the texture must match exactly.
+  gpu::Texture acquire(const gpu::TextureDescriptor& desc) {
     const RendererGeodeTextureKey key = RendererGeodeTextureKey::From(desc);
     {
       std::lock_guard lock(mutex_);
       RendererGeodeTextureBucket& bucket = buckets_[key];
       bucket.lastUsedFrame = currentFrameIndex_;
       if (!bucket.free.empty()) {
-        wgpu::Texture texture = bucket.free.back().take();
+        gpu::Texture texture = std::move(bucket.free.back());
         bucket.free.pop_back();
         pooledTextureBytes_ -= textureByteSize(key);
         --pooledTextureCount_;
@@ -971,15 +984,18 @@ public:
       }
     }
 
-    wgpu::Texture texture = device.device().createTexture(desc);
-    if (texture) {
-      device.countTexture();
+    gpu::Result<gpu::Texture> created = device_->adapterDevice().createTexture(desc);
+    if (created.hasError()) {
+      return gpu::Texture{};
     }
-    return texture;
+    return std::move(created).result();
   }
 
-  void release(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
-    if (!texture) {
+  /// Returns \p texture to its bucket, or destroys it when a ceiling rejects it.
+  /// @param texture Texture to pool; consumed either way.
+  /// @param desc Descriptor \p texture was acquired with.
+  void release(gpu::Texture texture, const gpu::TextureDescriptor& desc) {
+    if (!texture.isValid()) {
       return;
     }
 
@@ -988,19 +1004,19 @@ public:
     const auto existingBucket = buckets_.find(key);
     if (existingBucket != buckets_.end() &&
         existingBucket->second.free.size() >= kMaxPoolEntriesPerKey) {
-      destroyReleasedTexture(std::move(texture));
+      destroyPooledTexture(std::move(texture));
       return;
     }
 
     const uint64_t textureBytes = textureByteSize(key);
     if (!evictPoolEntriesToFit(textureBytes)) {
-      destroyReleasedTexture(std::move(texture));
+      destroyPooledTexture(std::move(texture));
       return;
     }
 
     RendererGeodeTextureBucket& bucket = buckets_[key];
     bucket.lastUsedFrame = currentFrameIndex_;
-    bucket.free.push_back(geode::ScopedWgpuHandle<wgpu::Texture>(std::move(texture)));
+    bucket.free.push_back(std::move(texture));
     pooledTextureBytes_ += textureBytes;
     ++pooledTextureCount_;
   }
@@ -1023,19 +1039,25 @@ private:
     return static_cast<uint64_t>(key.width) * static_cast<uint64_t>(key.height) * 4u;
   }
 
-  static void destroyReleasedTexture(wgpu::Texture texture) {
-    geode::ScopedWgpuHandle<wgpu::Texture> owned(std::move(texture));
-    if (owned) {
-      owned.get().destroy();
+  /// Destroys the backend object behind \p texture, not just this pool's name for it.
+  ///
+  /// Dropping the handle alone releases the runtime slot and leaves the backend texture resident
+  /// until the host runtime collects it, which is exactly where a succession of evicted pool
+  /// entries shows up as retained memory.
+  /// @param texture Texture to destroy; consumed.
+  void destroyPooledTexture(gpu::Texture&& texture) {
+    if (!texture.isValid()) {
+      return;
     }
+    const gpu::Status destroyed =
+        device_->adapterDevice().destroyTextureBacking(std::move(texture));
+    (void)destroyed;  // A texture this pool owns is always live; a stale handle is already gone.
   }
 
   void destroyPoolBucket(const RendererGeodeTextureKey& key, RendererGeodeTextureBucket& bucket) {
     const uint64_t bucketBytes = textureByteSize(key) * static_cast<uint64_t>(bucket.free.size());
-    for (geode::ScopedWgpuHandle<wgpu::Texture>& texture : bucket.free) {
-      if (texture) {
-        texture.get().destroy();
-      }
+    for (gpu::Texture& texture : bucket.free) {
+      destroyPooledTexture(std::move(texture));
     }
     pooledTextureBytes_ -= bucketBytes;
     pooledTextureCount_ -= bucket.free.size();
@@ -1060,10 +1082,7 @@ private:
         return false;
       }
 
-      geode::ScopedWgpuHandle<wgpu::Texture>& texture = victim->second.free.back();
-      if (texture) {
-        texture.get().destroy();
-      }
+      destroyPooledTexture(std::move(victim->second.free.back()));
       victim->second.free.pop_back();
       pooledTextureBytes_ -= textureByteSize(victim->first);
       --pooledTextureCount_;
@@ -1085,6 +1104,7 @@ private:
     }
   }
 
+  std::shared_ptr<geode::GeodeDevice> device_;
   mutable std::mutex mutex_;
   std::map<RendererGeodeTextureKey, RendererGeodeTextureBucket> buckets_;
   uint64_t pooledTextureBytes_ = 0;
@@ -1092,7 +1112,12 @@ private:
   uint64_t currentFrameIndex_ = 0;
 };
 
-std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevice* device) {
+/// The one pool serving \p device, created on first use. Renderers sharing a device share its
+/// pool, so an exact-size texture one renderer released is available to the next.
+/// @param device Device to pool textures for; the pool holds it for as long as it lives, because
+///   it destroys its textures through that device.
+std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(
+    const std::shared_ptr<geode::GeodeDevice>& device) {
   static std::mutex registryMutex;
   static std::map<geode::GeodeDevice*, std::weak_ptr<RendererGeodeTexturePool>> pools;
 
@@ -1105,14 +1130,14 @@ std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevic
     }
   }
 
-  if (const auto existing = pools.find(device); existing != pools.end()) {
+  if (const auto existing = pools.find(device.get()); existing != pools.end()) {
     if (std::shared_ptr<RendererGeodeTexturePool> pool = existing->second.lock()) {
       return pool;
     }
   }
 
-  auto pool = std::make_shared<RendererGeodeTexturePool>();
-  pools[device] = pool;
+  auto pool = std::make_shared<RendererGeodeTexturePool>(device);
+  pools[device.get()] = pool;
   return pool;
 }
 
@@ -1467,6 +1492,19 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
                              wgpu::TextureUsage::CopySrc);
   }
 
+  /// The backend texture behind a runtime handle, for the subsystems that still record through
+  /// wgpu directly (the filter engine, and the target alias the snapshot and readback paths
+  /// borrow). Borrowed: the runtime handle is what owns it.
+  /// @param texture Live runtime texture handle.
+  wgpu::Texture backendTextureOf(const gpu::Texture& texture) const {
+    return device->adapterDevice().wgpuTextureOf(texture);
+  }
+
+  /// The runtime's spelling of the renderer's surface format.
+  gpu::TextureFormat gpuTextureFormat() const {
+    return geode::GpuTextureFormatFromWgpu(textureFormat);
+  }
+
   /// Extent of the active render target, in texels, read from the target itself.
   gpu::Extent2d targetExtent() const {
     return gpu::Extent2d{target.getWidth(), target.getHeight()};
@@ -1716,12 +1754,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frameGenerationOpen = false;
   }
 
-  [[nodiscard]] bool reserveTextureSurface(const wgpu::TextureDescriptor& desc) {
-    if (!device || desc.size.width > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
-        desc.size.height > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
-        !surfaceBudget->reserve(static_cast<int>(desc.size.width),
-                                static_cast<int>(desc.size.height),
-                                static_cast<std::size_t>(desc.size.depthOrArrayLayers))) {
+  /// Charges one surface of \p size against the frame's surface budget.
+  /// @param size Extent of the surface about to be allocated, in texels.
+  [[nodiscard]] bool reserveTextureSurface(const gpu::Extent2d& size) {
+    if (!device || size.width > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        size.height > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        !surfaceBudget->reserve(static_cast<int>(size.width), static_cast<int>(size.height))) {
       return false;
     }
     return true;
@@ -1729,15 +1767,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
 
   /// Acquire a pooled texture matching `desc`, or create a fresh one
   /// on miss. Always increments the `textureCreates` counter on miss;
-  /// never on hit. Returns a null texture on device failure.
-  wgpu::Texture acquireTexture(const wgpu::TextureDescriptor& desc) {
-    if (!texturePool || !reserveTextureSurface(desc)) {
-      return wgpu::Texture{};
+  /// never on hit. Returns an invalid texture on device failure.
+  gpu::Texture acquireTexture(const gpu::TextureDescriptor& desc) {
+    if (!texturePool || !reserveTextureSurface(desc.size)) {
+      return gpu::Texture{};
     }
-    return texturePool->acquire(*device, desc);
+    return texturePool->acquire(desc);
   }
 
-  wgpu::Texture acquireFilterTexture(const wgpu::TextureDescriptor& desc) override {
+  gpu::Texture acquireFilterTexture(const gpu::TextureDescriptor& desc) override {
     return acquireTexture(desc);
   }
 
@@ -1750,22 +1788,24 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   /// mid-frame would let a subsequent `acquireTexture` on the same
   /// bucket hand the texture back out before the GPU has finished
   /// writing it.
-  void releaseTexture(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
-    if (!texture) {
+  void releaseTexture(gpu::Texture texture, const gpu::TextureDescriptor& desc) {
+    if (!texture.isValid()) {
       return;
     }
     const bool releasedSurface =
         desc.size.width <= static_cast<uint32_t>(std::numeric_limits<int>::max()) &&
         desc.size.height <= static_cast<uint32_t>(std::numeric_limits<int>::max()) &&
         surfaceBudget->release(static_cast<int>(desc.size.width),
-                               static_cast<int>(desc.size.height),
-                               static_cast<std::size_t>(desc.size.depthOrArrayLayers));
+                               static_cast<int>(desc.size.height));
     UTILS_RELEASE_ASSERT(releasedSurface);
     if (texturePool) {
       texturePool->release(std::move(texture), desc);
     } else {
-      geode::ScopedWgpuHandle<wgpu::Texture> owned(std::move(texture));
-      owned.get().destroy();
+      // No pool to return it to, so the backend object is destroyed here rather than left
+      // resident until the host runtime collects it.
+      const gpu::Status destroyed =
+          device->adapterDevice().destroyTextureBacking(std::move(texture));
+      (void)destroyed;
     }
   }
 
@@ -1774,20 +1814,20 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   /// where the layer texture is still referenced by commands recorded
   /// into the frame encoder and must not be recycled mid-frame.
   struct PendingRelease {
-    wgpu::Texture texture;
-    wgpu::TextureDescriptor desc;
+    gpu::Texture texture;
+    gpu::TextureDescriptor desc;
   };
   std::vector<PendingRelease> framePendingReleases;
 
-  void releaseTextureAtFrameEnd(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
-    if (!texture) {
+  void releaseTextureAtFrameEnd(gpu::Texture texture, const gpu::TextureDescriptor& desc) {
+    if (!texture.isValid()) {
       return;
     }
     framePendingReleases.push_back({std::move(texture), desc});
   }
 
-  void releaseFilterTextureAtFrameEnd(wgpu::Texture texture,
-                                      const wgpu::TextureDescriptor& desc) override {
+  void releaseFilterTextureAtFrameEnd(gpu::Texture texture,
+                                      const gpu::TextureDescriptor& desc) override {
     releaseTextureAtFrameEnd(std::move(texture), desc);
   }
 
@@ -1849,11 +1889,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   struct LayerStackFrame {
     std::unique_ptr<geode::GeoEncoder> savedEncoder;
     wgpu::Texture savedTarget;
-    wgpu::Texture layerTexture;
+    gpu::Texture layerTexture;
     /// Descriptors captured at push time so `popIsolatedLayer` can
     /// release the textures back to the correct pool bucket via
     /// `releaseTexture`.
-    wgpu::TextureDescriptor layerDesc = {};
+    gpu::TextureDescriptor layerDesc = {};
     double opacity = 1.0;
     /// SVG `mix-blend-mode`. `Normal` (default) keeps the
     /// plain premultiplied source-over compositing path;
@@ -1882,11 +1922,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     Phase phase = Phase::Capturing;
     std::unique_ptr<geode::GeoEncoder> savedEncoder;
     wgpu::Texture savedTarget;
-    wgpu::Texture maskTexture;     // Mask element's content (RGBA).
-    wgpu::Texture contentTexture;  // Masked element's content (RGBA).
+    gpu::Texture maskTexture;     // Mask element's content (RGBA).
+    gpu::Texture contentTexture;  // Masked element's content (RGBA).
     /// Descriptors captured at push for texture-pool release.
-    wgpu::TextureDescriptor maskDesc = {};
-    wgpu::TextureDescriptor contentDesc = {};
+    gpu::TextureDescriptor maskDesc = {};
+    gpu::TextureDescriptor contentDesc = {};
     /// Raw mask-bounds rectangle from the driver, in the coordinate
     /// space of `maskBoundsTransform` (userSpaceOnUse or the
     /// objectBoundingBox-mapped user space - either way, NOT yet in
@@ -1937,14 +1977,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     /// input clip mask so every outer shape is intersected with the
     /// deeper union. The outermost layer's resolve is the one named here.
     ///
-    /// Both are aliases owned by the frame's import lists, so they are valid
-    /// for the rest of the frame and are null together.
+    /// The texture handle names the entry in \ref maskLayerTextures that owns the mask; the
+    /// view is an alias owned by the frame's import list. Both are valid for the rest of the
+    /// frame and are null together.
     const gpu::Texture* maskResolveTextureHandle = nullptr;
     const gpu::TextureView* maskResolveViewHandle = nullptr;
     /// Paired (texture, descriptor) entries. Every clip-mask texture
     /// allocated by `pushClip` (across all nested layers) lives here
     /// until `popClip` hands them back to the texture pool.
-    std::vector<PendingRelease> maskLayerTextures;
+    /// A deque, not a vector: \ref maskResolveTextureHandle points at one of these entries and
+    /// stays valid while the owning clip entry is moved between the live stack and a filter
+    /// frame's saved stack, which a vector's reallocation would not survive.
+    std::deque<PendingRelease> maskLayerTextures;
   };
 
   /// State for an in-progress filter layer. Captures all draws
@@ -1954,9 +1998,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   struct FilterStackFrame {
     std::unique_ptr<geode::GeoEncoder> savedEncoder;
     wgpu::Texture savedTarget;
-    wgpu::Texture layerTexture;
+    gpu::Texture layerTexture;
     /// Descriptors captured at push for texture-pool release.
-    wgpu::TextureDescriptor layerDesc = {};
+    gpu::TextureDescriptor layerDesc = {};
     components::FilterGraph filterGraph;
     components::FilterExecutionBudget::Reservation filterReservation;
     Box2d filterRegion;
@@ -2022,18 +2066,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   bool beginFilterCapture(const components::FilterGraph& filterGraph,
                           const GeodeFilterAdmission& admission,
                           const Transform2d& deviceFromFilter) {
-    wgpu::TextureDescriptor textureDesc{};
-    textureDesc.label = wgpuLabel("RendererGeodeFilterLayer");
-    textureDesc.size = {static_cast<uint32_t>(admission.bufferWidth),
-                        static_cast<uint32_t>(admission.bufferHeight), 1u};
-    textureDesc.format = textureFormat;
-    textureDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-                        wgpu::TextureUsage::CopySrc;
-    textureDesc.mipLevelCount = 1;
-    textureDesc.sampleCount = 1;
-    textureDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture layerTexture = acquireTexture(textureDesc);
-    if (!layerTexture) {
+    const gpu::TextureDescriptor textureDesc{
+        "RendererGeodeFilterLayer",
+        gpu::Extent2d{static_cast<uint32_t>(admission.bufferWidth),
+                      static_cast<uint32_t>(admission.bufferHeight)},
+        gpuTextureFormat(),
+        gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::Sampled |
+            gpu::TextureUsage::CopySrc};
+    gpu::Texture layerTexture = acquireTexture(textureDesc);
+    if (!layerTexture.isValid()) {
       return false;
     }
 
@@ -2041,7 +2082,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     FilterStackFrame frame;
     frame.savedEncoder = std::move(encoder);
     frame.savedTarget = target;
-    frame.layerTexture = layerTexture;
     frame.layerDesc = textureDesc;
     frame.filterGraph = filterGraph;
     frame.filterReservation = admission.reservation;
@@ -2054,10 +2094,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frame.savedClipStack = std::move(clipStack);
     clipStack.clear();
 
-    target = layerTexture;
-    auto newEncoder = std::make_unique<geode::GeoEncoder>(
-        *device, *pipeline, *gradientPipeline, *imagePipeline,
-        importTexture(layerTexture, textureDesc), extentOf(layerTexture), *frameGpuEncoder);
+    frame.layerTexture = std::move(layerTexture);
+    target = backendTextureOf(frame.layerTexture);
+    auto newEncoder = std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline,
+                                                          *imagePipeline, importTarget(target),
+                                                          textureDesc.size, *frameGpuEncoder);
     configurePathEncoder(*newEncoder, /*collectGeometry=*/true, admission.bufferOffsetX,
                          admission.bufferOffsetY);
     newEncoder->clear(css::RGBA(0, 0, 0, 0));
@@ -2090,19 +2131,16 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       return false;
     }
 
-    wgpu::TextureDescriptor localDesc{};
-    localDesc.label = wgpuLabel("RendererGeodeBlurLocal");
-    localDesc.size = {geometry->width, geometry->height, 1u};
-    localDesc.format = textureFormat;
-    localDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-                      wgpu::TextureUsage::CopySrc;
-    localDesc.mipLevelCount = 1;
-    localDesc.sampleCount = 1;
-    localDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture localTexture = acquireTexture(localDesc);
-    if (!localTexture) {
+    const gpu::TextureDescriptor localDesc{
+        "RendererGeodeBlurLocal", gpu::Extent2d{geometry->width, geometry->height},
+        gpuTextureFormat(),
+        gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::Sampled |
+            gpu::TextureUsage::CopySrc};
+    gpu::Texture localTexture = acquireTexture(localDesc);
+    if (!localTexture.isValid()) {
       return false;
     }
+    const wgpu::Texture localBackendTexture = backendTextureOf(localTexture);
 
     const Transform2d filterFromDevice = frame.deviceFromFilter.inverse();
     const Transform2d localFromDevice = filterFromDevice *
@@ -2110,12 +2148,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
                                                                -geometry->paddedRegion.topLeft.y) *
                                         Transform2d::Scale(geometry->scaleX, geometry->scaleY);
     geode::GeoEncoder resampleEncoder(*device, *pipeline, *gradientPipeline, *imagePipeline,
-                                      importTexture(localTexture, localDesc),
-                                      extentOf(localTexture), *frameGpuEncoder);
+                                      importTarget(localBackendTexture), localDesc.size,
+                                      *frameGpuEncoder);
     configureEncoder(resampleEncoder);
     resampleEncoder.setTransform(localFromDevice);
     resampleEncoder.drawTexture(
-        importTexture(frame.layerTexture, frame.layerDesc),
+        importTarget(backendTextureOf(frame.layerTexture)),
         Box2d::FromXYWH(0.0, 0.0, static_cast<double>(frame.layerDesc.size.width),
                         static_cast<double>(frame.layerDesc.size.height)),
         kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
@@ -2132,7 +2170,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     const WGPUCommandEncoder encoderBeforeFilter =
         static_cast<WGPUCommandEncoder>(frameCommandEncoder.get());
     wgpu::Texture localFiltered =
-        filterEngine->execute(frame.filterGraph, localTexture, localFilterRegion,
+        filterEngine->execute(frame.filterGraph, localBackendTexture, localFilterRegion,
                               localDeviceFromFilter, *this, frameCommandEncoder);
     rebindHostCommandEncoder(encoderBeforeFilter);
 
@@ -4365,7 +4403,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
 
   static void releaseTexture(wgpu::Texture& texture) { geode::ReleaseWgpuHandle(texture); }
 
-  static void releasePendingTexture(PendingRelease& release) { releaseTexture(release.texture); }
+  /// Drops a runtime texture handle without pooling it, for teardown paths where the pool and
+  /// the surface budget are on their way out too.
+  /// @param texture Handle to drop; left invalid.
+  static void releaseRuntimeTexture(gpu::Texture& texture) { texture = gpu::Texture(); }
+
+  static void releasePendingTexture(PendingRelease& release) {
+    releaseRuntimeTexture(release.texture);
+  }
 
   static void releaseClipStackTextures(std::vector<ClipStackEntry>& entries) {
     for (ClipStackEntry& entry : entries) {
@@ -4545,19 +4590,19 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     framePendingReleases.clear();
 
     for (LayerStackFrame& frame : layerStack) {
-      releaseTexture(frame.layerTexture);
+      releaseRuntimeTexture(frame.layerTexture);
     }
     layerStack.clear();
 
     for (MaskStackFrame& frame : maskStack) {
-      releaseTexture(frame.maskTexture);
-      releaseTexture(frame.contentTexture);
+      releaseRuntimeTexture(frame.maskTexture);
+      releaseRuntimeTexture(frame.contentTexture);
     }
     maskStack.clear();
 
     releaseClipStackTextures(clipStack);
     for (FilterStackFrame& frame : filterStack) {
-      releaseTexture(frame.layerTexture);
+      releaseRuntimeTexture(frame.layerTexture);
       releaseClipStackTextures(frame.savedClipStack);
     }
     filterStack.clear();
@@ -4603,7 +4648,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   /// no longer toggles filter-engine logging - the shared filter engine
   /// is always constructed with `verbose=false`.
   void initPipelines(bool /*verboseFlag*/) {
-    texturePool = TexturePoolForDevice(device.get());
+    texturePool = TexturePoolForDevice(device);
     textureFormat = device->textureFormat();
     device->setCounters(&counters);
     pipeline = &device->pipeline();
@@ -5135,16 +5180,13 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
   // binding the previously-rendered deeper mask as the input clip.
   if (!clip.clipPaths.empty() && impl_->device && impl_->encoder && impl_->pixelWidth > 0 &&
       impl_->pixelHeight > 0) {
-    const auto makeMaskTexture = [&](const char* label, wgpu::TextureDescriptor& outDesc) {
-      outDesc = wgpu::TextureDescriptor{};
-      outDesc.label = wgpuLabel(label);
-      outDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                      static_cast<uint32_t>(impl_->pixelHeight), 1u};
-      outDesc.format = wgpu::TextureFormat::RGBA8Unorm;
-      outDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding;
-      outDesc.mipLevelCount = 1;
-      outDesc.sampleCount = 1;
-      outDesc.dimension = wgpu::TextureDimension::_2D;
+    const auto makeMaskTexture = [&](const char* label, gpu::TextureDescriptor& outDesc) {
+      outDesc =
+          gpu::TextureDescriptor{RcString(label),
+                                 gpu::Extent2d{static_cast<uint32_t>(impl_->pixelWidth),
+                                               static_cast<uint32_t>(impl_->pixelHeight)},
+                                 gpu::TextureFormat::RGBA8Unorm,
+                                 gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::Sampled};
       return impl_->acquireTexture(outDesc);
     };
     // Partition `clip.clipPaths` into contiguous [begin, end) ranges,
@@ -5196,9 +5238,9 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
     }
 
     for (auto it = runs.rbegin(); it != runs.rend(); ++it) {
-      wgpu::TextureDescriptor maskDesc = {};
-      wgpu::Texture maskTexture = makeMaskTexture("RendererGeodeClipMask", maskDesc);
-      if (!maskTexture) {
+      gpu::TextureDescriptor maskDesc = {};
+      gpu::Texture maskTexture = makeMaskTexture("RendererGeodeClipMask", maskDesc);
+      if (!maskTexture.isValid()) {
         entry.allocationRejected = true;
         break;
       }
@@ -5211,7 +5253,10 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
         impl_->encoder->clearClipMask();
       }
 
-      const gpu::Texture& maskTextureHandle = impl_->importTexture(maskTexture, maskDesc);
+      // The mask is parked in the clip entry that owns it before anything names it, so the
+      // handle recorded below points at the owner rather than at a copy that outlives its scope.
+      entry.maskLayerTextures.push_back({std::move(maskTexture), maskDesc});
+      const gpu::Texture& maskTextureHandle = entry.maskLayerTextures.back().texture;
       impl_->encoder->beginMaskPass(maskTextureHandle);
       for (size_t s = it->begin; s < it->end; ++s) {
         const ClipPathShape& shape = clip.clipPaths[s];
@@ -5224,10 +5269,6 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 
       nestedMaskTextureHandle = &maskTextureHandle;
       nestedMaskViewHandle = &impl_->importTextureView(maskTextureHandle);
-
-      // Keep the intermediate textures alive until popClip, paired
-      // with their descs for texture-pool release.
-      entry.maskLayerTextures.push_back({maskTexture, maskDesc});
 
       // The outermost layer (the LAST one processed by this loop,
       // i.e. the FIRST run in `runs`) provides the mask view the
@@ -5286,18 +5327,14 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
 
   // Allocate an offscreen layer. All draws issued between push/pop land
   // here; pop composites it back onto the outer target with the stored opacity.
-  wgpu::TextureDescriptor td = {};
-  td.label = wgpuLabel("RendererGeodeIsolatedLayer");
-  td.size = {static_cast<uint32_t>(impl_->pixelWidth), static_cast<uint32_t>(impl_->pixelHeight),
-             1u};
-  td.format = impl_->textureFormat;
-  td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-             wgpu::TextureUsage::CopySrc;
-  td.mipLevelCount = 1;
-  td.sampleCount = 1;
-  td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture layerTexture = impl_->acquireTexture(td);
-  if (!layerTexture) {
+  const gpu::TextureDescriptor td{"RendererGeodeIsolatedLayer",
+                                  gpu::Extent2d{static_cast<uint32_t>(impl_->pixelWidth),
+                                                static_cast<uint32_t>(impl_->pixelHeight)},
+                                  impl_->gpuTextureFormat(),
+                                  gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::Sampled |
+                                      gpu::TextureUsage::CopySrc};
+  gpu::Texture layerTexture = impl_->acquireTexture(td);
+  if (!layerTexture.isValid()) {
     impl_->layerStack.push_back({});
     return;
   }
@@ -5311,16 +5348,15 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   Impl::LayerStackFrame frame;
   frame.savedEncoder = std::move(impl_->encoder);
   frame.savedTarget = impl_->target;
-  frame.layerTexture = layerTexture;
+  frame.layerTexture = std::move(layerTexture);
   frame.layerDesc = td;
   frame.opacity = opacity;
   frame.blendMode = blendMode;
 
-  impl_->target = layerTexture;
+  impl_->target = impl_->backendTextureOf(frame.layerTexture);
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      impl_->importTexture(layerTexture, td), Impl::extentOf(layerTexture),
-      *impl_->frameGpuEncoder);
+      impl_->importTarget(impl_->target), td.size, *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder);
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
@@ -5338,7 +5374,7 @@ void RendererGeode::popIsolatedLayer() {
   Impl::LayerStackFrame frame = std::move(impl_->layerStack.back());
   impl_->layerStack.pop_back();
 
-  if (!frame.layerTexture) {
+  if (!frame.layerTexture.isValid()) {
     return;  // Placeholder frame from the headless/error path.
   }
 
@@ -5357,20 +5393,16 @@ void RendererGeode::popIsolatedLayer() {
     // parent's 1-sample resolve target into a separate texture with a texture-to-texture copy,
     // then open a fresh parent encoder over the parent target; the load-op note further down
     // covers why that encoder preserves the target's contents.
-    wgpu::TextureDescriptor snapDesc = {};
-    snapDesc.label = wgpuLabel("RendererGeodeBlendDstSnapshot");
-    snapDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                     static_cast<uint32_t>(impl_->pixelHeight), 1u};
-    snapDesc.format = impl_->textureFormat;
-    snapDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    snapDesc.mipLevelCount = 1;
-    snapDesc.sampleCount = 1;
-    snapDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture snapshot = impl_->acquireTexture(snapDesc);
+    const gpu::TextureDescriptor snapDesc{"RendererGeodeBlendDstSnapshot",
+                                          gpu::Extent2d{static_cast<uint32_t>(impl_->pixelWidth),
+                                                        static_cast<uint32_t>(impl_->pixelHeight)},
+                                          impl_->gpuTextureFormat(),
+                                          gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst};
+    gpu::Texture snapshot = impl_->acquireTexture(snapDesc);
 
-    if (snapshot) {
+    if (snapshot.isValid()) {
       const gpu::Texture& savedTargetHandle = impl_->importTarget(frame.savedTarget);
-      const gpu::Texture& snapshotHandle = impl_->importTexture(snapshot, snapDesc);
+      const gpu::Texture& snapshotHandle = snapshot;
 
       // The layer's render pass ended when its encoder was retired above, so the copy can be
       // recorded outside a pass. It joins the frame's recorded stream after those draws and
@@ -5403,9 +5435,8 @@ void RendererGeode::popIsolatedLayer() {
       newEncoder->setLoadPreserve();
       impl_->encoder = std::move(newEncoder);
       impl_->updateEncoderScissor();
-      impl_->encoder->blitFullTargetBlended(
-          impl_->importTexture(frame.layerTexture, frame.layerDesc), snapshotHandle,
-          static_cast<uint32_t>(frame.blendMode), frame.opacity);
+      impl_->encoder->blitFullTargetBlended(frame.layerTexture, snapshotHandle,
+                                            static_cast<uint32_t>(frame.blendMode), frame.opacity);
       // Defer release: `blitFullTargetBlended` recorded samples from
       // both `frame.layerTexture` and `snapshot` into the shared
       // frameCommandEncoder; they must stay alive until that buffer
@@ -5428,8 +5459,7 @@ void RendererGeode::popIsolatedLayer() {
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
-  impl_->encoder->blitFullTarget(impl_->importTexture(frame.layerTexture, frame.layerDesc),
-                                 frame.opacity);
+  impl_->encoder->blitFullTarget(frame.layerTexture, frame.opacity);
   // Same deferred-release rationale as the blend-mode branch above.
   impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
 }
@@ -5488,7 +5518,7 @@ void RendererGeode::popFilterLayer() {
     return;
   }
 
-  if (!frame.layerTexture) {
+  if (!frame.layerTexture.isValid()) {
     return;  // Placeholder frame from the headless/error path.
   }
 
@@ -5512,8 +5542,11 @@ void RendererGeode::popFilterLayer() {
     return;
   }
 
-  // Run the filter graph on the captured layer texture.
-  wgpu::Texture filteredTexture = frame.layerTexture;
+  // Run the filter graph on the captured layer texture. The filter engine still records
+  // through wgpu directly, so it takes the backend alias of the pooled capture and hands back
+  // another backend texture its own arena owns.
+  const wgpu::Texture layerBackendTexture = impl_->backendTextureOf(frame.layerTexture);
+  wgpu::Texture filteredTexture = layerBackendTexture;
   const bool discardCapturedLayer = frame.localRasterRequiredForBudget;
   if (frame.localRasterRequiredForBudget) {
     impl_->filterExecutionBudget->reject();
@@ -5525,7 +5558,7 @@ void RendererGeode::popFilterLayer() {
     const WGPUCommandEncoder encoderBeforeFilter =
         static_cast<WGPUCommandEncoder>(impl_->frameCommandEncoder.get());
     filteredTexture =
-        impl_->filterEngine->execute(frame.filterGraph, frame.layerTexture, frame.filterRegion,
+        impl_->filterEngine->execute(frame.filterGraph, layerBackendTexture, frame.filterRegion,
                                      bufferDeviceFromFilter, *impl_, impl_->frameCommandEncoder);
     impl_->rebindHostCommandEncoder(encoderBeforeFilter);
   }
@@ -5552,19 +5585,14 @@ void RendererGeode::popFilterLayer() {
     const uint32_t vpW = static_cast<uint32_t>(impl_->pixelWidth);
     const uint32_t vpH = static_cast<uint32_t>(impl_->pixelHeight);
 
-    wgpu::TextureDescriptor vpDesc{};
-    vpDesc.label = wgpuLabel("RendererGeodeFilterViewport");
-    vpDesc.size = {vpW, vpH, 1u};
-    vpDesc.format = kFilterIntermediateFormat;
-    vpDesc.usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::TextureBinding;
-    vpDesc.mipLevelCount = 1;
-    vpDesc.sampleCount = 1;
-    vpDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture viewportTexture = impl_->acquireTexture(vpDesc);
+    const gpu::TextureDescriptor vpDesc{"RendererGeodeFilterViewport", gpu::Extent2d{vpW, vpH},
+                                        geode::GpuTextureFormatFromWgpu(kFilterIntermediateFormat),
+                                        gpu::TextureUsage::CopyDst | gpu::TextureUsage::Sampled};
+    gpu::Texture viewportTexture = impl_->acquireTexture(vpDesc);
 
-    if (viewportTexture) {
+    if (viewportTexture.isValid()) {
       const gpu::Texture& filteredHandle = impl_->importFilterResult(filteredTexture);
-      const gpu::Texture& viewportHandle = impl_->importTexture(viewportTexture, vpDesc);
+      const gpu::Texture& viewportHandle = viewportTexture;
 
       // Everything recorded before this point has already been replayed into the frame command
       // encoder by the encoder retire above, so the copy lands after those draws and before the
@@ -5605,25 +5633,21 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds, MaskType ma
     return;
   }
 
-  const auto allocTexture = [&](const char* label, wgpu::Texture& outTexture,
-                                wgpu::TextureDescriptor& outDesc) {
-    outDesc = wgpu::TextureDescriptor{};
-    outDesc.label = wgpuLabel(label);
-    outDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                    static_cast<uint32_t>(impl_->pixelHeight), 1u};
-    outDesc.format = impl_->textureFormat;
-    outDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-                    wgpu::TextureUsage::CopySrc;
-    outDesc.mipLevelCount = 1;
-    outDesc.sampleCount = 1;
-    outDesc.dimension = wgpu::TextureDimension::_2D;
+  const auto allocTexture = [&](const char* label, gpu::Texture& outTexture,
+                                gpu::TextureDescriptor& outDesc) {
+    outDesc = gpu::TextureDescriptor{RcString(label),
+                                     gpu::Extent2d{static_cast<uint32_t>(impl_->pixelWidth),
+                                                   static_cast<uint32_t>(impl_->pixelHeight)},
+                                     impl_->gpuTextureFormat(),
+                                     gpu::TextureUsage::RenderAttachment |
+                                         gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc};
     outTexture = impl_->acquireTexture(outDesc);
   };
 
   Impl::MaskStackFrame frame;
   allocTexture("RendererGeodeMaskCapture", frame.maskTexture, frame.maskDesc);
   allocTexture("RendererGeodeMaskContent", frame.contentTexture, frame.contentDesc);
-  if (!frame.maskTexture || !frame.contentTexture) {
+  if (!frame.maskTexture.isValid() || !frame.contentTexture.isValid()) {
     impl_->maskStack.push_back({});
     return;
   }
@@ -5639,11 +5663,10 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds, MaskType ma
   frame.savedTarget = impl_->target;
   frame.phase = Impl::MaskStackFrame::Phase::Capturing;
 
-  impl_->target = frame.maskTexture;
+  impl_->target = impl_->backendTextureOf(frame.maskTexture);
   auto captureEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      impl_->importTexture(frame.maskTexture, frame.maskDesc), Impl::extentOf(frame.maskTexture),
-      *impl_->frameGpuEncoder);
+      impl_->importTarget(impl_->target), frame.maskDesc.size, *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*captureEncoder);
   captureEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(captureEncoder);
@@ -5660,7 +5683,7 @@ void RendererGeode::transitionMaskToContent() {
   if (frame.phase != Impl::MaskStackFrame::Phase::Capturing) {
     return;
   }
-  if (!frame.contentTexture || !impl_->encoder) {
+  if (!frame.contentTexture.isValid() || !impl_->encoder) {
     frame.phase = Impl::MaskStackFrame::Phase::Content;
     return;
   }
@@ -5669,11 +5692,10 @@ void RendererGeode::transitionMaskToContent() {
   // sample in popMask.
   impl_->retireActiveEncoder();
 
-  impl_->target = frame.contentTexture;
+  impl_->target = impl_->backendTextureOf(frame.contentTexture);
   auto contentEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      impl_->importTexture(frame.contentTexture, frame.contentDesc),
-      Impl::extentOf(frame.contentTexture), *impl_->frameGpuEncoder);
+      impl_->importTarget(impl_->target), frame.contentDesc.size, *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*contentEncoder);
   contentEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(contentEncoder);
@@ -5722,9 +5744,8 @@ void RendererGeode::popMask() {
   }
 
   // Composite content through the selected luminance or alpha mask onto the outer target.
-  impl_->encoder->blitFullTargetMasked(
-      impl_->importTexture(frame.contentTexture, frame.contentDesc),
-      impl_->importTexture(frame.maskTexture, frame.maskDesc), frame.maskType, pixelMaskBounds);
+  impl_->encoder->blitFullTargetMasked(frame.contentTexture, frame.maskTexture, frame.maskType,
+                                       pixelMaskBounds);
 
   // Defer release to endFrame - `blitFullTargetMasked` recorded
   // samples from both `contentTexture` and `maskTexture` into the
@@ -5759,7 +5780,8 @@ bool RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
-  if (!impl_->reserveTextureSurface(td)) {
+  if (!impl_->reserveTextureSurface(gpu::Extent2d{static_cast<uint32_t>(tilePixelWidth),
+                                                  static_cast<uint32_t>(tilePixelHeight)})) {
     return false;
   }
   geode::ScopedWgpuHandle<wgpu::Texture> tileTexture(impl_->device->device().createTexture(td));

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -336,6 +336,7 @@ donner_cc_test(
         "//donner/base:gtest_timeout_main",
         "//donner/gpu",
         "//donner/gpu:gpu_test_utils",
+        "//donner/gpu:sub_rectangle_copy_scene",
     ],
 )
 

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -15,6 +15,7 @@
 #include "donner/svg/renderer/PixelFormatUtils.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeShaders.h"
+#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
@@ -32,20 +33,28 @@ struct FilterResourceArena {
       device_.deferDestroy(buffer.take());
     }
     for (auto& owned : textures_) {
-      textureAllocator_.releaseFilterTextureAtFrameEnd(owned.texture.take(), owned.desc);
+      textureAllocator_.releaseFilterTextureAtFrameEnd(std::move(owned.texture), owned.desc);
     }
   }
 
   FilterResourceArena(const FilterResourceArena&) = delete;
   FilterResourceArena& operator=(const FilterResourceArena&) = delete;
 
-  wgpu::Texture createTexture(const wgpu::TextureDescriptor& desc) {
-    ScopedWgpuHandle<wgpu::Texture> texture(textureAllocator_.acquireFilterTexture(desc));
-    if (!texture) {
+  /// Takes a filter intermediate from the renderer's pool, owned by this arena until the frame
+  /// ends.
+  ///
+  /// The arena's currency with the renderer is the runtime handle, which is what the pool
+  /// allocates and what the frame-end release takes back. The backend texture is returned to the
+  /// engine's own recording code, which still speaks wgpu directly; it borrows, and this arena
+  /// owns.
+  /// @param desc Descriptor the intermediate is allocated with.
+  wgpu::Texture createTexture(const gpu::TextureDescriptor& desc) {
+    gpu::Texture texture = textureAllocator_.acquireFilterTexture(desc);
+    if (!texture.isValid()) {
       return {};
     }
 
-    wgpu::Texture result = texture.get();
+    wgpu::Texture result = device_.adapterDevice().wgpuTextureOf(texture);
     textures_.push_back({std::move(texture), desc});
     return result;
   }
@@ -129,8 +138,8 @@ struct FilterResourceArena {
 
 private:
   struct OwnedTexture {
-    ScopedWgpuHandle<wgpu::Texture> texture;
-    wgpu::TextureDescriptor desc;
+    gpu::Texture texture;
+    gpu::TextureDescriptor desc;
   };
 
   GeodeDevice& device_;
@@ -668,16 +677,9 @@ uint32_t toShaderEdgeMode(svg::components::filter_primitive::GaussianBlur::EdgeM
 /// subsequent compute / render input (texture binding).
 wgpu::Texture createIntermediateTexture(FilterResourceArena& arena, const wgpu::Device&,
                                         uint32_t width, uint32_t height, const char* label) {
-  wgpu::TextureDescriptor td{};
-  td.label = wgpuLabel(label);
-  td.size = {width, height, 1};
-  td.format = kFormat;
-  td.usage = wgpu::TextureUsage::StorageBinding | wgpu::TextureUsage::TextureBinding |
-             wgpu::TextureUsage::CopySrc;
-  td.mipLevelCount = 1;
-  td.sampleCount = 1;
-  td.dimension = wgpu::TextureDimension::_2D;
-  return arena.createTexture(td);
+  return arena.createTexture(gpu::TextureDescriptor{
+      RcString(label), gpu::Extent2d{width, height}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::StorageBinding | gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
 }
 
 /// Create and explicitly clear an intermediate texture to transparent black.
@@ -687,16 +689,10 @@ wgpu::Texture createIntermediateTexture(FilterResourceArena& arena, const wgpu::
 /// returning the texture.
 wgpu::Texture createTransparentIntermediateTexture(FilterResourceArena& arena, uint32_t width,
                                                    uint32_t height, const char* label) {
-  wgpu::TextureDescriptor td{};
-  td.label = wgpuLabel(label);
-  td.size = {width, height, 1};
-  td.format = wgpu::TextureFormat::RGBA8Unorm;
-  td.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::StorageBinding |
-             wgpu::TextureUsage::CopySrc | wgpu::TextureUsage::RenderAttachment;
-  td.mipLevelCount = 1;
-  td.sampleCount = 1;
-  td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture texture = arena.createTexture(td);
+  wgpu::Texture texture = arena.createTexture(gpu::TextureDescriptor{
+      RcString(label), gpu::Extent2d{width, height}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::StorageBinding | gpu::TextureUsage::CopySrc |
+          gpu::TextureUsage::RenderAttachment});
   if (!texture) {
     return {};
   }
@@ -3686,15 +3682,9 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterImageOutput");
 
   const auto renderTransparentOutput = [&]() {
-    wgpu::TextureDescriptor imgDesc{};
-    imgDesc.label = wgpuLabel("FilterImageEmptySource");
-    imgDesc.size = {1, 1, 1};
-    imgDesc.format = kFormat;
-    imgDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    imgDesc.mipLevelCount = 1;
-    imgDesc.sampleCount = 1;
-    imgDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture emptyTex = arena.createTexture(imgDesc);
+    wgpu::Texture emptyTex = arena.createTexture(gpu::TextureDescriptor{
+        "FilterImageEmptySource", gpu::Extent2d{1, 1}, gpu::TextureFormat::RGBA8Unorm,
+        gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst});
     const uint8_t zero[4] = {0, 0, 0, 0};
     wgpu::TexelCopyTextureInfo dstInfo{};
     dstInfo.texture = emptyTex;
@@ -3727,15 +3717,9 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   const uint32_t imgH = static_cast<uint32_t>(primitive.imageHeight);
   const std::vector<uint8_t> premul = svg::PremultiplyRgba(imageData);
 
-  wgpu::TextureDescriptor imgDesc{};
-  imgDesc.label = wgpuLabel("FilterImageSource");
-  imgDesc.size = {imgW, imgH, 1};
-  imgDesc.format = kFormat;
-  imgDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-  imgDesc.mipLevelCount = 1;
-  imgDesc.sampleCount = 1;
-  imgDesc.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture imgTex = arena.createTexture(imgDesc);
+  wgpu::Texture imgTex = arena.createTexture(gpu::TextureDescriptor{
+      "FilterImageSource", gpu::Extent2d{imgW, imgH}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst});
   if (!imgTex) {
     return renderTransparentOutput();
   }

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -19,6 +19,7 @@
 
 #include "donner/base/Box.h"
 #include "donner/base/Transform.h"
+#include "donner/gpu/Device.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::svg::components {
@@ -65,9 +66,17 @@ class FilterTextureAllocator {
 public:
   virtual ~FilterTextureAllocator() = default;
 
-  virtual wgpu::Texture acquireFilterTexture(const wgpu::TextureDescriptor& desc) = 0;
-  virtual void releaseFilterTextureAtFrameEnd(wgpu::Texture texture,
-                                              const wgpu::TextureDescriptor& desc) = 0;
+  /// Takes a filter intermediate matching \p desc from the renderer's pool, or an invalid
+  /// texture when the renderer's budget refuses it.
+  /// @param desc Descriptor the intermediate is allocated with.
+  virtual gpu::Texture acquireFilterTexture(const gpu::TextureDescriptor& desc) = 0;
+
+  /// Hands \p texture back for reuse once the frame it was recorded into has submitted.
+  /// @param texture Texture to return; consumed.
+  /// @param desc Descriptor \p texture was acquired with; must match, or the next acquire for
+  ///   that descriptor misses its bucket.
+  virtual void releaseFilterTextureAtFrameEnd(gpu::Texture texture,
+                                              const gpu::TextureDescriptor& desc) = 0;
 };
 
 /**

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -1339,8 +1339,10 @@ gpu::Status GeodeWgpuAdapterDevice::encodeCopyTextureToTexture(
   }
   wgpu::TexelCopyTextureInfo source = {};
   source.texture = sourceTexture;
+  source.origin = {textureCopy.sourceOrigin.x, textureCopy.sourceOrigin.y, 0u};
   wgpu::TexelCopyTextureInfo destination = {};
   destination.texture = destinationTexture;
+  destination.origin = {textureCopy.destinationOrigin.x, textureCopy.destinationOrigin.y, 0u};
   const wgpu::Extent3D extent = {textureCopy.copySize.width, textureCopy.copySize.height, 1u};
   state.encoder.copyTextureToTexture(source, destination, extent);
   return OkStatus();

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -17,6 +17,7 @@
 
 #include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/tests/GpuTestUtils.h"
+#include "donner/gpu/tests/SubRectangleCopyScene.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeCounters.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
@@ -76,11 +77,15 @@ std::vector<uint8_t> MakeBytes(size_t count) {
 constexpr uint32_t kSceneSize = 4;
 constexpr uint32_t kReadbackBytesPerRow = 256;  // 4x4 RGBA rows padded to the copy alignment.
 
-/// Reads a 4x4 RGBA8 texture back to the host through raw wgpu (the adapter has no readback API
-/// of its own yet), mirroring the map-and-poll pattern the existing Geode tests use. Returns the
-/// padded rows (kReadbackBytesPerRow per row), or empty on failure.
-std::vector<uint8_t> ReadbackTexturePixels(GeodeDevice& device, wgpu::Texture texture) {
-  const uint64_t byteSize = uint64_t{kReadbackBytesPerRow} * kSceneSize;
+/// Reads a square RGBA8 texture back to the host through raw wgpu (the adapter has no readback
+/// API of its own yet), mirroring the map-and-poll pattern the existing Geode tests use. Returns
+/// the padded rows (kReadbackBytesPerRow per row), or empty on failure.
+/// @param device Device owning \p texture.
+/// @param texture Texture to read; needs CopySrc.
+/// @param sceneSize Width and height of \p texture in texels; rows must fit the padded pitch.
+std::vector<uint8_t> ReadbackTexturePixels(GeodeDevice& device, wgpu::Texture texture,
+                                           uint32_t sceneSize = kSceneSize) {
+  const uint64_t byteSize = uint64_t{kReadbackBytesPerRow} * sceneSize;
   wgpu::BufferDescriptor bufferDescriptor = {};
   bufferDescriptor.label = wgpuLabel("readbackStaging");
   bufferDescriptor.size = byteSize;
@@ -96,8 +101,8 @@ std::vector<uint8_t> ReadbackTexturePixels(GeodeDevice& device, wgpu::Texture te
   wgpu::TexelCopyBufferInfo destination = {};
   destination.buffer = readback.get();
   destination.layout.bytesPerRow = kReadbackBytesPerRow;
-  destination.layout.rowsPerImage = kSceneSize;
-  const wgpu::Extent3D copySize = {kSceneSize, kSceneSize, 1};
+  destination.layout.rowsPerImage = sceneSize;
+  const wgpu::Extent3D copySize = {sceneSize, sceneSize, 1};
   encoder.get().copyTextureToBuffer(source, destination, copySize);
   ScopedWgpuHandle<wgpu::CommandBuffer> commandBuffer(encoder.get().finish());
   device.queue().submit(1, &commandBuffer.get());
@@ -431,6 +436,117 @@ TEST_F(GeodeWgpuAdapterDeviceTests, HostEncoderReplayInterleavesInOneBufferAndDe
   EXPECT_THAT(PixelAt(copiedPixels, 3, 3), ElementsAre(0, 0, 128, 255));
 
   geodeDevice_->setCounters(nullptr);
+}
+
+/// The sub-rectangle copy scene on this adapter: a source holding the shared coordinate-encoding
+/// pattern and a destination pre-filled with the shared sentinel, both uploaded through the
+/// runtime so the copy under test is the only thing that moves texels between them.
+struct SubRectCopyScene {
+  gpu::Texture source;       //!< Source holding the coordinate-encoding pattern.
+  gpu::Texture destination;  //!< Destination pre-filled with the sentinel.
+};
+
+/// Creates and fills the sub-rectangle copy scene on \p device.
+/// @param device Device to create the textures on.
+SubRectCopyScene MakeSubRectCopyScene(gpu::Device& device) {
+  const gpu::Extent2d extent{gpu::tests::kSubRectCopyExtent, gpu::tests::kSubRectCopyExtent};
+  const gpu::TexelCopyBufferLayout layout{0, gpu::tests::kSubRectCopyBytesPerRow,
+                                          gpu::tests::kSubRectCopyExtent};
+  SubRectCopyScene scene{gpu::GetResultOrFail(device.createTexture(gpu::TextureDescriptor{
+                             "subRectSource", extent, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::CopySrc | gpu::TextureUsage::CopyDst})),
+                         gpu::GetResultOrFail(device.createTexture(gpu::TextureDescriptor{
+                             "subRectDestination", extent, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::CopyDst | gpu::TextureUsage::CopySrc}))};
+  EXPECT_THAT(
+      device.writeTexture(scene.source, gpu::tests::SubRectCopySourceUpload(), layout, extent),
+      gpu::IsOk());
+  EXPECT_THAT(device.writeTexture(scene.destination, gpu::tests::SubRectCopyDestinationUpload(),
+                                  layout, extent),
+              gpu::IsOk());
+  return scene;
+}
+
+/// Checks \p pixels against the shared expected image for the sub-rectangle copy.
+/// @param pixels Padded readback rows of the destination texture.
+void ExpectSubRectCopyResult(const std::vector<uint8_t>& pixels) {
+  for (uint32_t y = 0; y < gpu::tests::kSubRectCopyExtent; ++y) {
+    for (uint32_t x = 0; x < gpu::tests::kSubRectCopyExtent; ++x) {
+      const std::array<uint8_t, 4> expected = gpu::tests::SubRectCopyExpectedTexel(x, y);
+      EXPECT_THAT(PixelAt(pixels, x, y),
+                  ElementsAre(expected[0], expected[1], expected[2], expected[3]))
+          << "texel (" << x << ", " << y << ")";
+    }
+  }
+}
+
+/// Records the sub-rectangle copy on \p encoder, reading from the scene's source origin and
+/// writing at its destination origin.
+/// @param encoder Encoder to record into.
+/// @param scene Scene whose textures the copy runs over.
+void RecordSubRectCopy(gpu::CommandEncoder& encoder, const SubRectCopyScene& scene) {
+  EXPECT_THAT(encoder.copyTextureToTexture(
+                  scene.source, scene.destination,
+                  gpu::Extent2d{gpu::tests::kSubRectCopyWidth, gpu::tests::kSubRectCopyHeight},
+                  gpu::Origin2d{gpu::tests::kSubRectCopySourceX, gpu::tests::kSubRectCopySourceY},
+                  gpu::Origin2d{gpu::tests::kSubRectCopyDestinationX,
+                                gpu::tests::kSubRectCopyDestinationY}),
+              gpu::IsOk());
+}
+
+/// A recorded sub-rectangle copy must reach wgpu with both origins intact. Whole-rect copies
+/// could not tell an ignored origin from an honored one; this scene can, because the source
+/// rectangle and the destination rectangle sit at different corners of textures whose texels
+/// encode their own coordinates.
+TEST_F(GeodeWgpuAdapterDeviceTests, SubRectangleCopyHonorsBothOriginsWhenTheAdapterSubmits) {
+  const SubRectCopyScene scene = MakeSubRectCopyScene(*adapter_);
+
+  std::unique_ptr<gpu::CommandEncoder> encoder =
+      gpu::GetResultOrFail(adapter_->createCommandEncoder());
+  RecordSubRectCopy(*encoder, scene);
+  const uint64_t serial =
+      gpu::GetResultOrFail(adapter_->submit(gpu::GetResultOrFail(encoder->finish())));
+  ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
+      << "submission " << serial << " did not complete";
+
+  const std::vector<uint8_t> pixels = ReadbackTexturePixels(
+      *geodeDevice_, adapter_->wgpuTextureOf(scene.destination), gpu::tests::kSubRectCopyExtent);
+  ASSERT_THAT(pixels, Not(testing::IsEmpty())) << "destination readback failed";
+  ExpectSubRectCopyResult(pixels);
+}
+
+/// The same copy replayed into a host-owned encoder. The replay path builds its own wgpu copy
+/// descriptors, so it can drop an origin independently of the owned-submit path.
+TEST_F(GeodeWgpuAdapterDeviceTests, SubRectangleCopyHonorsBothOriginsWhenReplayedIntoAHostEncoder) {
+  const SubRectCopyScene scene = MakeSubRectCopyScene(*adapter_);
+
+  wgpu::CommandEncoderDescriptor hostDescriptor = {};
+  ScopedWgpuHandle<wgpu::CommandEncoder> hostEncoder(
+      geodeDevice_->device().createCommandEncoder(hostDescriptor));
+  ASSERT_TRUE(static_cast<bool>(hostEncoder.get()));
+  adapter_->setHostCommandEncoder(hostEncoder.get());
+
+  std::unique_ptr<gpu::CommandEncoder> encoder =
+      gpu::GetResultOrFail(adapter_->createCommandEncoder());
+  RecordSubRectCopy(*encoder, scene);
+  const uint64_t serial =
+      gpu::GetResultOrFail(adapter_->submit(gpu::GetResultOrFail(encoder->finish())));
+
+  {
+    ScopedWgpuHandle<wgpu::CommandBuffer> hostCommands(hostEncoder.get().finish());
+    ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
+    geodeDevice_->queue().submit(1, &hostCommands.get());
+  }
+  adapter_->notifyHostSubmitted();
+  adapter_->clearHostCommandEncoder();
+
+  ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
+      << "submission " << serial << " did not complete after the host submit";
+
+  const std::vector<uint8_t> pixels = ReadbackTexturePixels(
+      *geodeDevice_, adapter_->wgpuTextureOf(scene.destination), gpu::tests::kSubRectCopyExtent);
+  ASSERT_THAT(pixels, Not(testing::IsEmpty())) << "destination readback failed";
+  ExpectSubRectCopyResult(pixels);
 }
 
 /// Clearing the host encoder returns the adapter to owning and submitting its own encoders, so

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -1147,7 +1147,8 @@
         "mapAsync",
         "poll",
         "submit",
-        "unmap"
+        "unmap",
+        "writeTexture"
       ],
       "wgpuCFunctions": [
         "wgpuLabel",

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -677,7 +677,8 @@
         "writeTexture"
       ],
       "wgpuCFunctions": [
-        "wgpuLabel"
+        "wgpuLabel",
+        "wgpuTextureOf"
       ],
       "wgpuCTypes": [
         "WGPUBindGroupLayout"
@@ -715,11 +716,8 @@
         "TexelCopyBufferLayout",
         "TexelCopyTextureInfo",
         "Texture",
-        "TextureDescriptor",
-        "TextureDimension",
         "TextureFormat",
         "TextureSampleType",
-        "TextureUsage",
         "TextureView",
         "TextureViewDimension"
       ]
@@ -730,8 +728,7 @@
         "CommandEncoder",
         "ComputePipeline",
         "Device",
-        "Texture",
-        "TextureDescriptor"
+        "Texture"
       ]
     },
     "donner/svg/renderer/geode/GeodePipeline.cc": {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -427,7 +427,6 @@
       "operations": [
         "beginComputePass",
         "copyTextureToBuffer",
-        "copyTextureToTexture",
         "createBindGroup",
         "createBuffer",
         "createCommandEncoder",


### PR DESCRIPTION
The renderer's device-shared transient texture pool allocated raw wgpu textures, so every layer, mask, clip mask, and filter intermediate had to be named to the runtime again each frame through the temporary import escape hatch before anything could record against it. This moves the pool's currency, and the filter engine's allocation boundary, onto the runtime.

The RHI enabler comes first: `copyTextureToTexture` could only copy a whole rectangle anchored at texel (0, 0) of both textures, which is why the filter-layer viewport extraction was the last copy in the renderer recorded straight onto the frame's wgpu encoder. The recorded copy now carries a source origin and a destination origin, both defaulting to (0, 0) so every existing call keeps its meaning. Each far edge is computed in 64 bits, because a near-`UINT32_MAX` origin plus a large extent wraps in 32-bit arithmetic and would otherwise be accepted and then read outside the texture. Same-texture copies stay rejected: WebGPU allows them when the rectangles do not overlap, but a copy whose rectangles do overlap is undefined rather than diagnosable.

Neither native backend executed this copy at all - both reported it `Unsupported` at submit - so both gain it here rather than only gaining origins: Vulkan through `vkCmdCopyImage` with the two transfer-layout transitions staged so a later pass's transition prescan starts from what the copy left behind, and Metal through a blit encoder. The wgpu transition adapter maps both origins in each of its submit modes. Each backend and each adapter submit mode is covered by a slice over one shared scene whose source texels encode their own coordinates and whose two rectangles sit at different corners, so dropping an origin, swapping the two, or clamping either one lands different bytes in different places and no single mistake reproduces the expected image.

The pool then allocates through the runtime device, keys buckets on `gpu::TextureDescriptor`, and destroys evicted entries through `destroyTextureBacking` rather than dropping a handle and leaving the backend object resident until the host runtime collects it. Because the runtime counts a texture creation itself, the pool no longer ticks the counter on a miss, which keeps one tick per real creation and none on a hit - the invariant the steady-state and ceiling gates ratchet on. The pool holds the device it allocates from, since eviction and its own destructor have to destroy textures with no caller present to supply one.

`FilterTextureAllocator` is the on-ramp and speaks runtime handles in both directions. The filter engine's arena owns what it takes and hands the backend alias to the engine's own recording code, which still speaks wgpu; that is the one seam left at this boundary, and it is one call rather than the descriptor plumbing that used to cross it. The layer, mask, and clip-mask stacks now hold the owning handle, so the composite draws bind the pool's texture directly instead of a per-frame import of it.

The renderer's surface budget, the pool's per-key and byte ceilings, its LRU and stale-bucket eviction, and the deferred release that holds a texture until the frame it was recorded into has submitted are all unchanged. The twenty filter compute pipelines and the frame-encoder bridge are untouched and remain the next steps.
