### PR TITLE
Remove Windows from the plan surfaces and the GPU surface API

### DIFF
--- a/docs/design_docs/0017-geode_renderer.md
+++ b/docs/design_docs/0017-geode_renderer.md
@@ -266,7 +266,9 @@ Rust `wgpu` crate's C ABI surface) and uses
 [eliemichel/WebGPU-distribution](https://github.com/eliemichel/WebGPU-distribution)'s
 single-header `webgpu.hpp` C++ wrapper for idiomatic RAII handles. This gives us:
 
-- Cross-platform support (Windows, macOS, Linux, Android, iOS, Web via wasm)
+- Cross-platform support across Donner's targets (macOS, Linux, Web via wasm,
+  with iOS planned); the underlying API is broader, but Windows is out of scope
+  for this project
 - Modern GPU features (compute shaders for v2 filters, storage buffers)
 - No platform-specific code in the renderer
 - Future path to native Vulkan/Metal for applications that need it
@@ -281,8 +283,10 @@ cmake-from-source build to a prebuilt-binary drop.
 #### Bazel vendoring strategy (wgpu-native)
 
 wgpu-native publishes pre-built release archives on its GitHub Releases page
-for `{linux, macos, windows} × {x86_64, aarch64}`. We consume those directly
-via `http_archive`: one repository per platform tuple, each carrying an
+for `{linux, macos, windows} × {x86_64, aarch64}`. We consume the four
+Linux and macOS tuples directly via `http_archive` (Windows is out of scope
+for this project, so its archives are not wired): one repository per consumed
+platform tuple, each carrying an
 overlay `BUILD.wgpu_native_platform` file that exposes
 `lib/libwgpu_native.{so,dylib}` plus the `include/webgpu/{webgpu,wgpu}.h`
 headers as a single `cc_library`. `//third_party/webgpu-cpp` then `select()`s

--- a/docs/design_docs/0023-editor_sandbox.md
+++ b/docs/design_docs/0023-editor_sandbox.md
@@ -83,8 +83,8 @@ whole stack falls out of one decision.
   editor's WASM build (M6) continues to run the parser in-process, with the
   browser's own sandbox as the trust boundary. The IPC abstraction exists,
   but `SandboxedParseSVG` is a direct call in WASM builds.
-- **Not Windows in milestone 1.** Editor M3 targets macOS + Linux; the
-  sandbox follows the same platform cut. Windows is Future Work.
+- **Not Windows.** Editor M3 targets macOS + Linux; the sandbox follows
+  the same platform cut. Windows is out of scope for the project.
 - **Not a replacement for the fuzzer.** `SVGParser_fuzzer` continues to find
   bugs at the parser level. The sandbox is defense-in-depth, not defense-in-first.
 - **Not a general-purpose IPC framework.** This is one protocol
@@ -966,9 +966,6 @@ Three new fuzzers:
   currently out of scope. Most interesting path forward: route through the
   host via a request-from-sandbox protocol. Delayed until after S6.
 - **Shared memory for `ImageResource`**: measure first.
-- **Windows sandboxing**: requires a separate story (Job Objects +
-  AppContainer). Not blocking M1; Windows editor support is itself Future
-  Work in [editor.md](./0020-editor.md).
 - **DOM mirror strategy**: S3 ships read-only (option 3 from Proposed
   Architecture). Decision on option 1 vs. option 2 happens when S3 closes.
 
@@ -978,7 +975,6 @@ Three new fuzzers:
       returns bytes). Allows `<image href>`, `<use href>` cross-document,
       `@font-face src=url()`.
 - [ ] Shared-memory fast path for `drawImage` payloads larger than 1 MB.
-- [ ] Windows sandbox via Job Object + AppContainer.
 - [ ] `kDomStructure` wire message for structured editor DOM mirror
       (replaces the "re-parse on host" path).
 - [ ] C++26 reflection migration (S5) assuming toolchain support lands.

--- a/docs/design_docs/0053-native_gpu_hal.md
+++ b/docs/design_docs/0053-native_gpu_hal.md
@@ -2,15 +2,15 @@
 
 **Status:** Design\
 **Created:** 2026-07-05\
-**Updated:** 2026-08-24\
+**Updated:** 2026-08-27\
 **Author:** GPT-5.6 Sol
 
 ## Summary
 
 Donner will replace its native `wgpu-native` dependency with an original C++20 GPU runtime built
 inside Donner. The runtime will expose a narrow Donner-owned rendering hardware interface, not the
-WebGPU C ABI. It will target Metal on Apple platforms, Vulkan on Linux and Windows, and the browser's
-WebGPU service through a small Donner-owned WebAssembly bridge.
+WebGPU C ABI. It will target Metal on Apple platforms, Vulkan on Linux, and the browser's WebGPU
+service through a small Donner-owned WebAssembly bridge.
 
 This is a clean-room, specification-led implementation. It must not copy, translate, vendor, link,
 or ship implementation code from `wgpu`, `wgpu-native`, Naga, Dawn, or Tint. Those projects may not
@@ -89,6 +89,8 @@ sunsetted, output-only transition baseline.
   allowlisted upstream reference snapshot remain separate from the GPU runtime.
 - Rewriting Git history. The requirement applies to the checked-out release tree, generated source
   archives, build dependency closure, and shipped artifacts.
+- Supporting Windows. Windows is out of scope for the project, so the Vulkan backend targets Linux
+  only and no Windows surface type, release floor, driver qualification, or CI lane is planned.
 
 ## Clean-Room and Provenance Rules
 
@@ -288,9 +290,8 @@ compute chains, readback, and editor presentation.
 
 ### Vulkan
 
-Vulkan supports Linux and Windows. It owns instance/device selection, queue families, descriptor
-pools, memory allocation, pipeline caches, surfaces/swapchains, submission fences, and device-loss
-recovery.
+Vulkan supports Linux. It owns instance/device selection, queue families, descriptor pools, memory
+allocation, pipeline caches, surfaces/swapchains, submission fences, and device-loss recovery.
 
 The load-bearing subsystem is explicit synchronization. Every resource tracks its last writer,
 stage/access state, image layout, queue ownership, and submission serial. Encoders derive barriers
@@ -398,7 +399,7 @@ directory drops.
       ([0064: GPU release matrix](0064-gpu_release_matrix.md)). The matrix is derived from the
       lanes and targets in the tree and labels every combination as executed, compiled but not
       executed, developer-machine-only, or uncovered; the largest uncovered groups are physical
-      Vulkan drivers, Vulkan validation layers, Windows, and physical iOS. The budgets replace the
+      Vulkan drivers, Vulkan validation layers, and physical iOS. The budgets replace the
       0.3-0.5 MB estimate with measured code-and-data sizes: 900,049 bytes for a Metal
       configuration and 974,189 for a Vulkan one, roughly twice the estimate.
 
@@ -464,10 +465,10 @@ three backends and validated by the Metal compiler, `spirv-val`, and WebGPU pipe
 - [ ] Implement device selection, resource allocation, descriptors, pipelines, synchronization,
       submission, readback, and swapchains.
 - [ ] Prove the resource-state model with model tests and Vulkan validation layers.
-- [ ] Replace Linux and Windows editor presentation.
+- [ ] Replace Linux editor presentation.
 - [ ] Pass software and physical-driver matrices, deterministic replay, goldens, fuzzing,
       performance, memory, and device-loss tests.
-- [ ] Cut Linux/Windows production builds to Vulkan and remove their `wgpu-native` archives.
+- [ ] Cut Linux production builds to Vulkan and remove the Linux `wgpu-native` archives.
 
 ### Phase 5: Browser bridge
 
@@ -517,13 +518,12 @@ The expected sequence is 16 to 24 normal-sized pull requests:
 13. Vulkan synchronization/resource manager.
 14. Vulkan presentation and editor integration.
 15. Linux cutover and dependency deletion.
-16. Windows Vulkan enablement and physical-device qualification.
-17. Browser bridge and generated WGSL path.
-18. Donner ImGui renderer and WebGPU integration deletion.
-19. Tiny-skia Rust FFI removal, inert-reference quarantine, and replacement tests.
-20. Bzlmod/CMake/CI/source-package Rust dependency purge.
-21. Security and provenance fixes from independent review.
-22. Documentation, release qualification, and final size/performance report.
+16. Browser bridge and generated WGSL path.
+17. Donner ImGui renderer and WebGPU integration deletion.
+18. Tiny-skia Rust FFI removal, inert-reference quarantine, and replacement tests.
+19. Bzlmod/CMake/CI/source-package Rust dependency purge.
+20. Security and provenance fixes from independent review.
+21. Documentation, release qualification, and final size/performance report.
 
 Packets may split when review surface becomes too large. They may not combine backend code,
 shader migration, build-graph deletion, and broad golden updates into one unreviewable change.
@@ -614,7 +614,6 @@ dependency into a new artifact.
   device adoption after platform cutover?
 - Vulkan memory allocator scope: implement only the allocation patterns in the manifest, or add
   suballocation in the first production backend?
-- Windows release floor and required Vulkan driver versions.
 - Whether iOS uses the Metal backend natively in v1.0 or remains browser-only until a native host
   exists.
 - Which exact physical GPUs are release-blocking rather than best-effort.

--- a/docs/design_docs/0064-gpu_release_matrix.md
+++ b/docs/design_docs/0064-gpu_release_matrix.md
@@ -15,7 +15,8 @@ The matrix below is derived from the lanes and targets in this repository, not f
 row says which of three things is true today: the combination is exercised by a CI lane, it is
 only reachable on a developer machine, or nothing anywhere runs it. Several rows in the third
 category are combinations 0053 names as release-blocking, and stating that plainly is the point of
-the document.
+the document. A fourth label separates the combinations the project has decided not to ship from
+the ones it has not gotten to: an uncovered target is a gap, a non-target is not.
 
 ## Goals
 
@@ -46,6 +47,7 @@ the document.
 | **Compile-only** | Built by a lane that never executes it. Proves it links, proves nothing else. |
 | **Dev-host**     | Runnable, but only by a person on a machine; no lane executes it.             |
 | **None**         | Nothing in the repository executes this combination.                          |
+| **Out of scope** | Not a target: the project has decided not to ship it, so it is not a gap.     |
 | **Fails closed** | Not covered, and an automated lane says so by going red instead of green.     |
 
 A target that self-skips when its device is missing is only coverage on a lane that actually has
@@ -99,19 +101,19 @@ Notes:
 
 ## Vulkan
 
-| Platform                 | Driver / adapter                        | Coverage        | Where                                                            |
-| ------------------------ | --------------------------------------- | --------------- | ---------------------------------------------------------------- |
-| Linux x86_64             | Mesa lavapipe (software)                | **PR-gated**    | `vulkan_solid_fill_tests`, ICD pinned to `lvp_icd.json`          |
-| Linux arm64              | Mesa lavapipe (software)                | **PR-gated**    | The self-hosted Linux routing, when it is the selected lane      |
-| Linux x86_64/arm64       | Frozen pixel identity, software adapter | **PR-gated**    | `baseline_pixels_tests`, against the committed lavapipe baseline |
-| Linux, SPIR-V validation | `spirv-val`                             | **PR-gated**    | `spirv_val_validation_tests`; only one lane installs SPIRV-Tools |
-| Linux                    | Vulkan validation layers                | **None**        | No lane enables them; the design requires zero validation errors |
-| Linux x86_64/arm64       | Intel physical                          | **None**        | No lane has a GPU device; the shared executor advertises none    |
-| Linux x86_64             | AMD physical                            | **None**        | As above                                                         |
-| Linux x86_64             | NVIDIA physical                         | **None**        | As above                                                         |
-| Linux, Geode + ASan      | Mesa lavapipe                           | **Conditional** | Fires only when the Geode renderer paths change                  |
-| Linux, Geode fuzzing     | Mesa lavapipe                           | **Scheduled**   | Nightly                                                          |
-| Windows                  | Any Vulkan driver                       | **None**        | No Windows runner, no Windows platform constraint, no D3D        |
+| Platform                 | Driver / adapter                        | Coverage         | Where                                                            |
+| ------------------------ | --------------------------------------- | ---------------- | ---------------------------------------------------------------- |
+| Linux x86_64             | Mesa lavapipe (software)                | **PR-gated**     | `vulkan_solid_fill_tests`, ICD pinned to `lvp_icd.json`          |
+| Linux arm64              | Mesa lavapipe (software)                | **PR-gated**     | The self-hosted Linux routing, when it is the selected lane      |
+| Linux x86_64/arm64       | Frozen pixel identity, software adapter | **PR-gated**     | `baseline_pixels_tests`, against the committed lavapipe baseline |
+| Linux, SPIR-V validation | `spirv-val`                             | **PR-gated**     | `spirv_val_validation_tests`; only one lane installs SPIRV-Tools |
+| Linux                    | Vulkan validation layers                | **None**         | No lane enables them; the design requires zero validation errors |
+| Linux x86_64/arm64       | Intel physical                          | **None**         | No lane has a GPU device; the shared executor advertises none    |
+| Linux x86_64             | AMD physical                            | **None**         | As above                                                         |
+| Linux x86_64             | NVIDIA physical                         | **None**         | As above                                                         |
+| Linux, Geode + ASan      | Mesa lavapipe                           | **Conditional**  | Fires only when the Geode renderer paths change                  |
+| Linux, Geode fuzzing     | Mesa lavapipe                           | **Scheduled**    | Nightly                                                          |
+| Windows                  | Any Vulkan driver                       | **Out of scope** | Windows is not a target platform; nothing is planned for it      |
 
 Notes:
 
@@ -127,17 +129,17 @@ Notes:
 
 ## Browser WebGPU
 
-| Browser                              | Host         | Coverage        | Where                                                 |
-| ------------------------------------ | ------------ | --------------- | ----------------------------------------------------- |
-| Chromium, headless                   | macOS arm64  | **Conditional** | Browser suites, path-filtered pull requests           |
-| Chromium, headless                   | macOS arm64  | **Scheduled**   | The same suites, nightly                              |
-| Chromium, headed on the platform GPU | macOS arm64  | **Conditional** | The composited-output lane, ANGLE over Metal          |
-| Firefox                              | macOS arm64  | **Conditional** | Resize and composited-invariant projects              |
-| WebKit (Playwright)                  | macOS arm64  | **Conditional** | Carousel project                                      |
-| Safari (the shipping browser)        | macOS        | **Dev-host**    | A regression script exists; no workflow invokes it    |
-| Any browser                          | Linux        | **None**        | The pixel-presenting smoke target is macOS-arm64 only |
-| Any browser                          | Windows      | **None**        | No runner                                             |
-| Mobile Safari                        | iOS / iPadOS | **None**        | 0053 requires physical iOS presentation checks        |
+| Browser                              | Host         | Coverage         | Where                                                 |
+| ------------------------------------ | ------------ | ---------------- | ----------------------------------------------------- |
+| Chromium, headless                   | macOS arm64  | **Conditional**  | Browser suites, path-filtered pull requests           |
+| Chromium, headless                   | macOS arm64  | **Scheduled**    | The same suites, nightly                              |
+| Chromium, headed on the platform GPU | macOS arm64  | **Conditional**  | The composited-output lane, ANGLE over Metal          |
+| Firefox                              | macOS arm64  | **Conditional**  | Resize and composited-invariant projects              |
+| WebKit (Playwright)                  | macOS arm64  | **Conditional**  | Carousel project                                      |
+| Safari (the shipping browser)        | macOS        | **Dev-host**     | A regression script exists; no workflow invokes it    |
+| Any browser                          | Linux        | **None**         | The pixel-presenting smoke target is macOS-arm64 only |
+| Any browser                          | Windows      | **Out of scope** | Windows is not a target platform                      |
+| Mobile Safari                        | iOS / iPadOS | **None**         | 0053 requires physical iOS presentation checks        |
 
 Notes:
 
@@ -151,20 +153,21 @@ Notes:
 
 ## Cross-cutting gaps
 
-These are the combinations 0053's gates depend on that nothing currently executes:
+These are the combinations 0053's gates depend on that nothing currently executes. Windows is not
+among them: it is a non-target, listed as out of scope in the tables above rather than counted as a
+gap.
 
 1. Any physical Vulkan driver. Intel, AMD, and NVIDIA are all unqualified, and the executor pool
    advertises no GPU worker class, so adding one is a hardware and scheduling decision rather than
    a lane edit.
 2. Vulkan validation layers. The synchronization model 0053 calls its load-bearing subsystem has
    no validation gate.
-3. Windows, entirely.
-4. Physical iOS presentation.
-5. More than one Apple GPU generation per change.
-6. Geode through CMake. The CMake lanes build the CPU backend on both platforms, while the README
+3. Physical iOS presentation.
+4. More than one Apple GPU generation per change.
+5. Geode through CMake. The CMake lanes build the CPU backend on both platforms, while the README
    describes both backends as selectable. 0053 requires CMake to gain equivalent native GPU targets
    as each backend reaches production, so this gap is on the cutover path.
-7. macOS Geode fuzzing. The Linux nightly fuzz job has a Geode step; the macOS one does not.
+6. macOS Geode fuzzing. The Linux nightly fuzz job has a Geode step; the macOS one does not.
 
 ## Binary-size budgets
 
@@ -305,7 +308,6 @@ checklist item, not as an invariant.
   emitted artifacts are produced at build time and the emitters are dropped from the product. That
   choice moves roughly 435 KiB and changes every budget above.
 - Whether `RecordingDevice` ships.
-- The Windows release floor and required Vulkan driver versions, unchanged from 0053.
 
 ## Related Designs
 

--- a/donner/gpu/Descriptors.cc
+++ b/donner/gpu/Descriptors.cc
@@ -189,7 +189,6 @@ std::ostream& operator<<(std::ostream& os, NativeSurfaceKind value) {
     case NativeSurfaceKind::MetalLayer: return os << "MetalLayer";
     case NativeSurfaceKind::XlibWindow: return os << "XlibWindow";
     case NativeSurfaceKind::WaylandSurface: return os << "WaylandSurface";
-    case NativeSurfaceKind::Win32Window: return os << "Win32Window";
     case NativeSurfaceKind::CanvasSelector: return os << "CanvasSelector";
   }
   return os << "Unknown";
@@ -229,7 +228,6 @@ bool IsKnownEnumValue(NativeSurfaceKind value) {
     case NativeSurfaceKind::MetalLayer:
     case NativeSurfaceKind::XlibWindow:
     case NativeSurfaceKind::WaylandSurface:
-    case NativeSurfaceKind::Win32Window:
     case NativeSurfaceKind::CanvasSelector: return true;
   }
   return false;

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -116,7 +116,6 @@ enum class NativeSurfaceKind : uint8_t {
   MetalLayer,      //!< Core Animation Metal layer.
   XlibWindow,      //!< X11 display plus window id.
   WaylandSurface,  //!< Wayland display plus surface.
-  Win32Window,     //!< Win32 module instance plus window handle.
   /// CSS selector naming a browser canvas element.
   ///
   /// A browser drives presentation from its own frame loop, so a surface of this kind presents
@@ -135,11 +134,11 @@ struct NativeSurfaceHandle {
   // Exactly the slots \ref kind uses must be populated: a filled slot the kind does not use means
   // the caller and the handle disagree about what this names, which is rejected rather than
   // silently ignored.
-  /// MetalLayer: the layer. XlibWindow: the display. WaylandSurface: the display. Win32Window:
-  /// the module instance. Null for CanvasSelector.
+  /// MetalLayer: the layer. XlibWindow: the display. WaylandSurface: the display. Null for
+  /// CanvasSelector.
   void* display = nullptr;
-  /// XlibWindow: the window id. WaylandSurface: the surface. Win32Window: the window handle.
-  /// Zero for MetalLayer and CanvasSelector.
+  /// XlibWindow: the window id. WaylandSurface: the surface. Zero for MetalLayer and
+  /// CanvasSelector.
   uint64_t window = 0;
   /// CanvasSelector: the selector naming the canvas. Empty for every other kind.
   RcString selector;

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1271,8 +1271,7 @@ NativeSurfacePayload PayloadForKind(NativeSurfaceKind kind) {
   switch (kind) {
     case NativeSurfaceKind::MetalLayer: return NativeSurfacePayload{true, false, false};
     case NativeSurfaceKind::XlibWindow:
-    case NativeSurfaceKind::WaylandSurface:
-    case NativeSurfaceKind::Win32Window: return NativeSurfacePayload{true, true, false};
+    case NativeSurfaceKind::WaylandSurface: return NativeSurfacePayload{true, true, false};
     case NativeSurfaceKind::CanvasSelector: return NativeSurfacePayload{false, false, true};
   }
   return NativeSurfacePayload{};


### PR DESCRIPTION
Windows is out of scope for this project. The plan documents and the GPU runtime's surface type still named it as a target, so this removes it from both.

The design docs now describe a Linux-only Vulkan path. 0053 states Metal on Apple platforms and Vulkan on Linux, carries an explicit "Supporting Windows" non-goal, and drops the Windows lines from Phase 4, the change sequence, and the open questions. 0023 restates its Windows non-goal and drops the Windows sandbox open question and future-work item. Historical narration is untouched: 0017's note that upstream publishes Windows archives is a fact about an upstream project, not a Donner plan.

0064 keeps its Windows rows, because a release matrix that silently drops a platform is less honest than one that says the platform is deliberately not covered. Those rows get a new "Out of scope" coverage label that separates a non-target from an uncovered target, and Windows leaves the cross-cutting gap list, which is for combinations the gates depend on and nothing runs.

On the runtime side, `NativeSurfaceKind::Win32Window` named a platform the runtime does not build for. Nothing constructed it, no backend consumed it, and its payload documentation described slots no caller could fill. Removing the kind and its `operator<<`, `IsKnownEnumValue`, and payload-validation arms leaves the enum modelling only real targets: MetalLayer, XlibWindow, WaylandSurface, and CanvasSelector.

General Windows-portability code elsewhere in the tree (the Vulkan loader's `LoadLibrary` arm, the sandboxed file loader's Win32 arm, `FileUtils`, the msvc attribute in `Utils.h`) is unchanged: those are portability arms in working code, not plan surface.

`bazel test --config=re //...` passes (473 passed, 29 skipped), along with `tools/lint.sh`, the CMake generator check, the design-doc provenance check, and the GPU manifest freshness tests.
