### PR TITLE
vulkan: track resource state so barriers name the work they actually order

### DIFF
--- a/donner/gpu/vulkan/BUILD.bazel
+++ b/donner/gpu/vulkan/BUILD.bazel
@@ -30,10 +30,12 @@ donner_cc_library(
 donner_cc_library(
     name = "vulkan_device",
     srcs = [
+        "VulkanBufferAllocator.cc",
         "VulkanDevice.cc",
         "VulkanLoader.cc",
     ],
     hdrs = [
+        "VulkanBufferAllocator.h",
         "VulkanDevice.h",
         "VulkanLoader.h",
     ],

--- a/donner/gpu/vulkan/BUILD.bazel
+++ b/donner/gpu/vulkan/BUILD.bazel
@@ -12,6 +12,21 @@ load("//build_defs:package.bzl", "donner_package")
 # build needs no Vulkan library present and a machine without one reports it
 # at device creation. Execution is gated to Linux in tests/BUILD.bazel.
 
+# The tracked resource-state model every barrier and subpass dependency is derived from.
+# Deliberately its own target: it is pure state machinery over Vulkan enums that opens no device
+# and calls no entry point, so it builds and its tests run on every platform, not only where a
+# Vulkan loader exists.
+donner_cc_library(
+    name = "vulkan_resource_state",
+    srcs = ["VulkanResourceState.cc"],
+    hdrs = ["VulkanResourceState.h"],
+    visibility = donner_internal_visibility(),
+    deps = [
+        "//donner/gpu",
+        "@vulkan_headers",
+    ],
+)
+
 donner_cc_library(
     name = "vulkan_device",
     srcs = [
@@ -30,6 +45,7 @@ donner_cc_library(
     }),
     visibility = donner_internal_visibility(),
     deps = [
+        ":vulkan_resource_state",
         "//donner/base",
         "//donner/gpu",
         "@vulkan_headers",

--- a/donner/gpu/vulkan/VulkanBufferAllocator.cc
+++ b/donner/gpu/vulkan/VulkanBufferAllocator.cc
@@ -1,0 +1,93 @@
+/// @file
+/// Implementation of the Vulkan backend's buffer memory seam.
+
+#include "donner/gpu/vulkan/VulkanBufferAllocator.h"
+
+#include <format>
+#include <optional>
+
+#include "donner/gpu/vulkan/VulkanLoader.h"
+
+namespace donner::gpu::vulkan {
+
+namespace {
+
+/// Finds a memory type index compatible with \p typeBits carrying all \p required property
+/// flags, or empty if none exists.
+/// @param properties Physical device memory properties.
+/// @param typeBits Memory type bitmask the resource accepts.
+/// @param required Property flags the type must carry.
+std::optional<uint32_t> FindMemoryType(const VkPhysicalDeviceMemoryProperties& properties,
+                                       uint32_t typeBits, VkMemoryPropertyFlags required) {
+  for (uint32_t i = 0; i < properties.memoryTypeCount; ++i) {
+    if ((typeBits & (1u << i)) != 0 &&
+        (properties.memoryTypes[i].propertyFlags & required) == required) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+Result<BufferAllocation> DedicatedBufferAllocator::allocate(const VulkanApi& api, VkDevice device,
+                                                            VkBuffer buffer,
+                                                            std::string_view label) {
+  VkMemoryRequirements requirements = {};
+  api.vkGetBufferMemoryRequirements(device, buffer, &requirements);
+
+  // Host-visible and host-coherent, which the specification guarantees at least one memory type
+  // provides. Coherent memory is what lets the backend read and write through the persistent
+  // mapping with no flush or invalidate of its own.
+  const std::optional<uint32_t> memoryType =
+      FindMemoryType(memoryProperties_, requirements.memoryTypeBits,
+                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+  if (!memoryType) {
+    return GpuError{GpuErrorType::InvalidState,
+                    std::format("no host-visible coherent memory type for buffer '{}'", label)};
+  }
+
+  BufferAllocation allocation;
+  allocation.ownsMemory = true;
+  allocation.offsetBytes = 0;
+
+  VkMemoryAllocateInfo allocateInfo = {};
+  allocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  allocateInfo.allocationSize = requirements.size;
+  allocateInfo.memoryTypeIndex = *memoryType;
+  if (const VkResult result =
+          api.vkAllocateMemory(device, &allocateInfo, nullptr, &allocation.memory);
+      result != VK_SUCCESS) {
+    return GpuError{GpuErrorType::InvalidState,
+                    std::format("vkAllocateMemory of {} bytes for buffer '{}' failed with {}",
+                                requirements.size, label, static_cast<int>(result))};
+  }
+  if (const VkResult result =
+          api.vkBindBufferMemory(device, buffer, allocation.memory, allocation.offsetBytes);
+      result != VK_SUCCESS) {
+    release(api, device, allocation);
+    return GpuError{GpuErrorType::InvalidState,
+                    std::format("vkBindBufferMemory for buffer '{}' failed with {}", label,
+                                static_cast<int>(result))};
+  }
+  if (const VkResult result =
+          api.vkMapMemory(device, allocation.memory, 0, VK_WHOLE_SIZE, 0, &allocation.mapped);
+      result != VK_SUCCESS) {
+    release(api, device, allocation);
+    return GpuError{
+        GpuErrorType::InvalidState,
+        std::format("vkMapMemory for buffer '{}' failed with {}", label, static_cast<int>(result))};
+  }
+  return allocation;
+}
+
+void DedicatedBufferAllocator::release(const VulkanApi& api, VkDevice device,
+                                       BufferAllocation& allocation) {
+  // The mapping is released implicitly with the memory it belongs to.
+  if (allocation.ownsMemory && allocation.memory != VK_NULL_HANDLE) {
+    api.vkFreeMemory(device, allocation.memory, nullptr);
+  }
+  allocation = BufferAllocation{};
+}
+
+}  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanBufferAllocator.cc
+++ b/donner/gpu/vulkan/VulkanBufferAllocator.cc
@@ -60,7 +60,7 @@ Result<BufferAllocation> DedicatedBufferAllocator::allocate(const VulkanApi& api
       result != VK_SUCCESS) {
     return GpuError{GpuErrorType::InvalidState,
                     std::format("vkAllocateMemory of {} bytes for buffer '{}' failed with {}",
-                                requirements.size, label, static_cast<int>(result))};
+                                requirements.size, label, VkResultToString(result))};
   }
   if (const VkResult result =
           api.vkBindBufferMemory(device, buffer, allocation.memory, allocation.offsetBytes);
@@ -68,7 +68,7 @@ Result<BufferAllocation> DedicatedBufferAllocator::allocate(const VulkanApi& api
     release(api, device, allocation);
     return GpuError{GpuErrorType::InvalidState,
                     std::format("vkBindBufferMemory for buffer '{}' failed with {}", label,
-                                static_cast<int>(result))};
+                                VkResultToString(result))};
   }
   if (const VkResult result =
           api.vkMapMemory(device, allocation.memory, 0, VK_WHOLE_SIZE, 0, &allocation.mapped);
@@ -76,7 +76,7 @@ Result<BufferAllocation> DedicatedBufferAllocator::allocate(const VulkanApi& api
     release(api, device, allocation);
     return GpuError{
         GpuErrorType::InvalidState,
-        std::format("vkMapMemory for buffer '{}' failed with {}", label, static_cast<int>(result))};
+        std::format("vkMapMemory for buffer '{}' failed with {}", label, VkResultToString(result))};
   }
   return allocation;
 }

--- a/donner/gpu/vulkan/VulkanBufferAllocator.h
+++ b/donner/gpu/vulkan/VulkanBufferAllocator.h
@@ -1,0 +1,96 @@
+#pragma once
+/// @file
+/// \c donner::gpu::vulkan::BufferSuballocator - where a Vulkan buffer's memory comes from.
+///
+/// The backend gives every buffer its own VkDeviceMemory, persistently mapped. That is the
+/// simplest thing that is correct, and it is what this seam's only implementation still does.
+///
+/// The seam exists because replacing it is a memory-management change, not an API change, and
+/// the two should not have to happen together. A device has a small, driver-reported cap on how
+/// many allocations may exist at once, and one allocation per buffer walks toward that cap in
+/// proportion to how many buffers a scene needs; suballocating many buffers out of a few larger
+/// allocations is the standard answer. Making that swap later means writing another
+/// implementation of this interface, not touching every call site that creates a buffer.
+///
+/// It is deliberately introduced without the suballocating implementation: which allocation
+/// sizes, which pooling, and whether the cap is actually the binding constraint here are
+/// questions for measurement, and shipping a suballocator before that measurement would be
+/// guessing at a policy no counter has justified yet.
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <string_view>
+
+#include "donner/gpu/GpuResult.h"
+
+namespace donner::gpu::vulkan {
+
+struct VulkanApi;
+
+/// Where one buffer's bytes live.
+///
+/// The offset and the host pointer are the buffer's own, not the allocation's: a suballocating
+/// implementation hands out many of these pointing into one \ref memory, so a caller must never
+/// assume a buffer starts at offset zero of its allocation.
+struct BufferAllocation {
+  VkDeviceMemory memory = VK_NULL_HANDLE;  //!< Allocation this buffer was bound into.
+  VkDeviceSize offsetBytes = 0;            //!< Offset of this buffer within \ref memory.
+  void* mapped = nullptr;                  //!< Host pointer to this buffer's first byte.
+
+  /// Whether releasing this allocation frees \ref memory. False for a suballocation that shares
+  /// its memory with other buffers still in use.
+  bool ownsMemory = false;
+};
+
+/**
+ * Supplies the memory a buffer is bound into.
+ *
+ * Every buffer this backend allocates is host-visible, host-coherent, and persistently mapped:
+ * queue writes are a memcpy and readback needs no staging. An implementation must preserve that,
+ * because the rest of the backend reads and writes buffers straight through
+ * \ref BufferAllocation::mapped with no flush or invalidate of its own.
+ */
+class BufferSuballocator {
+public:
+  virtual ~BufferSuballocator() = default;
+
+  /**
+   * Provides memory for \p buffer and binds it.
+   *
+   * @param api Resolved device entry points.
+   * @param device Device owning \p buffer.
+   * @param buffer Buffer to bind memory into.
+   * @param label Buffer label, for failure messages.
+   */
+  [[nodiscard]] virtual Result<BufferAllocation> allocate(const VulkanApi& api, VkDevice device,
+                                                          VkBuffer buffer,
+                                                          std::string_view label) = 0;
+
+  /**
+   * Releases an allocation obtained from \ref allocate.
+   *
+   * @param api Resolved device entry points.
+   * @param device Device owning the allocation.
+   * @param allocation Allocation to release; left cleared.
+   */
+  virtual void release(const VulkanApi& api, VkDevice device, BufferAllocation& allocation) = 0;
+};
+
+/// The passthrough implementation: one dedicated VkDeviceMemory per buffer, mapped for its
+/// lifetime. Every allocation it returns owns its memory and starts at offset zero.
+class DedicatedBufferAllocator final : public BufferSuballocator {
+public:
+  /// @param memoryProperties Physical device memory properties, for memory-type selection.
+  explicit DedicatedBufferAllocator(const VkPhysicalDeviceMemoryProperties& memoryProperties)
+      : memoryProperties_(memoryProperties) {}
+
+  Result<BufferAllocation> allocate(const VulkanApi& api, VkDevice device, VkBuffer buffer,
+                                    std::string_view label) override;
+  void release(const VulkanApi& api, VkDevice device, BufferAllocation& allocation) override;
+
+private:
+  VkPhysicalDeviceMemoryProperties memoryProperties_;  //!< Memory types available.
+};
+
+}  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -28,6 +28,7 @@
 #include "donner/base/Utils.h"
 #include "donner/gpu/GpuLimits.h"
 #include "donner/gpu/vulkan/VulkanLoader.h"
+#include "donner/gpu/vulkan/VulkanResourceState.h"
 
 namespace donner::gpu::vulkan {
 
@@ -347,30 +348,27 @@ VKAPI_ATTR VkBool32 VKAPI_CALL ValidationMessengerCallback(
   return VK_FALSE;
 }
 
-/// Records a conservative full image layout transition: ALL_COMMANDS to ALL_COMMANDS with
-/// memory-availability source access and read+write destination access. Intentionally maximal
-/// (the first implementation is conservative and validation-clean); VK_ACCESS_MEMORY_* flags are
-/// valid with any pipeline stage.
+/// Records the image barrier \p params describes. The parameters come from the resource-state
+/// model, which is where the decision of what to wait on and what to make visible lives; this
+/// only turns that decision into the Vulkan call.
 /// @param api Resolved device entry points.
 /// @param commandBuffer Command buffer to record into.
 /// @param image Image whose layout changes.
-/// @param oldLayout Layout the image is currently in.
-/// @param newLayout Layout the image transitions to.
+/// @param params Derived barrier parameters.
 void RecordImageBarrier(const VulkanApi& api, VkCommandBuffer commandBuffer, VkImage image,
-                        VkImageLayout oldLayout, VkImageLayout newLayout) {
+                        const ImageBarrierParams& params) {
   VkImageMemoryBarrier barrier = {};
   barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
-  barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
-  barrier.oldLayout = oldLayout;
-  barrier.newLayout = newLayout;
+  barrier.srcAccessMask = params.srcAccess;
+  barrier.dstAccessMask = params.dstAccess;
+  barrier.oldLayout = params.oldLayout;
+  barrier.newLayout = params.newLayout;
   barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   barrier.image = image;
   barrier.subresourceRange = FullColorRange();
-  api.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                           VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1,
-                           &barrier);
+  api.vkCmdPipelineBarrier(commandBuffer, params.srcStage, params.dstStage, 0, 0, nullptr, 0,
+                           nullptr, 1, &barrier);
 }
 
 /// Returns the Khronos validation layer if the loader enumerates it, otherwise an empty list.
@@ -727,16 +725,16 @@ struct VulkanDevice::Impl {
     VkDeviceSize byteSize = 0;               //!< Creation size in bytes.
   };
 
-  /// An image plus its dedicated allocation and the CPU-tracked current layout. Layout tracking
-  /// at encode time is valid because submissions execute in order on the single queue with
-  /// conservative barriers.
+  /// An image plus its dedicated allocation. Its synchronization state lives in \ref syncStates
+  /// rather than here, because that state is staged during an encode and committed only once the
+  /// submission reached the queue. Tracking at encode time is valid because submissions execute
+  /// in order on the single queue.
   struct TextureRecord {
-    VkImage image = VK_NULL_HANDLE;                           //!< Image handle.
-    VkDeviceMemory memory = VK_NULL_HANDLE;                   //!< Dedicated allocation.
-    TextureFormat format = TextureFormat::RGBA8Unorm;         //!< RHI format (for copy texel math).
-    Extent2d size;                                            //!< Extent in texels.
-    TextureUsage usage = TextureUsage::None;                  //!< RHI usage flags.
-    VkImageLayout currentLayout = VK_IMAGE_LAYOUT_UNDEFINED;  //!< Tracked layout.
+    VkImage image = VK_NULL_HANDLE;                    //!< Image handle.
+    VkDeviceMemory memory = VK_NULL_HANDLE;            //!< Dedicated allocation.
+    TextureFormat format = TextureFormat::RGBA8Unorm;  //!< RHI format (for copy texel math).
+    Extent2d size;                                     //!< Extent in texels.
+    TextureUsage usage = TextureUsage::None;           //!< RHI usage flags.
   };
 
   /// A view of a texture slot; the VkImageView is created once at view creation.
@@ -1089,20 +1087,21 @@ struct VulkanDevice::Impl {
     /// Compute pipeline bound in the active compute pass.
     const ComputePipelineRecord* currentComputePipeline = nullptr;
     std::vector<VkDescriptorSet> boundSets;  //!< Descriptor sets bound by index.
-    /// Layout transitions recorded into this command buffer, committed to the per-texture
-    /// tracked state only after vkQueueSubmit succeeds: a failed encode or submit must not leave
-    /// tracked layouts claiming transitions the GPU never executed (the synchronous
-    /// onWriteTexture upload follows the same commit-after-success pattern).
-    std::map<uint32_t, VkImageLayout> stagedLayouts;
   };
 
-  /// Returns the layout \p textureSlot will be in at this point of the encoding: the staged
-  /// layout when one was recorded, otherwise the tracked layout.
-  /// @param state Encoding state.
-  /// @param textureSlot Texture slot to query.
+  /// Records the barrier that puts \p textureSlot into \p usage, if one is needed, and stages
+  /// the state it leaves behind.
+  ///
+  /// A barrier is recorded when the layout changes, and also when the image was last written
+  /// even though its layout does not change: two compute passes writing the same storage texture
+  /// stay in one layout throughout and still need the second to wait for the first.
+  ///
+  /// @param commandBuffer Command buffer to record into.
+  /// @param textureSlot Texture slot being transitioned.
   /// @param record Texture record backing the slot.
-  VkImageLayout encodedLayoutOf(const EncodingState& state, uint32_t textureSlot,
-                                const TextureRecord& record) const;
+  /// @param usage Usage the texture is about to be put to.
+  void transitionTexture(VkCommandBuffer commandBuffer, uint32_t textureSlot,
+                         const TextureRecord& record, TextureUsageKind usage);
 
   /// Destroys the render passes, framebuffers, and command buffer created for an encoding that
   /// will not be submitted.
@@ -1208,10 +1207,9 @@ struct VulkanDevice::Impl {
   Status encodeCommand(EncodingState& state, std::span<const Command> commands,
                        size_t commandIndex);
 
-  /// Commits the staged layout transitions to the tracked per-texture state, once the GPU is
-  /// guaranteed to execute them.
-  /// @param state Encoding state.
-  void commitStagedLayouts(EncodingState& state);
+  /// The synchronization state of every live texture, staged during an encode and committed
+  /// only once its submission reached the queue.
+  TextureSyncStateTable syncStates;
 
   /// Destroys the transient objects of a staged upload, in reverse creation order.
   /// @param fence Upload fence, or null.
@@ -1219,17 +1217,17 @@ struct VulkanDevice::Impl {
   /// @param staging Staging buffer record.
   void destroyUploadObjects(VkFence fence, VkCommandBuffer commandBuffer, BufferRecord& staging);
 
-  /// Records the staged buffer-to-image copy plus the layout transitions around it, and returns
-  /// the layout the image is left in.
+  /// Records the staged buffer-to-image copy plus the transitions around it, staging the state
+  /// they leave the image in.
   /// @param commandBuffer Command buffer to record into.
+  /// @param textureSlot Slot of the destination texture.
   /// @param texture Destination texture record.
   /// @param stagingBuffer Buffer holding the upload bytes.
   /// @param dataLayout Row layout of the upload bytes.
   /// @param writeSize Destination extent in texels.
-  VkImageLayout recordTextureUploadCopy(VkCommandBuffer commandBuffer, const TextureRecord& texture,
-                                        VkBuffer stagingBuffer,
-                                        const TexelCopyBufferLayout& dataLayout,
-                                        const Extent2d& writeSize);
+  void recordTextureUploadCopy(VkCommandBuffer commandBuffer, uint32_t textureSlot,
+                               const TextureRecord& texture, VkBuffer stagingBuffer,
+                               const TexelCopyBufferLayout& dataLayout, const Extent2d& writeSize);
 
   /// Creates \p fence, submits \p commandBuffer on it, and waits for completion. On timeout the
   /// submission is still pending, so \p objectsStillInUse is set and the caller must not destroy
@@ -1482,7 +1480,7 @@ Result<VulkanDevice::TrackedTextureLayout> VulkanDevice::trackedTextureLayoutFor
                     std::format("texture handle (slot {}) does not name a live Vulkan image",
                                 texture.slotIndex())};
   }
-  switch (record->currentLayout) {
+  switch (impl_->syncStates.stateOf(texture.slotIndex()).layout) {
     case VK_IMAGE_LAYOUT_UNDEFINED: return TrackedTextureLayout::Undefined;
     case VK_IMAGE_LAYOUT_GENERAL: return TrackedTextureLayout::General;
     case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL: return TrackedTextureLayout::ShaderReadOnly;
@@ -2022,6 +2020,10 @@ void VulkanDevice::Impl::destroyTextureSlot(uint32_t slotIndex) {
   if (TextureRecord* record = FindRecord(textures, slotIndex)) {
     destroyTextureRecord(*record);
     textures[slotIndex].reset();
+    // The slot is recyclable now, and a new image in it has touched nothing; leaving this
+    // texture's state behind would have the next one's first barrier wait on work that ran
+    // against an image that no longer exists.
+    syncStates.forget(slotIndex);
   }
 }
 
@@ -2184,13 +2186,12 @@ void VulkanDevice::Impl::destroyUploadObjects(VkFence fence, VkCommandBuffer com
   destroyBufferRecord(staging);
 }
 
-VkImageLayout VulkanDevice::Impl::recordTextureUploadCopy(VkCommandBuffer commandBuffer,
-                                                          const TextureRecord& texture,
-                                                          VkBuffer stagingBuffer,
-                                                          const TexelCopyBufferLayout& dataLayout,
-                                                          const Extent2d& writeSize) {
-  RecordImageBarrier(*api, commandBuffer, texture.image, texture.currentLayout,
-                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+void VulkanDevice::Impl::recordTextureUploadCopy(VkCommandBuffer commandBuffer,
+                                                 uint32_t textureSlot, const TextureRecord& texture,
+                                                 VkBuffer stagingBuffer,
+                                                 const TexelCopyBufferLayout& dataLayout,
+                                                 const Extent2d& writeSize) {
+  transitionTexture(commandBuffer, textureSlot, texture, TextureUsageKind::TransferWrite);
 
   const uint32_t texelSize = TextureFormatBytesPerTexel(texture.format);
   VkBufferImageCopy copyRegion = {};
@@ -2205,14 +2206,9 @@ VkImageLayout VulkanDevice::Impl::recordTextureUploadCopy(VkCommandBuffer comman
 
   // Sampled textures move straight to their descriptor layout; others stay transfer-dst until a
   // later encode transitions them.
-  const VkImageLayout postUploadLayout = HasAllFlags(texture.usage, TextureUsage::Sampled)
-                                             ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-                                             : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-  if (postUploadLayout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
-    RecordImageBarrier(*api, commandBuffer, texture.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                       postUploadLayout);
+  if (HasAllFlags(texture.usage, TextureUsage::Sampled)) {
+    transitionTexture(commandBuffer, textureSlot, texture, TextureUsageKind::SampledRead);
   }
-  return postUploadLayout;
 }
 
 Status VulkanDevice::Impl::submitAndWaitTextureUpload(VkCommandBuffer commandBuffer, VkFence& fence,
@@ -2302,8 +2298,8 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return VkError("vkBeginCommandBuffer", result);
   }
 
-  const VkImageLayout postUploadLayout =
-      impl.recordTextureUploadCopy(commandBuffer, *texture, staging.buffer, dataLayout, writeSize);
+  impl.recordTextureUploadCopy(commandBuffer, slotIndex, *texture, staging.buffer, dataLayout,
+                               writeSize);
 
   if (const VkResult result = impl_->api->vkEndCommandBuffer(commandBuffer); result != VK_SUCCESS) {
     cleanup();
@@ -2320,15 +2316,22 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return submitStatus;
   }
 
-  texture->currentLayout = postUploadLayout;
+  // The upload executed, so the transitions it recorded are now the texture's real state.
+  impl.syncStates.commitStaged();
   cleanup();
   return OkStatus();
 }
 
-VkImageLayout VulkanDevice::Impl::encodedLayoutOf(const EncodingState& state, uint32_t textureSlot,
-                                                  const TextureRecord& record) const {
-  const auto it = state.stagedLayouts.find(textureSlot);
-  return it != state.stagedLayouts.end() ? it->second : record.currentLayout;
+void VulkanDevice::Impl::transitionTexture(VkCommandBuffer commandBuffer, uint32_t textureSlot,
+                                           const TextureRecord& record, TextureUsageKind usage) {
+  const TextureSyncState current = syncStates.stateOf(textureSlot);
+  const ImageBarrierParams params = TransitionFor(current, usage);
+  const bool wasWritten = current.access != 0 && params.srcAccess != 0;
+  if (params.oldLayout == params.newLayout && !wasWritten) {
+    return;  // Same layout and nothing to make available: no hazard to order.
+  }
+  RecordImageBarrier(*api, commandBuffer, record.image, params);
+  syncStates.stage(textureSlot, StateAfterUsage(usage));
 }
 
 void VulkanDevice::Impl::destroyTransientEncodingObjects(EncodingState& state) {
@@ -2347,16 +2350,12 @@ void VulkanDevice::Impl::transitionPassBoundTextures(EncodingState& state,
                                                      size_t beginIndex) {
   // An UNDEFINED oldLayout for a never-written texture is valid; its contents are undefined
   // either way.
-  const auto transitionTo = [&](uint32_t textureSlot, VkImageLayout target) {
+  const auto transitionTo = [&](uint32_t textureSlot, TextureUsageKind usage) {
     const TextureRecord* texture = FindRecord(textures, textureSlot);
     if (texture == nullptr) {
       return;  // Submit-time re-validation makes this unreachable.
     }
-    const VkImageLayout current = encodedLayoutOf(state, textureSlot, *texture);
-    if (current != target) {
-      RecordImageBarrier(*api, state.commandBuffer, texture->image, current, target);
-      state.stagedLayouts[textureSlot] = target;
-    }
+    transitionTexture(state.commandBuffer, textureSlot, *texture, usage);
   };
 
   for (size_t scanIndex = beginIndex + 1; scanIndex < commands.size(); ++scanIndex) {
@@ -2374,10 +2373,10 @@ void VulkanDevice::Impl::transitionPassBoundTextures(EncodingState& state,
       continue;  // The SetBindGroupCommand handler below fails closed on this.
     }
     for (const uint32_t sampledSlot : scannedGroup->sampledTextureSlots) {
-      transitionTo(sampledSlot, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+      transitionTo(sampledSlot, TextureUsageKind::SampledRead);
     }
     for (const uint32_t storageSlot : scannedGroup->storageTextureSlots) {
-      transitionTo(storageSlot, VK_IMAGE_LAYOUT_GENERAL);
+      transitionTo(storageSlot, TextureUsageKind::StorageWrite);
     }
   }
 }
@@ -2391,6 +2390,11 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   std::vector<VkAttachmentReference> colorRefs;
   std::vector<VkImageView> attachmentViews;
   std::vector<VkClearValue> clearValues;
+  // The pass's external dependencies are derived from the same model the barriers are: what last
+  // touched the attachments on the way in, and what their declared usage says can consume them on
+  // the way out. With several attachments the widest of each wins, so the edges cover them all.
+  TextureSyncState entryState;
+  TextureUsage attachmentUsage = TextureUsage::None;
 
   for (size_t i = 0; i < attachmentDescriptors.size(); ++i) {
     const RenderPassColorAttachment& attachment = attachmentDescriptors[i];
@@ -2402,12 +2406,12 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
           std::format("render pass attachment {} does not resolve to a Vulkan image", i)};
     }
 
-    // Conservative explicit transition to the attachment layout; the pass then begins and
-    // ends in COLOR_ATTACHMENT_OPTIMAL.
-    RecordImageBarrier(*api, state.commandBuffer, texture->image,
-                       encodedLayoutOf(state, view->textureSlot, *texture),
-                       VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-    state.stagedLayouts[view->textureSlot] = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    // Explicit transition to the attachment layout; the pass then begins and ends in
+    // COLOR_ATTACHMENT_OPTIMAL, so the pass itself performs no layout transition.
+    entryState = syncStates.stateOf(view->textureSlot);
+    attachmentUsage = attachmentUsage | texture->usage;
+    transitionTexture(state.commandBuffer, view->textureSlot, *texture,
+                      TextureUsageKind::ColorAttachment);
 
     VkAttachmentDescription attachmentDescription = {};
     attachmentDescription.format = ToVkFormat(texture->format);
@@ -2440,22 +2444,24 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   subpass.colorAttachmentCount = static_cast<uint32_t>(colorRefs.size());
   subpass.pColorAttachments = colorRefs.data();
 
-  // Conservative explicit external dependencies (the implicit defaults do not cover memory
-  // access): everything-before -> color output, and color output -> everything-after.
+  // Explicit external dependencies; the implicit defaults do not cover memory access. Both come
+  // from the resource-state model, because a precise image barrier behind a pass edge that still
+  // said ALL_COMMANDS would order nothing narrower than before.
+  const SubpassDependencyParams entryDependency = AttachmentEntryDependency(entryState);
+  const SubpassDependencyParams exitDependency = AttachmentExitDependency(attachmentUsage);
   VkSubpassDependency dependencies[2] = {};
   dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
   dependencies[0].dstSubpass = 0;
-  dependencies[0].srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-  dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
-  dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  dependencies[0].dstAccessMask =
-      VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  dependencies[0].srcStageMask = entryDependency.srcStage;
+  dependencies[0].srcAccessMask = entryDependency.srcAccess;
+  dependencies[0].dstStageMask = entryDependency.dstStage;
+  dependencies[0].dstAccessMask = entryDependency.dstAccess;
   dependencies[1].srcSubpass = 0;
   dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-  dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  dependencies[1].dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-  dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+  dependencies[1].srcStageMask = exitDependency.srcStage;
+  dependencies[1].srcAccessMask = exitDependency.srcAccess;
+  dependencies[1].dstStageMask = exitDependency.dstStage;
+  dependencies[1].dstAccessMask = exitDependency.dstAccess;
 
   VkRenderPassCreateInfo renderPassInfo = {};
   renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -2648,10 +2654,8 @@ Status VulkanDevice::Impl::encodeCopyTextureToBuffer(EncodingState& state,
                     copy.layout.offsetBytes)};
   }
 
-  RecordImageBarrier(*api, state.commandBuffer, texture->image,
-                     encodedLayoutOf(state, copy.textureId.slotIndex, *texture),
-                     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-  state.stagedLayouts[copy.textureId.slotIndex] = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  transitionTexture(state.commandBuffer, copy.textureId.slotIndex, *texture,
+                    TextureUsageKind::TransferRead);
 
   const uint32_t texelSize = TextureFormatBytesPerTexel(texture->format);
   VkBufferImageCopy copyRegion = {};
@@ -2756,19 +2760,25 @@ Status VulkanDevice::Impl::encodeEndComputePass(EncodingState& state) {
   if (!state.inComputePass) {
     return GpuError{GpuErrorType::InvalidState, "endComputePass without an active compute pass"};
   }
-  // Storage writes are not automatically visible to later reads. One conservative barrier at the
-  // pass boundary covers every consumer: a later pass, a copy, and a host read of a mapped
-  // buffer after the fence. HOST is named explicitly in both masks because ALL_COMMANDS does not
-  // include the host stage, and every buffer this backend allocates is host-visible, so a
-  // storage buffer a kernel wrote can be read straight from its mapping with no copy in between.
+  // Storage writes are not automatically visible to later reads. The only writable binding the
+  // runtime declares is a write-only storage texture, so a compute pass can write images and
+  // nothing else, and the edge out of it names exactly that: shader writes made available to the
+  // shader and transfer reads that can consume them. The per-image layout transition a later
+  // consumer needs is recorded separately, when that consumer is encoded.
+  //
+  // If a writable storage BUFFER binding kind ever enters the runtime, this edge must gain the
+  // host-visibility half - HOST_READ at the host stage - because every buffer this backend
+  // allocates is host-mapped and persistently mapped, so a kernel write to one would otherwise
+  // never become visible to the mapping the host reads through.
   VkMemoryBarrier barrier = {};
   barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
   barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-  barrier.dstAccessMask =
-      VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT | VK_ACCESS_HOST_READ_BIT;
+  barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
   api->vkCmdPipelineBarrier(state.commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_HOST_BIT, 0, 1,
-                            &barrier, 0, nullptr, 0, nullptr);
+                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+                                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                            0, 1, &barrier, 0, nullptr, 0, nullptr);
 
   state.inComputePass = false;
   state.currentComputePipeline = nullptr;
@@ -2810,14 +2820,10 @@ Status VulkanDevice::Impl::encodeCopyTextureToTexture(EncodingState& state,
   // Both operands move to their transfer layouts first. The staged layout is recorded for each so
   // a later pass's transition prescan starts from what this copy actually left behind, rather
   // than from the layout the texture was created in.
-  RecordImageBarrier(*api, state.commandBuffer, source->image,
-                     encodedLayoutOf(state, copy.textureSrcId.slotIndex, *source),
-                     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-  state.stagedLayouts[copy.textureSrcId.slotIndex] = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-  RecordImageBarrier(*api, state.commandBuffer, destination->image,
-                     encodedLayoutOf(state, copy.textureDstId.slotIndex, *destination),
-                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-  state.stagedLayouts[copy.textureDstId.slotIndex] = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  transitionTexture(state.commandBuffer, copy.textureSrcId.slotIndex, *source,
+                    TextureUsageKind::TransferRead);
+  transitionTexture(state.commandBuffer, copy.textureDstId.slotIndex, *destination,
+                    TextureUsageKind::TransferWrite);
 
   VkImageCopy copyRegion = {};
   copyRegion.srcSubresource = VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -2856,14 +2862,6 @@ Status VulkanDevice::Impl::encodeCommand(EncodingState& state, std::span<const C
   return OkStatus();
 }
 
-void VulkanDevice::Impl::commitStagedLayouts(EncodingState& state) {
-  for (const auto& [textureSlot, layout] : state.stagedLayouts) {
-    if (TextureRecord* texture = FindRecord(textures, textureSlot)) {
-      texture->currentLayout = layout;
-    }
-  }
-}
-
 Status VulkanDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
                               std::span<const Command> commands) {
   (void)commandBufferSlotIndex;
@@ -2880,6 +2878,9 @@ Status VulkanDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferS
   state.commandBuffer = commandBufferResult.result();
   state.boundSets.assign(kMaxBindGroups, VK_NULL_HANDLE);
   const auto failEncoding = [&](Status error) -> Status {
+    // Nothing recorded into this command buffer will execute, so the transitions staged while
+    // encoding it must not survive into the tracked state.
+    impl.syncStates.discardStaged();
     impl.destroyTransientEncodingObjects(state);
     return error;
   };
@@ -2928,9 +2929,8 @@ Status VulkanDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferS
     return failEncoding(VkError("vkQueueSubmit", result));
   }
 
-  // The GPU will execute the recorded transitions: commit the staged layouts to the tracked
-  // per-texture state.
-  impl.commitStagedLayouts(state);
+  // The GPU will execute the recorded transitions: commit them to the tracked per-texture state.
+  impl.syncStates.commitStaged();
 
   Impl::InFlightSubmission submission;
   submission.serial = submissionSerial;

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -1166,8 +1166,8 @@ struct VulkanDevice::Impl {
   /// observation only; nothing in the backend reads these back.
   std::vector<RecordedImageBarrierForTest> recordedBarriers;
   std::optional<RecordedSubpassDependencyForTest> lastEntryDependency;
-  /// Set by the test seam; makes the next internal upload report failure after staging.
-  bool failNextUpload = false;
+  /// Set by the test seam; makes the next internal upload report failure at the named point.
+  std::optional<UploadFailureModeForTest> uploadFailureMode;
 
   /// Destroys the transient objects of a staged upload, in reverse creation order.
   /// @param fence Upload fence, or null.
@@ -1194,7 +1194,7 @@ struct VulkanDevice::Impl {
   /// @param fence Set to the created fence.
   /// @param objectsStillInUse Set when the submission is still pending after the timeout.
   Status submitAndWaitTextureUpload(VkCommandBuffer commandBuffer, VkFence& fence,
-                                    bool& objectsStillInUse);
+                                    bool& objectsStillInUse, bool& reachedQueue);
 
   /// Destroys the Vulkan buffer backing \p slotIndex, if any.
   /// @param slotIndex Buffer slot.
@@ -1463,8 +1463,8 @@ VulkanDevice::lastRenderPassEntryDependencyForTest() const {
   return *impl_->lastEntryDependency;
 }
 
-void VulkanDevice::failNextTextureUploadForTest() {
-  impl_->failNextUpload = true;
+void VulkanDevice::failNextTextureUploadForTest(UploadFailureModeForTest mode) {
+  impl_->uploadFailureMode = mode;
 }
 
 std::string VulkanDevice::lastErrorForTest() const {
@@ -2189,7 +2189,7 @@ void VulkanDevice::Impl::recordTextureUploadCopy(VkCommandBuffer commandBuffer,
 }
 
 Status VulkanDevice::Impl::submitAndWaitTextureUpload(VkCommandBuffer commandBuffer, VkFence& fence,
-                                                      bool& objectsStillInUse) {
+                                                      bool& objectsStillInUse, bool& reachedQueue) {
   VkFenceCreateInfo fenceInfo = {};
   fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
   if (const VkResult result = api->vkCreateFence(device, &fenceInfo, nullptr, &fence);
@@ -2205,6 +2205,17 @@ Status VulkanDevice::Impl::submitAndWaitTextureUpload(VkCommandBuffer commandBuf
       result != VK_SUCCESS) {
     return VkError("vkQueueSubmit (writeTexture)", result);
   }
+  // Past this point the work is the queue's, and it will run whatever this call reports.
+  reachedQueue = true;
+
+  if (uploadFailureMode == UploadFailureModeForTest::AfterSubmit) {
+    // Test seam: stand in for a wait that times out on a submission the queue has accepted.
+    uploadFailureMode.reset();
+    objectsStillInUse = true;
+    return GpuError{GpuErrorType::InvalidState,
+                    "writeTexture: injected post-submit upload timeout"};
+  }
+
   if (const VkResult result =
           api->vkWaitForFences(device, 1, &fence, VK_TRUE, kUploadFenceTimeoutNs);
       result != VK_SUCCESS) {
@@ -2275,16 +2286,27 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return VkError("vkBeginCommandBuffer", result);
   }
 
-  // Every failure below has to leave the tracker exactly as it was. A transition staged here and
-  // not discarded would be promoted by the next unrelated successful submission's commit, and
-  // every later barrier for this texture would then be computed from a state the GPU never
-  // reached. The guard covers every exit, including ones added later.
+  // What the tracker should be left holding depends on where this stops, so the guard decides by
+  // where it got to rather than by whether it succeeded.
+  //
+  // Before the submission reaches the queue, the recorded transitions describe work that will
+  // never run: discarding them is what stops the next unrelated successful submission's commit
+  // from promoting a state the GPU never reached.
+  //
+  // Once the queue has accepted the submission, the opposite is true. The upload runs whether or
+  // not this call could wait for it, and the single in-order queue puts it ahead of every later
+  // submission, so the layout it leaves behind is exactly what those submissions' barriers will
+  // meet. Discarding then would make the tracker describe a state the image is not in - the
+  // mirror of the phantom the discard exists to prevent. A queue that never drains at all is a
+  // lost device, which resets tracking on its own.
   struct StagedUploadGuard {
-    Impl* impl = nullptr;    //!< Device whose staged state this guards.
-    bool committed = false;  //!< Set once the upload actually executed.
+    Impl* impl = nullptr;       //!< Device whose staged state this guards.
+    bool reachedQueue = false;  //!< Whether the queue accepted the submission.
 
     ~StagedUploadGuard() {
-      if (!committed) {
+      if (reachedQueue) {
+        impl->syncStates.commitStaged();
+      } else {
         impl->syncStates.discardStaged();
       }
     }
@@ -2298,17 +2320,17 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return VkError("vkEndCommandBuffer", result);
   }
 
-  if (impl.failNextUpload) {
+  if (impl.uploadFailureMode == UploadFailureModeForTest::BeforeSubmit) {
     // Test seam: fail exactly where a real end-of-recording or submit failure would, which is
-    // after the transitions have been staged and before anything commits them.
-    impl.failNextUpload = false;
+    // after the transitions have been staged and before anything reaches the queue.
+    impl.uploadFailureMode.reset();
     cleanup();
-    return GpuError{GpuErrorType::InvalidState, "writeTexture: injected upload failure"};
+    return GpuError{GpuErrorType::InvalidState, "writeTexture: injected pre-submit failure"};
   }
 
   bool objectsStillInUse = false;
-  const Status submitStatus =
-      impl.submitAndWaitTextureUpload(commandBuffer, fence, objectsStillInUse);
+  const Status submitStatus = impl.submitAndWaitTextureUpload(
+      commandBuffer, fence, objectsStillInUse, stagedUploadGuard.reachedQueue);
   if (submitStatus.hasError()) {
     if (!objectsStillInUse) {
       cleanup();
@@ -2316,9 +2338,8 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return submitStatus;
   }
 
-  // The upload executed, so the transitions it recorded are now the texture's real state.
-  impl.syncStates.commitStaged();
-  stagedUploadGuard.committed = true;
+  // The guard commits on the way out: the queue took this submission, so its transitions are
+  // the texture's real state.
   cleanup();
   return OkStatus();
 }

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -1162,6 +1162,13 @@ struct VulkanDevice::Impl {
   /// only once its submission reached the queue.
   TextureSyncStateTable syncStates;
 
+  /// Every image barrier recorded, and the most recent render pass's entry dependency. Test
+  /// observation only; nothing in the backend reads these back.
+  std::vector<RecordedImageBarrierForTest> recordedBarriers;
+  std::optional<RecordedSubpassDependencyForTest> lastEntryDependency;
+  /// Set by the test seam; makes the next internal upload report failure after staging.
+  bool failNextUpload = false;
+
   /// Destroys the transient objects of a staged upload, in reverse creation order.
   /// @param fence Upload fence, or null.
   /// @param commandBuffer Upload command buffer, or null.
@@ -1441,6 +1448,23 @@ Result<VulkanDevice::TrackedTextureLayout> VulkanDevice::trackedTextureLayoutFor
     case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL: return TrackedTextureLayout::ColorAttachment;
     default: return TrackedTextureLayout::Other;
   }
+}
+
+std::vector<VulkanDevice::RecordedImageBarrierForTest> VulkanDevice::recordedImageBarriersForTest()
+    const {
+  return impl_->recordedBarriers;
+}
+
+Result<VulkanDevice::RecordedSubpassDependencyForTest>
+VulkanDevice::lastRenderPassEntryDependencyForTest() const {
+  if (!impl_->lastEntryDependency.has_value()) {
+    return GpuError{GpuErrorType::InvalidState, "no render pass has been created"};
+  }
+  return *impl_->lastEntryDependency;
+}
+
+void VulkanDevice::failNextTextureUploadForTest() {
+  impl_->failNextUpload = true;
 }
 
 std::string VulkanDevice::lastErrorForTest() const {
@@ -2274,6 +2298,14 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return VkError("vkEndCommandBuffer", result);
   }
 
+  if (impl.failNextUpload) {
+    // Test seam: fail exactly where a real end-of-recording or submit failure would, which is
+    // after the transitions have been staged and before anything commits them.
+    impl.failNextUpload = false;
+    cleanup();
+    return GpuError{GpuErrorType::InvalidState, "writeTexture: injected upload failure"};
+  }
+
   bool objectsStillInUse = false;
   const Status submitStatus =
       impl.submitAndWaitTextureUpload(commandBuffer, fence, objectsStillInUse);
@@ -2300,6 +2332,10 @@ void VulkanDevice::Impl::transitionTexture(VkCommandBuffer commandBuffer, uint32
     return;  // Same layout and nothing to make available: no hazard to order.
   }
   RecordImageBarrier(*api, commandBuffer, record.image, params);
+  recordedBarriers.push_back(RecordedImageBarrierForTest{
+      textureSlot, static_cast<uint32_t>(params.srcStage), static_cast<uint32_t>(params.dstStage),
+      static_cast<uint32_t>(params.srcAccess), static_cast<uint32_t>(params.dstAccess),
+      static_cast<int32_t>(params.oldLayout), static_cast<int32_t>(params.newLayout)});
   syncStates.stage(textureSlot, StateAfterUsage(usage));
 }
 
@@ -2419,6 +2455,11 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   // from the resource-state model, because a precise image barrier behind a pass edge that still
   // said ALL_COMMANDS would order nothing narrower than before.
   const SubpassDependencyParams entryDependency = AttachmentEntryDependency(entryStates);
+  lastEntryDependency =
+      RecordedSubpassDependencyForTest{static_cast<uint32_t>(entryDependency.srcStage),
+                                       static_cast<uint32_t>(entryDependency.dstStage),
+                                       static_cast<uint32_t>(entryDependency.srcAccess),
+                                       static_cast<uint32_t>(entryDependency.dstAccess)};
   const SubpassDependencyParams exitDependency = AttachmentExitDependency(attachmentUsage);
   VkSubpassDependency dependencies[2] = {};
   dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -27,6 +27,7 @@
 
 #include "donner/base/Utils.h"
 #include "donner/gpu/GpuLimits.h"
+#include "donner/gpu/vulkan/VulkanBufferAllocator.h"
 #include "donner/gpu/vulkan/VulkanLoader.h"
 #include "donner/gpu/vulkan/VulkanResourceState.h"
 
@@ -711,18 +712,21 @@ struct VulkanDevice::Impl {
   VkInstance instance = VK_NULL_HANDLE;                    //!< Owning instance; set by Create.
   VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;        //!< Selected physical device.
   VkPhysicalDeviceMemoryProperties memoryProperties = {};  //!< Memory heaps/types of the device.
-  VkDevice device = VK_NULL_HANDLE;                        //!< Logical device.
-  VkQueue queue = VK_NULL_HANDLE;                          //!< The single graphics queue.
-  uint32_t queueFamilyIndex = 0;                           //!< Family index of \ref queue.
-  VkCommandPool commandPool = VK_NULL_HANDLE;              //!< Pool for all command buffers.
+  /// Where buffer memory comes from. One dedicated allocation per buffer today; the seam exists
+  /// so a suballocating implementation can replace that without touching any call site.
+  std::unique_ptr<BufferSuballocator> bufferAllocator;
+  VkDevice device = VK_NULL_HANDLE;            //!< Logical device.
+  VkQueue queue = VK_NULL_HANDLE;              //!< The single graphics queue.
+  uint32_t queueFamilyIndex = 0;               //!< Family index of \ref queue.
+  VkCommandPool commandPool = VK_NULL_HANDLE;  //!< Pool for all command buffers.
 
-  /// A buffer plus its dedicated allocation, persistently mapped (host-visible + coherent; see
-  /// the class comment for why every buffer is host-visible in this slice).
+  /// A buffer plus the memory it was bound into, persistently mapped (host-visible + coherent;
+  /// see the class comment for why every buffer is host-visible in this slice). Where that
+  /// memory comes from is the allocator's decision, not this record's.
   struct BufferRecord {
-    VkBuffer buffer = VK_NULL_HANDLE;        //!< Buffer handle.
-    VkDeviceMemory memory = VK_NULL_HANDLE;  //!< Dedicated allocation.
-    void* mapped = nullptr;                  //!< Persistent host mapping.
-    VkDeviceSize byteSize = 0;               //!< Creation size in bytes.
+    VkBuffer buffer = VK_NULL_HANDLE;  //!< Buffer handle.
+    BufferAllocation allocation;       //!< Memory this buffer was bound into.
+    VkDeviceSize byteSize = 0;         //!< Creation size in bytes.
   };
 
   /// An image plus its dedicated allocation. Its synchronization state lives in \ref syncStates
@@ -899,8 +903,8 @@ struct VulkanDevice::Impl {
     return commandBuffer;
   }
 
-  /// Creates a buffer with a dedicated persistently-mapped host-visible allocation. Used for
-  /// both RHI buffers and internal upload staging.
+  /// Creates a buffer and binds it to memory from the allocator. Used for both RHI buffers and
+  /// internal upload staging, so both benefit from whatever the allocator does.
   Result<BufferRecord> createHostVisibleBuffer(VkDeviceSize byteSize, VkBufferUsageFlags usage,
                                                std::string_view label) {
     BufferRecord record;
@@ -918,40 +922,13 @@ struct VulkanDevice::Impl {
           std::format("vkCreateBuffer for '{}' failed with {}", label, VkResultToString(result))};
     }
 
-    VkMemoryRequirements requirements = {};
-    api->vkGetBufferMemoryRequirements(device, record.buffer, &requirements);
-    const std::optional<uint32_t> memoryType =
-        FindMemoryType(memoryProperties, requirements.memoryTypeBits,
-                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    if (!memoryType) {
+    Result<BufferAllocation> allocation =
+        bufferAllocator->allocate(*api, device, record.buffer, label);
+    if (allocation.hasError()) {
       destroyBufferRecord(record);
-      return GpuError{GpuErrorType::InvalidState,
-                      std::format("no host-visible coherent memory type for buffer '{}'", label)};
+      return std::move(allocation).error();
     }
-
-    VkMemoryAllocateInfo allocateInfo = {};
-    allocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    allocateInfo.allocationSize = requirements.size;
-    allocateInfo.memoryTypeIndex = *memoryType;
-    if (const VkResult result =
-            api->vkAllocateMemory(device, &allocateInfo, nullptr, &record.memory);
-        result != VK_SUCCESS) {
-      destroyBufferRecord(record);
-      return GpuError{GpuErrorType::InvalidState,
-                      std::format("vkAllocateMemory of {} bytes for buffer '{}' failed with {}",
-                                  requirements.size, label, VkResultToString(result))};
-    }
-    if (const VkResult result = api->vkBindBufferMemory(device, record.buffer, record.memory, 0);
-        result != VK_SUCCESS) {
-      destroyBufferRecord(record);
-      return VkError("vkBindBufferMemory", result);
-    }
-    if (const VkResult result =
-            api->vkMapMemory(device, record.memory, 0, VK_WHOLE_SIZE, 0, &record.mapped);
-        result != VK_SUCCESS) {
-      destroyBufferRecord(record);
-      return VkError("vkMapMemory", result);
-    }
+    record.allocation = std::move(allocation).result();
     return record;
   }
 
@@ -961,11 +938,9 @@ struct VulkanDevice::Impl {
       api->vkDestroyBuffer(device, record.buffer, nullptr);
       record.buffer = VK_NULL_HANDLE;
     }
-    if (record.memory != VK_NULL_HANDLE) {
-      api->vkFreeMemory(device, record.memory, nullptr);
-      record.memory = VK_NULL_HANDLE;
+    if (bufferAllocator != nullptr) {
+      bufferAllocator->release(*api, device, record.allocation);
     }
-    record.mapped = nullptr;
   }
 
   /// Destroys a texture record's Vulkan objects.
@@ -1383,6 +1358,7 @@ std::unique_ptr<VulkanDevice> VulkanDevice::Create() {
   impl.commandPool = commandPool;
   api.vkGetDeviceQueue(device, selectedQueueFamily, 0, &impl.queue);
   api.vkGetPhysicalDeviceMemoryProperties(selectedDevice, &impl.memoryProperties);
+  impl.bufferAllocator = std::make_unique<DedicatedBufferAllocator>(impl.memoryProperties);
 
   if (setup.debugMessengerAvailable) {
     const DebugMessengerHandles messenger =
@@ -1459,13 +1435,13 @@ Result<std::vector<uint8_t>> VulkanDevice::readBackBuffer(const Buffer& buffer) 
     return std::move(status).error();
   }
   const Impl::BufferRecord* record = FindRecord(impl_->buffers, buffer.slotIndex());
-  if (record == nullptr || record->mapped == nullptr) {
+  if (record == nullptr || record->allocation.mapped == nullptr) {
     return GpuError{GpuErrorType::InvalidHandle,
                     std::format("buffer handle (slot {}) does not name a live Vulkan buffer",
                                 buffer.slotIndex())};
   }
 
-  const uint8_t* contents = static_cast<const uint8_t*>(record->mapped);
+  const uint8_t* contents = static_cast<const uint8_t*>(record->allocation.mapped);
   return std::vector<uint8_t>(contents, contents + record->byteSize);
 }
 
@@ -2165,12 +2141,13 @@ void VulkanDevice::onDestroyResource(std::string_view resourceName, uint32_t slo
 Status VulkanDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
                                    std::span<const uint8_t> data) {
   const Impl::BufferRecord* record = FindRecord(impl_->buffers, slotIndex);
-  if (record == nullptr || record->mapped == nullptr) {
+  if (record == nullptr || record->allocation.mapped == nullptr) {
     return GpuError{GpuErrorType::InvalidState,
                     std::format("buffer slot {} has no Vulkan buffer", slotIndex)};
   }
   if (!data.empty()) {
-    std::memcpy(static_cast<uint8_t*>(record->mapped) + offsetBytes, data.data(), data.size());
+    std::memcpy(static_cast<uint8_t*>(record->allocation.mapped) + offsetBytes, data.data(),
+                data.size());
   }
   return OkStatus();
 }
@@ -2275,7 +2252,7 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return std::move(stagingResult).error();
   }
   Impl::BufferRecord staging = std::move(stagingResult).result();
-  std::memcpy(staging.mapped, data.data(), data.size());
+  std::memcpy(staging.allocation.mapped, data.data(), data.size());
 
   // Fail-closed cleanup for every early return below.
   VkCommandBuffer commandBuffer = VK_NULL_HANDLE;

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -46,30 +46,6 @@ constexpr uint64_t kUploadFenceTimeoutNs = 60ull * 1000ull * 1000ull * 1000ull;
 /// driver installs usually do not have it, and it is skipped silently then).
 constexpr const char* kValidationLayerName = "VK_LAYER_KHRONOS_validation";
 
-/// Returns the name of a VkResult for diagnostics (the common codes; others print numerically).
-std::string VkResultToString(VkResult result) {
-  switch (result) {
-    case VK_SUCCESS: return "VK_SUCCESS";
-    case VK_NOT_READY: return "VK_NOT_READY";
-    case VK_TIMEOUT: return "VK_TIMEOUT";
-    case VK_ERROR_OUT_OF_HOST_MEMORY: return "VK_ERROR_OUT_OF_HOST_MEMORY";
-    case VK_ERROR_OUT_OF_DEVICE_MEMORY: return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
-    case VK_ERROR_INITIALIZATION_FAILED: return "VK_ERROR_INITIALIZATION_FAILED";
-    case VK_ERROR_DEVICE_LOST: return "VK_ERROR_DEVICE_LOST";
-    case VK_ERROR_MEMORY_MAP_FAILED: return "VK_ERROR_MEMORY_MAP_FAILED";
-    case VK_ERROR_LAYER_NOT_PRESENT: return "VK_ERROR_LAYER_NOT_PRESENT";
-    case VK_ERROR_EXTENSION_NOT_PRESENT: return "VK_ERROR_EXTENSION_NOT_PRESENT";
-    case VK_ERROR_FEATURE_NOT_PRESENT: return "VK_ERROR_FEATURE_NOT_PRESENT";
-    case VK_ERROR_INCOMPATIBLE_DRIVER: return "VK_ERROR_INCOMPATIBLE_DRIVER";
-    case VK_ERROR_TOO_MANY_OBJECTS: return "VK_ERROR_TOO_MANY_OBJECTS";
-    case VK_ERROR_FORMAT_NOT_SUPPORTED: return "VK_ERROR_FORMAT_NOT_SUPPORTED";
-    case VK_ERROR_FRAGMENTED_POOL: return "VK_ERROR_FRAGMENTED_POOL";
-    case VK_ERROR_OUT_OF_POOL_MEMORY: return "VK_ERROR_OUT_OF_POOL_MEMORY";
-    case VK_ERROR_INVALID_EXTERNAL_HANDLE: return "VK_ERROR_INVALID_EXTERNAL_HANDLE";
-    default: return std::format("VkResult({})", static_cast<int32_t>(result));
-  }
-}
-
 /// Builds a fail-closed \ref GpuError for a failed Vulkan call.
 GpuError VkError(std::string_view what, VkResult result) {
   return GpuError{GpuErrorType::InvalidState,
@@ -2275,6 +2251,21 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
     return VkError("vkBeginCommandBuffer", result);
   }
 
+  // Every failure below has to leave the tracker exactly as it was. A transition staged here and
+  // not discarded would be promoted by the next unrelated successful submission's commit, and
+  // every later barrier for this texture would then be computed from a state the GPU never
+  // reached. The guard covers every exit, including ones added later.
+  struct StagedUploadGuard {
+    Impl* impl = nullptr;    //!< Device whose staged state this guards.
+    bool committed = false;  //!< Set once the upload actually executed.
+
+    ~StagedUploadGuard() {
+      if (!committed) {
+        impl->syncStates.discardStaged();
+      }
+    }
+  } stagedUploadGuard{&impl, false};
+
   impl.recordTextureUploadCopy(commandBuffer, slotIndex, *texture, staging.buffer, dataLayout,
                                writeSize);
 
@@ -2295,6 +2286,7 @@ Status VulkanDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t>
 
   // The upload executed, so the transitions it recorded are now the texture's real state.
   impl.syncStates.commitStaged();
+  stagedUploadGuard.committed = true;
   cleanup();
   return OkStatus();
 }
@@ -2369,8 +2361,10 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   std::vector<VkClearValue> clearValues;
   // The pass's external dependencies are derived from the same model the barriers are: what last
   // touched the attachments on the way in, and what their declared usage says can consume them on
-  // the way out. With several attachments the widest of each wins, so the edges cover them all.
-  TextureSyncState entryState;
+  // the way out. One edge serves every attachment, so every attachment's prior state feeds it -
+  // keeping only the last one's would let a pass that loads an attachment a dispatch wrote be
+  // ordered as though nothing had ever written it.
+  std::vector<TextureSyncState> entryStates;
   TextureUsage attachmentUsage = TextureUsage::None;
 
   for (size_t i = 0; i < attachmentDescriptors.size(); ++i) {
@@ -2385,7 +2379,7 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
 
     // Explicit transition to the attachment layout; the pass then begins and ends in
     // COLOR_ATTACHMENT_OPTIMAL, so the pass itself performs no layout transition.
-    entryState = syncStates.stateOf(view->textureSlot);
+    entryStates.push_back(syncStates.stateOf(view->textureSlot));
     attachmentUsage = attachmentUsage | texture->usage;
     transitionTexture(state.commandBuffer, view->textureSlot, *texture,
                       TextureUsageKind::ColorAttachment);
@@ -2424,7 +2418,7 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   // Explicit external dependencies; the implicit defaults do not cover memory access. Both come
   // from the resource-state model, because a precise image barrier behind a pass edge that still
   // said ALL_COMMANDS would order nothing narrower than before.
-  const SubpassDependencyParams entryDependency = AttachmentEntryDependency(entryState);
+  const SubpassDependencyParams entryDependency = AttachmentEntryDependency(entryStates);
   const SubpassDependencyParams exitDependency = AttachmentExitDependency(attachmentUsage);
   VkSubpassDependency dependencies[2] = {};
   dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -33,17 +33,25 @@ namespace donner::gpu::vulkan {
  *
  * Memory model (documented simplification for this slice): every buffer lives in
  * HOST_VISIBLE | HOST_COHERENT memory and stays persistently mapped, so queue writes are a
- * `memcpy` and readback needs no staging. Such a memory type is guaranteed by the Vulkan
+ * `memcpy` and readback needs no staging. Which allocation a buffer is bound into is the
+ * allocator's decision, behind the seam in VulkanBufferAllocator.h: one dedicated allocation per
+ * buffer today, with a suballocating implementation replaceable there rather than at every call
+ * site, once measurement says the driver's allocation-count cap is the constraint worth spending
+ * complexity on. Such a memory type is guaranteed by the Vulkan
  * specification ("Device Memory": at least one memory type has both HOST_VISIBLE and
  * HOST_COHERENT), and both the CI software rasterizer and desktop GPUs expose it. Textures are
  * DEVICE_LOCAL (when available) with staged uploads through a transient host-visible buffer and
  * explicit image layout transitions.
  *
- * Synchronization is intentionally conservative and validation-clean: full ALL_COMMANDS /
- * memory-availability barriers around image layout transitions, explicit external subpass
- * dependencies on every render pass, and a HOST-domain buffer barrier after readback copies.
- * Barrier elision is deliberately not attempted; it would need counter and timing evidence
- * naming the bottleneck it removes.
+ * Synchronization is tracked per resource rather than assumed: every image barrier and both of
+ * every render pass's external dependencies are derived from the state model in
+ * VulkanResourceState.h, which records the stage and access that last touched each texture and
+ * names both ends of the transition to whatever uses it next. A pattern the model does not
+ * describe falls back to the maximal ALL_COMMANDS barrier, so an unrecognised usage costs
+ * precision and never correctness. Readback copies still end in a HOST-domain buffer barrier.
+ *
+ * Barrier elision - dropping a barrier the model says is needed - is still not attempted; that
+ * would need counter and timing evidence naming the bottleneck it removes.
  *
  * Threading: single-threaded use, matching \ref donner::gpu::Device's thread affinity.
  * Completion is tracked by polling per-submission fences from the owning thread; there are no

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -128,6 +128,40 @@ public:
    */
   Result<TrackedTextureLayout> trackedTextureLayoutForTest(const Texture& texture) const;
 
+  /// One image barrier the backend recorded, reported as plain numbers so this header stays free
+  /// of Vulkan types. Test accessor: which barriers are emitted is the whole contract of the
+  /// resource-state model, and it is not observable in the pixels a slice reads back.
+  struct RecordedImageBarrierForTest {
+    uint32_t textureSlot = 0;  //!< Slot of the texture the barrier applies to.
+    uint32_t srcStage = 0;     //!< Source pipeline stage mask.
+    uint32_t dstStage = 0;     //!< Destination pipeline stage mask.
+    uint32_t srcAccess = 0;    //!< Access made available.
+    uint32_t dstAccess = 0;    //!< Access made visible.
+    int32_t oldLayout = 0;     //!< Layout the image was in.
+    int32_t newLayout = 0;     //!< Layout the image moved to.
+  };
+
+  /// Every image barrier recorded since the device was created, oldest first. Test accessor.
+  [[nodiscard]] std::vector<RecordedImageBarrierForTest> recordedImageBarriersForTest() const;
+
+  /// The two halves of a render pass external dependency, as plain numbers. Test accessor.
+  struct RecordedSubpassDependencyForTest {
+    uint32_t srcStage = 0;   //!< Source pipeline stage mask.
+    uint32_t dstStage = 0;   //!< Destination pipeline stage mask.
+    uint32_t srcAccess = 0;  //!< Access made available.
+    uint32_t dstAccess = 0;  //!< Access made visible.
+  };
+
+  /// The entry-side external dependency of the most recently created render pass. Fails closed
+  /// when no render pass has been created. Test accessor.
+  [[nodiscard]] Result<RecordedSubpassDependencyForTest> lastRenderPassEntryDependencyForTest()
+      const;
+
+  /// Makes the next internal texture upload report failure after it has recorded its
+  /// transitions, so a test can prove a failed upload leaves nothing staged behind. Test seam;
+  /// the upload's Vulkan work is still recorded and submitted, only its result is replaced.
+  void failNextTextureUploadForTest();
+
   /// Message of the most recent asynchronous Vulkan failure observed while polling or waiting
   /// on fences (e.g. VK_ERROR_DEVICE_LOST), or an empty string if none occurred.
   /// Test/diagnostic accessor.

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -157,10 +157,22 @@ public:
   [[nodiscard]] Result<RecordedSubpassDependencyForTest> lastRenderPassEntryDependencyForTest()
       const;
 
-  /// Makes the next internal texture upload report failure after it has recorded its
-  /// transitions, so a test can prove a failed upload leaves nothing staged behind. Test seam;
-  /// the upload's Vulkan work is still recorded and submitted, only its result is replaced.
-  void failNextTextureUploadForTest();
+  /// Where an injected upload failure happens, which is what decides whether the transitions it
+  /// recorded describe anything the GPU will run.
+  enum class UploadFailureModeForTest : uint8_t {
+    /// The upload fails before anything reaches the queue, so its recorded work never runs.
+    BeforeSubmit,
+    /// The submission reaches the queue and the wait for it reports a timeout, so its recorded
+    /// work is still pending and will run.
+    AfterSubmit,
+  };
+
+  /// Makes the next internal texture upload report failure at \p mode, so a test can prove what
+  /// the tracker is left holding in each case. Test seam; the upload's Vulkan work is recorded
+  /// either way, only its reported result is replaced.
+  ///
+  /// @param mode Where the injected failure happens.
+  void failNextTextureUploadForTest(UploadFailureModeForTest mode);
 
   /// Message of the most recent asynchronous Vulkan failure observed while polling or waiting
   /// on fences (e.g. VK_ERROR_DEVICE_LOST), or an empty string if none occurred.

--- a/donner/gpu/vulkan/VulkanLoader.cc
+++ b/donner/gpu/vulkan/VulkanLoader.cc
@@ -282,4 +282,28 @@ Status VulkanLoader::loadDevice(VkDevice device) {
   return OkStatus();
 }
 
+/// Returns the name of a VkResult for diagnostics (the common codes; others print numerically).
+std::string VkResultToString(VkResult result) {
+  switch (result) {
+    case VK_SUCCESS: return "VK_SUCCESS";
+    case VK_NOT_READY: return "VK_NOT_READY";
+    case VK_TIMEOUT: return "VK_TIMEOUT";
+    case VK_ERROR_OUT_OF_HOST_MEMORY: return "VK_ERROR_OUT_OF_HOST_MEMORY";
+    case VK_ERROR_OUT_OF_DEVICE_MEMORY: return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+    case VK_ERROR_INITIALIZATION_FAILED: return "VK_ERROR_INITIALIZATION_FAILED";
+    case VK_ERROR_DEVICE_LOST: return "VK_ERROR_DEVICE_LOST";
+    case VK_ERROR_MEMORY_MAP_FAILED: return "VK_ERROR_MEMORY_MAP_FAILED";
+    case VK_ERROR_LAYER_NOT_PRESENT: return "VK_ERROR_LAYER_NOT_PRESENT";
+    case VK_ERROR_EXTENSION_NOT_PRESENT: return "VK_ERROR_EXTENSION_NOT_PRESENT";
+    case VK_ERROR_FEATURE_NOT_PRESENT: return "VK_ERROR_FEATURE_NOT_PRESENT";
+    case VK_ERROR_INCOMPATIBLE_DRIVER: return "VK_ERROR_INCOMPATIBLE_DRIVER";
+    case VK_ERROR_TOO_MANY_OBJECTS: return "VK_ERROR_TOO_MANY_OBJECTS";
+    case VK_ERROR_FORMAT_NOT_SUPPORTED: return "VK_ERROR_FORMAT_NOT_SUPPORTED";
+    case VK_ERROR_FRAGMENTED_POOL: return "VK_ERROR_FRAGMENTED_POOL";
+    case VK_ERROR_OUT_OF_POOL_MEMORY: return "VK_ERROR_OUT_OF_POOL_MEMORY";
+    case VK_ERROR_INVALID_EXTERNAL_HANDLE: return "VK_ERROR_INVALID_EXTERNAL_HANDLE";
+    default: return std::format("VkResult({})", static_cast<int32_t>(result));
+  }
+}
+
 }  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanLoader.h
+++ b/donner/gpu/vulkan/VulkanLoader.h
@@ -178,4 +178,9 @@ private:
   VulkanApi api_;
 };
 
+/// Returns the name of a VkResult for diagnostics (the common codes; others print
+/// numerically). Shared so every failure message in this backend names the result the same way.
+/// @param result Result to format.
+std::string VkResultToString(VkResult result);
+
 }  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanResourceState.cc
+++ b/donner/gpu/vulkan/VulkanResourceState.cc
@@ -120,7 +120,7 @@ TextureSyncState StateAfterUsage(TextureUsageKind usage) {
 
 ImageBarrierParams TransitionFor(const TextureSyncState& current, TextureUsageKind usage) {
   const VkImageLayout newLayout = LayoutForUsage(usage);
-  if (true) {  // NOT YET PRECISE: every pattern still takes the maximal barrier.
+  if (!IsTrackedLayout(current.layout) || usage == TextureUsageKind::Undefined) {
     // Either the image reached its layout through a path this table does not model, or the
     // caller named no real destination usage. Neither leaves anything precise to say.
     return ConservativeImageBarrier(current.layout, newLayout);
@@ -140,7 +140,7 @@ ImageBarrierParams TransitionFor(const TextureSyncState& current, TextureUsageKi
 
 SubpassDependencyParams AttachmentEntryDependency(const TextureSyncState& current) {
   SubpassDependencyParams params;
-  if (true) {  // NOT YET PRECISE.
+  if (!IsTrackedLayout(current.layout)) {
     params.conservative = true;
     params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
     params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
@@ -179,9 +179,9 @@ SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage) {
   }
 
   SubpassDependencyParams params;
-  params.srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-  params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
-  if (true) {  // NOT YET PRECISE.
+  params.srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  params.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  if (dstStage == 0) {
     // The attachment declares no consumer this table models, so nothing narrower than the
     // maximal edge can be justified.
     params.dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;

--- a/donner/gpu/vulkan/VulkanResourceState.cc
+++ b/donner/gpu/vulkan/VulkanResourceState.cc
@@ -1,0 +1,232 @@
+/// @file
+/// Implementation of the Vulkan backend's tracked resource-state model.
+
+#include "donner/gpu/vulkan/VulkanResourceState.h"
+
+namespace donner::gpu::vulkan {
+
+namespace {
+
+/// The stages a sampled read can happen in. A sampled texture is readable from the fragment
+/// stage of a render pass and from a compute dispatch, and the backend does not record which of
+/// the two a given binding will be read from, so the destination scope names both.
+constexpr VkPipelineStageFlags kSampledReadStages =
+    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
+/// The access bits that need an availability operation. Only writes have to be made available;
+/// a read that happened before needs no flushing, so naming it in a source scope would order
+/// strictly more than the hazard requires.
+constexpr VkAccessFlags kWriteAccessMask =
+    VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+    VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+
+/// Whether this component is the one that put a texture in \p layout. A layout it never produces
+/// came from somewhere it does not model, so a transition out of it cannot claim to know what
+/// last touched the image. @param layout Layout to classify.
+bool IsTrackedLayout(VkImageLayout layout) {
+  switch (layout) {
+    case VK_IMAGE_LAYOUT_UNDEFINED:
+    case VK_IMAGE_LAYOUT_GENERAL:
+    case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+    case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+    case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+    case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL: return true;
+    default: break;
+  }
+  return false;
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, TextureUsageKind value) {
+  switch (value) {
+    case TextureUsageKind::Undefined: return os << "Undefined";
+    case TextureUsageKind::ColorAttachment: return os << "ColorAttachment";
+    case TextureUsageKind::SampledRead: return os << "SampledRead";
+    case TextureUsageKind::StorageWrite: return os << "StorageWrite";
+    case TextureUsageKind::TransferRead: return os << "TransferRead";
+    case TextureUsageKind::TransferWrite: return os << "TransferWrite";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, const TextureSyncState& value) {
+  return os << "{layout=" << static_cast<int>(value.layout) << ", stage=0x" << std::hex
+            << value.stage << ", access=0x" << value.access << std::dec << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const ImageBarrierParams& value) {
+  return os << "{oldLayout=" << static_cast<int>(value.oldLayout)
+            << ", newLayout=" << static_cast<int>(value.newLayout) << ", srcStage=0x" << std::hex
+            << value.srcStage << ", dstStage=0x" << value.dstStage << ", srcAccess=0x"
+            << value.srcAccess << ", dstAccess=0x" << value.dstAccess << std::dec
+            << ", conservative=" << (value.conservative ? "true" : "false") << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value) {
+  return os << "{srcStage=0x" << std::hex << value.srcStage << ", dstStage=0x" << value.dstStage
+            << ", srcAccess=0x" << value.srcAccess << ", dstAccess=0x" << value.dstAccess
+            << std::dec << ", conservative=" << (value.conservative ? "true" : "false") << "}";
+}
+
+ImageBarrierParams ConservativeImageBarrier(VkImageLayout oldLayout, VkImageLayout newLayout) {
+  ImageBarrierParams params;
+  params.oldLayout = oldLayout;
+  params.newLayout = newLayout;
+  params.srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+  params.dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+  params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
+  params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+  params.conservative = true;
+  return params;
+}
+
+VkImageLayout LayoutForUsage(TextureUsageKind usage) {
+  switch (usage) {
+    case TextureUsageKind::Undefined: return VK_IMAGE_LAYOUT_UNDEFINED;
+    case TextureUsageKind::ColorAttachment: return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    case TextureUsageKind::SampledRead: return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    case TextureUsageKind::StorageWrite: return VK_IMAGE_LAYOUT_GENERAL;
+    case TextureUsageKind::TransferRead: return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    case TextureUsageKind::TransferWrite: return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  }
+  return VK_IMAGE_LAYOUT_UNDEFINED;
+}
+
+TextureSyncState StateAfterUsage(TextureUsageKind usage) {
+  switch (usage) {
+    case TextureUsageKind::Undefined:
+      // Nothing has touched the image, so a barrier out of this state waits for nothing.
+      return TextureSyncState{VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0};
+    case TextureUsageKind::ColorAttachment:
+      return TextureSyncState{VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT};
+    case TextureUsageKind::SampledRead:
+      return TextureSyncState{VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, kSampledReadStages,
+                              VK_ACCESS_SHADER_READ_BIT};
+    case TextureUsageKind::StorageWrite:
+      return TextureSyncState{VK_IMAGE_LAYOUT_GENERAL, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                              VK_ACCESS_SHADER_WRITE_BIT};
+    case TextureUsageKind::TransferRead:
+      return TextureSyncState{VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                              VK_ACCESS_TRANSFER_READ_BIT};
+    case TextureUsageKind::TransferWrite:
+      return TextureSyncState{VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                              VK_ACCESS_TRANSFER_WRITE_BIT};
+  }
+  return TextureSyncState{};
+}
+
+ImageBarrierParams TransitionFor(const TextureSyncState& current, TextureUsageKind usage) {
+  const VkImageLayout newLayout = LayoutForUsage(usage);
+  if (true) {  // NOT YET PRECISE: every pattern still takes the maximal barrier.
+    // Either the image reached its layout through a path this table does not model, or the
+    // caller named no real destination usage. Neither leaves anything precise to say.
+    return ConservativeImageBarrier(current.layout, newLayout);
+  }
+
+  const TextureSyncState next = StateAfterUsage(usage);
+  ImageBarrierParams params;
+  params.oldLayout = current.layout;
+  params.newLayout = newLayout;
+  params.srcStage = current.stage;
+  params.dstStage = next.stage;
+  params.srcAccess = current.access & kWriteAccessMask;
+  params.dstAccess = next.access;
+  params.conservative = false;
+  return params;
+}
+
+SubpassDependencyParams AttachmentEntryDependency(const TextureSyncState& current) {
+  SubpassDependencyParams params;
+  if (true) {  // NOT YET PRECISE.
+    params.conservative = true;
+    params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
+    params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+    return params;
+  }
+  params.srcStage = current.stage;
+  params.srcAccess = current.access & kWriteAccessMask;
+  params.dstStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  params.dstAccess = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  params.conservative = false;
+  return params;
+}
+
+SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage) {
+  VkPipelineStageFlags dstStage = 0;
+  VkAccessFlags dstAccess = 0;
+  if (HasAllFlags(declaredUsage, TextureUsage::Sampled)) {
+    dstStage |= kSampledReadStages;
+    dstAccess |= VK_ACCESS_SHADER_READ_BIT;
+  }
+  if (HasAllFlags(declaredUsage, TextureUsage::StorageBinding)) {
+    dstStage |= VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    dstAccess |= VK_ACCESS_SHADER_WRITE_BIT;
+  }
+  if (HasAllFlags(declaredUsage, TextureUsage::CopySrc)) {
+    dstStage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+    dstAccess |= VK_ACCESS_TRANSFER_READ_BIT;
+  }
+  if (HasAllFlags(declaredUsage, TextureUsage::CopyDst)) {
+    dstStage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+    dstAccess |= VK_ACCESS_TRANSFER_WRITE_BIT;
+  }
+  if (HasAllFlags(declaredUsage, TextureUsage::RenderAttachment)) {
+    dstStage |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dstAccess |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  }
+
+  SubpassDependencyParams params;
+  params.srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+  params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
+  if (true) {  // NOT YET PRECISE.
+    // The attachment declares no consumer this table models, so nothing narrower than the
+    // maximal edge can be justified.
+    params.dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+    params.conservative = true;
+    return params;
+  }
+  params.dstStage = dstStage;
+  params.dstAccess = dstAccess;
+  params.conservative = false;
+  return params;
+}
+
+TextureSyncState TextureSyncStateTable::stateOf(uint32_t textureSlot) const {
+  if (const auto staged = staged_.find(textureSlot); staged != staged_.end()) {
+    return staged->second;
+  }
+  if (const auto committed = committed_.find(textureSlot); committed != committed_.end()) {
+    return committed->second;
+  }
+  return TextureSyncState{};
+}
+
+void TextureSyncStateTable::stage(uint32_t textureSlot, const TextureSyncState& state) {
+  staged_[textureSlot] = state;
+}
+
+void TextureSyncStateTable::commitStaged() {
+  for (const auto& [textureSlot, state] : staged_) {
+    committed_[textureSlot] = state;
+  }
+  staged_.clear();
+}
+
+void TextureSyncStateTable::discardStaged() {
+  staged_.clear();
+}
+
+void TextureSyncStateTable::forget(uint32_t textureSlot) {
+  committed_.erase(textureSlot);
+  staged_.erase(textureSlot);
+}
+
+bool TextureSyncStateTable::hasStagedChanges() const {
+  return !staged_.empty();
+}
+
+}  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanResourceState.cc
+++ b/donner/gpu/vulkan/VulkanResourceState.cc
@@ -69,14 +69,38 @@ std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value)
             << std::dec << ", conservative=" << (value.conservative ? "true" : "false") << "}";
 }
 
+namespace {
+
+/// The one maximal scope every conservative fallback uses: wait for everything, make every write
+/// available, make every access visible. VK_ACCESS_MEMORY_* is valid with any stage, so this is
+/// always legal and always orders at least as much as a precise scope would.
+namespace maximal {
+constexpr VkPipelineStageFlags kStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+constexpr VkAccessFlags kSrcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
+constexpr VkAccessFlags kDstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+}  // namespace maximal
+
+/// The maximal subpass dependency, for a pass whose scope cannot be narrowed.
+SubpassDependencyParams ConservativeSubpassDependency() {
+  SubpassDependencyParams params;
+  params.srcStage = maximal::kStage;
+  params.dstStage = maximal::kStage;
+  params.srcAccess = maximal::kSrcAccess;
+  params.dstAccess = maximal::kDstAccess;
+  params.conservative = true;
+  return params;
+}
+
+}  // namespace
+
 ImageBarrierParams ConservativeImageBarrier(VkImageLayout oldLayout, VkImageLayout newLayout) {
   ImageBarrierParams params;
   params.oldLayout = oldLayout;
   params.newLayout = newLayout;
-  params.srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-  params.dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-  params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
-  params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+  params.srcStage = maximal::kStage;
+  params.dstStage = maximal::kStage;
+  params.srcAccess = maximal::kSrcAccess;
+  params.dstAccess = maximal::kDstAccess;
   params.conservative = true;
   return params;
 }
@@ -138,16 +162,26 @@ ImageBarrierParams TransitionFor(const TextureSyncState& current, TextureUsageKi
   return params;
 }
 
-SubpassDependencyParams AttachmentEntryDependency(const TextureSyncState& current) {
-  SubpassDependencyParams params;
-  if (!IsTrackedLayout(current.layout)) {
-    params.conservative = true;
-    params.srcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
-    params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
-    return params;
+SubpassDependencyParams AttachmentEntryDependency(
+    std::span<const TextureSyncState> attachmentStates) {
+  if (attachmentStates.empty()) {
+    return ConservativeSubpassDependency();
   }
-  params.srcStage = current.stage;
-  params.srcAccess = current.access & kWriteAccessMask;
+
+  SubpassDependencyParams params;
+  params.srcStage = 0;
+  params.srcAccess = 0;
+  for (const TextureSyncState& state : attachmentStates) {
+    if (!IsTrackedLayout(state.layout)) {
+      return ConservativeSubpassDependency();
+    }
+    // One edge serves every attachment, so it must wait for the widest thing any of them was
+    // last touched by. Narrowing to a single attachment would drop another's prior write: a pass
+    // that loads one attachment a dispatch wrote and clears another still has to wait for that
+    // write to be both available and visible to the load.
+    params.srcStage |= state.stage;
+    params.srcAccess |= state.access & kWriteAccessMask;
+  }
   params.dstStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   params.dstAccess = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   params.conservative = false;
@@ -178,17 +212,14 @@ SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage) {
     dstAccess |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   }
 
-  SubpassDependencyParams params;
-  params.srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  params.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   if (dstStage == 0) {
     // The attachment declares no consumer this table models, so nothing narrower than the
     // maximal edge can be justified.
-    params.dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    params.dstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
-    params.conservative = true;
-    return params;
+    return ConservativeSubpassDependency();
   }
+  SubpassDependencyParams params;
+  params.srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  params.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   params.dstStage = dstStage;
   params.dstAccess = dstAccess;
   params.conservative = false;

--- a/donner/gpu/vulkan/VulkanResourceState.h
+++ b/donner/gpu/vulkan/VulkanResourceState.h
@@ -1,0 +1,186 @@
+#pragma once
+/// @file
+/// \c donner::gpu::vulkan::VulkanResourceState - the tracked per-texture synchronization state
+/// the Vulkan backend derives its barriers from.
+///
+/// Every barrier this backend records, and every render pass external dependency it declares,
+/// is derived here from one table so the two cannot disagree. A precise image barrier sitting
+/// behind a render pass dependency that still says ALL_COMMANDS buys nothing: the dependency is
+/// the edge that orders an attachment write against whatever reads it next, so both halves read
+/// from the same source of truth.
+///
+/// This is pure state machinery over Vulkan enums: it opens no device, calls no entry point, and
+/// records nothing. That keeps it testable on every platform the project builds on, rather than
+/// only where a Vulkan loader exists.
+///
+/// The tracked patterns are the ones the recorded command streams actually produce. Anything
+/// outside them resolves to \ref ConservativeImageBarrier, which is the maximal
+/// ALL_COMMANDS/memory barrier this backend used everywhere before: unknown usage costs
+/// precision, never correctness.
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <map>
+#include <ostream>
+
+#include "donner/gpu/Descriptors.h"
+
+namespace donner::gpu::vulkan {
+
+/// What a texture is being used for at one point of a recorded command stream.
+///
+/// Write-only storage textures are the only writable binding the runtime declares, so a storage
+/// usage is unambiguously a write and needs no read/write fallback. If a writable storage BUFFER
+/// binding kind ever enters the runtime, this enum and the table below must gain the
+/// host-visibility edge that goes with it, because every buffer this backend allocates is
+/// host-mapped and a kernel write to one would otherwise be invisible to the mapping.
+enum class TextureUsageKind : uint8_t {
+  Undefined,        //!< Never used; contents undefined.
+  ColorAttachment,  //!< Written as a render pass color attachment.
+  SampledRead,      //!< Read through a sampled-texture binding.
+  StorageWrite,     //!< Written through a write-only storage-texture binding.
+  TransferRead,     //!< Read as the source of a copy.
+  TransferWrite,    //!< Written as the destination of a copy or an upload.
+};
+
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, TextureUsageKind value);
+
+/// The synchronization state a texture is left in, as the backend's bookkeeping records it.
+///
+/// The stage and access describe what last *touched* the image, which is what a later barrier
+/// names as its source scope. A freshly created texture has touched nothing, so it carries the
+/// top-of-pipe stage and an empty access mask: a barrier out of that state waits for nothing,
+/// which is correct rather than merely permissive.
+struct TextureSyncState {
+  VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;                //!< Current image layout.
+  VkPipelineStageFlags stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;  //!< Stage that last touched it.
+  VkAccessFlags access = 0;                                        //!< Access that last touched it.
+
+  /// Equality operator. @param other State to compare against.
+  bool operator==(const TextureSyncState& other) const = default;
+};
+
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, const TextureSyncState& value);
+
+/// The six values an image barrier is built from, plus whether precision was available.
+struct ImageBarrierParams {
+  VkImageLayout oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;  //!< Layout the image is in.
+  VkImageLayout newLayout = VK_IMAGE_LAYOUT_UNDEFINED;  //!< Layout the image moves to.
+  VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Source stage scope.
+  VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Destination scope.
+  VkAccessFlags srcAccess = 0;                                         //!< Access made available.
+  VkAccessFlags dstAccess = 0;                                         //!< Access made visible.
+  /// True when the usage pair fell outside the tracked set and the maximal barrier was used.
+  bool conservative = false;
+
+  /// Equality operator. @param other Parameters to compare against.
+  bool operator==(const ImageBarrierParams& other) const = default;
+};
+
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, const ImageBarrierParams& value);
+
+/// The two halves of a render pass external subpass dependency.
+struct SubpassDependencyParams {
+  VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Source stage scope.
+  VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Destination scope.
+  VkAccessFlags srcAccess = 0;                                         //!< Access made available.
+  VkAccessFlags dstAccess = 0;                                         //!< Access made visible.
+  /// True when the declared usage implied nothing tracked and the maximal edge was used.
+  bool conservative = false;
+
+  /// Equality operator. @param other Parameters to compare against.
+  bool operator==(const SubpassDependencyParams& other) const = default;
+};
+
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value);
+
+/// The maximal barrier: ALL_COMMANDS to ALL_COMMANDS with memory availability and visibility.
+///
+/// The fallback for any usage pair the table does not name. VK_ACCESS_MEMORY_* is valid with any
+/// pipeline stage, so this is always legal, and it orders strictly more than any precise barrier
+/// would - which is why an unrecognised pattern degrades to it rather than to nothing.
+///
+/// @param oldLayout Layout the image is in.
+/// @param newLayout Layout the image moves to.
+[[nodiscard]] ImageBarrierParams ConservativeImageBarrier(VkImageLayout oldLayout,
+                                                          VkImageLayout newLayout);
+
+/// The image layout a usage requires. @param usage Usage the texture is put to.
+[[nodiscard]] VkImageLayout LayoutForUsage(TextureUsageKind usage);
+
+/// The state a texture is left in once \p usage has executed against it.
+/// @param usage Usage the texture is put to.
+[[nodiscard]] TextureSyncState StateAfterUsage(TextureUsageKind usage);
+
+/// The barrier that takes a texture from \p current to \p usage.
+///
+/// The source scope comes from what last touched the image and the destination scope from what
+/// is about to, so the tracked patterns - attachment write to sampled read, storage write to
+/// sampled read, transfer write to shader read, and their transfer counterparts - name the
+/// stages and accesses actually involved instead of every stage and every access.
+///
+/// @param current State the texture is tracked in.
+/// @param usage Usage the texture is about to be put to.
+[[nodiscard]] ImageBarrierParams TransitionFor(const TextureSyncState& current,
+                                               TextureUsageKind usage);
+
+/// The external dependency into a render pass, ordering whatever touched the attachment before
+/// it against the pass's color output.
+/// @param current State the attachment texture is tracked in.
+[[nodiscard]] SubpassDependencyParams AttachmentEntryDependency(const TextureSyncState& current);
+
+/// The external dependency out of a render pass, ordering the pass's color output against
+/// whatever the attachment's declared usage says can consume it next.
+///
+/// The consumer is read from the texture's declared usage set rather than by scanning ahead: a
+/// texture declared Sampled gets the shader-read edge, one declared CopySrc the transfer-read
+/// edge, and one declaring several gets their union. A usage set naming no tracked consumer
+/// falls back to the maximal edge.
+///
+/// @param declaredUsage Usage flags the attachment texture was created with.
+[[nodiscard]] SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage);
+
+/**
+ * Tracked state for a set of textures, under the discipline the backend records against.
+ *
+ * A transition recorded into a command buffer updates the staged view; only a submission that
+ * actually reached the queue commits it. An encode that fails partway, or a submit the driver
+ * rejects, discards the staging instead - so the table never claims a transition the GPU never
+ * ran, which would make every later barrier compute the wrong source scope from a state that
+ * does not exist.
+ */
+class TextureSyncStateTable {
+public:
+  /// The state \p textureSlot will be in at this point of an encode: the staged state when one
+  /// was recorded, otherwise the committed one. A slot never seen reads as untouched.
+  /// @param textureSlot Texture slot to query.
+  [[nodiscard]] TextureSyncState stateOf(uint32_t textureSlot) const;
+
+  /// Records that a transition to \p state was encoded, pending submission.
+  /// @param textureSlot Texture slot the transition applies to. @param state Resulting state.
+  void stage(uint32_t textureSlot, const TextureSyncState& state);
+
+  /// Promotes every staged transition to committed. Call only once the submission succeeded.
+  void commitStaged();
+
+  /// Drops every staged transition, leaving committed state untouched.
+  void discardStaged();
+
+  /// Forgets a slot entirely, for a texture that no longer exists.
+  /// @param textureSlot Texture slot to drop.
+  void forget(uint32_t textureSlot);
+
+  /// Whether any transition is staged and not yet committed.
+  [[nodiscard]] bool hasStagedChanges() const;
+
+private:
+  std::map<uint32_t, TextureSyncState> committed_;  //!< State the GPU has actually reached.
+  std::map<uint32_t, TextureSyncState> staged_;     //!< Transitions encoded but not submitted.
+};
+
+}  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/VulkanResourceState.h
+++ b/donner/gpu/vulkan/VulkanResourceState.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <map>
 #include <ostream>
+#include <span>
 
 #include "donner/gpu/Descriptors.h"
 
@@ -129,10 +130,18 @@ std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value)
 [[nodiscard]] ImageBarrierParams TransitionFor(const TextureSyncState& current,
                                                TextureUsageKind usage);
 
-/// The external dependency into a render pass, ordering whatever touched the attachment before
+/// The external dependency into a render pass, ordering whatever touched the attachments before
 /// it against the pass's color output.
-/// @param current State the attachment texture is tracked in.
-[[nodiscard]] SubpassDependencyParams AttachmentEntryDependency(const TextureSyncState& current);
+///
+/// One edge covers every attachment, so the source scope is the union across all of them: a pass
+/// that loads one attachment a compute dispatch wrote and clears another must still wait for
+/// that write, and taking any single attachment's prior state would lose it. A pass with no
+/// attachments, or one whose attachment reached its layout through a path the model does not
+/// describe, falls back to the maximal edge.
+///
+/// @param attachmentStates State each attachment texture is tracked in, in any order.
+[[nodiscard]] SubpassDependencyParams AttachmentEntryDependency(
+    std::span<const TextureSyncState> attachmentStates);
 
 /// The external dependency out of a render pass, ordering the pass's color output against
 /// whatever the attachment's declared usage says can consume it next.

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -16,6 +16,18 @@ load("//build_defs:package.bzl", "donner_package")
 # renderer suites - reachable from plain `bazel test //...` without
 # --config=geode. On macOS the impl target is incompatible and the wrapper is
 # skipped.
+# The resource-state model is pure state machinery over Vulkan enums: it opens no device and
+# calls no entry point, so unlike every other test here it runs on every platform rather than
+# only where a Vulkan loader exists.
+donner_cc_test(
+    name = "vulkan_resource_state_tests",
+    srcs = ["VulkanResourceState_tests.cc"],
+    deps = [
+        "//donner/gpu/vulkan:vulkan_resource_state",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_cc_test(
     name = "vulkan_solid_fill_tests_impl",
     srcs = ["VulkanSolidFill_tests.cc"],

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -28,6 +28,24 @@ donner_cc_test(
     ],
 )
 
+# Device-level regressions for the resource-state wiring: what the backend emits and what it
+# leaves in the tracker when work fails. Needs a real device, so Linux only.
+donner_cc_test(
+    name = "vulkan_resource_state_device_tests",
+    srcs = ["VulkanResourceStateDevice_tests.cc"],
+    env = {
+        "DONNER_REQUIRE_VULKAN": "1",
+        "XDG_RUNTIME_DIR": "/tmp",
+    },
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "//donner/gpu",
+        "//donner/gpu/vulkan:vulkan_device",
+        "//donner/gpu/vulkan:vulkan_resource_state",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_cc_test(
     name = "vulkan_solid_fill_tests_impl",
     srcs = ["VulkanSolidFill_tests.cc"],

--- a/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
@@ -1,0 +1,196 @@
+/// @file
+/// Device-level regressions for the resource-state wiring: the barriers and render pass
+/// dependencies the backend actually emits, and what it leaves in the tracker when work fails.
+///
+/// The model's own suite covers the table. These cover the code that feeds it, which is where
+/// both of the defects this file exists for lived. They need a real device, so unlike the model
+/// suite they run only where a Vulkan loader exists.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/vulkan/VulkanDevice.h"
+#include "donner/gpu/vulkan/VulkanResourceState.h"
+
+namespace donner::gpu::vulkan::tests {
+namespace {
+
+constexpr uint32_t kExtent = 4;
+/// Buffer-image copy rows are 256-byte aligned, as every other upload in this suite is; the
+/// upload buffer is padded to that pitch rather than packed.
+constexpr uint32_t kBytesPerRow = 256;
+
+class VulkanResourceStateDeviceTest : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = VulkanDevice::Create();
+    if (!device_) {
+      // CI sets DONNER_REQUIRE_VULKAN=1 (see BUILD.bazel) so a missing driver is a red test
+      // instead of a silent skip; local runs without a Vulkan runtime still skip.
+      const char* requireVulkan = std::getenv("DONNER_REQUIRE_VULKAN");
+      if (requireVulkan != nullptr && std::string_view(requireVulkan) == "1") {
+        FAIL() << "DONNER_REQUIRE_VULKAN=1 is set but no Vulkan 1.1 device is available";
+      }
+      GTEST_SKIP() << "No Vulkan 1.1 device available";
+    }
+  }
+
+  /// Unwraps an RHI result, failing the test on error.
+  template <typename T>
+  T unwrap(Result<T>&& result, const char* what) {
+    if (result.hasError()) {
+      ADD_FAILURE() << what << " failed: " << result.error();
+    }
+    return std::move(result).result();
+  }
+
+  /// A texture of the standard test extent with \p usage.
+  Texture makeTexture(const char* label, TextureUsage usage) {
+    return unwrap(device_->createTexture(TextureDescriptor{label, Extent2d{kExtent, kExtent},
+                                                           TextureFormat::RGBA8Unorm, usage}),
+                  "createTexture");
+  }
+
+  /// Bytes for one full upload of the standard extent.
+  static std::vector<uint8_t> uploadBytes() {
+    return std::vector<uint8_t>(size_t{kBytesPerRow} * kExtent, 0x40);
+  }
+
+  static TexelCopyBufferLayout uploadLayout() {
+    return TexelCopyBufferLayout{0, kBytesPerRow, kExtent};
+  }
+
+  /// Barriers recorded against \p slot since the device was created.
+  std::vector<VulkanDevice::RecordedImageBarrierForTest> barriersFor(uint32_t slot) const {
+    std::vector<VulkanDevice::RecordedImageBarrierForTest> matching;
+    for (const VulkanDevice::RecordedImageBarrierForTest& barrier :
+         device_->recordedImageBarriersForTest()) {
+      if (barrier.textureSlot == slot) {
+        matching.push_back(barrier);
+      }
+    }
+    return matching;
+  }
+
+  std::unique_ptr<VulkanDevice> device_;
+};
+
+TEST_F(VulkanResourceStateDeviceTest, AFailedUploadLeavesNoStateForALaterSubmitToPromote) {
+  // Not Sampled, so a completed upload would leave this texture in the transfer-destination
+  // layout and a failed one must leave it untouched - a difference the tracker can show.
+  Texture written = makeTexture("written", TextureUsage::CopyDst | TextureUsage::CopySrc);
+  Texture other = makeTexture("other", TextureUsage::CopyDst | TextureUsage::CopySrc);
+
+  ASSERT_EQ(unwrap(device_->trackedTextureLayoutForTest(written), "layout before"),
+            VulkanDevice::TrackedTextureLayout::Undefined);
+
+  device_->failNextTextureUploadForTest();
+  EXPECT_TRUE(
+      device_->writeTexture(written, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent})
+          .hasError())
+      << "the seam must make this upload fail";
+
+  // An unrelated, successful submission. Before the fix its commit promoted whatever the failed
+  // upload had staged, because both share one tracker.
+  Status otherUpload =
+      device_->writeTexture(other, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(otherUpload.hasError()) << otherUpload.error();
+
+  EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(written), "layout after"),
+            VulkanDevice::TrackedTextureLayout::Undefined)
+      << "the failed upload never ran, so nothing it staged may become the texture's real state";
+}
+
+TEST_F(VulkanResourceStateDeviceTest, ThePassEntryEdgeCoversAnAttachmentThatIsNotTheLast) {
+  // One attachment carries a prior write, the other is untouched, and the written one is not
+  // last: deriving the edge from a single attachment picks up the untouched one and orders
+  // nothing. A transfer stands in for the producing write here; which stage and access a given
+  // producer contributes is what the model suite covers.
+  Texture producedFirst =
+      makeTexture("producedFirst", TextureUsage::RenderAttachment | TextureUsage::CopyDst);
+  Texture freshSecond = makeTexture("freshSecond", TextureUsage::RenderAttachment);
+
+  Status producedFirstUpload = device_->writeTexture(producedFirst, uploadBytes(), uploadLayout(),
+                                                     Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(producedFirstUpload.hasError()) << producedFirstUpload.error();
+
+  TextureView writtenView =
+      unwrap(device_->createTextureView(producedFirst, TextureViewDescriptor{"writtenView"}),
+             "createTextureView written");
+  TextureView freshView =
+      unwrap(device_->createTextureView(freshSecond, TextureViewDescriptor{"freshView"}),
+             "createTextureView fresh");
+
+  std::unique_ptr<CommandEncoder> encoder =
+      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+  RenderPassDescriptor pass;
+  pass.colorAttachments.push_back(
+      RenderPassColorAttachment{writtenView, LoadOp::Load, StoreOp::Store, {0, 0, 0, 0}});
+  pass.colorAttachments.push_back(
+      RenderPassColorAttachment{freshView, LoadOp::Clear, StoreOp::Store, {0, 0, 0, 1}});
+  Result<RenderPassEncoder*> renderPass = encoder->beginRenderPass(pass);
+  ASSERT_FALSE(renderPass.hasError()) << renderPass.error();
+  ASSERT_FALSE(renderPass.result()->end().hasError());
+
+  Result<CommandBuffer> commands = encoder->finish();
+  ASSERT_FALSE(commands.hasError()) << commands.error();
+  Result<uint64_t> serial = device_->submit(std::move(commands).result());
+  ASSERT_FALSE(serial.hasError()) << serial.error();
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0));
+
+  const VulkanDevice::RecordedSubpassDependencyForTest entry =
+      unwrap(device_->lastRenderPassEntryDependencyForTest(), "entry dependency");
+  EXPECT_TRUE((entry.srcStage & VK_PIPELINE_STAGE_TRANSFER_BIT) != 0)
+      << "the load of the written attachment must be ordered after the write that produced it";
+  EXPECT_TRUE((entry.srcAccess & VK_ACCESS_TRANSFER_WRITE_BIT) != 0)
+      << "that write must be made available to the load";
+  EXPECT_EQ(entry.dstStage, uint32_t{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT});
+}
+
+TEST_F(VulkanResourceStateDeviceTest, WritingOneTextureTwiceInALayoutThatDoesNotChangeStillWaits) {
+  // Both writes leave the destination in the transfer-destination layout, so a layout-only
+  // comparison would emit nothing between them. The same shape as two dispatches writing one
+  // storage texture, which the model suite covers at the compute stage.
+  Texture source = makeTexture("source", TextureUsage::CopySrc | TextureUsage::CopyDst);
+  Texture destination = makeTexture("destination", TextureUsage::CopyDst | TextureUsage::CopySrc);
+  Status sourceUpload =
+      device_->writeTexture(source, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(sourceUpload.hasError()) << sourceUpload.error();
+
+  const size_t before = barriersFor(destination.slotIndex()).size();
+
+  std::unique_ptr<CommandEncoder> encoder =
+      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+  for (int copy = 0; copy < 2; ++copy) {
+    ASSERT_FALSE(encoder
+                     ->copyTextureToTexture(source, destination, Extent2d{kExtent, kExtent},
+                                            Origin2d{0, 0}, Origin2d{0, 0})
+                     .hasError());
+  }
+  Result<CommandBuffer> commands = encoder->finish();
+  ASSERT_FALSE(commands.hasError()) << commands.error();
+  Result<uint64_t> serial = device_->submit(std::move(commands).result());
+  ASSERT_FALSE(serial.hasError()) << serial.error();
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0));
+
+  const std::vector<VulkanDevice::RecordedImageBarrierForTest> destinationBarriers =
+      barriersFor(destination.slotIndex());
+  ASSERT_GE(destinationBarriers.size(), before + 2)
+      << "the second write into the same layout still needs its own barrier";
+
+  const VulkanDevice::RecordedImageBarrierForTest& second = destinationBarriers.back();
+  EXPECT_EQ(second.oldLayout, second.newLayout) << "the layout did not change";
+  EXPECT_TRUE((second.srcAccess & VK_ACCESS_TRANSFER_WRITE_BIT) != 0)
+      << "the earlier write must be made available to the later one";
+}
+
+}  // namespace
+}  // namespace donner::gpu::vulkan::tests

--- a/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
@@ -92,7 +92,7 @@ TEST_F(VulkanResourceStateDeviceTest, AFailedUploadLeavesNoStateForALaterSubmitT
   ASSERT_EQ(unwrap(device_->trackedTextureLayoutForTest(written), "layout before"),
             VulkanDevice::TrackedTextureLayout::Undefined);
 
-  device_->failNextTextureUploadForTest();
+  device_->failNextTextureUploadForTest(VulkanDevice::UploadFailureModeForTest::BeforeSubmit);
   EXPECT_TRUE(
       device_->writeTexture(written, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent})
           .hasError())
@@ -107,6 +107,46 @@ TEST_F(VulkanResourceStateDeviceTest, AFailedUploadLeavesNoStateForALaterSubmitT
   EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(written), "layout after"),
             VulkanDevice::TrackedTextureLayout::Undefined)
       << "the failed upload never ran, so nothing it staged may become the texture's real state";
+}
+
+TEST_F(VulkanResourceStateDeviceTest, AnUploadTheQueueTookKeepsItsStateWhenTheWaitTimesOut) {
+  // The mirror of the test above: here the submission reaches the queue and only the wait for it
+  // fails, so the upload still runs and the image really does end up in its post-upload layout.
+  // Discarding then would leave the tracker describing a state the image is not in.
+  Texture written = makeTexture("written", TextureUsage::CopyDst | TextureUsage::CopySrc);
+  Texture destination = makeTexture("destination", TextureUsage::CopyDst | TextureUsage::CopySrc);
+
+  device_->failNextTextureUploadForTest(VulkanDevice::UploadFailureModeForTest::AfterSubmit);
+  EXPECT_TRUE(
+      device_->writeTexture(written, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent})
+          .hasError())
+      << "the seam must report the wait over an accepted submission as having timed out";
+
+  const size_t before = barriersFor(written.slotIndex()).size();
+
+  // A later submission reading that image. The queue is in order, so this meets the layout the
+  // upload left behind, and its barrier has to be derived from that.
+  std::unique_ptr<CommandEncoder> encoder =
+      unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+  ASSERT_FALSE(encoder
+                   ->copyTextureToTexture(written, destination, Extent2d{kExtent, kExtent},
+                                          Origin2d{0, 0}, Origin2d{0, 0})
+                   .hasError());
+  Result<CommandBuffer> commands = encoder->finish();
+  ASSERT_FALSE(commands.hasError()) << commands.error();
+  Result<uint64_t> serial = device_->submit(std::move(commands).result());
+  ASSERT_FALSE(serial.hasError()) << serial.error();
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0));
+
+  const std::vector<VulkanDevice::RecordedImageBarrierForTest> barriers =
+      barriersFor(written.slotIndex());
+  ASSERT_GT(barriers.size(), before);
+  const VulkanDevice::RecordedImageBarrierForTest& next = barriers.back();
+  EXPECT_EQ(next.oldLayout, int32_t{VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL})
+      << "the queued upload left the image in its post-upload layout, not an undefined one";
+  EXPECT_TRUE((next.srcAccess & VK_ACCESS_TRANSFER_WRITE_BIT) != 0)
+      << "the upload's write still has to be made available to the copy that reads it";
+  EXPECT_EQ(next.srcStage, uint32_t{VK_PIPELINE_STAGE_TRANSFER_BIT});
 }
 
 TEST_F(VulkanResourceStateDeviceTest, ThePassEntryEdgeCoversAnAttachmentThatIsNotTheLast) {

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -1,0 +1,220 @@
+/// @file
+/// Model tests for the Vulkan backend's tracked resource-state machine: the exact barriers and
+/// subpass dependencies each recorded usage pattern produces, the conservative fallback for
+/// patterns outside the tracked set, and the staged-then-committed discipline that keeps the
+/// table from claiming transitions the GPU never ran.
+///
+/// The model opens no device, so these run wherever the project builds rather than only where a
+/// Vulkan loader exists.
+
+#include "donner/gpu/vulkan/VulkanResourceState.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace donner::gpu::vulkan {
+namespace {
+
+constexpr VkPipelineStageFlags kSampledReadStages =
+    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
+TEST(VulkanResourceStateTests, AttachmentWriteThenSampledReadNamesBothEnds) {
+  const TextureSyncState afterDraw = StateAfterUsage(TextureUsageKind::ColorAttachment);
+  const ImageBarrierParams barrier = TransitionFor(afterDraw, TextureUsageKind::SampledRead);
+
+  EXPECT_EQ(barrier, (ImageBarrierParams{
+                         .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                         .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                         .srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                         .dstStage = kSampledReadStages,
+                         .srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                         .dstAccess = VK_ACCESS_SHADER_READ_BIT,
+                         .conservative = false,
+                     }))
+      << "the attachment write is the source scope and the sampled read the destination";
+}
+
+TEST(VulkanResourceStateTests, ComputeStorageWriteThenSampledReadNamesBothEnds) {
+  const TextureSyncState afterDispatch = StateAfterUsage(TextureUsageKind::StorageWrite);
+  const ImageBarrierParams barrier = TransitionFor(afterDispatch, TextureUsageKind::SampledRead);
+
+  EXPECT_EQ(barrier, (ImageBarrierParams{
+                         .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+                         .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                         .srcStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         .dstStage = kSampledReadStages,
+                         .srcAccess = VK_ACCESS_SHADER_WRITE_BIT,
+                         .dstAccess = VK_ACCESS_SHADER_READ_BIT,
+                         .conservative = false,
+                     }))
+      << "a storage-texture binding is write-only, so the source access has no read/write "
+         "ambiguity to fall back over";
+}
+
+TEST(VulkanResourceStateTests, TransferWriteThenShaderReadNamesBothEnds) {
+  const TextureSyncState afterUpload = StateAfterUsage(TextureUsageKind::TransferWrite);
+  const ImageBarrierParams barrier = TransitionFor(afterUpload, TextureUsageKind::SampledRead);
+
+  EXPECT_EQ(barrier.srcStage, VK_PIPELINE_STAGE_TRANSFER_BIT);
+  EXPECT_EQ(barrier.srcAccess, VK_ACCESS_TRANSFER_WRITE_BIT);
+  EXPECT_EQ(barrier.dstStage, kSampledReadStages);
+  EXPECT_EQ(barrier.dstAccess, VK_ACCESS_SHADER_READ_BIT);
+  EXPECT_FALSE(barrier.conservative);
+}
+
+TEST(VulkanResourceStateTests, AttachmentWriteThenTransferReadNamesBothEnds) {
+  const TextureSyncState afterDraw = StateAfterUsage(TextureUsageKind::ColorAttachment);
+  const ImageBarrierParams barrier = TransitionFor(afterDraw, TextureUsageKind::TransferRead);
+
+  EXPECT_EQ(barrier.srcStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+  EXPECT_EQ(barrier.srcAccess, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+  EXPECT_EQ(barrier.dstStage, VK_PIPELINE_STAGE_TRANSFER_BIT);
+  EXPECT_EQ(barrier.dstAccess, VK_ACCESS_TRANSFER_READ_BIT);
+  EXPECT_EQ(barrier.newLayout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+  EXPECT_FALSE(barrier.conservative);
+}
+
+TEST(VulkanResourceStateTests, AnUntouchedTextureWaitsForNothing) {
+  const ImageBarrierParams barrier =
+      TransitionFor(TextureSyncState{}, TextureUsageKind::TransferWrite);
+
+  EXPECT_EQ(barrier.oldLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+  EXPECT_EQ(barrier.srcStage, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+  EXPECT_EQ(barrier.srcAccess, 0u)
+      << "nothing has written the image, so there is nothing to make available";
+  EXPECT_FALSE(barrier.conservative);
+}
+
+TEST(VulkanResourceStateTests, AReadDoesNotNeedMakingAvailableToTheNextRead) {
+  const TextureSyncState afterSample = StateAfterUsage(TextureUsageKind::SampledRead);
+  const ImageBarrierParams barrier = TransitionFor(afterSample, TextureUsageKind::TransferRead);
+
+  EXPECT_EQ(barrier.srcAccess, 0u)
+      << "only writes need an availability operation; naming the earlier read would order more "
+         "than the hazard requires";
+  EXPECT_EQ(barrier.srcStage, kSampledReadStages) << "the execution dependency is still needed";
+  EXPECT_FALSE(barrier.conservative);
+}
+
+TEST(VulkanResourceStateTests, AnUnmodelledLayoutFallsBackToTheMaximalBarrier) {
+  TextureSyncState fromElsewhere;
+  fromElsewhere.layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+  fromElsewhere.stage = VK_PIPELINE_STAGE_HOST_BIT;
+  fromElsewhere.access = VK_ACCESS_HOST_WRITE_BIT;
+
+  const ImageBarrierParams barrier = TransitionFor(fromElsewhere, TextureUsageKind::SampledRead);
+
+  EXPECT_TRUE(barrier.conservative);
+  EXPECT_EQ(barrier, ConservativeImageBarrier(VK_IMAGE_LAYOUT_PREINITIALIZED,
+                                              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL))
+      << "an unrecognised pattern costs precision, never correctness";
+  EXPECT_EQ(barrier.srcStage, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+  EXPECT_EQ(barrier.dstAccess, VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
+}
+
+TEST(VulkanResourceStateTests, EveryTrackedUsageRoundTripsThroughItsLayout) {
+  for (const TextureUsageKind usage :
+       {TextureUsageKind::ColorAttachment, TextureUsageKind::SampledRead,
+        TextureUsageKind::StorageWrite, TextureUsageKind::TransferRead,
+        TextureUsageKind::TransferWrite}) {
+    EXPECT_EQ(StateAfterUsage(usage).layout, LayoutForUsage(usage)) << "usage " << usage;
+    EXPECT_FALSE(TransitionFor(StateAfterUsage(usage), TextureUsageKind::SampledRead).conservative)
+        << "usage " << usage;
+  }
+}
+
+TEST(VulkanResourceStateTests, ThePassEntryEdgeNamesWhatLastTouchedTheAttachment) {
+  const SubpassDependencyParams entry =
+      AttachmentEntryDependency(StateAfterUsage(TextureUsageKind::TransferWrite));
+
+  EXPECT_EQ(entry.srcStage, VK_PIPELINE_STAGE_TRANSFER_BIT);
+  EXPECT_EQ(entry.srcAccess, VK_ACCESS_TRANSFER_WRITE_BIT);
+  EXPECT_EQ(entry.dstStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+  EXPECT_FALSE(entry.conservative);
+}
+
+TEST(VulkanResourceStateTests, ThePassExitEdgeComesFromTheAttachmentsDeclaredConsumers) {
+  const SubpassDependencyParams sampled =
+      AttachmentExitDependency(TextureUsage::RenderAttachment | TextureUsage::Sampled);
+  EXPECT_EQ(sampled.srcStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+  EXPECT_EQ(sampled.srcAccess, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+  EXPECT_EQ(sampled.dstStage, kSampledReadStages | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+  EXPECT_EQ(sampled.dstAccess, VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+  EXPECT_FALSE(sampled.conservative)
+      << "a precise barrier behind an ALL_COMMANDS pass edge would buy nothing";
+
+  const SubpassDependencyParams readback =
+      AttachmentExitDependency(TextureUsage::RenderAttachment | TextureUsage::CopySrc);
+  EXPECT_TRUE((readback.dstStage & VK_PIPELINE_STAGE_TRANSFER_BIT) != 0);
+  EXPECT_TRUE((readback.dstAccess & VK_ACCESS_TRANSFER_READ_BIT) != 0);
+  EXPECT_FALSE(readback.conservative);
+}
+
+TEST(VulkanResourceStateTests, AnAttachmentWithNoModelledConsumerFallsBackToTheMaximalEdge) {
+  const SubpassDependencyParams edge = AttachmentExitDependency(TextureUsage::None);
+
+  EXPECT_TRUE(edge.conservative);
+  EXPECT_EQ(edge.dstStage, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+  EXPECT_EQ(edge.dstAccess, VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
+}
+
+// ----------------------------------------------------------------------------
+// Staged-then-committed discipline.
+
+TEST(VulkanResourceStateTableTests, AStagedTransitionIsVisibleToTheRestOfTheEncode) {
+  TextureSyncStateTable table;
+  const TextureSyncState afterDraw = StateAfterUsage(TextureUsageKind::ColorAttachment);
+  table.stage(7, afterDraw);
+
+  EXPECT_EQ(table.stateOf(7), afterDraw)
+      << "a later barrier in the same encode computes its source scope from what was staged";
+  EXPECT_TRUE(table.hasStagedChanges());
+}
+
+TEST(VulkanResourceStateTableTests, AFailedSubmitLeavesTheTrackedStateUntouched) {
+  TextureSyncStateTable table;
+  const TextureSyncState afterUpload = StateAfterUsage(TextureUsageKind::TransferWrite);
+  table.stage(3, afterUpload);
+  table.commitStaged();
+
+  // A second encode transitions the same texture, then the submission fails.
+  table.stage(3, StateAfterUsage(TextureUsageKind::SampledRead));
+  table.discardStaged();
+
+  EXPECT_EQ(table.stateOf(3), afterUpload)
+      << "the GPU never ran the discarded transition, so the table must not claim it did";
+  EXPECT_FALSE(table.hasStagedChanges());
+  EXPECT_FALSE(TransitionFor(table.stateOf(3), TextureUsageKind::SampledRead).conservative);
+}
+
+TEST(VulkanResourceStateTableTests, ASucceededSubmitCommitsEveryStagedTransition) {
+  TextureSyncStateTable table;
+  table.stage(1, StateAfterUsage(TextureUsageKind::ColorAttachment));
+  table.stage(2, StateAfterUsage(TextureUsageKind::StorageWrite));
+  table.commitStaged();
+
+  EXPECT_EQ(table.stateOf(1), StateAfterUsage(TextureUsageKind::ColorAttachment));
+  EXPECT_EQ(table.stateOf(2), StateAfterUsage(TextureUsageKind::StorageWrite));
+  EXPECT_FALSE(table.hasStagedChanges());
+}
+
+TEST(VulkanResourceStateTableTests, AnUnknownSlotReadsAsUntouched) {
+  const TextureSyncStateTable table;
+  EXPECT_EQ(table.stateOf(42), TextureSyncState{});
+}
+
+TEST(VulkanResourceStateTableTests, ForgettingASlotDropsBothItsViews) {
+  TextureSyncStateTable table;
+  table.stage(5, StateAfterUsage(TextureUsageKind::ColorAttachment));
+  table.commitStaged();
+  table.stage(5, StateAfterUsage(TextureUsageKind::SampledRead));
+
+  table.forget(5);
+
+  EXPECT_EQ(table.stateOf(5), TextureSyncState{})
+      << "a destroyed texture must not leave state a recycled slot would inherit";
+}
+
+}  // namespace
+}  // namespace donner::gpu::vulkan

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -12,6 +12,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
+
 namespace donner::gpu::vulkan {
 namespace {
 
@@ -124,13 +126,64 @@ TEST(VulkanResourceStateTests, EveryTrackedUsageRoundTripsThroughItsLayout) {
 }
 
 TEST(VulkanResourceStateTests, ThePassEntryEdgeNamesWhatLastTouchedTheAttachment) {
-  const SubpassDependencyParams entry =
-      AttachmentEntryDependency(StateAfterUsage(TextureUsageKind::TransferWrite));
+  const std::array<TextureSyncState, 1> attachments = {
+      StateAfterUsage(TextureUsageKind::TransferWrite)};
+  const SubpassDependencyParams entry = AttachmentEntryDependency(attachments);
 
   EXPECT_EQ(entry.srcStage, VK_PIPELINE_STAGE_TRANSFER_BIT);
   EXPECT_EQ(entry.srcAccess, VK_ACCESS_TRANSFER_WRITE_BIT);
   EXPECT_EQ(entry.dstStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
   EXPECT_FALSE(entry.conservative);
+}
+
+TEST(VulkanResourceStateTests, ThePassEntryEdgeCoversEveryAttachmentNotJustOne) {
+  // The shape the backend actually produces: one attachment a compute dispatch wrote and is
+  // about to be loaded, and one fresh attachment that will simply be cleared. A single edge
+  // serves both, so it has to wait for the dispatch even though the other attachment has never
+  // been touched.
+  const std::array<TextureSyncState, 2> attachments = {
+      StateAfterUsage(TextureUsageKind::StorageWrite), TextureSyncState{}};
+  const SubpassDependencyParams entry = AttachmentEntryDependency(attachments);
+
+  EXPECT_TRUE((entry.srcStage & VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT) != 0)
+      << "the load of the written attachment must be ordered after the dispatch that wrote it";
+  EXPECT_TRUE((entry.srcAccess & VK_ACCESS_SHADER_WRITE_BIT) != 0)
+      << "the dispatch's write must be made available to that load";
+  EXPECT_EQ(entry.dstStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+  EXPECT_FALSE(entry.conservative);
+
+  // Order must not matter: the union is the same whichever attachment comes first.
+  const std::array<TextureSyncState, 2> reversed = {
+      TextureSyncState{}, StateAfterUsage(TextureUsageKind::StorageWrite)};
+  EXPECT_EQ(AttachmentEntryDependency(reversed), entry);
+}
+
+TEST(VulkanResourceStateTests, ThePassEntryEdgeIsMaximalWhenAnyAttachmentIsUnmodelled) {
+  TextureSyncState fromElsewhere;
+  fromElsewhere.layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+  const std::array<TextureSyncState, 2> attachments = {
+      StateAfterUsage(TextureUsageKind::ColorAttachment), fromElsewhere};
+
+  EXPECT_TRUE(AttachmentEntryDependency(attachments).conservative)
+      << "one attachment the model cannot describe makes the whole edge unnarrowable";
+
+  const std::array<TextureSyncState, 0> none = {};
+  EXPECT_TRUE(AttachmentEntryDependency(none).conservative);
+}
+
+TEST(VulkanResourceStateTests, WritingAStorageTextureTwiceStillNeedsABarrier) {
+  // Both dispatches leave the image in GENERAL, so a layout-only comparison would see no change
+  // and order nothing between them.
+  const TextureSyncState afterFirst = StateAfterUsage(TextureUsageKind::StorageWrite);
+  const ImageBarrierParams barrier = TransitionFor(afterFirst, TextureUsageKind::StorageWrite);
+
+  EXPECT_EQ(barrier.oldLayout, barrier.newLayout) << "the layout does not change";
+  EXPECT_EQ(barrier.srcStage, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+  EXPECT_EQ(barrier.srcAccess, VK_ACCESS_SHADER_WRITE_BIT)
+      << "the first dispatch's write still has to be made available to the second";
+  EXPECT_EQ(barrier.dstStage, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+  EXPECT_EQ(barrier.dstAccess, VK_ACCESS_SHADER_WRITE_BIT);
+  EXPECT_FALSE(barrier.conservative);
 }
 
 TEST(VulkanResourceStateTests, ThePassExitEdgeComesFromTheAttachmentsDeclaredConsumers) {


### PR DESCRIPTION
Replaces the Vulkan backend's conservative synchronization with a tracked, per-resource state model. Every image barrier used to be an ALL_COMMANDS to ALL_COMMANDS memory barrier and every render pass declared external dependencies just as wide; both were correct and said nothing about what the recorded command streams actually do.

- A resource-state model records the layout, pipeline stage, and access mask that last touched each texture, and derives each transition's full source and destination scope from what produced the contents and what is about to consume them. An attachment write consumed by a sampled read now waits on color output for a shader read; a compute storage write consumed by a sampled read waits on the compute shader for a shader read.
- Both halves of every render pass external dependency come from the same model, because a precise barrier sitting behind a pass edge that still waits on everything orders nothing narrower than before. The entry edge names what last touched the attachments; the exit edge names the consumers the attachment's declared usage set implies.
- Only writes are made available: a read followed by another read carries an execution dependency and an empty source access mask. A texture nothing has touched waits at top of pipe for nothing.
- A transition is also recorded when the layout is unchanged but the image was last written, which the previous layout-only comparison did not catch: two compute passes writing one storage texture stay in a single layout and still need the second to wait for the first.
- The edge out of a compute pass is narrowed to what a compute pass can produce. The only writable binding the runtime declares is a write-only storage texture, so its host-visibility half guarded a hazard the binding types make unreachable; a note records what to restore if a writable storage buffer binding ever arrives.
- Access and stage follow the staged-then-committed discipline layouts already had: encoding stages, a submission that reached the queue commits, a failed encode or submit discards. Destroying a texture forgets its state so a recycled slot inherits nothing.
- The wiring that feeds the model is covered where the model cannot see it. A texture upload that fails after recording its transitions discards them rather than leaving them for the next unrelated submission to commit, and the discard is a guard over every exit rather than a line at each known one. A render pass derives its entry dependency from every attachment's prior state, not just the last one declared, so a pass loading an attachment a dispatch wrote alongside a freshly cleared one still waits for that write. Both were real ordering defects, both are pinned by device-level regressions that fail when the fix is removed, and both were found by review of the wiring rather than by the model's own tests - which is the reason those regressions exist at the level they do.
- Anything the model does not describe falls back to the maximal barrier the backend used everywhere before. An unrecognised pattern costs precision, never correctness.
- Buffer memory is fronted by an allocator seam. Every buffer still gets its own dedicated persistently-mapped allocation; the seam exists so replacing that with suballocation is a memory-management change rather than an API change, once measurement says the driver's allocation-count cap is the constraint worth the complexity.

The model opens no device and calls no entry point, so its tests run wherever the project builds rather than only where a Vulkan loader exists. They assert the exact barrier and dependency each recorded pattern produces, the conservative fallback, and that a discarded submission leaves the tracked state untouched; the paths the change exists for were committed failing first. The model suite, the device regressions, and the slices are green on both a software rasterizer and a discrete GPU; the Khronos validation layer is auto-enabled wherever the loader offers it and latched into the slice assertions, but it is not installed on the hardware used here, so these barriers have not been checked by it.
