### PR TITLE
geode: map snapshot readback buffers through the GPU runtime

### DIFF
--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1849,6 +1849,14 @@ Status Device::validateBufferHandleForBackend(const Buffer& buffer) const {
   return OkStatus();
 }
 
+Status Device::validateBufferMappingHandleForBackend(const BufferMapping& mapping) const {
+  auto record = resolve(bufferMappings_, mapping, BufferMappingTag::kName);
+  if (record.hasError()) {
+    return std::move(record).error();
+  }
+  return OkStatus();
+}
+
 Status Device::validateTextureHandleForBackend(const Texture& texture) const {
   auto record = resolve(textures_, texture, TextureTag::kName);
   if (record.hasError()) {

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -617,6 +617,15 @@ protected:
   Status validateTextureViewHandleForBackend(const TextureView& textureView) const;
 
   /**
+   * Validates a buffer-mapping handle for backend-provided auxiliary entry points, running the
+   * same null/device-identity/generation checks the template-method public API performs, so a
+   * stale handle cannot read state belonging to the slot's new occupant.
+   *
+   * @param mapping Handle to validate.
+   */
+  Status validateBufferMappingHandleForBackend(const BufferMapping& mapping) const;
+
+  /**
    * Backend hook: begin mapping a buffer range. Defaults to reporting the capability as
    * unsupported, so a backend without host mapping needs no implementation and callers get a
    * clean unsupported result rather than a missing symbol.

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -7062,58 +7062,65 @@ enum class ReadbackMapStatus {
   Failed,
 };
 
+/// One slice of the readback map wait.
+///
+/// The runtime's wait takes a slice and a budget; this path drives its own budget so the poll
+/// count, the cancellation cadence, and the timeout attribution stay exactly what they were
+/// before the wait moved onto the runtime, so each call is given a budget of one slice and the
+/// loop below owns the deadline.
+constexpr double kReadbackWaitSliceSeconds =
+    std::chrono::duration<double>(geode::kGpuWaitPollInterval).count();
+
+/// Result of \ref MapAndWaitReadback: the outcome, plus the live mapping on success.
+struct ReadbackMapResult {
+  ReadbackMapStatus status = ReadbackMapStatus::Failed;  //!< How the wait ended.
+  gpu::BufferMapping mapping;                            //!< Live mapping; valid only on success.
+};
+
 /// Map `buffer` for read and wait for the GPU to deliver it. On cancellation,
 /// timeout, or map failure the buffer is unmapped and destroyed and a
 /// non-success status is returned. Readback poll statistics are recorded on
 /// the device regardless of the outcome.
-ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& device,
-                                     const wgpu::Buffer& buffer, uint64_t mapSize,
+///
+/// The wait is a loop of single-slice runtime waits rather than one runtime wait with the full
+/// budget, because four things this path reports are properties of the loop and not of the
+/// runtime's wait: the number of slices actually run, whether the backend waited on the map's
+/// completion event or polled for it, the wait-site attribution a timeout declares on the
+/// device, and destroying the buffer whose map was abandoned.
+///
+/// @param device Device the buffer belongs to.
+/// @param buffer Buffer to map; destroyed and left invalid on cancellation or timeout.
+/// @param mapSize Bytes to map, from offset zero.
+/// @param shouldCancel Optional cancellation predicate, polled once per slice.
+ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& device,
+                                     gpu::Buffer& buffer, uint64_t mapSize,
                                      const std::function<bool()>& shouldCancel) {
   if (device->isDeviceLost()) {
     // A lost device will never deliver the map. Fail fast so a caller does
     // not spend another full readback deadline against a hung driver; the
     // caller drops the buffer without pooling it.
-    return ReadbackMapStatus::DeviceLost;
+    return ReadbackMapResult{ReadbackMapStatus::DeviceLost, {}};
   }
-  // `BufferMapCallbackInfo` takes raw userdata rather than a std::function, and a
-  // cancellation may return before WebGPU delivers that callback. Keep its payload alive
-  // independently of this stack frame: one reference belongs to this caller, the other to the
-  // callback. The state intentionally owns no WebGPU handles, so its final release is safe even
-  // when AllowSpontaneous invokes it from inside a WebGPU call.
-  struct MapState {
-    std::atomic<int> references{2};
-    std::atomic<bool> done{false};
-    std::atomic<bool> ok{false};
 
-    void release() {
-      if (references.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        delete this;
-      }
-    }
-  };
-  MapState* mapState = new MapState();
-  wgpu::BufferMapCallbackInfo mapCb{wgpu::Default};
-  mapCb.callback = [](WGPUMapAsyncStatus status, WGPUStringView /*message*/, void* userdata1,
-                      void* /*userdata2*/) {
-    auto* s = static_cast<MapState*>(userdata1);
-    s->ok.store(status == WGPUMapAsyncStatus_Success, std::memory_order_relaxed);
-    s->done.store(true, std::memory_order_release);
-    s->release();
-  };
-  mapCb.userdata1 = mapState;
-  mapCb.userdata2 = nullptr;
-  mapCb.mode = wgpu::CallbackMode::AllowSpontaneous;
-  // Emscripten-only: the browser timed-wait path below consumes `mapFuture`;
-  // native builds finish without touching it.
-  [[maybe_unused]] const wgpu::Future mapFuture =
-      buffer.mapAsync(wgpu::MapMode::Read, 0, mapSize, mapCb);
+  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
+  gpu::Result<gpu::BufferMapping> mapping =
+      runtime.mapBufferAsync(buffer, gpu::MapMode::Read, 0, mapSize);
+  if (mapping.hasError()) {
+    // The request never started, so no slice ran and there are no poll statistics to record. A
+    // device lost between the check above and here is reported as such rather than as a plain
+    // failure, because the caller retries a failure and must not retry a lost device.
+    return ReadbackMapResult{
+        device->isDeviceLost() ? ReadbackMapStatus::DeviceLost : ReadbackMapStatus::Failed, {}};
+  }
+  gpu::BufferMapping liveMapping = std::move(mapping).result();
+
   int pollIter = 0;
   bool cancelled = false;
   bool timedOut = false;
-  bool usedTimedWaitAny = false;
+  gpu::MapWaitOutcome outcome = gpu::MapWaitOutcome::TimedOut;
   const auto readbackWaitStart = std::chrono::steady_clock::now();
   const auto readbackDeadline = readbackWaitStart + geode::kReadbackMapTimeout;
-  while (!mapState->done.load(std::memory_order_acquire)) {
+  while (true) {
     if (shouldCancel && shouldCancel()) {
       cancelled = true;
       break;
@@ -7122,72 +7129,55 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
       timedOut = true;
       break;
     }
+    // Counted after the two checks above, so a wait that was cancelled or already past its
+    // deadline reports zero slices - the signal a caller uses to tell "gave up immediately"
+    // from "waited and then gave up".
     ++pollIter;
-#ifdef __EMSCRIPTEN__
-    // The browser instance is created with TimedWaitAny (see
-    // CreateEditorWgpuInstance) exactly so this wait exists: on a pthread the
-    // map completion is a browser-side event, and poll-plus-yield loops only
-    // observe it at whatever cadence the yields happen to align with the
-    // browser's delivery (measured: a first-sample snapshot readback burned
-    // 265 five-millisecond yields, 1.85 seconds, before the completion was
-    // seen). A 5 ms timed wait returns the moment the map resolves while a
-    // cancellation or a superseding request is still observed within the
-    // slice.
-    static std::atomic<bool> instanceWaitUsable{true};
-    if (device->instance() && instanceWaitUsable.load(std::memory_order_relaxed)) {
-      wgpu::FutureWaitInfo waitInfo{};
-      waitInfo.future = mapFuture;
-      constexpr std::uint64_t kSliceNs = 5'000'000;
-      const wgpu::WaitStatus waitStatus = device->instance().waitAny(1, &waitInfo, kSliceNs);
-      if (waitStatus == wgpu::WaitStatus::Success || waitStatus == wgpu::WaitStatus::TimedOut) {
-        usedTimedWaitAny = true;
-        // Success delivers the callback before returning; TimedOut re-checks
-        // cancellation. Either way the loop condition observes `done`.
-        continue;
-      }
-      // Any other status means this thread cannot time-wait this future
-      // (instance thread affinity, unsupported timeout). Remember that and
-      // fall back to the yield-poll below for the rest of the process.
-      instanceWaitUsable.store(false, std::memory_order_relaxed);
+
+    const gpu::Result<gpu::MapWaitOutcome> slice = runtime.waitForMapping(
+        liveMapping, gpu::MapWaitParams{kReadbackWaitSliceSeconds, kReadbackWaitSliceSeconds},
+        /*shouldCancel=*/{});
+    if (slice.hasError()) {
+      outcome = gpu::MapWaitOutcome::Failed;
+      break;
     }
-#endif
-    // Never ask wgpu-native to block until the GPU map completes: a low-priority thumbnail must
-    // observe a superseding main-document request promptly. Native polling is
-    // non-blocking and gets a short sleep to avoid spinning. The
-    // kGpuWaitPollInterval (100 us) sleep bounds the snapshot latency floor
-    // without the 1 ms quanta that used to dominate small-fixture readbacks;
-    // the poll itself processes the map completion callback as soon as the
-    // GPU delivers it.
-    device->pollSuspending(false);
-#ifndef __EMSCRIPTEN__
-    std::this_thread::sleep_for(geode::kGpuWaitPollInterval);
-#endif
+    outcome = slice.result();
+    // A slice budget equal to one slice reports TimedOut for "not ready yet"; every other
+    // outcome is terminal.
+    if (outcome != gpu::MapWaitOutcome::TimedOut) {
+      break;
+    }
   }
-  device->recordReadback(usedTimedWaitAny, pollIter);
+
+  device->recordReadback(runtime.mappingUsedTimedWaitAny(liveMapping), pollIter);
+
   if (cancelled || timedOut) {
     if (timedOut) {
-      // A full readback deadline with no map delivery is the observable
-      // signature of a hung device. Declare the loss so later waits on this
-      // device fail fast and teardown skips GPU waits entirely, and record the
-      // site and the measured wait so a consumer reading only the stats can
-      // tell this hang from a queue-drain hang.
       device->markDeviceLostAfterWaitTimeout(
           geode::GpuWaitSite::ReadbackMap,
           std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
                                                                 readbackWaitStart),
           "snapshot readback map did not complete within the readback deadline");
     }
-    // Cancelling a pending map schedules its callback with an aborted status. The callback's
-    // reference keeps `mapState` valid even when delivery happens after this method returns.
-    buffer.unmap();
-    buffer.destroy();
-    mapState->release();
-    return cancelled ? ReadbackMapStatus::Cancelled : ReadbackMapStatus::TimedOut;
+    // Abandoning a pending map leaves the buffer unusable for anything else, so it is destroyed
+    // here rather than returned to a pool that would hand it out again.
+    (void)runtime.unmapBuffer(std::move(liveMapping));
+    (void)runtime.destroyBufferBacking(std::move(buffer));
+    return ReadbackMapResult{cancelled ? ReadbackMapStatus::Cancelled : ReadbackMapStatus::TimedOut,
+                             {}};
   }
 
-  const bool mapOk = mapState->ok.load(std::memory_order_acquire);
-  mapState->release();
-  return mapOk ? ReadbackMapStatus::Success : ReadbackMapStatus::Failed;
+  if (outcome == gpu::MapWaitOutcome::Ready) {
+    return ReadbackMapResult{ReadbackMapStatus::Success, std::move(liveMapping)};
+  }
+
+  // Device loss and map failure leave the buffer alone: the caller drops the whole set rather
+  // than pooling it, and a lost device's buffers are going away with it.
+  (void)runtime.unmapBuffer(std::move(liveMapping));
+  return ReadbackMapResult{outcome == gpu::MapWaitOutcome::DeviceLost
+                               ? ReadbackMapStatus::DeviceLost
+                               : ReadbackMapStatus::Failed,
+                           {}};
 }
 
 /// GPU-side snapshot readback for premultiplied RGBA8Unorm render targets: a
@@ -7254,7 +7244,7 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
   src.mipLevel = 0;
   src.origin = {0, 0, 0};
   wgpu::TexelCopyBufferInfo dst = {};
-  dst.buffer = resources.readback.get();
+  dst.buffer = device->adapterDevice().wgpuBufferOf(resources.readback);
   dst.layout.bytesPerRow = bytesPerRow;
   dst.layout.rowsPerImage = height;
   wgpu::Extent3D copySize = {width, height, 1};
@@ -7265,8 +7255,9 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
   device->queue().submit(1, &cmd.get());
   device->countSubmit();
 
-  const ReadbackMapStatus mapStatus =
-      MapAndWaitReadback(device, resources.readback.get(), mapSize, shouldCancel);
+  ReadbackMapResult mapResult =
+      MapAndWaitReadback(device, resources.readback, mapSize, shouldCancel);
+  const ReadbackMapStatus mapStatus = mapResult.status;
   if (mapStatus != ReadbackMapStatus::Success) {
     // Cancelled, timed out, lost, or failed: on cancellation and timeout the
     // helper already unmapped and destroyed the readback buffer, and on a
@@ -7278,15 +7269,16 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
     return bitmap;
   }
 
-  const uint8_t* mapped =
-      static_cast<const uint8_t*>(resources.readback.get().getConstMappedRange(0, mapSize));
-  if (mapped == nullptr) {
-    // A mapped-range/buffer-size mismatch returns null instead of raising a
-    // validation error. Unmap and drop the entry (do not pool a buffer whose
-    // sizing math disagreed with ours) and let the CPU path take over.
-    resources.readback.get().unmap();
+  const gpu::Result<std::span<const uint8_t>> mappedBytes =
+      device->adapterDevice().mappedBytes(mapResult.mapping);
+  if (mappedBytes.hasError()) {
+    // A mapped-range/buffer-size mismatch is reported here rather than raising a validation
+    // error. Unmap and drop the entry (do not pool a buffer whose sizing math disagreed with
+    // ours) and let the CPU path take over.
+    (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
     return bitmap;
   }
+  const uint8_t* mapped = mappedBytes.result().data();
 
   // The staging texture already holds straight-alpha RGBA, so the CPU only
   // strips row padding.
@@ -7296,13 +7288,13 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
   bitmap.pixels.resize(bitmap.rowBytes * height);
   for (uint32_t y = 0; y < height; ++y) {
     if (shouldCancel && shouldCancel()) {
-      resources.readback.get().unmap();
+      (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
       return {};
     }
     std::memcpy(bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes,
                 mapped + static_cast<size_t>(y) * bytesPerRow, bitmap.rowBytes);
   }
-  resources.readback.get().unmap();
+  (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
   device->releaseSnapshotReadbackResources(std::move(resources));
   return bitmap;
 }
@@ -7359,13 +7351,17 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
 
   const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
 
-  // Allocate readback buffer.
-  wgpu::BufferDescriptor bd = {};
-  bd.label = wgpuLabel("RendererGeodeReadback");
-  bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
-  bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
-  geode::ScopedWgpuHandle<wgpu::Buffer> readback(device->device().createBuffer(bd));
-  device->countBuffer();
+  // Allocate readback buffer. Created through the runtime, which counts the allocation itself,
+  // so there is no explicit tick here.
+  const uint64_t readbackSize = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
+  gpu::Result<gpu::Buffer> createdReadback = device->adapterDevice().createBuffer(
+      gpu::BufferDescriptor{"RendererGeodeReadback", readbackSize,
+                            gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead});
+  if (createdReadback.hasError()) {
+    return bitmap;
+  }
+  gpu::Buffer readback = std::move(createdReadback).result();
+  const wgpu::Buffer readbackBackend = device->adapterDevice().wgpuBufferOf(readback);
 
   // Copy texture → readback buffer.
   geode::ScopedWgpuHandle<wgpu::CommandEncoder> enc(device->device().createCommandEncoder());
@@ -7374,7 +7370,7 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   src.mipLevel = 0;
   src.origin = {0, 0, 0};
   wgpu::TexelCopyBufferInfo dst = {};
-  dst.buffer = readback.get();
+  dst.buffer = readbackBackend;
   dst.layout.bytesPerRow = bytesPerRow;
   dst.layout.rowsPerImage = height;
   wgpu::Extent3D copySize = {width, height, 1};
@@ -7384,19 +7380,20 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   device->queue().submit(1, &cmd.get());
   device->countSubmit();
 
-  if (MapAndWaitReadback(device, readback.get(), bd.size, shouldCancel) !=
-      ReadbackMapStatus::Success) {
+  ReadbackMapResult mapResult = MapAndWaitReadback(device, readback, readbackSize, shouldCancel);
+  if (mapResult.status != ReadbackMapStatus::Success) {
     return bitmap;
   }
 
-  const uint8_t* mapped =
-      static_cast<const uint8_t*>(readback.get().getConstMappedRange(0, bd.size));
-  if (mapped == nullptr) {
-    // Size mismatch between the map request and the buffer returns null
-    // rather than raising a validation error; never memcpy from it.
-    readback.get().unmap();
+  const gpu::Result<std::span<const uint8_t>> mappedBytes =
+      device->adapterDevice().mappedBytes(mapResult.mapping);
+  if (mappedBytes.hasError()) {
+    // A size mismatch between the map request and the buffer is reported here rather than
+    // raising a validation error; never memcpy from it.
+    (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
     return bitmap;
   }
+  const uint8_t* mapped = mappedBytes.result().data();
 
   // Strip row padding and unpremultiply alpha so the consumer gets a tightly
   // packed *straight-alpha* RGBA buffer. `GeoEncoder::fillPath` premultiplies
@@ -7412,7 +7409,7 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   const bool sourceIsBgra = IsBgraTextureFormat(format);
   for (uint32_t y = 0; y < height; ++y) {
     if (shouldCancel && shouldCancel()) {
-      readback.get().unmap();
+      (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
       return {};
     }
     const uint8_t* srcRow = mapped + static_cast<size_t>(y) * bytesPerRow;
@@ -7452,7 +7449,7 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
       dstRow[x * 4 + 3] = srcA;
     }
   }
-  readback.get().unmap();
+  (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
   return bitmap;
 }
 

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -227,6 +227,26 @@ void DestroyResourceBacking(ScopedWgpuHandle<Handle>& handle) {
   }
 }
 
+/// Destroys a pooled readback buffer's backend object, not just this pool's name for it.
+///
+/// Pooled entries are idle by construction - a set is released only after its readback unmapped
+/// - so the backing can go eagerly. Releasing the handle alone would leave the buffer resident
+/// until the host runtime collects it, which is exactly the retained memory the pool ceiling
+/// exists to bound.
+/// @param adapter Adapter the buffer was created on, or null during teardown.
+/// @param buffer Buffer to destroy; left invalid.
+void DestroyPooledReadbackBuffer(GeodeWgpuAdapterDevice* adapter, gpu::Buffer& buffer) {
+  if (!buffer.isValid()) {
+    return;
+  }
+  if (adapter == nullptr) {
+    buffer = gpu::Buffer();
+    return;
+  }
+  const gpu::Status destroyed = adapter->destroyBufferBacking(std::move(buffer));
+  (void)destroyed;  // A pooled buffer is always live; a stale handle is already gone.
+}
+
 }  // namespace
 
 /// PIMPL struct: holds the wgpu::Instance so its lifetime is tied to
@@ -238,7 +258,7 @@ struct GeodeDevice::Impl {
     for (auto& [unusedKey, entry] : snapshotReadbackPool) {
       (void)unusedKey;
       DestroyResourceBacking(entry.resources.staging);
-      DestroyResourceBacking(entry.resources.readback);
+      DestroyPooledReadbackBuffer(adapterDevice.get(), entry.resources.readback);
     }
   }
 
@@ -812,13 +832,13 @@ SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t
   }
 
   const uint32_t bytesPerRow = AlignReadbackBytesPerRow(width * 4u);
-  wgpu::BufferDescriptor bd = {};
-  bd.label = wgpuLabel("RendererGeodeReadback");
-  bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
-  bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
-  resources.readback.reset(device_.createBuffer(bd));
-  if (resources.readback) {
-    countBuffer();
+  // Created through the runtime, which counts the allocation itself, so there is no explicit
+  // tick here; a second one would double-count every readback set against the buffer ceilings.
+  gpu::Result<gpu::Buffer> readback = adapterDevice().createBuffer(gpu::BufferDescriptor{
+      "RendererGeodeReadback", static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height),
+      gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead});
+  if (readback.hasResult()) {
+    resources.readback = std::move(readback).result();
   }
 
   if (resources.empty()) {
@@ -851,7 +871,7 @@ void GeodeDevice::releaseSnapshotReadbackResources(SnapshotReadbackResources res
     // the readback unmaps), so their backings can be destroyed eagerly
     // instead of deferred to a frame boundary.
     DestroyResourceBacking(lruIt->second.resources.staging);
-    DestroyResourceBacking(lruIt->second.resources.readback);
+    DestroyPooledReadbackBuffer(impl_->adapterDevice.get(), lruIt->second.resources.readback);
     impl_->snapshotReadbackPool.erase(lruIt);
   }
 }

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -13,6 +13,7 @@
 #include <webgpu/webgpu.hpp>
 
 #include "donner/base/Utils.h"
+#include "donner/gpu/Device.h"
 #include "donner/svg/renderer/geode/GeodeCounters.h"
 #include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
@@ -58,14 +59,14 @@ struct SnapshotReadbackResources {
   /// View of `staging`, kept with the pooled entry so it is created once.
   ScopedWgpuHandle<wgpu::TextureView> stagingView;
   /// Map-readable buffer the staging texture is copied into.
-  ScopedWgpuHandle<wgpu::Buffer> readback;
+  gpu::Buffer readback;
   /// Pool key: staging texture width in pixels.
   uint32_t width = 0;
   /// Pool key: staging texture height in pixels.
   uint32_t height = 0;
 
   /// True when any required handle is missing; an empty set cannot be used.
-  [[nodiscard]] bool empty() const { return !staging || !stagingView || !readback; }
+  [[nodiscard]] bool empty() const { return !staging || !stagingView || !readback.isValid(); }
 };
 
 /**

--- a/donner/svg/renderer/geode/GeodeGpuWait.cc
+++ b/donner/svg/renderer/geode/GeodeGpuWait.cc
@@ -25,7 +25,7 @@ bool DeclareDeviceLostAfterWaitTimeout(GeodeDeviceLostState& state, GpuWaitSite 
 }
 
 GpuWaitResult BoundedGpuWait(const std::function<bool()>& pollOnce,
-                             std::chrono::milliseconds timeout,
+                             std::chrono::microseconds timeout,
                              std::chrono::microseconds pollInterval,
                              const GpuWaitTestHooks& testHooks) {
   const auto now = [&testHooks]() {

--- a/donner/svg/renderer/geode/GeodeGpuWait.h
+++ b/donner/svg/renderer/geode/GeodeGpuWait.h
@@ -160,13 +160,15 @@ bool DeclareDeviceLostAfterWaitTimeout(GeodeDeviceLostState& state, GpuWaitSite 
  * an already-complete wait adds no measurable overhead.
  *
  * @param pollOnce Non-blocking poll; returns true when the wait is over.
- * @param timeout Total time budget for the wait.
+ * @param timeout Total time budget for the wait. Taken in microseconds because the readback
+ *   wait slices below a millisecond, and a budget rounded up to a whole millisecond would
+ *   coarsen the poll cadence the readback path is tuned to.
  * @param pollInterval Sleep between polls while the condition is pending.
  * @param testHooks Optional clock/sleep overrides for deterministic tests.
  * @return `Complete` if @p pollOnce returned true, `TimedOut` otherwise.
  */
 GpuWaitResult BoundedGpuWait(const std::function<bool()>& pollOnce,
-                             std::chrono::milliseconds timeout,
+                             std::chrono::microseconds timeout,
                              std::chrono::microseconds pollInterval = kGpuWaitPollInterval,
                              const GpuWaitTestHooks& testHooks = {});
 

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -637,13 +637,31 @@ gpu::Status GeodeWgpuAdapterDevice::onMapBufferAsync(uint32_t mappingSlotIndex,
   return OkStatus();
 }
 
-gpu::MapSliceState GeodeWgpuAdapterDevice::sliceStateOf(const MappingSlot::Completion& completion) {
-  return completion.ok.load(std::memory_order_relaxed) ? gpu::MapSliceState::Ready
-                                                       : gpu::MapSliceState::Failed;
+gpu::MapSliceState GeodeWgpuAdapterDevice::sliceStateOf(
+    const MappingSlot::Completion& completion) const {
+  // Total over the completion state on purpose. A wait that returns without the map having
+  // completed - a timed wait that expired, a poll that found nothing - has learned nothing about
+  // whether the map will succeed, and reading only the success flag there reports a map that is
+  // merely not finished yet as a failed one. Every caller reads the state through here so that
+  // mistake cannot be made at one site and not another.
+  if (completion.done.load(std::memory_order_acquire)) {
+    return completion.ok.load(std::memory_order_relaxed) ? gpu::MapSliceState::Ready
+                                                         : gpu::MapSliceState::Failed;
+  }
+  return geodeDevice_.isDeviceLost() ? gpu::MapSliceState::DeviceLost : gpu::MapSliceState::Pending;
 }
 
 bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
                                                   std::chrono::microseconds slice) {
+  if (simulateEventWaitForTest_) {
+    // Stands in for a browser timed wait that expired without the map completing. The real arm
+    // is compiled out everywhere the test suites run, so without this seam its contract - that a
+    // slice which waited and learned nothing reports "not finished", never "failed" - would be
+    // checked only by the browser lane.
+    (void)mappingSlotIndex;
+    (void)slice;
+    return true;
+  }
 #ifdef __EMSCRIPTEN__
   // The browser instance is created asking for TimedWaitAny (see GeodeDevice::CreateHeadless)
   // exactly so this wait exists: on a worker thread the map completion is a browser-side event,
@@ -664,8 +682,15 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
 
   wgpu::FutureWaitInfo waitInfo{};
   waitInfo.future = slot.mapFuture;
+  // The browser's timed wait keeps its own cadence rather than the caller's slice. Every wait
+  // here is an asyncify suspend and rewind of the whole call stack, so slicing at the native
+  // poll cadence would spend fifty of those per millisecond to learn the same thing; five
+  // milliseconds is what this path was tuned to, and a cancellation is still observed within it
+  // because the caller re-checks between slices.
+  constexpr std::chrono::microseconds kBrowserTimedWaitSlice{5000};
+  (void)slice;
   const auto sliceNs = static_cast<std::uint64_t>(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(slice).count());
+      std::chrono::duration_cast<std::chrono::nanoseconds>(kBrowserTimedWaitSlice).count());
   const wgpu::WaitStatus waitStatus = geodeDevice_.instance().waitAny(1, &waitInfo, sliceNs);
   if (waitStatus != wgpu::WaitStatus::Success && waitStatus != wgpu::WaitStatus::TimedOut) {
     instanceWaitUsable.store(false, std::memory_order_relaxed);
@@ -687,11 +712,8 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
     return gpu::MapSliceState::Failed;
   }
   MappingSlot::Completion& completion = *slotMappings_[mappingSlotIndex].completion;
-  if (completion.done.load(std::memory_order_acquire)) {
+  if (completion.done.load(std::memory_order_acquire) || geodeDevice_.isDeviceLost()) {
     return sliceStateOf(completion);
-  }
-  if (geodeDevice_.isDeviceLost()) {
-    return gpu::MapSliceState::DeviceLost;
   }
 
   // Wait out the slice the caller allowed rather than returning the moment one poll finds
@@ -714,10 +736,7 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
       },
       std::max(slice, std::chrono::microseconds(1)));
 
-  if (completion.done.load(std::memory_order_acquire)) {
-    return sliceStateOf(completion);
-  }
-  return geodeDevice_.isDeviceLost() ? gpu::MapSliceState::DeviceLost : gpu::MapSliceState::Pending;
+  return sliceStateOf(completion);
 }
 
 bool GeodeWgpuAdapterDevice::mappingUsedTimedWaitAny(const gpu::BufferMapping& mapping) const {

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -306,6 +306,18 @@ gpu::Status GeodeWgpuAdapterDevice::destroyTextureBacking(gpu::Texture&& texture
   return destroyTexture(std::move(texture));
 }
 
+gpu::Status GeodeWgpuAdapterDevice::destroyBufferBacking(gpu::Buffer&& buffer) {
+  // Validate before touching the slot so a stale or foreign handle cannot destroy whatever
+  // occupies that slot now.
+  if (gpu::Status status = validateBufferHandleForBackend(buffer); status.hasError()) {
+    return status;
+  }
+  if (buffer.slotIndex() < slotBuffers_.size()) {
+    slotBuffers_[buffer.slotIndex()].destroyBackingAndReset();
+  }
+  return destroyBuffer(std::move(buffer));
+}
+
 gpu::Result<gpu::Texture> GeodeWgpuAdapterDevice::importExternalTexture(wgpu::Texture texture,
                                                                         const gpu::Extent2d& size,
                                                                         gpu::TextureFormat format,
@@ -319,6 +331,16 @@ gpu::Result<gpu::Texture> GeodeWgpuAdapterDevice::importExternalTexture(wgpu::Te
       createTexture(gpu::TextureDescriptor{"externalTexture", size, format, usage});
   pendingImport_ = wgpu::Texture();  // Cleared on the failure paths too.
   return result;
+}
+
+wgpu::Buffer GeodeWgpuAdapterDevice::wgpuBufferOf(const gpu::Buffer& buffer) const {
+  // Full base-class validation (null, device identity, AND generation), so a stale or forged
+  // handle cannot bridge the slot's new occupant to raw wgpu.
+  if (validateBufferHandleForBackend(buffer).hasError() ||
+      buffer.slotIndex() >= slotBuffers_.size()) {
+    return wgpu::Buffer();
+  }
+  return slotBuffers_[buffer.slotIndex()].get();
 }
 
 wgpu::Texture GeodeWgpuAdapterDevice::wgpuTextureOf(const gpu::Texture& texture) const {
@@ -609,10 +631,53 @@ gpu::Status GeodeWgpuAdapterDevice::onMapBufferAsync(uint32_t mappingSlotIndex,
   // Spontaneous delivery is what lets a wait slice observe the completion from inside the
   // backend call it makes, rather than only at an explicit processing point.
   callbackInfo.mode = wgpu::CallbackMode::AllowSpontaneous;
-  (void)buffer.mapAsync(wgpu::MapMode::Read, offsetBytes, byteCount, callbackInfo);
+  slot.mapFuture = buffer.mapAsync(wgpu::MapMode::Read, offsetBytes, byteCount, callbackInfo);
 
   SetSlot(slotMappings_, mappingSlotIndex, std::move(slot));
   return OkStatus();
+}
+
+gpu::MapSliceState GeodeWgpuAdapterDevice::sliceStateOf(const MappingSlot::Completion& completion) {
+  return completion.ok.load(std::memory_order_relaxed) ? gpu::MapSliceState::Ready
+                                                       : gpu::MapSliceState::Failed;
+}
+
+bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
+                                                  std::chrono::microseconds slice) {
+#ifdef __EMSCRIPTEN__
+  // The browser instance is created asking for TimedWaitAny (see GeodeDevice::CreateHeadless)
+  // exactly so this wait exists: on a worker thread the map completion is a browser-side event,
+  // and a poll-and-yield loop only observes it when a yield happens to line up with the
+  // browser's delivery - measured at 265 five-millisecond yields, 1.85 seconds, for a first
+  // snapshot readback. Waiting on the future returns the moment the map resolves, while a
+  // timeout still returns within the slice so the caller's cancellation stays responsive.
+  //
+  // The latch is process-wide because the failure it guards against is a property of this
+  // thread's relationship to the instance, not of one mapping: once a status other than
+  // Success or TimedOut says this future cannot be time-waited here, every later wait polls.
+  static std::atomic<bool> instanceWaitUsable{true};
+  MappingSlot& slot = slotMappings_[mappingSlotIndex];
+  if (!geodeDevice_.instance() || !slot.mapFuture.id ||
+      !instanceWaitUsable.load(std::memory_order_relaxed)) {
+    return false;
+  }
+
+  wgpu::FutureWaitInfo waitInfo{};
+  waitInfo.future = slot.mapFuture;
+  const auto sliceNs = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(slice).count());
+  const wgpu::WaitStatus waitStatus = geodeDevice_.instance().waitAny(1, &waitInfo, sliceNs);
+  if (waitStatus != wgpu::WaitStatus::Success && waitStatus != wgpu::WaitStatus::TimedOut) {
+    instanceWaitUsable.store(false, std::memory_order_relaxed);
+    return false;
+  }
+  slot.usedTimedWaitAny = true;
+  return true;
+#else
+  (void)mappingSlotIndex;
+  (void)slice;
+  return false;
+#endif
 }
 
 gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSlotIndex,
@@ -623,8 +688,7 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
   }
   MappingSlot::Completion& completion = *slotMappings_[mappingSlotIndex].completion;
   if (completion.done.load(std::memory_order_acquire)) {
-    return completion.ok.load(std::memory_order_relaxed) ? gpu::MapSliceState::Ready
-                                                         : gpu::MapSliceState::Failed;
+    return sliceStateOf(completion);
   }
   if (geodeDevice_.isDeviceLost()) {
     return gpu::MapSliceState::DeviceLost;
@@ -633,20 +697,35 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
   // Wait out the slice the caller allowed rather than returning the moment one poll finds
   // nothing: the waiter's budget is wall time, so a slice that returns immediately turns a map
   // that is merely not ready yet into a burst of fast calls against that budget.
-  const auto slice = std::chrono::duration_cast<std::chrono::milliseconds>(
+  //
+  // Microseconds, not milliseconds: the readback path slices below a millisecond, and rounding
+  // a 100 us slice up to 1 ms would coarsen the cadence that path is tuned to.
+  const auto slice = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::duration<double>(sliceSeconds));
+
+  if (waitOnMapFutureSlice(mappingSlotIndex, slice)) {
+    return sliceStateOf(completion);
+  }
+
   (void)BoundedGpuWait(
       [&] {
         (void)geodeDevice_.pollSuspending(false);
         return completion.done.load(std::memory_order_acquire) || geodeDevice_.isDeviceLost();
       },
-      std::max(slice, std::chrono::milliseconds(1)));
+      std::max(slice, std::chrono::microseconds(1)));
 
   if (completion.done.load(std::memory_order_acquire)) {
-    return completion.ok.load(std::memory_order_relaxed) ? gpu::MapSliceState::Ready
-                                                         : gpu::MapSliceState::Failed;
+    return sliceStateOf(completion);
   }
   return geodeDevice_.isDeviceLost() ? gpu::MapSliceState::DeviceLost : gpu::MapSliceState::Pending;
+}
+
+bool GeodeWgpuAdapterDevice::mappingUsedTimedWaitAny(const gpu::BufferMapping& mapping) const {
+  if (validateBufferMappingHandleForBackend(mapping).hasError() ||
+      mapping.slotIndex() >= slotMappings_.size()) {
+    return false;
+  }
+  return slotMappings_[mapping.slotIndex()].usedTimedWaitAny;
 }
 
 gpu::Result<std::span<const uint8_t>> GeodeWgpuAdapterDevice::onMappedBytes(

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -7,6 +7,7 @@
 /// last caller.
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -100,6 +101,33 @@ public:
    */
   gpu::Status destroyTextureBacking(gpu::Texture&& texture);
 
+  /**
+   * Destroys the backend object behind \p buffer explicitly, then releases its slot.
+   *
+   * The buffer counterpart of \ref destroyTextureBacking, and needed for the same reason:
+   * releasing a buffer handle on its own only drops this adapter's reference, which leaves the
+   * backend object resident until the host runtime collects it. A readback buffer whose map was
+   * cancelled, and a pooled readback set evicted to keep the pool inside its ceiling, both have
+   * to release their memory at that moment rather than whenever a collector next runs.
+   *
+   * @param buffer Live buffer handle of this adapter; consumed either way.
+   */
+  gpu::Status destroyBufferBacking(gpu::Buffer&& buffer);
+
+  /**
+   * Whether any wait slice of \p mapping waited on the map's completion event rather than
+   * polling for it.
+   *
+   * The distinction is a property of how this adapter waited, so it is reported here rather than
+   * inferred by the caller; the readback statistics carry it because a browser frame that fell
+   * back to polling takes orders of magnitude longer to observe the same completion.
+   *
+   * @param mapping Live mapping handle of this adapter.
+   * @return True if a completion-event wait was used; false for a polled wait, an unknown
+   *   handle, or a mapping no slice ever waited on.
+   */
+  bool mappingUsedTimedWaitAny(const gpu::BufferMapping& mapping) const;
+
   gpu::Result<gpu::Texture> importExternalTexture(wgpu::Texture texture, const gpu::Extent2d& size,
                                                   gpu::TextureFormat format,
                                                   gpu::TextureUsage usage);
@@ -155,6 +183,15 @@ public:
    * @param texture Live texture handle of this adapter.
    */
   wgpu::Texture wgpuTextureOf(const gpu::Texture& texture) const;
+
+  /**
+   * TEMPORARY escape hatch (deleted with the readback and presentation migration): returns the
+   * wgpu buffer behind \p buffer, or a null handle if the handle does not name a live buffer of
+   * this adapter. Borrowed; this adapter retains ownership.
+   *
+   * @param buffer Live buffer handle of this adapter.
+   */
+  wgpu::Buffer wgpuBufferOf(const gpu::Buffer& buffer) const;
 
   /**
    * TEMPORARY escape hatch (deleted with the readback and presentation migration): returns the
@@ -373,7 +410,26 @@ private:
     wgpu::Buffer buffer;               //!< Buffer being mapped; borrowed from its slot.
     uint64_t offsetBytes = 0;          //!< Byte offset of the mapped range.
     uint64_t byteCount = 0;            //!< Length of the mapped range.
+    /// Future the map request returned, so a wait slice can wait on the completion event itself
+    /// where the platform supports it rather than polling for it.
+    wgpu::Future mapFuture{};
+    /// Whether any slice of this mapping waited on \ref mapFuture instead of polling. Reported
+    /// out through \ref GeodeWgpuAdapterDevice::mappingUsedTimedWaitAny, because the readback
+    /// stats distinguish the two and a browser frame that fell back to polling is a regression
+    /// worth seeing.
+    bool usedTimedWaitAny = false;
   };
+
+  /// Ready or Failed, from a completion that has already run.
+  /// @param completion Finished completion state.
+  static gpu::MapSliceState sliceStateOf(const MappingSlot::Completion& completion);
+
+  /// Waits out one slice on the map's completion event where the platform supports it.
+  /// @param mappingSlotIndex Slot of the mapping to wait on.
+  /// @param slice Length of this wait slice.
+  /// @return True if the slice was waited on the event (so the caller re-reads the completion
+  ///   rather than polling), false if this platform or this thread cannot event-wait it.
+  bool waitOnMapFutureSlice(uint32_t mappingSlotIndex, std::chrono::microseconds slice);
 
   /// One presentation surface and the texture it has handed out this frame.
   struct SurfaceSlot {

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -128,6 +128,17 @@ public:
    */
   bool mappingUsedTimedWaitAny(const gpu::BufferMapping& mapping) const;
 
+  /**
+   * Test seam: makes a wait slice behave as the browser's timed wait does when it expires
+   * without the map completing - it reports that it handled the slice, having learned nothing.
+   *
+   * That arm is compiled out on every platform the test suites run on, so its contract is
+   * otherwise checked only by the browser lane, which is exactly where it went unchecked.
+   *
+   * @param simulate Whether slices should take the simulated event-wait path.
+   */
+  void setSimulateEventWaitForTest(bool simulate) { simulateEventWaitForTest_ = simulate; }
+
   gpu::Result<gpu::Texture> importExternalTexture(wgpu::Texture texture, const gpu::Extent2d& size,
                                                   gpu::TextureFormat format,
                                                   gpu::TextureUsage usage);
@@ -420,9 +431,10 @@ private:
     bool usedTimedWaitAny = false;
   };
 
-  /// Ready or Failed, from a completion that has already run.
-  /// @param completion Finished completion state.
-  static gpu::MapSliceState sliceStateOf(const MappingSlot::Completion& completion);
+  /// The mapping's state right now: Ready or Failed once the map has completed, DeviceLost on a
+  /// lost device, and Pending until then.
+  /// @param completion Completion state to read.
+  gpu::MapSliceState sliceStateOf(const MappingSlot::Completion& completion) const;
 
   /// Waits out one slice on the map's completion event where the platform supports it.
   /// @param mappingSlotIndex Slot of the mapping to wait on.
@@ -430,6 +442,11 @@ private:
   /// @return True if the slice was waited on the event (so the caller re-reads the completion
   ///   rather than polling), false if this platform or this thread cannot event-wait it.
   bool waitOnMapFutureSlice(uint32_t mappingSlotIndex, std::chrono::microseconds slice);
+
+  /// Makes \ref waitOnMapFutureSlice report that an event wait handled the slice without one
+  /// having happened, so the browser arm's contract can be checked where that arm is compiled
+  /// out. See \ref simulateEventWaitForTest.
+  bool simulateEventWaitForTest_ = false;
 
   /// One presentation surface and the texture it has handed out this frame.
   struct SurfaceSlot {

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -112,9 +112,6 @@ TEST(BoundedGpuWait, ZeroTimeoutPollsOnceThenTimesOut) {
   EXPECT_TRUE(clock.sleeps.empty());
 }
 
-/// A device-lost record starts with no timeout attribution, so "lost with no
-/// site" is a meaningful state: it says the driver reported the loss rather
-/// than a deadline discovering it.
 TEST(BoundedGpuWait, ASubMillisecondBudgetIsNotRoundedUp) {
   // The snapshot readback waits one poll interval at a time, so its budget is smaller than a
   // millisecond. A budget expressed in whole milliseconds would round a 100 us slice up to
@@ -137,6 +134,9 @@ TEST(BoundedGpuWait, ASubMillisecondBudgetIsNotRoundedUp) {
   EXPECT_EQ(clock.current.time_since_epoch(), std::chrono::microseconds(100));
 }
 
+/// A device-lost record starts with no timeout attribution, so "lost with no
+/// site" is a meaningful state: it says the driver reported the loss rather
+/// than a deadline discovering it.
 TEST(GeodeDeviceLostState, StartsWithNoTimeoutAttribution) {
   const GeodeDeviceLostState state;
 

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -115,6 +115,28 @@ TEST(BoundedGpuWait, ZeroTimeoutPollsOnceThenTimesOut) {
 /// A device-lost record starts with no timeout attribution, so "lost with no
 /// site" is a meaningful state: it says the driver reported the loss rather
 /// than a deadline discovering it.
+TEST(BoundedGpuWait, ASubMillisecondBudgetIsNotRoundedUp) {
+  // The snapshot readback waits one poll interval at a time, so its budget is smaller than a
+  // millisecond. A budget expressed in whole milliseconds would round a 100 us slice up to
+  // 1 ms and coarsen the poll cadence tenfold, which is a cadence the readback path is tuned to
+  // and the perf ceilings assume.
+  FakeClock clock;
+  int pollCount = 0;
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return false;
+      },
+      100us, 100us, clock.hooks());
+
+  EXPECT_EQ(result, GpuWaitResult::TimedOut);
+  // One sleep of the whole budget, then the poll that observes the deadline. A budget rounded up
+  // to a millisecond would sleep ten times instead.
+  EXPECT_EQ(clock.sleeps.size(), 1u);
+  EXPECT_EQ(pollCount, 2);
+  EXPECT_EQ(clock.current.time_since_epoch(), std::chrono::microseconds(100));
+}
+
 TEST(GeodeDeviceLostState, StartsWithNoTimeoutAttribution) {
   const GeodeDeviceLostState state;
 

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -124,6 +124,36 @@ TEST_F(GeodeSnapshotReadbackTest, GpuAndCpuPathsAreByteIdentical) {
       << "GPU unpremultiply output differs from the CPU reference path";
 }
 
+/// A readback that actually waits must account for the slices it ran: one recorded readback, at
+/// least one slice, and a slice count that keeps growing across readbacks rather than resetting
+/// or being reported once. The zero-slice cases are pinned elsewhere (a pre-cancelled snapshot
+/// and a cancel observed before the first slice), so this is the other half of that contract -
+/// without it a wrapper that recorded a constant zero would pass every existing assertion.
+TEST_F(GeodeSnapshotReadbackTest, ACompletedReadbackAccountsForTheSlicesItRan) {
+  auto device = sharedDevice();
+  ASSERT_NE(device, nullptr);
+  ASSERT_TRUE(device->snapshotReadbackPipeline().valid());
+
+  wgpu::Texture texture = createTestTexture(device->device(), wgpu::TextureUsage::TextureBinding);
+  const Vector2i dimensions(static_cast<int>(kWidth), static_cast<int>(kHeight));
+  RendererGeodeTextureSnapshot snapshot(device, std::move(texture), dimensions,
+                                        wgpu::TextureFormat::RGBA8Unorm);
+  RendererGeode renderer(device);
+
+  (void)renderer.consumeReadbackStats();  // Drop anything an earlier case in this suite left.
+
+  ASSERT_FALSE(snapshot.takeSnapshot().empty());
+  const RendererReadbackStats first = renderer.consumeReadbackStats();
+  EXPECT_EQ(first.count, 1);
+  EXPECT_GE(first.pollIterations, 1)
+      << "a readback that waited for the GPU must report the slices it ran";
+
+  ASSERT_FALSE(snapshot.takeSnapshot().empty());
+  const RendererReadbackStats second = renderer.consumeReadbackStats();
+  EXPECT_EQ(second.count, 1) << "each readback is recorded exactly once";
+  EXPECT_GE(second.pollIterations, 1);
+}
+
 /// A snapshot against a lost device must return an empty bitmap promptly
 /// instead of spending the full readback deadline waiting for a map that a
 /// hung driver will never deliver. A fresh (non-shared) device is used so the

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -824,6 +824,39 @@ TEST_F(GeodeWgpuAdapterDeviceTests, TimedWaitReportingIsFalseForAPolledWaitAndFo
   EXPECT_FALSE(adapter_->mappingUsedTimedWaitAny(gpu::BufferMapping()));
 }
 
+/// The browser waits out a map slice on the map's completion event, and that wait returns for
+/// two reasons: the map finished, or the slice expired with the map still pending. The second
+/// case must report "not finished" so the caller waits again - reporting it as a failed map ends
+/// the readback on its first slice, the snapshot comes back empty, and the editor render that
+/// asked for it has nothing to present.
+///
+/// That arm is compiled out everywhere these suites run, which is how it reached the browser
+/// lane unchecked, so the seam below stands in for it.
+TEST_F(GeodeWgpuAdapterDeviceTests, AnEventWaitThatLearnedNothingReportsPendingNotFailed) {
+  const gpu::Buffer buffer = gpu::GetResultOrFail(adapter_->createBuffer(gpu::BufferDescriptor{
+      "readback", 256, gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead}));
+
+  gpu::BufferMapping mapping =
+      gpu::GetResultOrFail(adapter_->mapBufferAsync(buffer, gpu::MapMode::Read, 0, 256));
+
+  // Nothing has polled since the map was requested, so the map cannot already be complete.
+  adapter_->setSimulateEventWaitForTest(true);
+  const gpu::Result<gpu::MapWaitOutcome> expired =
+      adapter_->waitForMapping(mapping, gpu::MapWaitParams{0.0001, 0.0001}, {});
+  adapter_->setSimulateEventWaitForTest(false);
+
+  ASSERT_THAT(expired, gpu::HasResult());
+  EXPECT_EQ(expired.result(), gpu::MapWaitOutcome::TimedOut)
+      << "a slice that waited and learned nothing must leave the map waitable, not report it "
+         "failed";
+
+  // The mapping is still usable: a real wait now completes it.
+  EXPECT_EQ(
+      gpu::GetResultOrFail(adapter_->waitForMapping(mapping, gpu::MapWaitParams{0.01, 2.0}, {})),
+      gpu::MapWaitOutcome::Ready);
+  EXPECT_THAT(adapter_->unmapBuffer(std::move(mapping)), gpu::IsOk());
+}
+
 /// A readback buffer whose map was abandoned, and a pooled readback set evicted to stay inside
 /// its ceiling, both have to give their memory back at that moment. Releasing the handle alone
 /// only drops the adapter's reference, so the entry point that destroys the backend object is

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -800,6 +800,54 @@ TEST_F(GeodeWgpuAdapterDeviceTests, AMappingReleasedBeforeItsCallbackStillUnmaps
   EXPECT_THAT(adapter_->unmapBuffer(std::move(second)), gpu::IsOk());
 }
 
+/// The readback path reports whether the backend waited on the map's completion event or polled
+/// for it, and that answer belongs to the adapter that did the waiting. On a platform with no
+/// event wait the answer must be a plain false rather than an assumption baked into the caller,
+/// and a handle that no longer names a live mapping must not be able to read the flag out of
+/// whatever occupies that slot now.
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedWaitReportingIsFalseForAPolledWaitAndForADeadHandle) {
+  const gpu::Buffer buffer = gpu::GetResultOrFail(adapter_->createBuffer(gpu::BufferDescriptor{
+      "readback", 256, gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead}));
+
+  gpu::BufferMapping mapping =
+      gpu::GetResultOrFail(adapter_->mapBufferAsync(buffer, gpu::MapMode::Read, 0, 256));
+  EXPECT_FALSE(adapter_->mappingUsedTimedWaitAny(mapping))
+      << "no slice has run yet, so nothing can have waited on the completion event";
+
+  EXPECT_EQ(
+      gpu::GetResultOrFail(adapter_->waitForMapping(mapping, gpu::MapWaitParams{0.01, 2.0}, {})),
+      gpu::MapWaitOutcome::Ready);
+  // This build has no completion-event wait, so the slice above polled.
+  EXPECT_FALSE(adapter_->mappingUsedTimedWaitAny(mapping));
+
+  EXPECT_THAT(adapter_->unmapBuffer(std::move(mapping)), gpu::IsOk());
+  EXPECT_FALSE(adapter_->mappingUsedTimedWaitAny(gpu::BufferMapping()));
+}
+
+/// A readback buffer whose map was abandoned, and a pooled readback set evicted to stay inside
+/// its ceiling, both have to give their memory back at that moment. Releasing the handle alone
+/// only drops the adapter's reference, so the entry point that destroys the backend object is
+/// what the pool and the cancel path depend on - and it must refuse a handle that does not name
+/// a live buffer of this adapter rather than destroying the slot's new occupant.
+TEST_F(GeodeWgpuAdapterDeviceTests, DestroyingABufferBackingConsumesTheHandleAndRefusesStaleOnes) {
+  gpu::Buffer buffer = gpu::GetResultOrFail(adapter_->createBuffer(gpu::BufferDescriptor{
+      "readback", 256, gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead}));
+
+  EXPECT_THAT(adapter_->destroyBufferBacking(std::move(buffer)), gpu::IsOk());
+  EXPECT_FALSE(buffer.isValid()) << "the handle must be consumed either way";
+
+  EXPECT_THAT(adapter_->destroyBufferBacking(gpu::Buffer()),
+              gpu::IsGpuError(gpu::GpuErrorType::InvalidHandle));
+
+  // A destroyed buffer's slot can be reused; a second destroy through the old handle must not
+  // reach whatever now occupies it.
+  const gpu::Buffer replacement = gpu::GetResultOrFail(adapter_->createBuffer(gpu::BufferDescriptor{
+      "replacement", 256, gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead}));
+  EXPECT_TRUE(replacement.isValid());
+  EXPECT_FALSE(adapter_->wgpuBufferOf(gpu::Buffer())) << "a null handle names no backend buffer";
+  EXPECT_TRUE(adapter_->wgpuBufferOf(replacement));
+}
+
 /// The adapter presents to a Metal layer; the other platform surfaces are still created by the
 /// embedder, so asking it for one reports the capability as unsupported rather than appearing to
 /// work and then failing at the first frame.

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -346,6 +346,65 @@ TEST_F(RendererGeodeTest, PreCancelledInterruptibleSnapshotSkipsGpuReadback) {
   EXPECT_EQ(stats.pollIterations, 0);
 }
 
+/// A device lost AFTER the map is requested is a different route from one lost before it, and
+/// moving the wait onto the runtime created it: a wait slice checks the lost flag itself and
+/// reports the loss within about one slice, where the readback previously discovered it only
+/// when the ten-second deadline expired and declared a timeout.
+///
+/// Worth pinning in both directions. The readback must give up promptly, and it must NOT record
+/// a timeout attribution while doing so - that attribution says "a deadline discovered this",
+/// and here the driver did. The statistics must still be recorded, because they are taken
+/// before the mapping handle is consumed; a wrapper that unmapped first would have nothing left
+/// to read them from.
+///
+/// A fresh device, not the suite's shared one, so the injected loss cannot poison other cases.
+TEST_F(RendererGeodeTest, DeviceLostWhileTheMapIsPendingIsReportedWithinASlice) {
+  std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());
+  ASSERT_NE(device, nullptr);
+
+  RendererGeode renderer(device);
+  beginFrame(renderer);
+  renderer.endFrame();
+  (void)renderer.consumeReadbackStats();
+
+  // The cancellation predicate is polled once before the readback is set up at all, and then
+  // once per wait slice, before the slice itself. The second call is therefore the one place a
+  // test can stand between the map request and the first slice: the readback's own fast-fail on
+  // an already-lost device is behind us, no poll has run since the map was requested, so the
+  // slice cannot find the map already complete and must reach its lost-device check.
+  //
+  // If that call sequence ever changes, this lands on the fast-fail route instead, where no
+  // statistics are recorded - which the assertions below fail on rather than pass silently.
+  int predicateCalls = 0;
+  const auto start = std::chrono::steady_clock::now();
+  const RendererBitmap snapshot = renderer.takeSnapshotInterruptibly([&] {
+    if (++predicateCalls == 2) {
+      device->markDeviceLost("test-injected loss while the map was pending");
+    }
+    return false;  // Never cancel: the loss, not the caller, must end this wait.
+  });
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_TRUE(snapshot.empty());
+  EXPECT_GE(predicateCalls, 2) << "the wait must have reached at least one slice";
+  // Well under the ten-second readback deadline: the slice reports the loss rather than the
+  // deadline discovering it.
+  EXPECT_LT(elapsed, std::chrono::seconds(2));
+
+  const RendererReadbackStats stats = renderer.consumeReadbackStats();
+  EXPECT_EQ(stats.count, 1) << "the readback statistics are recorded before the mapping handle "
+                               "is consumed, so an abandoned map still reports";
+  EXPECT_GE(stats.pollIterations, 1);
+  EXPECT_TRUE(stats.deviceLost);
+  EXPECT_EQ(stats.timedOutWaitSite, GpuWaitTimeoutSite::None)
+      << "a driver-reported loss must not be attributed to a wait deadline";
+
+  // The abandoned readback leaves its buffer for the lost device to take with it rather than
+  // destroying it, so running the whole path again must neither crash nor double-free. On the
+  // sanitizer lanes this is where a double destroy would surface.
+  EXPECT_TRUE(renderer.takeSnapshot().empty());
+}
+
 TEST_F(RendererGeodeTest, InterruptibleSnapshotCancelsPromptlyAfterGpuSubmit) {
   RendererGeode renderer = createRenderer();
   beginFrame(renderer);

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -432,27 +432,21 @@
         "createCommandEncoder",
         "createTexture",
         "createView",
-        "destroy",
         "dispatchWorkgroups",
         "draw",
         "finish",
-        "getConstMappedRange",
-        "mapAsync",
         "setBindGroup",
         "setPipeline",
-        "submit",
-        "unmap"
+        "submit"
       ],
       "wgpuCFunctions": [
+        "wgpuBufferOf",
         "wgpuDevicePoll",
         "wgpuLabel",
         "wgpuTextureOf"
       ],
       "wgpuCTypes": [
         "WGPUCommandEncoder",
-        "WGPUMapAsyncStatus",
-        "WGPUMapAsyncStatus_Success",
-        "WGPUStringView",
         "WGPUTexture",
         "WGPUTextureFormat",
         "WGPUTextureFormat_BGRA8Unorm",
@@ -463,20 +457,12 @@
         "BindGroupDescriptor",
         "BindGroupEntry",
         "Buffer",
-        "BufferDescriptor",
-        "BufferMapCallbackInfo",
-        "BufferUsage",
-        "CallbackMode",
         "CommandBuffer",
         "CommandEncoder",
         "CommandEncoderDescriptor",
         "ComputePassDescriptor",
         "ComputePassEncoder",
-        "Default",
         "Extent3D",
-        "Future",
-        "FutureWaitInfo",
-        "MapMode",
         "TexelCopyBufferInfo",
         "TexelCopyTextureInfo",
         "Texture",
@@ -484,8 +470,7 @@
         "TextureDimension",
         "TextureFormat",
         "TextureUsage",
-        "TextureView",
-        "WaitStatus"
+        "TextureView"
       ]
     },
     "donner/svg/renderer/RendererGeode.h": {
@@ -612,8 +597,6 @@
         "Adapter",
         "BackendType",
         "Buffer",
-        "BufferDescriptor",
-        "BufferUsage",
         "CallbackMode",
         "Default",
         "Device",
@@ -827,6 +810,7 @@
         "writeTexture"
       ],
       "wgpuCFunctions": [
+        "wgpuBufferOf",
         "wgpuLabel",
         "wgpuTextureOf",
         "wgpuTextureViewOf"
@@ -886,6 +870,7 @@
         "Extent3D",
         "FilterMode",
         "FragmentState",
+        "FutureWaitInfo",
         "LoadOp",
         "MapMode",
         "PipelineLayout",
@@ -926,7 +911,8 @@
         "VertexAttribute",
         "VertexBufferLayout",
         "VertexFormat",
-        "VertexStepMode"
+        "VertexStepMode",
+        "WaitStatus"
       ]
     },
     "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h": {
@@ -935,6 +921,7 @@
         "unmap"
       ],
       "wgpuCFunctions": [
+        "wgpuBufferOf",
         "wgpuTextureOf",
         "wgpuTextureViewOf"
       ],
@@ -946,6 +933,7 @@
         "ComputePassEncoder",
         "ComputePipeline",
         "Device",
+        "Future",
         "PipelineLayout",
         "RenderPassEncoder",
         "RenderPipeline",

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -1135,6 +1135,7 @@
         "writeTexture"
       ],
       "wgpuCFunctions": [
+        "wgpuBufferOf",
         "wgpuLabel",
         "wgpuTextureOf",
         "wgpuTextureViewOf"


### PR DESCRIPTION
The snapshot readback allocated its buffers straight from wgpu and ran its own map-and-wait loop against `mapAsync`, so the one path in the renderer that blocks on the GPU was also the one furthest from the runtime.

The pooled readback buffers and the CPU fallback's own buffer are now `gpu::Buffer` created through the runtime, which counts the allocation itself, so neither site ticks the buffer counter any more; a second tick would double-count every readback set against the ceilings the steady-state gates ratchet on. Evicting a pooled set and dropping a buffer whose map was abandoned both destroy the backend object through a new `destroyBufferBacking`, the buffer counterpart of the texture entry point, because releasing the handle alone leaves the buffer resident until the host runtime collects it.

The wait is a loop of single-slice runtime waits under a renderer-owned wrapper rather than one runtime wait carrying the whole budget, because four things this path reports are properties of the loop rather than of the runtime's wait: the number of slices actually run, whether the backend waited on the map's completion event or polled for it, the wait-site attribution a timeout declares on the device, and destroying the buffer whose map was abandoned. Each is preserved exactly, including the slice count of zero that distinguishes "gave up immediately" from "waited and then gave up". The existing assertions only pinned those zero-slice cases, so a wrapper that recorded a constant zero would have satisfied every one of them; the other half of that contract is covered here.

One behavior change comes with the move: a device lost while a readback map is pending is now reported within about one wait slice, because a slice checks the lost flag itself, where the readback previously discovered it only when the ten-second deadline expired. The timeout-attribution path is now reserved for genuine timeouts - a driver-reported loss records no wait-site attribution, since that attribution says a deadline discovered the loss.

The browser's completion-event wait moves into the adapter, where the map's future lives, and whether it was used is now the adapter's answer rather than the caller's assumption. The instance feature that makes the wait available is requested where it always was.

The bounded wait now takes its budget in microseconds. It was milliseconds, and the readback slices at a hundred microseconds, so a slice was being rounded up to a whole millisecond - a tenfold coarsening of the poll cadence the readback path is tuned to.
