### PR TITLE
metal: stop assuming both processors address one copy of a resource

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -543,20 +543,22 @@ jobs:
               fi
               # Host-compatibility recheck. "Instrumentable" means HOST-
               # instrumentable: a wasm bridge shim is a plain cc_binary by
-              # kind but is target_compatible_with @platforms//:incompatible
-              # on the host, so --skip_incompatible_explicit_targets (set in
-              # --config=ci) silently drops it from the coverage build and
-              # the run is guaranteed to produce an empty report (the #810
-              # false RUN). Only when EVERY remaining instrumentable target
-              # is a cc_binary do we spend a cquery to test host
-              # compatibility; sets containing cc_library/cc_test/wrapper
-              # kinds are host code and run coverage with zero extra cost.
+              # kind, and a platform-gated backend test is a plain cc_test by
+              # kind, but either can be target_compatible_with a platform this
+              # lane does not run, so --skip_incompatible_explicit_targets
+              # (set in --config=ci) silently drops it from the coverage build
+              # and the run produces an empty report (the #810 false RUN, and
+              # its cc_test sibling: a macOS-only backend test selected on the
+              # Linux coverage lane). The recheck therefore runs whenever any
+              # instrumentable target exists - the earlier cc_binary-only
+              # scoping assumed cc_test kinds are always host code, which
+              # platform-gated backend tests falsified. Cost is one cquery.
               # Fail closed: cquery failure, or any label the cquery does
               # not report as incompatible, keeps the coverage run.
-              if [[ -s "$instrumentable_file" ]] && ! grep -qv '^cc_binary rule ' "$instrumentable_file"; then
-                echo "All instrumentable targets are cc_binary; rechecking host compatibility."
+              if [[ -s "$instrumentable_file" ]]; then
+                echo "Rechecking host compatibility of the instrumentable set."
                 compat_file="$work_dir/host-compat.txt"
-                sed 's/^cc_binary rule //' "$instrumentable_file" | tr '\n' ' ' > "$work_dir/compat-labels.txt"
+                sed 's/^[a-z_0-9]* rule //' "$instrumentable_file" | tr '\n' ' ' > "$work_dir/compat-labels.txt"
                 if ( cd "$head_dir" && bazelisk cquery "set($(cat "$work_dir/compat-labels.txt"))" \
                     --output=starlark \
                     --starlark:expr='"{} {}".format(target.label, "HOST_INCOMPATIBLE" if "IncompatiblePlatformProvider" in providers(target) else "HOST_COMPATIBLE")' \

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -19,7 +19,7 @@ namespace donner::gpu::metal {
  * object, compile error, encoder failure) fails closed with a \ref donner::gpu::GpuError; the
  * backend never crashes on such failures.
  *
- * Scope: shared-storage buffers and textures, MSL shader modules, render pipelines with a single
+ * Scope: host-visible buffers and textures, MSL shader modules, render pipelines with a single
  * vertex buffer layout at slot 0 and bind group 0 only, render passes with color attachments,
  * compute pipelines and compute passes, and texture-to-buffer readback copies. Bindings follow
  * the deterministic argument-table mapping in
@@ -27,9 +27,15 @@ namespace donner::gpu::metal {
  * texture and sampler bindings map directly, and stage-in vertex data occupies vertex buffer
  * index 30.
  *
- * Resources use `MTLStorageModeShared`: this backend targets Apple Silicon's unified memory, so
- * shared storage keeps queue writes (`memcpy` / `replaceRegion`) and buffer readback simple with
- * no staging copies.
+ * Memory model: the storage mode of host-visible resources follows what the device reports
+ * rather than an assumption about it. Where the CPU and GPU address one copy of a resource
+ * (`hasUnifiedMemory`), resources are `MTLStorageModeShared` and queue writes (`memcpy` /
+ * `replaceRegion`) and buffer readback need no staging and no publication step. Where they do
+ * not, resources are `MTLStorageModeManaged` and each side's changes must be published to the
+ * other explicitly: a host buffer write publishes its range, and every submission ends by
+ * publishing the device's changes back before it completes, since afterwards there is no encoder
+ * left to do it with. Neither omission is an API error, so a missing publication is not reported
+ * by validation - it shows up only as the host reading whatever its copy last held.
  *
  * Threading: single-threaded use, matching \ref donner::gpu::Device's thread affinity. The one
  * exception is command-buffer completion handlers, which Metal invokes on an internal queue;
@@ -62,12 +68,16 @@ public:
   /// Whether this device's resources are built for unified memory. Test accessor.
   [[nodiscard]] bool usesUnifiedMemoryForTest() const;
 
-  /// How many host writes have published their range to the device copy. Test accessor.
+  /// How many buffer writes have published their range to the device copy. Test accessor.
   ///
-  /// On unified memory nothing is published and this stays zero; where memory is not unified,
-  /// every host write must publish or the device reads a stale copy. The count is the only way
-  /// to see that from outside, because hardware that addresses one copy produces correct results
-  /// whether or not the publication happened.
+  /// Counts the buffer path only, where the write is a `memcpy` through the host pointer and the
+  /// range has to be published after it. Texture writes go through `replaceRegion`, which
+  /// publishes what it wrote on its own, so they are deliberately absent from this count rather
+  /// than missing from it.
+  ///
+  /// On unified memory nothing is published and this stays zero. The count exists because
+  /// hardware that addresses one copy produces correct results whether or not the publication
+  /// happened, so the results cannot show whether it did.
   [[nodiscard]] uint64_t hostWritePublishCountForTest() const;
 
   /// How many submissions have published the device's changes back to the host copy. Test

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -62,6 +62,18 @@ public:
   /// Whether this device's resources are built for unified memory. Test accessor.
   [[nodiscard]] bool usesUnifiedMemoryForTest() const;
 
+  /// How many host writes have published their range to the device copy. Test accessor.
+  ///
+  /// On unified memory nothing is published and this stays zero; where memory is not unified,
+  /// every host write must publish or the device reads a stale copy. The count is the only way
+  /// to see that from outside, because hardware that addresses one copy produces correct results
+  /// whether or not the publication happened.
+  [[nodiscard]] uint64_t hostWritePublishCountForTest() const;
+
+  /// How many submissions have published the device's changes back to the host copy. Test
+  /// accessor, for the same reason as above but in the other direction.
+  [[nodiscard]] uint64_t deviceWritePublishCountForTest() const;
+
   /// Destructor; releases all Metal objects still alive.
   ~MetalDevice() override;
 

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -41,11 +41,26 @@ namespace donner::gpu::metal {
  */
 class MetalDevice final : public Device {
 public:
+  /// Which memory model the backend builds its resources for.
+  enum class MemoryModel : uint8_t {
+    /// Take the model the Metal device reports. Production always uses this.
+    Detected,
+    /// Build for a device without unified memory whatever it reports, so the host-coherency
+    /// steps that model needs are exercised on hardware that would otherwise never take them.
+    ForceNonUnified,
+  };
+
   /**
    * Creates a device on the system default Metal device. Returns nullptr if no Metal device is
    * available (for example on a CI host without a GPU).
+   *
+   * @param memoryModel Which memory model to build resources for; production leaves this
+   *   detected, and a test forces the non-unified path to cover it on unified hardware.
    */
-  static std::unique_ptr<MetalDevice> Create();
+  static std::unique_ptr<MetalDevice> Create(MemoryModel memoryModel = MemoryModel::Detected);
+
+  /// Whether this device's resources are built for unified memory. Test accessor.
+  [[nodiscard]] bool usesUnifiedMemoryForTest() const;
 
   /// Destructor; releases all Metal objects still alive.
   ~MetalDevice() override;

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -378,8 +378,9 @@ struct MetalDevice::Impl {
   /// Whether host-visible resources need explicit publication in both directions.
   bool needsExplicitHostCoherency() const { return !unifiedMemory; }
 
-  /// Encodes the blit that publishes every live host-visible resource's GPU-side changes to the
-  /// host copy. Called only where the memory model needs it. @param state Encoding state.
+  /// Publishes every live host-visible resource's device-side changes back to the host copy, for
+  /// a memory model that keeps the two apart. A no-op where the two are one copy.
+  /// @param state Encoding state.
   Status encodeHostCoherencySync(EncodingState& state);
 };
 
@@ -1220,6 +1221,10 @@ void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t s
 }
 
 Status MetalDevice::Impl::encodeHostCoherencySync(EncodingState& state) {
+  if (!needsExplicitHostCoherency()) {
+    return OkStatus();  // One copy addressed from both sides; nothing to publish.
+  }
+
   id<MTLBlitCommandEncoder> blitEncoder = [state.commandBuffer blitCommandEncoder];
   if (blitEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState,
@@ -1290,10 +1295,8 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
   // there is no encoder left to do it with. It covers every live resource rather than tracking
   // which this stream touched - the cost falls only on the path that already needs the copy, and
   // a missed resource here is silently wrong data rather than a reported failure.
-  if (impl_->needsExplicitHostCoherency()) {
-    if (Status status = impl_->encodeHostCoherencySync(state); status.hasError()) {
-      return failEncoding(std::move(status));
-    }
+  if (Status status = impl_->encodeHostCoherencySync(state); status.hasError()) {
+    return failEncoding(std::move(status));
   }
 
   impl_->attachCompletionHandler(state, submissionSerial);

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -363,6 +363,8 @@ struct MetalDevice::Impl {
 
   /// Whether resources are built for unified memory; decides every storage mode below.
   bool unifiedMemory = true;
+  uint64_t hostWritePublishCount = 0;    //!< Host ranges published to the device copy.
+  uint64_t deviceWritePublishCount = 0;  //!< Submissions that published back to the host copy.
 
   /// Storage mode for a resource the host reads or writes.
   ///
@@ -401,6 +403,14 @@ std::unique_ptr<MetalDevice> MetalDevice::Create(MemoryModel memoryModel) {
 
 bool MetalDevice::usesUnifiedMemoryForTest() const {
   return impl_->unifiedMemory;
+}
+
+uint64_t MetalDevice::hostWritePublishCountForTest() const {
+  return impl_->hostWritePublishCount;
+}
+
+uint64_t MetalDevice::deviceWritePublishCountForTest() const {
+  return impl_->deviceWritePublishCount;
 }
 
 MetalDevice::MetalDevice() : impl_(std::make_unique<Impl>()) {}
@@ -767,6 +777,7 @@ Status MetalDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
       // The write landed in the host's copy; the GPU reads its own until the range is published.
       [buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(offsetBytes),
                                          static_cast<NSUInteger>(data.size()))];
+      ++impl_->hostWritePublishCount;
     }
   }
   return OkStatus();
@@ -1225,6 +1236,7 @@ Status MetalDevice::Impl::encodeHostCoherencySync(EncodingState& state) {
     }
   }
   [blitEncoder endEncoding];
+  ++deviceWritePublishCount;
   return OkStatus();
 }
 

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -360,9 +360,28 @@ struct MetalDevice::Impl {
   /// @param state Encoding state.
   /// @param submissionSerial Serial assigned to this submission.
   void attachCompletionHandler(EncodingState& state, uint64_t submissionSerial);
+
+  /// Whether resources are built for unified memory; decides every storage mode below.
+  bool unifiedMemory = true;
+
+  /// Storage mode for a resource the host reads or writes.
+  ///
+  /// Shared is right only where the two processors address one copy. Where they do not, Managed
+  /// keeps a copy on each side, and each side's changes have to be published to the other
+  /// explicitly - which is what the didModifyRange and synchronizeResource steps below do.
+  MTLStorageMode hostVisibleStorageMode() const {
+    return unifiedMemory ? MTLStorageModeShared : MTLStorageModeManaged;
+  }
+
+  /// Whether host-visible resources need explicit publication in both directions.
+  bool needsExplicitHostCoherency() const { return !unifiedMemory; }
+
+  /// Encodes the blit that publishes every live host-visible resource's GPU-side changes to the
+  /// host copy. Called only where the memory model needs it. @param state Encoding state.
+  Status encodeHostCoherencySync(EncodingState& state);
 };
 
-std::unique_ptr<MetalDevice> MetalDevice::Create() {
+std::unique_ptr<MetalDevice> MetalDevice::Create(MemoryModel memoryModel) {
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   if (device == nil) {
     return nullptr;
@@ -370,7 +389,18 @@ std::unique_ptr<MetalDevice> MetalDevice::Create() {
 
   std::unique_ptr<MetalDevice> result(new MetalDevice());
   result->impl_->device = device;
+  // Ask the device rather than assuming. On a unified-memory device the CPU and GPU address one
+  // copy of a shared resource and nothing has to be moved between them; on a device without it,
+  // a shared resource is not the same bytes on both sides, and reading GPU output through the
+  // CPU pointer without synchronizing returns whatever the host copy last held - which is zeros
+  // for a buffer nothing ever wrote from the host.
+  result->impl_->unifiedMemory =
+      memoryModel == MemoryModel::Detected ? (device.hasUnifiedMemory != NO) : false;
   return result;
+}
+
+bool MetalDevice::usesUnifiedMemoryForTest() const {
+  return impl_->unifiedMemory;
 }
 
 MetalDevice::MetalDevice() : impl_(std::make_unique<Impl>()) {}
@@ -433,8 +463,10 @@ std::string MetalDevice::lastErrorForTest() const {
 }
 
 Status MetalDevice::onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) {
+  const MTLResourceOptions bufferOptions =
+      impl_->unifiedMemory ? MTLResourceStorageModeShared : MTLResourceStorageModeManaged;
   id<MTLBuffer> buffer = [impl_->device newBufferWithLength:descriptor.byteSize
-                                                    options:MTLResourceStorageModeShared];
+                                                    options:bufferOptions];
   if (buffer == nil) {
     return GpuError{GpuErrorType::InvalidState,
                     std::format("Metal buffer allocation of {} bytes failed for '{}'",
@@ -463,9 +495,10 @@ Status MetalDevice::onCreateTexture(uint32_t slotIndex, const TextureDescriptor&
     usage |= MTLTextureUsageShaderWrite;
   }
   textureDescriptor.usage = usage;
-  // Shared storage: this backend targets Apple Silicon's unified memory, so render targets stay
-  // directly host-visible and blit readback needs no staging or synchronize step.
-  textureDescriptor.storageMode = MTLStorageModeShared;
+  // Host-visible either way: render targets and storage textures are read back through blits
+  // into host-visible buffers, and on a device without unified memory that means a managed
+  // texture whose GPU-side changes are published before the host reads them.
+  textureDescriptor.storageMode = impl_->hostVisibleStorageMode();
 
   id<MTLTexture> texture = [impl_->device newTextureWithDescriptor:textureDescriptor];
   if (texture == nil) {
@@ -730,6 +763,11 @@ Status MetalDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
 
   if (!data.empty()) {
     std::memcpy(static_cast<uint8_t*>(buffer.contents) + offsetBytes, data.data(), data.size());
+    if (impl_->needsExplicitHostCoherency()) {
+      // The write landed in the host's copy; the GPU reads its own until the range is published.
+      [buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(offsetBytes),
+                                         static_cast<NSUInteger>(data.size()))];
+    }
   }
   return OkStatus();
 }
@@ -1170,6 +1208,26 @@ void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t s
   }];
 }
 
+Status MetalDevice::Impl::encodeHostCoherencySync(EncodingState& state) {
+  id<MTLBlitCommandEncoder> blitEncoder = [state.commandBuffer blitCommandEncoder];
+  if (blitEncoder == nil) {
+    return GpuError{GpuErrorType::InvalidState,
+                    "Metal blit command encoder creation failed for the host-coherency sync"};
+  }
+  for (id<MTLBuffer> buffer : buffers) {
+    if (buffer != nil) {
+      [blitEncoder synchronizeResource:buffer];
+    }
+  }
+  for (id<MTLTexture> texture : textures) {
+    if (texture != nil) {
+      [blitEncoder synchronizeResource:texture];
+    }
+  }
+  [blitEncoder endEncoding];
+  return OkStatus();
+}
+
 Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
                              std::span<const Command> commands) {
   (void)commandBufferSlotIndex;
@@ -1212,6 +1270,18 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
     // The encoder state machine guarantees passes are ended before finish; fail closed anyway.
     return failEncoding(
         GpuError{GpuErrorType::InvalidState, "submitted command stream left a pass open"});
+  }
+
+  // Publish every host-visible resource's GPU-side changes before the buffer completes, so a
+  // host read after the completion sees them. Only a device without unified memory needs this,
+  // and there it has to happen inside the submission: once the command buffer has completed
+  // there is no encoder left to do it with. It covers every live resource rather than tracking
+  // which this stream touched - the cost falls only on the path that already needs the copy, and
+  // a missed resource here is silently wrong data rather than a reported failure.
+  if (impl_->needsExplicitHostCoherency()) {
+    if (Status status = impl_->encodeHostCoherencySync(state); status.hasError()) {
+      return failEncoding(std::move(status));
+    }
   }
 
   impl_->attachCompletionHandler(state, submissionSerial);

--- a/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
+++ b/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
@@ -239,6 +239,10 @@ TEST_F(MetalColorMatrixTest, UnifiedMemoryPublishesNothingBecauseThereIsOneCopy)
   EXPECT_EQ(device_->deviceWritePublishCountForTest(), 0u);
 }
 
+// This slice is the only one that runs under both memory models. The solid-fill and
+// sub-rectangle-copy slices run under the detected one, which is unified on every machine
+// available to run them, and they reach the host through the same publication the counters below
+// pin - so the mechanism is covered once here rather than repeated per slice.
 TEST_F(MetalColorMatrixTest, WithoutUnifiedMemoryEveryChangeIsPublishedInBothDirections) {
   // The behaviour this fix exists for cannot be observed in the pixels on hardware that
   // addresses one copy of a resource: the results come out right whether or not anything was

--- a/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
+++ b/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
@@ -229,6 +229,31 @@ TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResult) {
   runColorMatrixSlice(MetalDevice::MemoryModel::Detected);
 }
 
+TEST_F(MetalColorMatrixTest, UnifiedMemoryPublishesNothingBecauseThereIsOneCopy) {
+  runColorMatrixSlice(MetalDevice::MemoryModel::Detected);
+  if (!device_->usesUnifiedMemoryForTest()) {
+    GTEST_SKIP() << "this machine reports non-unified memory; the forced case below covers it";
+  }
+  EXPECT_EQ(device_->hostWritePublishCountForTest(), 0u)
+      << "both processors address one copy, so there is nothing to publish";
+  EXPECT_EQ(device_->deviceWritePublishCountForTest(), 0u);
+}
+
+TEST_F(MetalColorMatrixTest, WithoutUnifiedMemoryEveryChangeIsPublishedInBothDirections) {
+  // The behaviour this fix exists for cannot be observed in the pixels on hardware that
+  // addresses one copy of a resource: the results come out right whether or not anything was
+  // published, which is exactly why a virtualized device caught what every local run missed. So
+  // the assertion is on the publication itself, which is the mechanism the virtualized device
+  // needs and the part that was absent.
+  runColorMatrixSlice(MetalDevice::MemoryModel::ForceNonUnified);
+
+  EXPECT_GT(device_->hostWritePublishCountForTest(), 0u)
+      << "a host write the device never sees published leaves it reading a stale copy";
+  EXPECT_GT(device_->deviceWritePublishCountForTest(), 0u)
+      << "output the host reads must be published back before the submission completes, or the "
+         "read returns whatever the host copy last held";
+}
+
 TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResultWithoutUnifiedMemory) {
   // The same slice built for a device that does not address one copy of a resource from both
   // processors. On such a device the host's copy of the readback buffer is only whatever was

--- a/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
+++ b/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
@@ -1,5 +1,5 @@
 /// @file
-/// The Metal compute vertical slice: runs the color-matrix kernel emitted from the shader IR
+/// Runs the color-matrix kernel emitted from the shader IR on a real Metal device
 /// through donner::gpu::metal::MetalDevice and compares the destination texels byte-for-byte
 /// against the same result computed on the host.
 
@@ -65,7 +65,7 @@ protected:
     return std::move(result).result();
   }
 
-  /// Rebuilds the device for \p memoryModel and runs the whole slice against it.
+  /// Rebuilds the device for \p memoryModel and runs the whole color-matrix comparison against it.
   /// @param memoryModel Memory model the device builds its resources for.
   void runColorMatrixSlice(MetalDevice::MemoryModel memoryModel);
 
@@ -239,10 +239,10 @@ TEST_F(MetalColorMatrixTest, UnifiedMemoryPublishesNothingBecauseThereIsOneCopy)
   EXPECT_EQ(device_->deviceWritePublishCountForTest(), 0u);
 }
 
-// This slice is the only one that runs under both memory models. The solid-fill and
-// sub-rectangle-copy slices run under the detected one, which is unified on every machine
+// This test is the only one that runs under both memory models. The solid-fill and
+// sub-rectangle-copy tests run under the detected one, which is unified on every machine
 // available to run them, and they reach the host through the same publication the counters below
-// pin - so the mechanism is covered once here rather than repeated per slice.
+// pin - so the mechanism is covered once here rather than repeated per test.
 TEST_F(MetalColorMatrixTest, WithoutUnifiedMemoryEveryChangeIsPublishedInBothDirections) {
   // The behaviour this fix exists for cannot be observed in the pixels on hardware that
   // addresses one copy of a resource: the results come out right whether or not anything was
@@ -259,7 +259,7 @@ TEST_F(MetalColorMatrixTest, WithoutUnifiedMemoryEveryChangeIsPublishedInBothDir
 }
 
 TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResultWithoutUnifiedMemory) {
-  // The same slice built for a device that does not address one copy of a resource from both
+  // The same comparison built for a device that does not address one copy of a resource from both
   // processors. On such a device the host's copy of the readback buffer is only whatever was
   // published to it, so a dispatch whose output is never published reads back as zeros - which
   // is what a virtualized Metal device shows and what unified-memory hardware hides. Forcing the

--- a/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
+++ b/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
@@ -65,10 +65,21 @@ protected:
     return std::move(result).result();
   }
 
+  /// Rebuilds the device for \p memoryModel and runs the whole slice against it.
+  /// @param memoryModel Memory model the device builds its resources for.
+  void runColorMatrixSlice(MetalDevice::MemoryModel memoryModel);
+
   std::unique_ptr<MetalDevice> device_;
 };
 
-TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResult) {
+void MetalColorMatrixTest::runColorMatrixSlice(MetalDevice::MemoryModel memoryModel) {
+  device_ = MetalDevice::Create(memoryModel);
+  ASSERT_NE(device_, nullptr);
+  if (memoryModel == MetalDevice::MemoryModel::ForceNonUnified) {
+    ASSERT_FALSE(device_->usesUnifiedMemoryForTest())
+        << "the forced model must actually take the non-unified path";
+  }
+
   shader::ShaderResult<shader::IrModule> irModule = shader::programs::BuildColorMatrixModule();
   ASSERT_FALSE(irModule.hasError()) << irModule.error();
   shader::ShaderResult<std::string> msl = shader::EmitMsl(irModule.result());
@@ -212,6 +223,19 @@ TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResult) {
           << "texel (" << x << ", " << y << ")";
     }
   }
+}
+
+TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResult) {
+  runColorMatrixSlice(MetalDevice::MemoryModel::Detected);
+}
+
+TEST_F(MetalColorMatrixTest, DispatchMatchesTheHostComputedResultWithoutUnifiedMemory) {
+  // The same slice built for a device that does not address one copy of a resource from both
+  // processors. On such a device the host's copy of the readback buffer is only whatever was
+  // published to it, so a dispatch whose output is never published reads back as zeros - which
+  // is what a virtualized Metal device shows and what unified-memory hardware hides. Forcing the
+  // model here is what puts that path under test on hardware that would never take it.
+  runColorMatrixSlice(MetalDevice::MemoryModel::ForceNonUnified);
 }
 
 }  // namespace


### PR DESCRIPTION
The Metal backend created every buffer and texture shared and read results straight through the CPU pointer, on the stated assumption that it targets unified memory. Where that holds the code is correct and nothing needs moving between the two processors. Where it does not, a shared resource is not the same bytes on both sides: the host reads its own copy, which holds whatever was last published to it, and for a readback buffer nothing ever wrote from the host that is zeros.

- No API rule is broken by this, so Metal API and GPU validation have nothing to report. The output is simply never made visible, which is why every run on unified-memory hardware passed and the first run on a virtualized device returned all-zero texels for every pixel of the compute slice.
- The backend now asks the device rather than assuming. On a unified-memory device the storage modes and the code path are exactly what they were. Where memory is not unified, host-visible resources are managed, a host write publishes its range, and every submission ends by publishing the device's changes back before it completes.
- That final step happens inside the submission, because once the command buffer has completed there is no encoder left to do it with, and it covers every live resource rather than tracking which ones the stream touched: the cost falls only on the path that already pays for a copy, and missing one would be silently wrong data rather than a reported failure.
- Forcing the non-unified model and checking the pixels proves nothing on hardware that addresses one copy - the slice passes with the publication removed, which is the same blind spot that let this reach main. The gate therefore asserts the publication itself: counted in both directions, required on the forced non-unified path, and required to be absent on the unified one so the fast path keeps costing nothing. With the publication removed, the forced case fails on both counts.

This cannot be verified pre-merge. No local machine has a virtualized Metal device and the lanes that run before merge do not either, so what is proven here is that the code takes the path such a device needs, not that the device is fixed. The hosted lane's next run after merge is the final arbiter.
