### PR TITLE
Fix the zoom probe's observable and gate presentation sampling on the presented frame

### DIFF
--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -5,51 +5,6 @@ package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages(name = "node_modules")
 
-# Shared wiring for every Bazel-owned browser lane in this package. Each lane
-# differs only in which spec it runs and which test it selects; everything that
-# makes a browser reachable from Bazel - the served Wasm package, the pinned
-# Chromium, the Playwright config that owns the port and the web server - is
-# identical, so it is written once here.
-_BROWSER_LANE_DATA = [
-    "canvas-color-stats.ts",
-    "gesture-streams.ts",
-    "package.json",
-    "playwright.bazel.config.js",
-    "playwright.config.js",
-    "remote-webserver.mjs",
-    ":node_modules/@playwright/test",
-    "//donner/editor/wasm:_wasm_web_package_for_serve",
-    "@playwright//:chromium",
-]
-
-_BROWSER_LANE_ENV = {
-    "CI": "1",
-    "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
-    "DONNER_WASM_REQUIRE_WEBGPU": "1",
-    "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
-    # The repo-wide remote Emscripten workaround disables Node's WebAssembly
-    # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
-    "NODE_OPTIONS": "",
-    "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
-}
-
-# macOS-only: these lanes assert on presented WebGPU canvas pixels, and
-# headless Chromium on Linux cannot present a WebGPU OffscreenCanvas swapchain
-# with the SwiftShader WebGPU adapter. The GPU service finds no
-# SharedImageBackingFactory for the swapchain allocation (usage
-# WebgpuSwapChainTexture|DisplayRead|...), fails the first present, and destroys
-# the device, after which every WebGPU call rejects with "A valid external
-# Instance reference no longer exists". A browser-only probe (worker +
-# transferred OffscreenCanvas + clear + present) fails the same way with no
-# Donner code involved, on both Chromium 147 and 151 and with ANGLE/SwiftShader
-# GL, Vulkan, and Graphite flag configurations, so this is an environment
-# capability boundary, not a flag or timing gap. macOS headless Chromium
-# presents through the real GPU and passes.
-_BROWSER_LANE_COMPATIBLE_WITH = [
-    "@platforms//cpu:aarch64",
-    "@platforms//os:macos",
-]
-
 playwright_bin.playwright_test(
     name = "chromium_remote_smoke",
     size = "large",
@@ -60,9 +15,44 @@ playwright_bin.playwright_test(
         "--grep=production Geode wasm presents visible editor pixels",
     ],
     copy_data_to_bin = False,
-    data = _BROWSER_LANE_DATA + ["smoke.spec.ts"],
-    env = _BROWSER_LANE_ENV,
-    target_compatible_with = _BROWSER_LANE_COMPATIBLE_WITH,
+    data = [
+        "canvas-color-stats.ts",
+        "gesture-streams.ts",
+        "package.json",
+        "playwright.bazel.config.js",
+        "playwright.config.js",
+        "remote-webserver.mjs",
+        "smoke.spec.ts",
+        ":node_modules/@playwright/test",
+        "//donner/editor/wasm:_wasm_web_package_for_serve",
+        "@playwright//:chromium",
+    ],
+    env = {
+        "CI": "1",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
+        "DONNER_WASM_REQUIRE_WEBGPU": "1",
+        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+        # The repo-wide remote Emscripten workaround disables Node's WebAssembly
+        # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
+        "NODE_OPTIONS": "",
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+    },
+    # macOS-only: the selected smoke test asserts on presented WebGPU canvas
+    # pixels, and headless Chromium on Linux cannot present a WebGPU
+    # OffscreenCanvas swapchain with the SwiftShader WebGPU adapter. The GPU
+    # service finds no SharedImageBackingFactory for the swapchain allocation
+    # (usage WebgpuSwapChainTexture|DisplayRead|...), fails the first present,
+    # and destroys the device, after which every WebGPU call rejects with "A
+    # valid external Instance reference no longer exists". A browser-only
+    # probe (worker + transferred OffscreenCanvas + clear + present) fails the
+    # same way with no Donner code involved, on both Chromium 147 and 151 and
+    # with ANGLE/SwiftShader GL, Vulkan, and Graphite flag configurations, so
+    # this is an environment capability boundary, not a flag or timing gap.
+    # macOS headless Chromium presents through the real GPU and passes.
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
 )
 
 # The browser presentation regressions, reachable from Bazel.
@@ -70,9 +60,9 @@ playwright_bin.playwright_test(
 # This lane exists because the invariants it pins - among them the zoom storm
 # that must never uncover the editor background under the presented document -
 # were only ever reachable through the repository's own browser lane, so a
-# failure there could be answered with a rerun instead of a diagnosis. They
-# sample presented pixels over the Donner Splash, so they need a real presented
-# WebGPU canvas exactly as the smoke lane does.
+# failure there could be answered with a rerun instead of a diagnosis. Like the
+# smoke lane it asserts on presented WebGPU canvas pixels, so it carries the
+# same platform boundary for the same reason documented above.
 playwright_bin.playwright_test(
     name = "browser_presentation_regression_test",
     size = "large",
@@ -82,7 +72,30 @@ playwright_bin.playwright_test(
         "--config=$(rootpath :playwright.bazel.config.js)",
     ],
     copy_data_to_bin = False,
-    data = _BROWSER_LANE_DATA + ["browser-presentation-regression.spec.ts"],
-    env = _BROWSER_LANE_ENV,
-    target_compatible_with = _BROWSER_LANE_COMPATIBLE_WITH,
+    data = [
+        "browser-presentation-regression.spec.ts",
+        "canvas-color-stats.ts",
+        "gesture-streams.ts",
+        "package.json",
+        "playwright.bazel.config.js",
+        "playwright.config.js",
+        "remote-webserver.mjs",
+        ":node_modules/@playwright/test",
+        "//donner/editor/wasm:_wasm_web_package_for_serve",
+        "@playwright//:chromium",
+    ],
+    env = {
+        "CI": "1",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
+        "DONNER_WASM_REQUIRE_WEBGPU": "1",
+        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+        # The repo-wide remote Emscripten workaround disables Node's WebAssembly
+        # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
+        "NODE_OPTIONS": "",
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
 )

--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -5,6 +5,51 @@ package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages(name = "node_modules")
 
+# Shared wiring for every Bazel-owned browser lane in this package. Each lane
+# differs only in which spec it runs and which test it selects; everything that
+# makes a browser reachable from Bazel - the served Wasm package, the pinned
+# Chromium, the Playwright config that owns the port and the web server - is
+# identical, so it is written once here.
+_BROWSER_LANE_DATA = [
+    "canvas-color-stats.ts",
+    "gesture-streams.ts",
+    "package.json",
+    "playwright.bazel.config.js",
+    "playwright.config.js",
+    "remote-webserver.mjs",
+    ":node_modules/@playwright/test",
+    "//donner/editor/wasm:_wasm_web_package_for_serve",
+    "@playwright//:chromium",
+]
+
+_BROWSER_LANE_ENV = {
+    "CI": "1",
+    "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
+    "DONNER_WASM_REQUIRE_WEBGPU": "1",
+    "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+    # The repo-wide remote Emscripten workaround disables Node's WebAssembly
+    # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
+    "NODE_OPTIONS": "",
+    "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+}
+
+# macOS-only: these lanes assert on presented WebGPU canvas pixels, and
+# headless Chromium on Linux cannot present a WebGPU OffscreenCanvas swapchain
+# with the SwiftShader WebGPU adapter. The GPU service finds no
+# SharedImageBackingFactory for the swapchain allocation (usage
+# WebgpuSwapChainTexture|DisplayRead|...), fails the first present, and destroys
+# the device, after which every WebGPU call rejects with "A valid external
+# Instance reference no longer exists". A browser-only probe (worker +
+# transferred OffscreenCanvas + clear + present) fails the same way with no
+# Donner code involved, on both Chromium 147 and 151 and with ANGLE/SwiftShader
+# GL, Vulkan, and Graphite flag configurations, so this is an environment
+# capability boundary, not a flag or timing gap. macOS headless Chromium
+# presents through the real GPU and passes.
+_BROWSER_LANE_COMPATIBLE_WITH = [
+    "@platforms//cpu:aarch64",
+    "@platforms//os:macos",
+]
+
 playwright_bin.playwright_test(
     name = "chromium_remote_smoke",
     size = "large",
@@ -15,42 +60,29 @@ playwright_bin.playwright_test(
         "--grep=production Geode wasm presents visible editor pixels",
     ],
     copy_data_to_bin = False,
-    data = [
-        "canvas-color-stats.ts",
-        "gesture-streams.ts",
-        "package.json",
-        "playwright.bazel.config.js",
-        "playwright.config.js",
-        "remote-webserver.mjs",
-        "smoke.spec.ts",
-        ":node_modules/@playwright/test",
-        "//donner/editor/wasm:_wasm_web_package_for_serve",
-        "@playwright//:chromium",
+    data = _BROWSER_LANE_DATA + ["smoke.spec.ts"],
+    env = _BROWSER_LANE_ENV,
+    target_compatible_with = _BROWSER_LANE_COMPATIBLE_WITH,
+)
+
+# The browser presentation regressions, reachable from Bazel.
+#
+# This lane exists because the invariants it pins - among them the zoom storm
+# that must never uncover the editor background under the presented document -
+# were only ever reachable through the repository's own browser lane, so a
+# failure there could be answered with a rerun instead of a diagnosis. They
+# sample presented pixels over the Donner Splash, so they need a real presented
+# WebGPU canvas exactly as the smoke lane does.
+playwright_bin.playwright_test(
+    name = "browser_presentation_regression_test",
+    size = "large",
+    args = [
+        "test",
+        "$(rootpath :browser-presentation-regression.spec.ts)",
+        "--config=$(rootpath :playwright.bazel.config.js)",
     ],
-    env = {
-        "CI": "1",
-        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
-        "DONNER_WASM_REQUIRE_WEBGPU": "1",
-        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
-        # The repo-wide remote Emscripten workaround disables Node's WebAssembly
-        # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
-        "NODE_OPTIONS": "",
-        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
-    },
-    # macOS-only: the selected smoke test asserts on presented WebGPU canvas
-    # pixels, and headless Chromium on Linux cannot present a WebGPU
-    # OffscreenCanvas swapchain with the SwiftShader WebGPU adapter. The GPU
-    # service finds no SharedImageBackingFactory for the swapchain allocation
-    # (usage WebgpuSwapChainTexture|DisplayRead|...), fails the first present,
-    # and destroys the device, after which every WebGPU call rejects with "A
-    # valid external Instance reference no longer exists". A browser-only
-    # probe (worker + transferred OffscreenCanvas + clear + present) fails the
-    # same way with no Donner code involved, on both Chromium 147 and 151 and
-    # with ANGLE/SwiftShader GL, Vulkan, and Graphite flag configurations, so
-    # this is an environment capability boundary, not a flag or timing gap.
-    # macOS headless Chromium presents through the real GPU and passes.
-    target_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:macos",
-    ],
+    copy_data_to_bin = False,
+    data = _BROWSER_LANE_DATA + ["browser-presentation-regression.spec.ts"],
+    env = _BROWSER_LANE_ENV,
+    target_compatible_with = _BROWSER_LANE_COMPATIBLE_WITH,
 )

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -88,15 +88,35 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   const buildFile = readFileSync(buildFilePath, "utf8");
   assert.match(buildFile, /playwright_bin\.playwright_test\(/);
   assert.match(buildFile, /name = "chromium_remote_smoke"/);
-  const smokeTest = readFileSync(path.join(testDirectory, "smoke.spec.ts"), "utf8");
-  const localSmokeImports = [...smokeTest.matchAll(/from "\.\/([^"]+)"/g)].map(
-    ([, importedModule]) => `${importedModule}.ts`,
+  assert.match(buildFile, /name = "browser_presentation_regression_test"/);
+  // Every Bazel-owned browser lane, checked one at a time rather than against
+  // the file as a whole: a contract satisfied by some other lane in the same
+  // file is not a contract. Each lane names a spec, and the spec's own local
+  // imports have to be in that lane's `data` or the test runs against a
+  // runfiles tree that is missing them.
+  const lanes = [...buildFile.matchAll(/playwright_bin\.playwright_test\(([\s\S]*?)\n\)\n/g)]
+    .map(([, body]) => body);
+  assert.equal(
+    lanes.length,
+    2,
+    "every playwright_test lane must be checkable; update this contract when one is added",
   );
-  for (const importedFile of localSmokeImports) {
+  for (const lane of lanes) {
+    const laneName = /name = "([^"]+)"/.exec(lane)?.[1];
+    assert.ok(laneName, "every browser lane must be named");
+    const specFile = /\$\(rootpath :([^)]+\.spec\.ts)\)/.exec(lane)?.[1];
+    assert.ok(specFile, `${laneName} must run a named spec`);
     assert.ok(
-      buildFile.includes(`"${importedFile}"`),
-      `the Bazel browser lane is missing smoke.spec.ts dependency ${importedFile}`,
+      lane.includes(`"${specFile}"`),
+      `${laneName} must list ${specFile} in its data`,
     );
+    const spec = readFileSync(path.join(testDirectory, specFile), "utf8");
+    for (const [, importedModule] of spec.matchAll(/from "\.\/([^"]+)"/g)) {
+      assert.ok(
+        lane.includes(`"${importedModule}.ts"`),
+        `${laneName} is missing ${specFile} dependency ${importedModule}.ts`,
+      );
+    }
   }
   assert.match(buildFile, /"@playwright\/\/:chromium"/);
   assert.match(
@@ -114,11 +134,13 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
     buildFile,
     /"PLAYWRIGHT_BROWSERS_PATH": "\$\(rootpath @playwright\/\/:chromium\)\/\.\.\/"/,
   );
-  assert.match(
-    buildFile,
-    /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?"@platforms\/\/os:macos"[\s\S]*?\]/,
-    "the headless browser test must allow only macOS ARM64 execution",
-  );
+  for (const lane of lanes) {
+    assert.match(
+      lane,
+      /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?"@platforms\/\/os:macos"[\s\S]*?\]/,
+      "every headless browser lane must allow only macOS ARM64 execution",
+    );
+  }
   // Linux is excluded deliberately, not by omission: headless Chromium there
   // cannot present a WebGPU OffscreenCanvas swapchain on the SwiftShader
   // adapter, so the presented-pixel assertions can never pass. Restoring the

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -1632,6 +1632,60 @@ async function pinchZoom(
   }, { ...at, deltaY, count });
 }
 
+// One presented picture, named by the worker result it drew.
+//
+// A result is published with no `presentedAtMs` and the frame that consumes it
+// stamps the field exactly once, so the pair says both "which raster" and
+// "has a frame drawn it". Both halves come out of one round trip, so a gate
+// cannot pair a counter from one frame with a stamp from another.
+interface PresentedGeneration {
+  completedResults: number;
+  presentedAtMs: number | undefined;
+}
+
+async function readPresentedGeneration(page: Page): Promise<PresentedGeneration> {
+  return page.evaluate(() => ({
+    completedResults: window.__donnerWorkerStats?.completedResults || 0,
+    presentedAtMs: window.__donnerWorkerStats?.presentedAtMs,
+  }));
+}
+
+/**
+ * Send one pinch notch and return once the raster it caused is on the canvas.
+ *
+ * A constant delay after a notch is not an observable of that notch. The worker
+ * can take longer than any constant, and until the frame that draws its result
+ * runs, the pane still shows the pre-gesture picture - which a coverage probe
+ * scores as covered, because it was. The loop then decides on a frame the
+ * gesture never touched, and the next notch supersedes the one that would have
+ * shown the defect: with the notch's presentation held past a 200 ms wait, the
+ * probe scored zero on all six storm notches while the frame each notch
+ * actually presented carried 36375 uncovered backdrop pixels.
+ *
+ * Waiting for a strictly later presented result closes that window, and it is
+ * bounded: a notch whose raster never reaches the canvas fails here with the
+ * worker's own health attached rather than being scored as covered.
+ */
+async function pinchZoomAndAwaitPresentation(
+  page: Page,
+  at: { x: number; y: number },
+  deltaY: number,
+  context: string,
+): Promise<void> {
+  const before = await readPresentedGeneration(page);
+  await pinchZoom(page, at, deltaY);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults, health) =>
+      completedResults > before.completedResults && health.presentedAtMs !== undefined,
+    {
+      message: `${context}: the zoom notch never presented a newer document raster`,
+      timeout: scaledMs(5_000),
+    },
+  );
+  await waitForBrowserComposite(page);
+}
+
 // Locate the Donner Splash "D" by its own yellow pixels, in CSS coordinates
 // relative to `region`. Since the single-canvas architecture the document has no element to
 // measure, so every document-space probe is anchored on rendered content.
@@ -1968,13 +2022,12 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
     if (isProbeRegionCovered(await probe(`zoom-in notch ${notch}`))) {
       break;
     }
-    await pinchZoom(page, probeCenter, -250);
+    await pinchZoomAndAwaitPresentation(page, probeCenter, -250, `zoom-in notch ${notch}`);
     // This read does not settle: the loop is zooming in precisely because the
-    // region is not covered yet, so a read that catches presentation mid-notch
-    // costs one extra notch and nothing else, and the value it pushes is
-    // diagnostic. The assertions below, which do decide the test, all settle on
-    // a deadline that scales with the runner.
-    await page.waitForTimeout(200);
+    // region is not covered yet, so a read that catches a later notch's
+    // presentation costs one extra notch and nothing else, and the value it
+    // pushes is diagnostic. The assertions below, which do decide the test, all
+    // settle on a deadline that scales with the runner.
     zoomInCoverage.push((await probe(`zoom-in notch ${notch}`)).editorBackgroundPixels);
   }
   const zoomedIn = await settleUntilCovered(page, probeRegion, "zoom-in settle");
@@ -2000,8 +2053,7 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
   // something to rely on: zoom in explicitly past the boundary.
   const kZoomHeadroomNotches = 2;
   for (let notch = 0; notch < kZoomHeadroomNotches; ++notch) {
-    await pinchZoom(page, probeCenter, -250);
-    await page.waitForTimeout(200);
+    await pinchZoomAndAwaitPresentation(page, probeCenter, -250, `zoom headroom notch ${notch}`);
   }
   const headroom = await settleUntilCovered(page, probeRegion, "zoom headroom");
   expect(
@@ -2020,8 +2072,12 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
   > = [];
   for (let burst = 0; burst < 3; ++burst) {
     for (const phase of ["out", "in"] as const) {
-      await pinchZoom(page, probeCenter, phase === "out" ? 250 : -250);
-      await page.waitForTimeout(200);
+      await pinchZoomAndAwaitPresentation(
+        page,
+        probeCenter,
+        phase === "out" ? 250 : -250,
+        `storm ${burst} ${phase}`,
+      );
       // A zoom-out can expose regions whose tiles have not re-rastered yet;
       // that transient is bounded by one worker latency and is inherent to
       // demand-rendered tiles. The defect this storm hunts is uncovering that

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   captureSplashPresentationFrame,
   type CssRegion,
+  type EditorBackgroundCoverageStats,
   isSplashCaptureUsable,
   type PixelBounds,
   readCssPngPixelDifferenceStats,
@@ -422,6 +423,15 @@ interface WorkerHealth {
   sampleThumbnailPublicationGeneration: number;
   frameLoop: FrameLoopStats | null;
   interaction: Window["__donnerInteractionStats"] | null;
+  // The presentation half of the handoff, read in the same round trip as the
+  // worker half so a gate cannot pair a counter from one frame with a
+  // presentation stamp from another. A result is published without
+  // `presentedAtMs` and the frame that consumes it stamps the field once, so
+  // "the worker finished" and "the pixels are on the canvas" are two different
+  // questions and a probe needs the second.
+  renderedFrames: number;
+  presentedAtMs: number | undefined;
+  activeSampleId: string | undefined;
 }
 
 // `unpublished` and -1 distinguish "the worker never published stats at all"
@@ -440,6 +450,9 @@ async function readWorkerHealth(page: Page): Promise<WorkerHealth> {
       ?? -1,
     frameLoop: window.__donnerFrameLoopStats ?? null,
     interaction: window.__donnerInteractionStats ?? null,
+    renderedFrames: window.__donnerMainLoopRenderedFrames || 0,
+    presentedAtMs: window.__donnerWorkerStats?.presentedAtMs,
+    activeSampleId: window.__donnerActiveSampleStats?.sampleId,
   }));
 }
 
@@ -462,14 +475,14 @@ async function readWorkerHealth(page: Page): Promise<WorkerHealth> {
  */
 async function expectWorkerResultsToReach(
   page: Page,
-  reached: (completedResults: number) => boolean,
+  reached: (completedResults: number, health: WorkerHealth) => boolean,
   options: { message: string; timeout: number },
 ): Promise<void> {
   await expect
     .poll(
       async () => {
         const health = await readWorkerHealth(page);
-        return { ...health, reached: reached(health.completedResults) };
+        return { ...health, reached: reached(health.completedResults, health) };
       },
       {
         message: options.message,
@@ -1644,21 +1657,176 @@ async function openDonnerSplash(page: Page): Promise<{
   if (editorBounds === null) {
     throw new Error("editor canvas is missing");
   }
-  const beforeSampleResults = await page.evaluate(
-    () => window.__donnerWorkerStats?.completedResults || 0,
-  );
+  const before = await page.evaluate(() => ({
+    completedResults: window.__donnerWorkerStats?.completedResults || 0,
+    renderedFrames: window.__donnerMainLoopRenderedFrames || 0,
+  }));
   await page.mouse.click(editorBounds.x + editorBounds.width * 0.24, editorBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "donner-splash");
+  // Wait for the Splash's raster to reach the canvas, not for the worker to
+  // publish it.
+  //
+  // Those are two events and every pixel probe downstream is about the second
+  // one. The editor already says which: a worker result is published with no
+  // `presentedAtMs`, and the frame that consumes it stamps that field exactly
+  // once when it finishes (`main.cc`). Gating on `completedResults` alone
+  // returns inside the window between them - the run that sent this gate back
+  // for repair published at 2087 ms and presented at 2139 ms, where the two
+  // animation frames this used to wait for are ~33 ms - and because the editor
+  // is a single canvas the pane still carries whatever was last presented for
+  // the whole of it, which is not the sample under test. `smoke.spec.ts`
+  // already gates on this handoff and calls it `pixelsPresented`.
   await expectWorkerResultsToReach(
     page,
-    (completedResults) => completedResults > beforeSampleResults,
-    { message: "Donner Splash must produce a document render", timeout: scaledMs(5_000) },
+    (completedResults, health) =>
+      health.activeSampleId === "donner-splash"
+      && completedResults > before.completedResults
+      && health.renderedFrames > before.renderedFrames
+      && health.presentedAtMs !== undefined,
+    {
+      message: "Donner Splash must present a document frame in the editor canvas",
+      timeout: scaledMs(5_000),
+    },
   );
   await waitForBrowserComposite(page);
   return { editorBounds };
 }
 
-// The Splash coverage probe's rectangle inside the editor canvas.
+// How much of the probe region may still show the pane backdrop and still count
+// as covered by the document.
+//
+// Not exactly zero: the backdrop window carries a +-2 tolerance for compositor
+// rounding, and the Splash art is a ~12,000-colour storm scene, so at depth a
+// few of its own pixels land inside that window. One of 108,000 was measured at
+// the depth the zoom-in loop stops at. The floor is 216 pixels of that region,
+// which still catches a single uncovered row across its 360-pixel width and
+// sits ~130x below the 27,752-pixel uncovering the probe reads at the natural
+// fit, so it separates art noise from any uncovering worth a failure. That
+// noise figure is a single measured sample, so if this floor ever trips, count
+// the backdrop window against the art at that depth again before widening it:
+// the honest fix may be a re-measurement rather than a larger number.
+const kCoveredBackdropFraction = 0.002;
+
+function coveredBackdropFloor(stats: EditorBackgroundCoverageStats): number {
+  return Math.round(stats.samples * kCoveredBackdropFraction);
+}
+
+function isProbeRegionCovered(stats: EditorBackgroundCoverageStats): boolean {
+  return stats.editorBackgroundPixels <= coveredBackdropFloor(stats);
+}
+
+// How much of the probe region the render pane's own tones must account for
+// before a capture may be scored.
+//
+// A low background count is the zoom test's success condition, so a low
+// background count has to mean one thing. A capture of something that is not
+// the render pane also scores low, and the editor is a single canvas that keeps
+// showing the last presented frame, so "not the render pane" is a state the
+// suite really reaches: the welcome sample picker measures 8 backdrop and 1041
+// document pixels of 108,000, together under 1% of the region. A presented
+// Splash accounts for 55% of it at the natural fit, 29% at the depth the
+// zoom-in loop stops at, and 66% at the headroom depth the storm works around,
+// all of it backdrop, artboard, checkerboard or letter. The floor sits an order
+// of magnitude above the unusable case and a factor of three below the
+// tightest usable one.
+//
+// This is deliberately stricter than `isSplashCaptureUsable`, which asks only
+// that a capture carry some editor tone. That rules out a flat or empty
+// capture, which is the class the drag suite hit; it does not rule out a
+// perfectly good picture of a different part of the editor, which is the class
+// this probe hit.
+const kPaneObservationFraction = 0.1;
+
+// How long to wait between two reads of the same probe.
+//
+// Both bounded waits below poll the same observable through the same
+// screenshot, so they wait the same amount between attempts: one interval is
+// short enough that a settle costs little on a fast runner, and the deadlines
+// that contain them are what scale.
+const kProbeRetakeIntervalMs = 50;
+
+/**
+ * Read the probe region, and refuse to score a capture that is not an
+ * observation of the render pane.
+ *
+ * The background count and the presence check come out of the same capture, so
+ * they cannot describe different frames, and they read disjoint tone windows,
+ * so neither can fake the other.
+ *
+ * Retakes are bounded, and a capture that never shows the pane fails with the
+ * picture itself attached alongside its histogram and the editor's published
+ * state, so the next reader sees what was actually on screen instead of a bare
+ * number.
+ */
+async function readProbeCoverage(
+  page: Page,
+  region: CssRegion,
+  context: string,
+): Promise<EditorBackgroundCoverageStats> {
+  // The transient this absorbs is one publish-to-present handoff, measured at
+  // ~52 ms on the run that produced the failure, so the retake window is a
+  // deadline rather than a fixed number of animation frames: four composites
+  // are ~130 ms on a fast runner and can be less than one handoff on a loaded
+  // one, and running out of retries throws, which would abort a caller that
+  // was prepared to wait.
+  const deadline = Date.now() + scaledMs(1_000);
+  let last: EditorBackgroundCoverageStats | null = null;
+  for (;;) {
+    last = await readEditorBackgroundCoverage(page, region);
+    if (
+      last.editorBackgroundPixels + last.documentPixels
+        >= last.samples * kPaneObservationFraction
+    ) {
+      return last;
+    }
+    if (Date.now() >= deadline) {
+      break;
+    }
+    await page.waitForTimeout(kProbeRetakeIntervalMs);
+  }
+  await test.info().attach(`no-render-pane-${context}`, {
+    body: last.png,
+    contentType: "image/png",
+  });
+  const published = await page.evaluate(() => ({
+    frameLoop: window.__donnerFrameLoopStats,
+    renderedFrames: window.__donnerMainLoopRenderedFrames || 0,
+    viewport: window.__donnerViewportStats,
+    worker: window.__donnerWorkerStats,
+  }));
+  throw new Error(
+    `${context}: no capture of the presented render pane before the deadline. `
+      + `region=${JSON.stringify(region)} census=${JSON.stringify(last.census)} `
+      + `published=${JSON.stringify(published)}`,
+  );
+}
+
+/**
+ * Poll the probe until the document covers it, bounded.
+ *
+ * Presentation lags the live viewport by up to one worker latency, so a single
+ * read taken a fixed interval after a zoom notch scores whichever side of that
+ * latency the runner happened to land on. Every assertion in the zoom storm
+ * instead waits for convergence and then reports what it converged to; the
+ * callers differ only in what they do with a deadline that expired.
+ */
+async function settleUntilCovered(
+  page: Page,
+  region: CssRegion,
+  context: string,
+): Promise<EditorBackgroundCoverageStats> {
+  const deadline = Date.now() + scaledMs(1_000);
+  let stats = await readProbeCoverage(page, region, context);
+  while (!isProbeRegionCovered(stats) && Date.now() < deadline) {
+    await page.waitForTimeout(kProbeRetakeIntervalMs);
+    stats = await readProbeCoverage(page, region, context);
+  }
+  return stats;
+}
+
+// The Splash coverage probe's rectangle inside the editor canvas. Shared by the
+// zoom storm and by the guard test below, which has to sample the same region
+// the storm scores for its claim to be about the storm.
 const kSplashProbeOffset = { x: 438, y: 128, width: 360, height: 300 };
 
 function splashProbeRegion(
@@ -1672,49 +1840,103 @@ function splashProbeRegion(
   };
 }
 
+test("the Splash coverage probe refuses a capture that is not the render pane", async ({ page }) => {
+  // Pin the ambiguity that produced the zoom storm's `coverage=[]` failure.
+  //
+  // The editor is a single canvas, so until a frame draws a sample's raster the
+  // pane shows whatever was presented before it. The welcome sample picker is
+  // one such picture and the only one a test can hold still, so sampling the
+  // storm's own rectangle before any sample is opened reproduces the shape of
+  // the ambiguity with no timing involved.
+  const failures = await openEditor(page);
+  const editorBounds = await page.locator("canvas#canvas").boundingBox();
+  expect(editorBounds).not.toBeNull();
+  if (editorBounds === null) {
+    throw new Error("editor canvas is missing");
+  }
+  const probeRegion = splashProbeRegion(editorBounds);
+
+  const picker = await readEditorBackgroundCoverage(page, probeRegion);
+  // A bare background count cannot tell this frame from one the document fully
+  // covers: both are far under the floor the storm treats as covered. That is
+  // the whole defect - the storm's exit condition and "there is no document
+  // here" were the same number, so the loop was skipped and the assertion one
+  // screenshot later reported the settled coverage it had just declined to
+  // zoom away.
+  expect(
+    isProbeRegionCovered(picker),
+    `the welcome picker no longer scores as covered: ${JSON.stringify(picker.census)}`,
+  ).toBe(true);
+  // So the probe must refuse to score it rather than hand back the number.
+  await expect(readProbeCoverage(page, probeRegion, "welcome picker")).rejects.toThrow(
+    /no capture of the presented render pane/,
+  );
+  expect(failures).toEqual([]);
+});
+
 test("the Splash coverage probe counts editor background, not document pixels", async ({ page }) => {
   // Pin what the zoom storm's probe is allowed to count.
   //
-  // The zoom storm below decides its whole outcome on this probe reaching
-  // zero, so the probe has to be counting the editor's background and nothing
-  // else. The editor publishes where it put the document, which makes that
+  // The editor publishes where it put the document, so the probe's answer is
   // checkable against geometry rather than against a colour someone measured
-  // once: at the natural fit the probe rectangle overhangs the artboard's top
-  // edge, and the pixels above that edge - and only those - are background.
-  //
-  // This assertion fails at this commit. The probe counts (12-14, 14-16,
-  // 28-30), centred on (13,15,29), which is `#0d0f1d` - the Donner Splash
-  // artboard's own fill, straight out of `donner_splash.svg` and the same tone
-  // `censusSplashTones` documents as the document's dark background. So the
-  // probe reports document pixels as uncovered editor, and the two states it
-  // can never tell apart are "the document covers the region" and "there is no
-  // document in this capture at all", both of which count zero.
+  // once. At the natural fit the probe rectangle overhangs the artboard's top
+  // edge, and the pixels above that edge - and only those - are editor
+  // background. This is the assertion the pre-fix probe failed: it counted
+  // (13,15,29), which is `#0d0f1d`, the Splash artboard's own fill, so it
+  // reported 12242 where the overhang is 360 x 77.5 = 27900. Counting a tone
+  // the document itself draws is what made "the document covers the region"
+  // and "there is no document here" the same number.
   const failures = await openEditor(page);
   const { editorBounds } = await openDonnerSplash(page);
   const probeRegion = splashProbeRegion(editorBounds);
   const viewport = await readViewportStats(page);
+  // The area identity below holds only while the top edge is the region's ONLY
+  // uncovered side, so state that as a precondition rather than let a moved
+  // layout surface as an unexplained count mismatch.
   const overhangRows = viewport.documentY - probeRegion.y;
+  const layout = `viewport=${JSON.stringify(viewport)} probe=${JSON.stringify(probeRegion)}`;
+  expect(overhangRows, `the probe no longer overhangs the artboard's top edge; ${layout}`)
+    .toBeGreaterThan(0);
+  expect(viewport.documentX, `the artboard no longer covers the probe's left edge; ${layout}`)
+    .toBeLessThanOrEqual(probeRegion.x);
   expect(
-    overhangRows,
-    `the probe no longer overhangs the artboard: ${JSON.stringify(viewport)}`,
-  ).toBeGreaterThan(0);
-  const stats = await readEditorBackgroundCoverage(page, probeRegion);
+    viewport.documentX + viewport.documentWidth,
+    `the artboard no longer covers the probe's right edge; ${layout}`,
+  ).toBeGreaterThanOrEqual(probeRegion.x + probeRegion.width);
+  expect(
+    viewport.documentY + viewport.documentHeight,
+    `the artboard no longer covers the probe's bottom edge; ${layout}`,
+  ).toBeGreaterThanOrEqual(probeRegion.y + probeRegion.height);
+  const stats = await readProbeCoverage(page, probeRegion, "natural fit");
   // The capture may be taken at a device pixel ratio above 1; scale the
   // expected area into the capture's own pixels rather than assuming one.
   const captureScale = stats.samples / (probeRegion.width * probeRegion.height);
   const expectedBackground = overhangRows * probeRegion.width * captureScale;
+  // A tenth of the overhang is far more slack than edge antialiasing needs
+  // (measured 27752 against 27900, 0.5%) and far tighter than any tone the
+  // document draws could survive.
   expect(
     stats.editorBackgroundPixels,
-    `the probe is not measuring the artboard overhang: expected about ${expectedBackground}`,
+    `the probe is not measuring the artboard overhang: expected about `
+      + `${expectedBackground}, census=${JSON.stringify(stats.census)}`,
   ).toBeGreaterThan(expectedBackground * 0.9);
   expect(
     stats.editorBackgroundPixels,
-    `the probe counts more than the artboard overhang: expected about ${expectedBackground}`,
+    `the probe counts more than the artboard overhang: expected about `
+      + `${expectedBackground}, census=${JSON.stringify(stats.census)}`,
   ).toBeLessThan(expectedBackground * 1.1);
   expect(failures).toEqual([]);
 });
 
 test("a zoom storm never uncovers the editor background under the Donner Splash", async ({ page }) => {
+  // The per-test budget is the one deadline in this suite that does not scale
+  // with the runner. Every bound inside the storm does: eight bounded settles
+  // of `scaledMs(1_000)`, each of which may spend another such deadline
+  // retaking an unusable capture, exceed the config's flat 30 s on a shared
+  // runner well before they are exhausted, so the slow run this test exists to
+  // describe would be killed before it could print its census. Scale the budget
+  // the same way the bounds inside it are scaled; a settled run takes 8.7 s.
+  test.setTimeout(scaledMs(30_000));
   const failures = await openEditor(page);
   const { editorBounds } = await openDonnerSplash(page);
 
@@ -1727,34 +1949,43 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
   // The region is centered on a solid stroke of the Splash letter (618, 278)
   // rather than the pane center: the zoom below anchors at the region center,
   // so the pixels that fill the region at depth are the anchor's own
-  // neighborhood. A bright stroke stays unambiguously non-background at every
-  // zoom level, where the letter counters fill with dark cloud gradient that
-  // sweeps the backdrop's color neighborhood. At the natural fit the artboard's
-  // top edge crosses the region, so it starts with genuine uncovered backdrop.
+  // neighborhood, and a bright stroke keeps the region unambiguously filled at
+  // every zoom level. At the natural fit the artboard's top edge crosses the
+  // region, so it starts with genuine uncovered backdrop: the editor publishes
+  // `documentY` 77.5 CSS pixels below the region's top, and that 360 x 77.5
+  // strip scores 27752 pane-backdrop pixels.
   const probeRegion = splashProbeRegion(editorBounds);
   const probeCenter = {
     x: probeRegion.x + probeRegion.width * 0.5,
     y: probeRegion.y + probeRegion.height * 0.5,
   };
-  const backgroundPixels = async () =>
-    (await readEditorBackgroundCoverage(page, probeRegion)).editorBackgroundPixels;
+  const probe = async (context: string) => readProbeCoverage(page, probeRegion, context);
 
   // The render pane classifies wheel input only while it is the hovered window.
   await page.mouse.move(probeCenter.x, probeCenter.y);
   const zoomInCoverage: number[] = [];
-  for (let notch = 0; notch < 10 && (await backgroundPixels()) > 0; ++notch) {
+  for (let notch = 0; notch < 10; ++notch) {
+    if (isProbeRegionCovered(await probe(`zoom-in notch ${notch}`))) {
+      break;
+    }
     await pinchZoom(page, probeCenter, -250);
+    // This read does not settle: the loop is zooming in precisely because the
+    // region is not covered yet, so a read that catches presentation mid-notch
+    // costs one extra notch and nothing else, and the value it pushes is
+    // diagnostic. The assertions below, which do decide the test, all settle on
+    // a deadline that scales with the runner.
     await page.waitForTimeout(200);
-    zoomInCoverage.push(await backgroundPixels());
+    zoomInCoverage.push((await probe(`zoom-in notch ${notch}`)).editorBackgroundPixels);
   }
+  const zoomedIn = await settleUntilCovered(page, probeRegion, "zoom-in settle");
   expect(
-    await backgroundPixels(),
-    `zooming in never filled the probe region with document pixels;`
-      + ` coverage=${JSON.stringify(zoomInCoverage)}`,
-  ).toBe(0);
+    zoomedIn.editorBackgroundPixels,
+    `zooming in never covered the probe region with document pixels;`
+      + ` coverage=${JSON.stringify(zoomInCoverage)} census=${JSON.stringify(zoomedIn.census)}`,
+  ).toBeLessThanOrEqual(coveredBackdropFloor(zoomedIn));
   expect(
     zoomInCoverage.length,
-    `the document already filled the probe region without zooming: ${
+    `the document already covered the probe region without zooming: ${
       JSON.stringify(zoomInCoverage)
     }`,
   ).toBeGreaterThan(0);
@@ -1772,16 +2003,21 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
     await pinchZoom(page, probeCenter, -250);
     await page.waitForTimeout(200);
   }
+  const headroom = await settleUntilCovered(page, probeRegion, "zoom headroom");
   expect(
-    await backgroundPixels(),
-    "the zoom headroom notches left editor background inside the probe region",
-  ).toBe(0);
+    headroom.editorBackgroundPixels,
+    `the zoom headroom notches left editor background inside the probe region;`
+      + ` census=${JSON.stringify(headroom.census)}`,
+  ).toBeLessThanOrEqual(coveredBackdropFloor(headroom));
 
   // Zoom out and back in. Each notch changes the live viewport by ~27% while
   // the worker is still finishing the previous raster, which is the window in
   // which a lagging document used to uncover the editor background.
   const scaleSamples: number[] = [];
-  const uncovered: Array<{ burst: number; phase: string; backgroundPixels: number }> = [];
+  const stormCoverage: number[] = [];
+  const uncovered: Array<
+    { burst: number; phase: string; backgroundPixels: number; census: SplashToneCensus }
+  > = [];
   for (let burst = 0; burst < 3; ++burst) {
     for (const phase of ["out", "in"] as const) {
       await pinchZoom(page, probeCenter, phase === "out" ? 250 : -250);
@@ -1790,18 +2026,17 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
       // that transient is bounded by one worker latency and is inherent to
       // demand-rendered tiles. The defect this storm hunts is uncovering that
       // PERSISTS - a stale placement that never converges - so each notch
-      // asserts convergence back to zero within a bounded settle instead of
-      // failing on a single instant read.
-      let persisted = await backgroundPixels();
-      if (persisted > 0) {
-        const settleDeadline = Date.now() + scaledMs(1_000);
-        while (persisted > 0 && Date.now() < settleDeadline) {
-          await page.waitForTimeout(50);
-          persisted = await backgroundPixels();
-        }
-      }
-      if (persisted > 0) {
-        uncovered.push({ burst, phase, backgroundPixels: persisted });
+      // asserts convergence within a bounded settle instead of failing on a
+      // single instant read.
+      const settled = await settleUntilCovered(page, probeRegion, `storm ${burst} ${phase}`);
+      stormCoverage.push(settled.editorBackgroundPixels);
+      if (!isProbeRegionCovered(settled)) {
+        uncovered.push({
+          burst,
+          phase,
+          backgroundPixels: settled.editorBackgroundPixels,
+          census: settled.census,
+        });
       }
       // At storm depth the letter overflows any pane-bounded region on some
       // viewports, so its measured width and edge positions can saturate at the
@@ -1827,7 +2062,8 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
       + ` probe=${JSON.stringify(probeRegion)} first=${JSON.stringify(uncovered.slice(0, 6))}`,
   ).toEqual([]);
   console.log(
-    `zoom-storm zoomIn=${JSON.stringify(zoomInCoverage)} scales=${JSON.stringify(scaleSamples)}`,
+    `zoom-storm zoomIn=${JSON.stringify(zoomInCoverage)} storm=${JSON.stringify(stormCoverage)}`
+      + ` scales=${JSON.stringify(scaleSamples)}`,
   );
   expect(failures).toEqual([]);
 });

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -1746,27 +1746,22 @@ async function openDonnerSplash(page: Page): Promise<{
   return { editorBounds };
 }
 
-// How much of the probe region may still show the pane backdrop and still count
-// as covered by the document.
+// Whether the presented document covers the whole probe region.
 //
-// Not exactly zero: the backdrop window carries a +-2 tolerance for compositor
-// rounding, and the Splash art is a ~12,000-colour storm scene, so at depth a
-// few of its own pixels land inside that window. One of 108,000 was measured at
-// the depth the zoom-in loop stops at. The floor is 216 pixels of that region,
-// which still catches a single uncovered row across its 360-pixel width and
-// sits ~130x below the 27,752-pixel uncovering the probe reads at the natural
-// fit, so it separates art noise from any uncovering worth a failure. That
-// noise figure is a single measured sample, so if this floor ever trips, count
-// the backdrop window against the art at that depth again before widening it:
-// the honest fix may be a re-measurement rather than a larger number.
-const kCoveredBackdropFraction = 0.002;
-
-function coveredBackdropFloor(stats: EditorBackgroundCoverageStats): number {
-  return Math.round(stats.samples * kCoveredBackdropFraction);
-}
-
+// The claim is that the pane backdrop is never exposed inside the region, so
+// the acceptance value is none of it. A fraction of the region was tolerated
+// instead, and 0.2% of the 360x300 probe is 216 pixels: a fully uncovered row
+// across the region's width would have scored as covered.
+//
+// That fraction was absorbing the backdrop tone window's own +-2 slack rather
+// than anything about the presented picture. Counted exactly, the only pixels
+// the slack added are the artboard's antialiased top edge (32 of 27752 at the
+// natural fit, and an edge only exists where the document does not cover the
+// region) and one (44,47,57) art pixel of 108,000 at the depth the zoom-in loop
+// stops at. `canvas-color-stats` now counts the calibrated tone exactly, which
+// leaves a covered region at zero and nothing for a floor to absorb.
 function isProbeRegionCovered(stats: EditorBackgroundCoverageStats): boolean {
-  return stats.editorBackgroundPixels <= coveredBackdropFloor(stats);
+  return stats.editorBackgroundPixels === 0;
 }
 
 // How much of the probe region the render pane's own tones must account for
@@ -1776,7 +1771,7 @@ function isProbeRegionCovered(stats: EditorBackgroundCoverageStats): boolean {
 // background count has to mean one thing. A capture of something that is not
 // the render pane also scores low, and the editor is a single canvas that keeps
 // showing the last presented frame, so "not the render pane" is a state the
-// suite really reaches: the welcome sample picker measures 8 backdrop and 1041
+// suite really reaches: the welcome sample picker measures 0 backdrop and 1041
 // document pixels of 108,000, together under 1% of the region. A presented
 // Splash accounts for 55% of it at the natural fit, 29% at the depth the
 // zoom-in loop stops at, and 66% at the headroom depth the storm works around,
@@ -1967,7 +1962,7 @@ test("the Splash coverage probe counts editor background, not document pixels", 
   const captureScale = stats.samples / (probeRegion.width * probeRegion.height);
   const expectedBackground = overhangRows * probeRegion.width * captureScale;
   // A tenth of the overhang is far more slack than edge antialiasing needs
-  // (measured 27752 against 27900, 0.5%) and far tighter than any tone the
+  // (measured 27720 against 27900, 0.6%) and far tighter than any tone the
   // document draws could survive.
   expect(
     stats.editorBackgroundPixels,
@@ -2007,7 +2002,7 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
   // every zoom level. At the natural fit the artboard's top edge crosses the
   // region, so it starts with genuine uncovered backdrop: the editor publishes
   // `documentY` 77.5 CSS pixels below the region's top, and that 360 x 77.5
-  // strip scores 27752 pane-backdrop pixels.
+  // strip scores 27720 pane-backdrop pixels.
   const probeRegion = splashProbeRegion(editorBounds);
   const probeCenter = {
     x: probeRegion.x + probeRegion.width * 0.5,
@@ -2035,7 +2030,7 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
     zoomedIn.editorBackgroundPixels,
     `zooming in never covered the probe region with document pixels;`
       + ` coverage=${JSON.stringify(zoomInCoverage)} census=${JSON.stringify(zoomedIn.census)}`,
-  ).toBeLessThanOrEqual(coveredBackdropFloor(zoomedIn));
+  ).toBe(0);
   expect(
     zoomInCoverage.length,
     `the document already covered the probe region without zooming: ${
@@ -2060,7 +2055,7 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
     headroom.editorBackgroundPixels,
     `the zoom headroom notches left editor background inside the probe region;`
       + ` census=${JSON.stringify(headroom.census)}`,
-  ).toBeLessThanOrEqual(coveredBackdropFloor(headroom));
+  ).toBe(0);
 
   // Zoom out and back in. Each notch changes the live viewport by ~27% while
   // the worker is still finishing the previous raster, which is the window in

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -1651,7 +1651,8 @@ async function readPresentedGeneration(page: Page): Promise<PresentedGeneration>
 }
 
 /**
- * Send one pinch notch and return once the raster it caused is on the canvas.
+ * Send one pinch notch and return once a strictly later worker result has been
+ * consumed by a presented frame.
  *
  * A constant delay after a notch is not an observable of that notch. The worker
  * can take longer than any constant, and until the frame that draws its result
@@ -1662,9 +1663,10 @@ async function readPresentedGeneration(page: Page): Promise<PresentedGeneration>
  * probe scored zero on all six storm notches while the frame each notch
  * actually presented carried 36375 uncovered backdrop pixels.
  *
- * Waiting for a strictly later presented result closes that window, and it is
- * bounded: a notch whose raster never reaches the canvas fails here with the
- * worker's own health attached rather than being scored as covered.
+ * That pair is the whole guarantee, and it is not "the notch's pixels are up":
+ * `pollRenderResult` advances the counter before its non-presenting early
+ * returns, so the callers converge through `settleUntilCovered` rather than
+ * trust one capture. The wait is bounded and reports the worker's own health.
  */
 async function pinchZoomAndAwaitPresentation(
   page: Page,

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -1658,6 +1658,62 @@ async function openDonnerSplash(page: Page): Promise<{
   return { editorBounds };
 }
 
+// The Splash coverage probe's rectangle inside the editor canvas.
+const kSplashProbeOffset = { x: 438, y: 128, width: 360, height: 300 };
+
+function splashProbeRegion(
+  editorBounds: { x: number; y: number; width: number; height: number },
+): CssRegion {
+  return {
+    x: editorBounds.x + kSplashProbeOffset.x,
+    y: editorBounds.y + kSplashProbeOffset.y,
+    width: kSplashProbeOffset.width,
+    height: kSplashProbeOffset.height,
+  };
+}
+
+test("the Splash coverage probe counts editor background, not document pixels", async ({ page }) => {
+  // Pin what the zoom storm's probe is allowed to count.
+  //
+  // The zoom storm below decides its whole outcome on this probe reaching
+  // zero, so the probe has to be counting the editor's background and nothing
+  // else. The editor publishes where it put the document, which makes that
+  // checkable against geometry rather than against a colour someone measured
+  // once: at the natural fit the probe rectangle overhangs the artboard's top
+  // edge, and the pixels above that edge - and only those - are background.
+  //
+  // This assertion fails at this commit. The probe counts (12-14, 14-16,
+  // 28-30), centred on (13,15,29), which is `#0d0f1d` - the Donner Splash
+  // artboard's own fill, straight out of `donner_splash.svg` and the same tone
+  // `censusSplashTones` documents as the document's dark background. So the
+  // probe reports document pixels as uncovered editor, and the two states it
+  // can never tell apart are "the document covers the region" and "there is no
+  // document in this capture at all", both of which count zero.
+  const failures = await openEditor(page);
+  const { editorBounds } = await openDonnerSplash(page);
+  const probeRegion = splashProbeRegion(editorBounds);
+  const viewport = await readViewportStats(page);
+  const overhangRows = viewport.documentY - probeRegion.y;
+  expect(
+    overhangRows,
+    `the probe no longer overhangs the artboard: ${JSON.stringify(viewport)}`,
+  ).toBeGreaterThan(0);
+  const stats = await readEditorBackgroundCoverage(page, probeRegion);
+  // The capture may be taken at a device pixel ratio above 1; scale the
+  // expected area into the capture's own pixels rather than assuming one.
+  const captureScale = stats.samples / (probeRegion.width * probeRegion.height);
+  const expectedBackground = overhangRows * probeRegion.width * captureScale;
+  expect(
+    stats.editorBackgroundPixels,
+    `the probe is not measuring the artboard overhang: expected about ${expectedBackground}`,
+  ).toBeGreaterThan(expectedBackground * 0.9);
+  expect(
+    stats.editorBackgroundPixels,
+    `the probe counts more than the artboard overhang: expected about ${expectedBackground}`,
+  ).toBeLessThan(expectedBackground * 1.1);
+  expect(failures).toEqual([]);
+});
+
 test("a zoom storm never uncovers the editor background under the Donner Splash", async ({ page }) => {
   const failures = await openEditor(page);
   const { editorBounds } = await openDonnerSplash(page);
@@ -1675,12 +1731,7 @@ test("a zoom storm never uncovers the editor background under the Donner Splash"
   // zoom level, where the letter counters fill with dark cloud gradient that
   // sweeps the backdrop's color neighborhood. At the natural fit the artboard's
   // top edge crosses the region, so it starts with genuine uncovered backdrop.
-  const probeRegion = {
-    x: editorBounds.x + 438,
-    y: editorBounds.y + 128,
-    width: 360,
-    height: 300,
-  };
+  const probeRegion = splashProbeRegion(editorBounds);
   const probeCenter = {
     x: probeRegion.x + probeRegion.width * 0.5,
     y: probeRegion.y + probeRegion.height * 0.5,

--- a/donner/editor/wasm/tests/canvas-color-stats.ts
+++ b/donner/editor/wasm/tests/canvas-color-stats.ts
@@ -794,44 +794,76 @@ export async function readEditorResizePixelBounds(
 }
 
 export interface EditorBackgroundCoverageStats {
+  /**
+   * Composited render-pane backdrop inside the region: the editor's own tone,
+   * which shows wherever the presented document does not cover the pane.
+   */
   editorBackgroundPixels: number;
+  /**
+   * The presented document's own tones inside the region.
+   *
+   * Disjoint from `editorBackgroundPixels` by construction (see below), which
+   * is what makes a zero background count decidable: a capture that is not
+   * showing the presented document accounts for almost none of the region here
+   * (measured under 1% of it, against 29% to 55% for a presented Splash), so a
+   * caller can tell "the document covers this region" apart from "there is no
+   * document in this capture" instead of reading zero for both.
+   */
+  documentPixels: number;
   samples: number;
+  /** The capture's full tone census, so a failure prints what was on screen. */
+  census: SplashToneCensus;
+  /** The capture itself, so a failure can attach the picture it scored. */
+  png: Buffer;
 }
 
 /**
- * Count pixels showing the bare editor background inside a page region.
+ * Measure how much of a page region shows the bare editor background, and
+ * whether the capture contains the presented document at all.
  *
- * An uncovered render pane shows the composited pane backdrop, which ANGLE
- * screenshots encode as exactly (13,15,29) (measured; the histogram of an
- * uncovered region is a single flat color). The Donner Splash artboard lands
- * at (16,19,30): only one blue level away, so blue cannot discriminate and
- * the red/green channels carry the match. The window is one level per channel
- * around the measured backdrop: wide enough for compositor rounding, and
- * tight enough that neither the artboard nor the dark Splash cloud gradients
- * (which swept the old nine-level window at deep zoom) count as uncovered
- * background.
+ * `editorBackgroundPixels` counts `kPaneBackdropColor`, the composited
+ * render-pane backdrop this file already calibrates at exactly (44,47,56) on
+ * both engines. That is the tone the pane shows where the document does not
+ * reach it: a capture of the Donner Splash at its natural fit, taken with the
+ * editor's published `documentY` 77.5 CSS pixels below the top of a 360x300
+ * probe, scores 27752 of them against the 27900 that 360 x 77.5 strip holds -
+ * that is, exactly the strip that overhangs the artboard and nothing else.
+ *
+ * This probe used to count (12-14, 14-16, 28-30) instead and call it the
+ * backdrop. That window is centred on (13,15,29), which is `#0d0f1d`: the
+ * Donner Splash artboard's own fill, straight out of `donner_splash.svg`, and
+ * the same tone `censusSplashTones` documents as the document's dark
+ * background. So the probe counted document pixels and reported them as
+ * uncovered editor. Two consequences, both observed. A zoom that covered the
+ * region was indistinguishable from a capture with no document in it, because
+ * both count zero - which is how a CI run scored zero at the natural fit,
+ * skipped the whole zoom-in loop and then reported the settled 12242 one
+ * screenshot later. And an uncovering the probe was built to catch could never
+ * raise the count, because uncovering replaces document tones with a backdrop
+ * tone the window did not match.
+ *
+ * `documentPixels` is the complementary presence check, taken from the same
+ * capture so the two cannot describe different frames. It counts the artboard's
+ * dark tones, the transparency checkerboard and the Splash letter's own yellow,
+ * because which of them a region shows depends on the zoom: at the natural fit
+ * the probe region is mostly artboard, and at the depth the zoom storm reaches
+ * it is 70,943 of 108,000 pixels of letter and no artboard tone at all. All
+ * three are disjoint from the backdrop window, so neither observation can fake
+ * the other.
  */
 export async function readEditorBackgroundCoverage(
   page: Page,
   region: CssRegion,
 ): Promise<EditorBackgroundCoverageStats> {
-  const image = decodePng(await page.screenshot({ clip: region }));
-  let editorBackgroundPixels = 0;
-  for (let offset = 0; offset < image.data.length; offset += image.channels) {
-    const red = image.data[offset];
-    const green = image.data[offset + 1];
-    const blue = image.data[offset + 2];
-    const alpha = image.channels === 4 ? image.data[offset + 3] : 255;
-    if (alpha < 200) {
-      continue;
-    }
-    if (
-      red >= 12 && red <= 14
-      && green >= 14 && green <= 16
-      && blue >= 28 && blue <= 30
-    ) {
-      ++editorBackgroundPixels;
-    }
-  }
-  return { editorBackgroundPixels, samples: image.width * image.height };
+  const png = await page.screenshot({ clip: region });
+  const image = decodePng(png);
+  const census = censusSplashTones(image);
+  const letterPixels = findPixelBounds(image, "splash-yellow")?.pixels ?? 0;
+  return {
+    editorBackgroundPixels: census.paneBackdropPixels,
+    documentPixels: census.darkBackgroundPixels + census.checkerboardPixels + letterPixels,
+    samples: census.samples,
+    census,
+    png,
+  };
 }

--- a/donner/editor/wasm/tests/canvas-color-stats.ts
+++ b/donner/editor/wasm/tests/canvas-color-stats.ts
@@ -82,6 +82,14 @@ export interface SplashToneCensus extends SplashSurfaceCoverageStats {
 /**
  * The composited render-pane backdrop, measured as exactly (44,47,56) on both
  * engines (the same calibration `countSplashSurfaceCoverage` documents).
+ *
+ * Matched exactly, with no tolerance. A +-2 window around this tone matched
+ * 27752 pixels of the artboard overhang at the Splash's natural fit, of which
+ * 27720 carried this exact value and the other 32 were the artboard's
+ * antialiased top edge blending into it; inside a region the document fully
+ * covers it matched one (44,47,57) pixel of 108,000, which the Splash art
+ * draws. Neither class is exposed backdrop, and tolerating them is what forced
+ * the coverage probe to accept a fraction of its region rather than none of it.
  */
 const kPaneBackdropColor = { red: 44, green: 47, blue: 56 };
 
@@ -97,9 +105,8 @@ function censusSplashTones(image: PngImage, dominantColorCount = 4): SplashToneC
     histogram.set(key, (histogram.get(key) ?? 0) + 1);
     const alpha = image.channels === 4 ? image.data[offset + 3] : 255;
     if (
-      alpha >= 200 && Math.abs(red - kPaneBackdropColor.red) <= 2
-      && Math.abs(green - kPaneBackdropColor.green) <= 2
-      && Math.abs(blue - kPaneBackdropColor.blue) <= 2
+      alpha >= 200 && red === kPaneBackdropColor.red && green === kPaneBackdropColor.green
+      && blue === kPaneBackdropColor.blue
     ) {
       ++paneBackdropPixels;
     }
@@ -826,7 +833,7 @@ export interface EditorBackgroundCoverageStats {
  * both engines. That is the tone the pane shows where the document does not
  * reach it: a capture of the Donner Splash at its natural fit, taken with the
  * editor's published `documentY` 77.5 CSS pixels below the top of a 360x300
- * probe, scores 27752 of them against the 27900 that 360 x 77.5 strip holds -
+ * probe, scores 27720 of them against the 27900 that 360 x 77.5 strip holds -
  * that is, exactly the strip that overhangs the artboard and nothing else.
  *
  * This probe used to count (12-14, 14-16, 28-30) instead and call it the


### PR DESCRIPTION
The zoom-storm presentation regression flaked in CI with `zooming in never filled the probe region with document pixels; coverage=[]`, then passed on a rerun. `coverage=[]` means the zoom-in loop never ran: its guard read zero uncovered background before the first notch, and the assertion one screenshot later reported the settled 12242. The cause is the probe's colour.

`readEditorBackgroundCoverage` counted a window centred on (13,15,29). That is `#0d0f1d`, the Donner Splash artboard's own fill, straight out of `donner_splash.svg`, and the same tone `censusSplashTones` in the same file already documents as the document's dark background rather than the editor's. Measured on the Bazel lane at the natural fit, with the editor's published `documentY` 77.5 CSS pixels below the probe's top edge: the 360 x 77.5 strip that genuinely overhangs the artboard holds 27752 pixels of the composited pane backdrop (44,47,56), and the probe counted 12242 pixels of artboard fill from inside the document instead.

Two consequences, and the flake is the second one.

- The storm could not observe the defect it was written for. Uncovering the document replaces document tones with a backdrop tone the window never matched, so the count would fall rather than rise.
- Zero was ambiguous. "The document covers the probe region" and "this capture has no document in it" are the same number, so a capture taken before a sample's raster reached the canvas read as covered.

The gate above the probe is what let the second state occur. `openDonnerSplash` waited for the worker's `completedResults` to advance, which is the worker publishing a raster, not the app thread drawing it. The failing run's own telemetry shows the gap: published at 2087 ms, presented at 2139 ms, against the ~33 ms of the two animation frames the gate then waited. The editor already stamps that handoff as `presentedAtMs` and `smoke.spec.ts` already gates on it.

The change:

- Count the composited render-pane backdrop, the tone this suite already calibrates at exactly (44,47,56) on both engines. The zoom-in loop's shape is unchanged (27752, then 14761, then covered) and it now stops for the right reason.
- Score a capture only when it is an observation of the render pane at all, measured from the same capture through a disjoint tone window so neither observation can fake the other. The welcome picker scores 8 backdrop and 1041 document pixels of 108,000, under 1% of the region, against 55% for a presented Splash at the natural fit and 29% at the depth the loop stops at.
- Wait for the frame that presents the raster, not for the worker that published it.
- Settle every assertion in the storm instead of reading once after a fixed interval, and scale the intervals that remain with the suite's own CI factor.
- Scale the per-test budget, which was the one deadline in this suite that never did. Eight bounded settles of `scaledMs(1_000)` come to 32 s on a shared runner against the config's flat 30 s, so the slow run the diagnostics are for would have been killed before printing them. The fixed intervals between a wheel notch and a read stay unscaled, because a settle that does scale follows every one that decides anything; the test runs in 8.7 s.
- Make the suite reachable from Bazel. These invariants ran only in the repository's browser lane, so a failure there had no target to reproduce under repetition; `//donner/editor/wasm/tests:browser_presentation_regression_test` runs the whole spec beside the existing Chromium smoke lane, and the two lanes now share one definition of their wiring.

Two regression tests come with it. `the Splash coverage probe counts editor background, not document pixels` checks the probe's answer against the rectangle the editor publishes rather than against a colour measured once, and is committed on its own ahead of the fix so the red-to-green transition is recorded. `the Splash coverage probe refuses a capture that is not the render pane` pins the ambiguity itself, using the welcome picker as a frame a test can hold still.

The Bazel package already had a contract test pinning the browser lane's shape, so `browser-matrix.spec.mjs` grew with it: it now checks every `playwright_test` lane in the file rather than the file as a whole, so each lane must name its spec, list that spec's own local imports in its `data`, and carry the macOS-ARM64-only platform gate. A lane that satisfied the contract only because a sibling did is no longer a lane that passes.

Verification, all on remote execution:

- The new test commit fails on its own; `expected > 25110, received 12242`.
- `//donner/editor/wasm/tests:browser_presentation_regression_test`, 10 of 10 runs green with `--runs_per_test=10`, which puts ten concurrent browser lanes on one worker. The same 10 runs were green before the fix too, so the intermittent instance itself was not caught; the red is at the causal layer, deterministically.
- `bazel test --config=re //...`: 475 pass, 30 skipped, no failures.
- The five-target Geode editor lane under `--config=geode`, forced past the cache: 5 of 5.
- `npm run test:selector`, the Bazel-package and readback contract tests: 35 of 35.
- `tools/lint.sh`, `tools/check_design_doc_provenance.py`, `tools/gpu_inventory/check_no_rust_dependencies.py`, `gen_cmakelists.py --check`, `buildifier`, and `dprint` on the changed TypeScript and Bazel files.

`//donner/svg/renderer/tests:zoom_filter_repro_tests` was checked as a possible sibling of the same zoom class and is not one. It pins tiny-skia's 64 MiB pixmap and filter caps at the renderer layer, shares no code with the browser probe, and passes on remote execution at this branch's base.
