### PR TITLE
Decide PR coverage target selection once, on the final target list

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,31 +22,31 @@ name: Coverage
 # (fallback_reason == bazel_diff), the cheap smoke subset (coverage_smoke), and
 # the explicit ci:full-test opt-in still produce PR coverage.
 #
-# One more skip: a genuine incremental subset whose affected targets contain
-# NO instrumentable C/C++ (docs-only, shell/python tooling, filegroup/flag-only
-# changes) also SKIPs the coverage lane. Building coverage over such a subset
-# yields an empty LCOV report and trips check_lcov_report.py's "no executable
-# line data" guard -- a deterministic red no rerun can clear. That subset is
-# detected from target KINDS via a bazel query over the affected set
-# (fallback_reason == no_instrumentable_targets), never from file extensions,
-# and the detection fails closed: any query/classifier error or unrecognized
-# rule kind runs coverage with the guard intact. "Instrumentable" means
-# HOST-instrumentable: wasm-platform targets (the emsdk wasm_cc_binary
-# wrapper and its host-incompatible cc_binary shim, detected via a host
-# cquery) never emit host profile data, so a wasm-packaging-only subset
-# also skips instead of failing on a guaranteed-empty report. A subset
-# that DOES touch host-instrumentable code keeps the guard at full
-# strength: shared C++ sources always impact their host cc_library/cc_test
-# owners too, which classify as instrumentable. Future readers:
-# do not silently re-add a full instrumented PR coverage run.
+# Two more skips, both about a genuine incremental subset that has nothing a
+# coverage run could measure. Running anyway builds an empty or absent LCOV
+# report and trips check_lcov_report.py's "no executable line data" guard or the
+# "report was not generated" guard -- a deterministic red no rerun can clear.
 #
-# And the same shape one step further in: a genuine incremental subset that
-# holds instrumentable code but no TEST target at all has nothing to measure
-# either, because coverage data comes only from tests that run. `bazel coverage`
-# reports an empty test set as an error and writes no report, so the lane would
-# die on the "report was not generated" guard. Bazel itself is asked which of
-# the affected targets are tests (fallback_reason == no_test_targets), and that
-# detection fails closed too: a query failure runs coverage as before.
+#   * A subset with no TEST target (fallback_reason == no_test_targets):
+#     coverage data comes only from tests that run, and `bazel coverage` reports
+#     an empty test set as an error. Bazel itself is asked which affected
+#     targets are tests, minus the tags the coverage command filters out.
+#   * A subset whose final target list holds nothing HOST-instrumentable
+#     (fallback_reason == no_instrumentable_targets): docs-only, shell/python
+#     tooling, filegroup/flag-only changes, and also anything that is
+#     target_compatible_with a platform this lane does not run, which
+#     `coverage --skip_incompatible_explicit_targets` silently drops.
+#
+# Both are decided from Bazel's own answers (target KINDS from a query, host
+# compatibility from a cquery), never from file extensions, and both fail
+# closed: any query, filtering, or classifier error runs coverage with the
+# guard intact. The instrumentability decision is taken exactly once, on the
+# FINAL target list after every narrowing step, because three separate
+# production failures came from guards that each judged a different,
+# wider set than the one coverage actually ran; see the block in
+# determine-targets for that history. Future readers: do not silently re-add a
+# full instrumented PR coverage run, and do not add a fourth guard at a fourth
+# pipeline stage -- extend the single decision instead.
 on:
   push:
     branches: [main]
@@ -503,160 +503,119 @@ jobs:
             exit 0
           fi
 
-          # Instrumentability gate. A genuine incremental subset that contains
-          # zero instrumentable C/C++ targets (docs-only, shell/python tooling,
-          # filegroup/flag-only changes) would build an empty LCOV report and
-          # trip check_lcov_report.py's "no executable line data" guard -- a
-          # deterministic red no rerun can clear. Decide from target KINDS via a
-          # bazel query over the affected set (not file-extension heuristics) and
-          # skip only when nothing instrumentable is affected. Fail closed: any
-          # query/classifier error, or any unrecognized rule kind, keeps the
-          # guard by running the bazel_diff subset as before.
-          # Resolve aliases to their `actual` targets before classifying: an
-          # alias can point at an instrumentable cc_* target (for example the
-          # default alias donner_variant_cc_test emits, whose actual is a
-          # cc_test), so an alias-only affected set must be judged by what it
-          # resolves to, not by the `alias` kind. The query replaces every
-          # alias in the set with its actual; an alias that cannot be resolved
-          # stays an `alias` kind and the classifier treats it as instrumentable
-          # (fail closed).
-          # The alias-resolved affected set, shared by the kind query below and
-          # by the test-presence query after it. Keep it single-quoted: `$a` is
-          # a bazel query variable, not a shell one.
+          # ---------------------------------------------------------------
+          # Narrow to the FINAL coverage target list, then decide ONCE on it.
+          #
+          # This used to be three separate guards bolted on at three different
+          # points of the pipeline, and each one answered a question about a
+          # different set than the one coverage would actually run. Three
+          # production failures came out of that, all with the same ending: a
+          # subset sailed through the gates, `bazel coverage` dropped or found
+          # nothing to measure, and the lane died on an empty/absent report
+          # that no rerun could clear.
+          #
+          #   1. A subset whose surviving tests were only a py_test passed an
+          #      instrumentability check taken on the PRE-narrowing set, where
+          #      a manual-tagged cc_test (which the coverage command's
+          #      --test_tag_filters then removed) made it look instrumentable.
+          #   2. A subset of macOS-only Metal cc_tests passed a
+          #      host-compatibility recheck that was scoped to cc_binary-only
+          #      sets, on the assumption that a cc_test is always host code;
+          #      --skip_incompatible_explicit_targets dropped them all on the
+          #      Linux lane.
+          #   3. A subset of two macOS-only playwright wrapper tests passed
+          #      BOTH of the fixes for 1 and 2, because the two fixes ran on
+          #      two different sets and neither ran both criteria on the final
+          #      one. The kind query reported `js_test` (an unknown kind, which
+          #      fails open to instrumentable by design) plus a
+          #      `directory_path` __entry_point helper. The host-compatibility
+          #      cquery ran and was CORRECT - both js_tests came back
+          #      incompatible - but it was applied to the pre-narrowing set,
+          #      where the host-compatible non-test helper kept
+          #      instrumentable_present true. The later surviving-set recheck
+          #      then re-asked only the KIND question about the two js_tests
+          #      and threw the host-compatibility answer away.
+          #
+          # The lesson is not "add a fourth guard". It is that a decision is
+          # only sound on the set it is about. So: narrow first (tests only ->
+          # tag-filtered -> variant-trimmed), then ask both questions - rule
+          # kind AND host compatibility - about exactly that list, in one
+          # place, with the host-compatibility cquery run unconditionally
+          # rather than gated on a partial earlier verdict.
+          #
+          # Fail-closed for skipping, fail-open for running, exactly as the
+          # three guards individually intended: any query, filtering, or
+          # classifier failure keeps the coverage run with the guard intact.
+          # Only a positively proven all-non-instrumentable-or-host-
+          # incompatible final list skips, and it skips with the established
+          # `no_instrumentable_targets` reason.
+          # ---------------------------------------------------------------
+
+          # The alias-resolved affected set, shared by the test-presence query
+          # and by the final decision. Resolve aliases to their `actual`
+          # targets before classifying: an alias can point at an instrumentable
+          # cc_* target (for example the default alias donner_variant_cc_test
+          # emits, whose actual is a cc_test), so an alias-only affected set
+          # must be judged by what it resolves to, not by the `alias` kind. An
+          # alias that cannot be resolved stays an `alias` kind and the
+          # classifier treats it as instrumentable (fail closed).
+          # Keep it single-quoted: `$a` is a bazel query variable, not a shell
+          # one.
           # shellcheck disable=SC2016
           resolved_expr="$(printf 'let a = set(%s) in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))' "$(tr '\n' ' ' < "$work_dir/affected.txt")")"
           kind_query_file="$work_dir/affected-query.txt"
           printf '%s\n' "$resolved_expr" > "$kind_query_file"
           label_kind_file="$work_dir/affected-label-kind.txt"
+          kind_query_ok=true
           if ( cd "$head_dir" && bazelisk query --query_file="$kind_query_file" \
               --output label_kind --keep_going ) > "$label_kind_file" 2> "$diagnostics_dir/kind-query.log"; then
             cp "$label_kind_file" "$diagnostics_dir/affected-label-kind.txt"
-            instrumentable_file="$work_dir/instrumentable-label-kind.txt"
-            if instrumentable_decision="$(python3 tools/coverage_instrumentable_targets.py \
-                --label-kind-file "$label_kind_file" \
-                --instrumentable-out "$instrumentable_file" 2> "$diagnostics_dir/instrumentability.log")"; then
-              cat "$diagnostics_dir/instrumentability.log" || true
-              if [[ "$instrumentable_decision" == "instrumentable_present=false" ]]; then
-                echo "Affected subset has no instrumentable C/C++ targets; skipping PR coverage."
-                emit_targets true no_instrumentable_targets ""
-                exit 0
-              fi
-              # Host-compatibility recheck. "Instrumentable" means HOST-
-              # instrumentable: a wasm bridge shim is a plain cc_binary by
-              # kind, and a platform-gated backend test is a plain cc_test by
-              # kind, but either can be target_compatible_with a platform this
-              # lane does not run, so --skip_incompatible_explicit_targets
-              # (set in --config=ci) silently drops it from the coverage build
-              # and the run produces an empty report (the #810 false RUN, and
-              # its cc_test sibling: a macOS-only backend test selected on the
-              # Linux coverage lane). The recheck therefore runs whenever any
-              # instrumentable target exists - the earlier cc_binary-only
-              # scoping assumed cc_test kinds are always host code, which
-              # platform-gated backend tests falsified. Cost is one cquery.
-              # Fail closed: cquery failure, or any label the cquery does
-              # not report as incompatible, keeps the coverage run.
-              if [[ -s "$instrumentable_file" ]]; then
-                echo "Rechecking host compatibility of the instrumentable set."
-                compat_file="$work_dir/host-compat.txt"
-                sed 's/^[a-z_0-9]* rule //' "$instrumentable_file" | tr '\n' ' ' > "$work_dir/compat-labels.txt"
-                if ( cd "$head_dir" && bazelisk cquery "set($(cat "$work_dir/compat-labels.txt"))" \
-                    --output=starlark \
-                    --starlark:expr='"{} {}".format(target.label, "HOST_INCOMPATIBLE" if "IncompatiblePlatformProvider" in providers(target) else "HOST_COMPATIBLE")' \
-                    ) > "$compat_file" 2> "$diagnostics_dir/compat-query.log"; then
-                  cp "$compat_file" "$diagnostics_dir/host-compat.txt"
-                  grep ' HOST_INCOMPATIBLE$' "$compat_file" | sed 's/ HOST_INCOMPATIBLE$//' > "$work_dir/host-incompatible.txt" || true
-                  if recheck_decision="$(python3 tools/coverage_instrumentable_targets.py \
-                      --label-kind-file "$label_kind_file" \
-                      --host-incompatible-file "$work_dir/host-incompatible.txt" 2>> "$diagnostics_dir/instrumentability.log")"; then
-                    if [[ "$recheck_decision" == "instrumentable_present=false" ]]; then
-                      echo "All remaining instrumentable targets are host-incompatible (wasm-platform); skipping PR coverage."
-                      emit_targets true no_instrumentable_targets ""
-                      exit 0
-                    fi
-                  fi
-                else
-                  echo "Host-compatibility cquery failed; running coverage (guard intact)."
-                  cat "$diagnostics_dir/compat-query.log" || true
-                fi
-              fi
-              echo "Affected subset includes instrumentable C/C++ targets; running coverage."
-
-              # Test-presence gate. Instrumentable code is not enough: coverage
-              # data comes only from tests that RUN, so a subset holding a
-              # library or tool whose test reverse dependencies are not in the
-              # set has nothing to measure. `bazel coverage` reports that empty
-              # test set as an error and writes no report, so the lane dies on
-              # the "report was not generated" guard rather than saying what
-              # happened. Ask bazel which affected targets are tests, so
-              # test_suite expansion and rule kinds this workflow does not
-              # enumerate are handled by definition rather than by a name
-              # heuristic, and subtract the tags the coverage command itself
-              # filters out
-              # (--test_tag_filters=-fuzz_target,-lint,-manual,-perf in
-              # .bazelrc),
-              # because a subset whose only tests carry those tags leaves the
-              # coverage run with the very empty test set this gate exists to
-              # keep it out of. `attr` matches its pattern against the string
-              # form of the tag LIST ("[fuzz_target, manual]"), not against
-              # each element, so the tag names are bracketed by the list
-              # punctuation rather than anchored with ^$. Fail closed: a query
-              # failure keeps the coverage run.
-              test_query_file="$work_dir/affected-tests-query.txt"
-              printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint|manual|perf)[,\]]", tests(%s))\n' \
-                "$resolved_expr" "$resolved_expr" > "$test_query_file"
-              affected_tests_file="$work_dir/affected-tests.txt"
-              if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
-                  --keep_going ) > "$affected_tests_file" 2> "$diagnostics_dir/test-query.log"; then
-                cp "$affected_tests_file" "$diagnostics_dir/affected-tests.txt"
-                if [[ ! -s "$affected_tests_file" ]]; then
-                  echo "Affected subset contains no test targets; skipping PR coverage."
-                  emit_targets true no_test_targets ""
-                  exit 0
-                fi
-                affected="$(
-                  python3 -c 'import pathlib, sys; labels = [line.strip() for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]; print(" ".join(labels))' "$affected_tests_file"
-                )"
-
-                # Surviving-set instrumentability recheck. The first
-                # instrumentability decision ran on the FULL affected set,
-                # where a manual- or perf-tagged cc_test can make the subset
-                # look instrumentable; the test-presence gate then subtracts
-                # exactly those tags. A surviving set of only non-C++ tests
-                # (for example one py_test) passes the presence gate, runs
-                # coverage, produces a legitimately empty report, and dies on
-                # the empty-report guard. Re-ask the classifier about the
-                # tests that actually survived. Fail closed: filtering or
-                # classifier failure keeps the coverage run.
-                surviving_kind_file="$work_dir/surviving-label-kind.txt"
-                if python3 -c "import pathlib, sys; kind_lines = pathlib.Path(sys.argv[1]).read_text(encoding='utf-8').splitlines(); survivors = {line.strip() for line in pathlib.Path(sys.argv[2]).read_text(encoding='utf-8').splitlines() if line.strip()}; out = [line for line in kind_lines if line.strip() and line.split()[-1] in survivors]; pathlib.Path(sys.argv[3]).write_text('\\n'.join(out) + ('\\n' if out else ''), encoding='utf-8'); sys.exit(0 if len(out) == len(survivors) else 1)" \
-                    "$label_kind_file" "$affected_tests_file" "$surviving_kind_file"; then
-                  cp "$surviving_kind_file" "$diagnostics_dir/surviving-label-kind.txt" || true
-                  if surviving_decision="$(python3 tools/coverage_instrumentable_targets.py \
-                      --label-kind-file "$surviving_kind_file" 2>> "$diagnostics_dir/instrumentability.log")"; then
-                    if [[ "$surviving_decision" == "instrumentable_present=false" ]]; then
-                      echo "Surviving test subset has no instrumentable C/C++ targets; skipping PR coverage."
-                      emit_targets true no_instrumentable_targets ""
-                      exit 0
-                    fi
-                  else
-                    echo "Surviving-set instrumentability recheck errored; running coverage (guard intact)."
-                  fi
-                else
-                  echo "Surviving-set kind filtering incomplete; running coverage (guard intact)."
-                fi
-              else
-                echo "Test-presence query failed; running coverage on affected subset (guard intact)."
-                cat "$diagnostics_dir/test-query.log" || true
-              fi
-            else
-              echo "Instrumentability classifier errored; running coverage on affected subset (guard intact)."
-            fi
           else
+            kind_query_ok=false
             echo "Kind query failed; running coverage on affected subset (guard intact)."
             cat "$diagnostics_dir/kind-query.log" || true
           fi
 
-          # Representative-variant trim:
+          # Narrowing 1: tests only, minus the tags the coverage command itself
+          # filters out. Instrumentable code is not enough: coverage data comes
+          # only from tests that RUN, so a subset holding a library or tool
+          # whose test reverse dependencies are not in the set has nothing to
+          # measure, and `bazel coverage` reports that empty test set as an
+          # error and writes no report. Ask bazel which affected targets are
+          # tests, so test_suite expansion and rule kinds this workflow does not
+          # enumerate are handled by definition rather than by a name heuristic,
+          # and subtract the tags the coverage command filters out
+          # (--test_tag_filters=-fuzz_target,-lint,-manual,-perf in .bazelrc),
+          # because a subset whose only tests carry those tags leaves the
+          # coverage run with the very empty test set this narrowing exists to
+          # keep it out of. `attr` matches its pattern against the string form
+          # of the tag LIST ("[fuzz_target, manual]"), not against each element,
+          # so the tag names are bracketed by the list punctuation rather than
+          # anchored with ^$. Fail closed: a query failure keeps the wider set
+          # and the coverage run.
+          if [[ "$kind_query_ok" == "true" ]]; then
+            test_query_file="$work_dir/affected-tests-query.txt"
+            printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint|manual|perf)[,\]]", tests(%s))\n' \
+              "$resolved_expr" "$resolved_expr" > "$test_query_file"
+            affected_tests_file="$work_dir/affected-tests.txt"
+            if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
+                --keep_going ) > "$affected_tests_file" 2> "$diagnostics_dir/test-query.log"; then
+              cp "$affected_tests_file" "$diagnostics_dir/affected-tests.txt"
+              if [[ ! -s "$affected_tests_file" ]]; then
+                echo "Affected subset contains no test targets; skipping PR coverage."
+                emit_targets true no_test_targets ""
+                exit 0
+              fi
+              affected="$(
+                python3 -c 'import pathlib, sys; labels = [line.strip() for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]; print(" ".join(labels))' "$affected_tests_file"
+              )"
+            else
+              echo "Test-presence query failed; running coverage on affected subset (guard intact)."
+              cat "$diagnostics_dir/test-query.log" || true
+            fi
+          fi
+
+          # Representative-variant trim (narrowing 2):
           # PR patch coverage runs one representative variant per test - the
           # base/default target - and drops generated variant wrappers only
           # when their ordinary base or named representative is in the set.
@@ -690,6 +649,86 @@ jobs:
             echo "Variant trim tool errored; keeping untrimmed affected set (guard intact)."
             cat "$diagnostics_dir/variant-trim.log" || true
           fi
+
+          # The single decision point. Prints `skip` only when the final list is
+          # PROVEN to have nothing a coverage run could measure; prints `run`
+          # for every other outcome, including every failure. Progress goes to
+          # stderr so stdout carries the verdict alone.
+          #
+          # "Instrumentable" means HOST-instrumentable. A wasm bridge shim is a
+          # plain cc_binary by kind, a platform-gated backend test is a plain
+          # cc_test, and a playwright wrapper test is a `js_test` the classifier
+          # has never heard of - but any of them can be target_compatible_with a
+          # platform this lane does not run, and
+          # `coverage --skip_incompatible_explicit_targets` (set in --config=ci)
+          # then silently drops it from the build so the run produces an empty
+          # report. So the cquery runs on the whole final list, always, and its
+          # answer is handed to the same classifier call that judges kinds.
+          # Diagnostics: affected-label-kind.txt plus final-targets.txt name
+          # exactly what was classified.
+          # BEGIN coverage final-list decision (extracted by tools/coverage_selection_decision_tests.py)
+          coverage_final_decision() {
+            local final_file="$1"
+            local kinds_file="$2"
+            local scratch_dir="$3"
+            local diag_dir="$4"
+            local repo_dir="$5"
+
+            local compat_file="$scratch_dir/host-compat.txt"
+            local incompatible_file="$scratch_dir/host-incompatible.txt"
+            : > "$incompatible_file"
+            local labels
+            labels="$(tr '\n' ' ' < "$final_file")"
+            if ( cd "$repo_dir" && bazelisk cquery "set($labels)" \
+                --output=starlark \
+                --starlark:expr='"{} {}".format(target.label, "HOST_INCOMPATIBLE" if "IncompatiblePlatformProvider" in providers(target) else "HOST_COMPATIBLE")' \
+                ) > "$compat_file" 2> "$diag_dir/compat-query.log"; then
+              cp "$compat_file" "$diag_dir/host-compat.txt" || true
+              grep ' HOST_INCOMPATIBLE$' "$compat_file" \
+                | sed 's/ HOST_INCOMPATIBLE$//' > "$incompatible_file" || true
+              cp "$incompatible_file" "$diag_dir/host-incompatible.txt" || true
+            else
+              echo "Host-compatibility cquery failed; running coverage (guard intact)." >&2
+              cat "$diag_dir/compat-query.log" >&2 || true
+              echo run
+              return
+            fi
+
+            local decision
+            if ! decision="$(python3 tools/coverage_instrumentable_targets.py \
+                --label-kind-file "$kinds_file" \
+                --restrict-to-file "$final_file" \
+                --host-incompatible-file "$incompatible_file" \
+                2>> "$diag_dir/instrumentability.log")"; then
+              echo "Final-list instrumentability decision errored; running coverage (guard intact)." >&2
+              tail -n 5 "$diag_dir/instrumentability.log" >&2 || true
+              echo run
+              return
+            fi
+            if [[ "$decision" == "instrumentable_present=false" ]]; then
+              echo skip
+              return
+            fi
+            echo run
+          }
+          # END coverage final-list decision
+
+          final_file="$work_dir/final-targets.txt"
+          # Intentional word splitting: each Bazel label becomes one line.
+          # shellcheck disable=SC2086
+          printf '%s\n' $affected > "$final_file"
+          cp "$final_file" "$diagnostics_dir/final-targets.txt"
+          if [[ "$kind_query_ok" == "true" ]]; then
+            final_decision="$(coverage_final_decision \
+              "$final_file" "$label_kind_file" "$work_dir" "$diagnostics_dir" "$head_dir")"
+            cat "$diagnostics_dir/instrumentability.log" 2> /dev/null || true
+            if [[ "$final_decision" == "skip" ]]; then
+              echo "Final coverage target list has nothing host-instrumentable to measure; skipping PR coverage."
+              emit_targets true no_instrumentable_targets ""
+              exit 0
+            fi
+          fi
+          echo "Final coverage target list includes host-instrumentable targets; running coverage."
 
           emit_targets false bazel_diff "$affected"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -808,7 +808,8 @@ jobs:
             libgl1-mesa-dev libosmesa6-dev
           sudo apt-get clean
 
-      - name: Generate coverage
+      - id: coverage
+        name: Generate coverage
         shell: bash
         run: |
           set -euo pipefail
@@ -824,6 +825,19 @@ jobs:
           df -h / "$GITHUB_WORKSPACE" "$RUNNER_TEMP"
           echo "::endgroup::"
 
+          # Publish the report outcome so every consumer of the coverage
+          # artifact honours a legitimate skip. tools/coverage.sh writes this
+          # marker when the build event stream proves every selected target was
+          # dropped as incompatible with this lane's platform: there is no
+          # report, the lane is satisfied, and the upload steps below must not
+          # fail looking for a file that was correctly never written.
+          if [[ -f coverage-report/coverage_skipped ]]; then
+            echo "report_written=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Coverage produced no report: every selected target was skipped as incompatible with this lane's platform. The coverage uploads are skipped."
+          else
+            echo "report_written=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage diagnostics
         if: always()
         uses: actions/upload-artifact@v7
@@ -834,6 +848,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage to Codecov
+        if: steps.coverage.outputs.report_written == 'true'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -888,6 +903,8 @@ jobs:
     # still fails in about a minute regardless of this backstop; the CPU-capped
     # 2-3 h local re-run cannot recur because local fallback is disabled.
     timeout-minutes: 210
+    outputs:
+      report_written: ${{ steps.coverage.outputs.report_written }}
     # Admission control on the shared remote-execution backend. Both
     # self-hosted lanes execute on a backend that an interactive development
     # host also uses with priority, so unbounded concurrent instrumented builds
@@ -980,7 +997,8 @@ jobs:
           # NOTE: no `bazelisk shutdown` — Generate coverage reuses this
           # server's loading/analysis instead of paying a fresh JVM start.
 
-      - name: Generate coverage
+      - id: coverage
+        name: Generate coverage
         shell: bash
         run: |
           set -euo pipefail
@@ -990,7 +1008,23 @@ jobs:
           echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
           tools/coverage.sh --quiet --no-html "${TARGETS[@]}"
 
+          # Publish the report outcome so every consumer of the coverage
+          # artifact honours a legitimate skip. tools/coverage.sh writes this
+          # marker when the build event stream proves every selected target was
+          # dropped as incompatible with this lane's platform: there is no
+          # report, the lane is satisfied, and the upload steps below must not
+          # fail looking for a file that was correctly never written.
+          if [[ -f coverage-report/coverage_skipped ]]; then
+            echo "report_written=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Coverage produced no report: every selected target was skipped as incompatible with this lane's platform. The coverage uploads are skipped."
+          else
+            echo "report_written=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # if-no-files-found stays `error`: gated on report_written, a missing
+      # report here is a real defect, not a legitimate skip.
       - name: Upload coverage artifact
+        if: steps.coverage.outputs.report_written == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: self-hosted-coverage-report
@@ -1014,8 +1048,10 @@ jobs:
     runs-on: ubuntu-24.04
     # Mirrors coverage-self-hosted's gate so the upload skips whenever the
     # self-hosted coverage job skips or fails (full-fallback PRs produce no
-    # artifact).
-    if: ${{ needs.coverage-self-hosted.result == 'success' }}
+    # artifact), and also when that job ran but legitimately produced no report
+    # (every selected target incompatible with its platform). Without the
+    # second condition this job downloads an artifact that was never uploaded.
+    if: ${{ needs.coverage-self-hosted.result == 'success' && needs.coverage-self-hosted.outputs.report_written == 'true' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -393,7 +393,7 @@ jobs:
             esac
 
             case "$path" in
-              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py|tools/coverage_variant_trim.py|tools/coverage_variant_trim_tests.py)
+              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py|tools/coverage_variant_trim.py|tools/coverage_variant_trim_tests.py|tools/coverage_selection_decision_tests.py)
                 ;;
               *)
                 smoke_only=false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -727,8 +727,8 @@ jobs:
               emit_targets true no_instrumentable_targets ""
               exit 0
             fi
+            echo "Final coverage target list includes host-instrumentable targets; running coverage."
           fi
-          echo "Final coverage target list includes host-instrumentable targets; running coverage."
 
           emit_targets false bazel_diff "$affected"
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -173,6 +173,17 @@ py_test(
 )
 
 py_test(
+    name = "coverage_selection_decision_tests",
+    size = "small",
+    srcs = ["coverage_selection_decision_tests.py"],
+    data = [
+        "coverage_instrumentable_targets.py",
+        "//:.github/workflows/coverage.yml",
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
     name = "coverage_lane_routing_tests",
     size = "small",
     srcs = ["coverage_lane_routing_tests.py"],

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -93,6 +93,70 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 job = self._job_body(job_name)
                 self.assertEqual(1, job.count("--test_tag_filters=-manual,-perf"))
 
+    def _coverage_jobs(self):
+        """Every (name, body) pair for a top-level key in coverage.yml."""
+        parts = re.split(
+            r"^  ([A-Za-z0-9_-]+):\s*$", self.coverage, flags=re.MULTILINE
+        )
+        return list(zip(parts[1::2], parts[2::2]))
+
+    def test_coverage_records_a_legitimate_skip_instead_of_announcing_a_report(self):
+        """The all-skipped path must not name a file it did not write.
+
+        `bazel coverage` legitimately produces no report when every selected
+        target is incompatible with the lane's platform: nothing was measured,
+        and the lane is satisfied. That path used to exit the script's inner
+        subshell with 0, after which the tail of the script unconditionally
+        announced "Filtered coverage report saved to .../filtered_report.dat".
+        The upload step believed it, looked for that exact path with
+        if-no-files-found: error, and failed the job on a file the script had
+        just decided not to write.
+        """
+        self.assertIn(
+            'echo "all_skipped" > "$COVERAGE_HTML_DIR/coverage_skipped"',
+            self.coverage_script,
+        )
+        report_line = 'echo "Filtered coverage report saved to'
+        self.assertEqual(1, self.coverage_script.count(report_line))
+        guard = 'if [ -f "$COVERAGE_OUTPUT_DIR/coverage_skipped" ]; then'
+        self.assertIn(guard, self.coverage_script)
+        self.assertLess(
+            self.coverage_script.index(guard),
+            self.coverage_script.index(report_line),
+            "the report announcement is not guarded by the skip marker",
+        )
+
+    def test_every_coverage_report_consumer_honours_a_legitimate_skip(self):
+        """Discovered, not listed: anything reading the report must be gated.
+
+        The report outcome is published as a step output and, for the
+        cross-job handoff, as a job output. Every consumer of
+        filtered_report.dat gates on one of them, so a legitimate skip cannot
+        fail a lane by looking for a file that was correctly never written.
+        """
+        consumers = []
+        for job_name, job_body in self._coverage_jobs():
+            job_gated = re.search(
+                r"^    if: .*report_written", job_body, re.MULTILINE
+            ) is not None
+            for step_name, step_body in self._steps(job_body):
+                if "filtered_report.dat" not in step_body:
+                    continue
+                consumers.append("%s / %s" % (job_name, step_name))
+                self.assertTrue(
+                    job_gated
+                    or "outputs.report_written == 'true'" in step_body,
+                    "step %r in job %r consumes the coverage report without "
+                    "honouring the report-written outcome" % (step_name, job_name),
+                )
+        self.assertGreaterEqual(
+            len(consumers),
+            3,
+            "consumer discovery matched %r, which is fewer than exist; the "
+            "match is stale and this test is no longer checking anything"
+            % (consumers,),
+        )
+
     def test_coverage_excludes_all_opt_in_test_tags(self):
         """Coverage must not run manual/perf tests through its own override."""
         match = re.search(

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -409,6 +409,16 @@ fi
     if [ "$BEP_STATUS" = "all_skipped" ]; then
       echo "No coverage report: every selected target was skipped as incompatible with this platform."
       echo "Nothing to measure here; treating the lane as satisfied."
+      # Record the outcome instead of pretending a report exists. This path
+      # used to exit the subshell with 0, after which the tail of this script
+      # unconditionally announced "Filtered coverage report saved to
+      # <dir>/filtered_report.dat" -- a file it had just decided not to write.
+      # CI believed the announcement and its upload step, which names that
+      # exact path with if-no-files-found: error, failed on the missing file.
+      # The marker is the honest half of that contract: the script says a
+      # report was not written, and every consumer that needs one reads this
+      # and stands down.
+      echo "all_skipped" > "$COVERAGE_HTML_DIR/coverage_skipped"
       exit 0
     fi
     echo "ERROR: Coverage report was not generated"
@@ -446,7 +456,11 @@ fi
   phase_mark end
 )
 
-if [ "$NO_HTML" = true ]; then
+if [ -f "$COVERAGE_OUTPUT_DIR/coverage_skipped" ]; then
+  # The graceful all-skipped path above. Say what actually happened; do not
+  # name a report file that was deliberately not written.
+  echo "No coverage report written to $COVERAGE_OUTPUT_DIR: every selected target was skipped as incompatible with this platform."
+elif [ "$NO_HTML" = true ]; then
   echo "Filtered coverage report saved to $COVERAGE_OUTPUT_DIR/filtered_report.dat"
 else
   echo "Coverage report saved to $COVERAGE_OUTPUT_DIR/index.html"

--- a/tools/coverage_instrumentable_targets.py
+++ b/tools/coverage_instrumentable_targets.py
@@ -26,6 +26,16 @@ is indistinguishable from a host cc_binary) can be excluded by passing the
 host-configuration cquery incompatibility result via --host-incompatible-file.
 Labels absent from that file keep their kind-based classification, so a missing
 or partial incompatibility list still fails closed toward running coverage.
+
+Decide on the FINAL list, not on an intermediate one. The coverage lane narrows
+its affected set (tests only, tag-filtered, variant-trimmed) before it runs, and
+a decision taken on any wider set answers a question nobody asked: a non-test
+helper or a tag-filtered sibling in the wider set can carry the whole subset
+past the gate even though it never reaches the coverage command. Pass the final
+list via --restrict-to-file and both criteria - rule kind AND host
+compatibility - are applied to exactly the targets that will run. A final label
+with no kind line is an incomplete answer, not a skippable one, so it fails
+closed: the tool reports instrumentable_present=true and exits nonzero.
 """
 
 import argparse
@@ -114,10 +124,6 @@ class Classification:
 
     instrumentable: list[str] = field(default_factory=list)
     non_instrumentable: list[str] = field(default_factory=list)
-    # Original label_kind lines for the instrumentable bucket, so callers can
-    # inspect the kinds (e.g. the coverage lane's cc_binary-only
-    # host-compatibility recheck) without re-deriving them.
-    instrumentable_lines: list[str] = field(default_factory=list)
 
     @property
     def total(self) -> int:
@@ -166,6 +172,45 @@ def normalize_label(label: str) -> str:
     return label
 
 
+def restrict_lines(
+    lines: list[str], labels: list[str]
+) -> tuple[list[str], list[str]]:
+    """Select the label_kind lines for exactly `labels`, in `labels` order.
+
+    Args:
+        lines: Raw lines from `bazel query --output label_kind` for a set that
+            is a superset of `labels` (the coverage lane's alias-resolved
+            affected set).
+        labels: The final coverage target list, one label per entry.
+
+    Returns:
+        (selected lines, labels that had no kind line). A non-empty second
+        element means the caller cannot decide on this set: `tests()` expansion
+        can name a test_suite member that was never in the queried set, and an
+        unclassified target must keep the coverage run rather than skip it.
+    """
+    by_label: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        _, label = _split_kind_and_label(line)
+        by_label.setdefault(normalize_label(label), line)
+
+    selected: list[str] = []
+    missing: list[str] = []
+    for raw_label in labels:
+        label = normalize_label(raw_label.strip())
+        if not label:
+            continue
+        line = by_label.get(label)
+        if line is None:
+            missing.append(label)
+        else:
+            selected.append(line)
+    return selected, missing
+
+
 def classify(
     lines: list[str], host_incompatible: frozenset[str] = frozenset()
 ) -> Classification:
@@ -191,7 +236,6 @@ def classify(
         if not kind_phrase:
             # No kind phrase (malformed): fail closed and treat as instrumentable.
             result.instrumentable.append(label)
-            result.instrumentable_lines.append(line)
             continue
         if normalize_label(label) in host_incompatible:
             # Host-incompatible targets (e.g. a wasm bridge cc_binary marked
@@ -213,11 +257,9 @@ def classify(
                 # Every cc_* kind, the donner C++ wrapper rules, and any
                 # unrecognized rule kind land here: run coverage (fail closed).
                 result.instrumentable.append(label)
-                result.instrumentable_lines.append(line)
             continue
         # Unrecognized phrase shape: fail closed.
         result.instrumentable.append(label)
-        result.instrumentable_lines.append(line)
     return result
 
 
@@ -247,6 +289,17 @@ def main() -> int:
         help="File containing `bazel query --output label_kind` output.",
     )
     parser.add_argument(
+        "--restrict-to-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional file of labels (one per line) naming the FINAL coverage "
+            "target list. Classification is restricted to exactly those "
+            "targets; a label with no kind line fails closed (reports "
+            "instrumentable_present=true and exits nonzero)."
+        ),
+    )
+    parser.add_argument(
         "--host-incompatible-file",
         type=Path,
         default=None,
@@ -254,15 +307,6 @@ def main() -> int:
             "Optional file of labels (one per line) that a host-configuration "
             "cquery reported as incompatible (IncompatiblePlatformProvider). "
             "These classify as non-instrumentable regardless of kind."
-        ),
-    )
-    parser.add_argument(
-        "--instrumentable-out",
-        type=Path,
-        default=None,
-        help=(
-            "Optional path to write the label_kind lines of targets classified "
-            "as instrumentable, for the caller's host-compatibility recheck."
         ),
     )
     args = parser.parse_args()
@@ -295,20 +339,33 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-    classification = classify(text.splitlines(), host_incompatible)
-    _print_summary(classification)
-
-    if args.instrumentable_out is not None:
+    lines = text.splitlines()
+    if args.restrict_to_file is not None:
         try:
-            args.instrumentable_out.write_text(
-                "".join(f"{line}\n" for line in classification.instrumentable_lines),
-                encoding="utf-8",
-            )
+            final_labels = args.restrict_to_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()
         except OSError as error:
+            print("instrumentable_present=true")
             print(
-                f"WARNING: could not write {args.instrumentable_out}: {error}",
+                f"ERROR: could not read {args.restrict_to_file}: {error}",
                 file=sys.stderr,
             )
+            return 1
+        lines, missing = restrict_lines(lines, final_labels)
+        if missing:
+            # Fail closed: an unclassified member of the final list means the
+            # answer is unknown, and unknown must never skip the guard.
+            print("instrumentable_present=true")
+            print(
+                "ERROR: no kind line for %d of the final target(s): %s"
+                % (len(missing), ", ".join(missing[:5])),
+                file=sys.stderr,
+            )
+            return 1
+
+    classification = classify(lines, host_incompatible)
+    _print_summary(classification)
 
     value = "true" if classification.instrumentable_present else "false"
     print(f"instrumentable_present={value}")

--- a/tools/coverage_instrumentable_targets_tests.py
+++ b/tools/coverage_instrumentable_targets_tests.py
@@ -112,19 +112,6 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(result.instrumentable_present)
         self.assertEqual(result.instrumentable, ["//donner/svg/tool:donner-svg"])
 
-    def test_instrumentable_lines_expose_kinds(self):
-        # The coverage lane's recheck gate needs the KINDS of the instrumentable
-        # residue (it only cqueries cc_binary-only sets).
-        lines = [
-            "filegroup rule //:docs_files",
-            "cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin",
-        ]
-        result = mod.classify(lines)
-        self.assertEqual(
-            result.instrumentable_lines,
-            ["cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin"],
-        )
-
     def test_unknown_rule_kind_fails_closed(self):
         # An unrecognized rule kind must run coverage (uncertainty never skips).
         lines = [
@@ -188,6 +175,81 @@ class ClassifyTest(unittest.TestCase):
     def test_malformed_single_token_fails_closed(self):
         result = mod.classify(["//weird:label_with_no_kind"])
         self.assertTrue(result.instrumentable_present)
+
+
+class RestrictLinesTest(unittest.TestCase):
+    """The coverage lane decides on its FINAL list, not on the affected set.
+
+    Narrowing (tests only, tag-filtered, variant-trimmed) happens before the
+    decision, and judging a wider set is how three production failures got
+    past the gate: a tag-filtered cc_test and a non-test helper each voted in
+    a decision about targets they were not part of.
+    """
+
+    def test_selects_only_the_final_labels(self):
+        lines = [
+            "js_test rule //donner/editor/wasm/tests:browser_presentation_regression_test",
+            "directory_path rule //donner/editor/wasm/tests:"
+            "browser_presentation_regression_test__entry_point",
+            "js_test rule //donner/editor/wasm/tests:chromium_remote_smoke",
+        ]
+        selected, missing = mod.restrict_lines(
+            lines,
+            [
+                "//donner/editor/wasm/tests:browser_presentation_regression_test",
+                "//donner/editor/wasm/tests:chromium_remote_smoke",
+            ],
+        )
+        self.assertEqual([], missing)
+        self.assertEqual(
+            [
+                "js_test rule //donner/editor/wasm/tests:browser_presentation_regression_test",
+                "js_test rule //donner/editor/wasm/tests:chromium_remote_smoke",
+            ],
+            selected,
+        )
+
+    def test_the_narrowed_set_no_longer_inherits_a_helpers_verdict(self):
+        # The incident: the host-compatible `directory_path` __entry_point is
+        # not a test, so it is not in the final list. Restricted to the two
+        # host-incompatible js_tests, the set classifies as a skip; unrestricted
+        # (with the helper still voting) it does not.
+        lines = [
+            "js_test rule //donner/editor/wasm/tests:browser_presentation_regression_test",
+            "directory_path rule //donner/editor/wasm/tests:"
+            "browser_presentation_regression_test__entry_point",
+            "js_test rule //donner/editor/wasm/tests:chromium_remote_smoke",
+        ]
+        incompatible = frozenset(
+            [
+                "//donner/editor/wasm/tests:browser_presentation_regression_test",
+                "//donner/editor/wasm/tests:chromium_remote_smoke",
+            ]
+        )
+        self.assertTrue(mod.classify(lines, incompatible).instrumentable_present)
+
+        selected, _ = mod.restrict_lines(lines, sorted(incompatible))
+        self.assertFalse(mod.classify(selected, incompatible).instrumentable_present)
+
+    def test_missing_label_is_reported_not_dropped(self):
+        # `tests()` expansion can name a test_suite member that was never in
+        # the queried set. An unclassified target must keep the coverage run,
+        # so the caller has to hear about it rather than silently see a
+        # smaller, skippable set.
+        selected, missing = mod.restrict_lines(
+            ["py_test rule //tools:filter_coverage_tests"],
+            ["//tools:filter_coverage_tests", "//donner/svg:suite_member_tests"],
+        )
+        self.assertEqual(["py_test rule //tools:filter_coverage_tests"], selected)
+        self.assertEqual(["//donner/svg:suite_member_tests"], missing)
+
+    def test_canonical_and_apparent_labels_match(self):
+        selected, missing = mod.restrict_lines(
+            ["cc_test rule @@//donner/base:string_utils_tests"],
+            ["//donner/base:string_utils_tests"],
+        )
+        self.assertEqual([], missing)
+        self.assertEqual(1, len(selected))
 
 
 if __name__ == "__main__":

--- a/tools/coverage_selection_decision_tests.py
+++ b/tools/coverage_selection_decision_tests.py
@@ -1,0 +1,343 @@
+"""Replays the coverage lane's three target-selection failures.
+
+The coverage lane picks a PR target subset and then decides whether that subset
+is worth instrumenting. Three production failures came from taking that decision
+at three different pipeline stages, each about a DIFFERENT set than the one
+`bazel coverage` would actually run:
+
+  1. A subset whose surviving tests were only a py_test passed an
+     instrumentability check taken on the PRE-narrowing set, where a
+     manual-tagged cc_test made it look instrumentable. The coverage command's
+     own --test_tag_filters then removed that cc_test.
+  2. A subset of macOS-only Metal cc_tests passed a host-compatibility recheck
+     scoped to cc_binary-only sets, on the assumption that a cc_test is always
+     host code.
+  3. A subset of two macOS-only playwright wrapper tests passed BOTH earlier
+     fixes: the kind query reported the unknown kind `js_test` (fail-open) plus
+     a host-compatible `directory_path` helper that is not a test, the
+     host-compatibility cquery ran on the pre-narrowing set where that helper
+     kept the verdict positive, and the later surviving-set recheck re-asked
+     only the KIND question and discarded the host-compatibility answer.
+
+All three end the same way: coverage runs, every target is dropped or produces
+no data, and the lane dies on an empty/absent report that no rerun can clear.
+
+These tests exercise the CONSOLIDATED decision as it exists in coverage.yml --
+the shell function is extracted from the workflow and run against the real
+classifier, with `bazelisk cquery` stubbed to return each incident's recorded
+compatibility answer. They also pin the shape that makes a fourth sibling
+impossible: exactly one classifier call, exactly one cquery, both after every
+narrowing step.
+"""
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+from python.runfiles import runfiles
+
+_BEGIN = "# BEGIN coverage final-list decision"
+_END = "# END coverage final-list decision"
+
+_STUB_BAZELISK = """#!/bin/bash
+# Minimal `bazelisk` stand-in: the decision block only ever runs one cquery.
+if [[ "${1:-}" == "cquery" ]]; then
+  if [[ "${STUB_CQUERY_FAIL:-}" == "1" ]]; then
+    echo "stub: cquery failed" >&2
+    exit 1
+  fi
+  cat "$STUB_CQUERY_OUTPUT"
+  exit 0
+fi
+echo "stub: unexpected bazelisk invocation: $*" >&2
+exit 1
+"""
+
+
+def _runfile(path):
+    resolver = runfiles.Create()
+    return resolver.Rlocation("donner/%s" % path)
+
+
+def _read(path):
+    with open(_runfile(path), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class CoverageSelectionDecisionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = _read(".github/workflows/coverage.yml")
+        cls.decision = cls._extract_decision(cls.workflow)
+        cls.classifier = _runfile("tools/coverage_instrumentable_targets.py")
+
+    @staticmethod
+    def _extract_decision(workflow):
+        match = re.search(
+            r"^[ \t]*%s[^\n]*\n(?P<body>.*?)^[ \t]*%s[ \t]*$"
+            % (re.escape(_BEGIN), re.escape(_END)),
+            workflow,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert match is not None, "decision block markers not found in coverage.yml"
+        return textwrap.dedent(match.group("body"))
+
+    def _decide(self, label_kinds, final_targets, host_compat, cquery_fails=False):
+        """Run the extracted decision block and return its verdict.
+
+        Args:
+            label_kinds: `bazel query --output label_kind` lines for the
+                alias-resolved affected set.
+            final_targets: The final coverage target list, one label per entry.
+            host_compat: Lines the host-compatibility cquery reports.
+            cquery_fails: Make the stubbed cquery exit nonzero instead.
+
+        Returns:
+            The verdict word ("skip" or "run").
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "tools").mkdir()
+            shutil.copy(self.classifier, root / "tools")
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            stub = bin_dir / "bazelisk"
+            stub.write_text(_STUB_BAZELISK, encoding="utf-8")
+            stub.chmod(0o755)
+
+            scratch = root / "scratch"
+            scratch.mkdir()
+            diagnostics = root / "diagnostics"
+            diagnostics.mkdir()
+
+            kinds_file = scratch / "affected-label-kind.txt"
+            kinds_file.write_text(
+                "".join(f"{line}\n" for line in label_kinds), encoding="utf-8"
+            )
+            final_file = scratch / "final-targets.txt"
+            final_file.write_text(
+                "".join(f"{label}\n" for label in final_targets), encoding="utf-8"
+            )
+            compat_file = root / "cquery-output.txt"
+            compat_file.write_text(
+                "".join(f"{line}\n" for line in host_compat), encoding="utf-8"
+            )
+
+            fixture = root / "decide.sh"
+            fixture.write_text(
+                "#!/bin/bash\nset -euo pipefail\n"
+                + self.decision
+                + '\ncoverage_final_decision "$1" "$2" "$3" "$4" "$5"\n',
+                encoding="utf-8",
+            )
+            fixture.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = "%s:%s" % (bin_dir, env["PATH"])
+            env["STUB_CQUERY_OUTPUT"] = str(compat_file)
+            if cquery_fails:
+                env["STUB_CQUERY_FAIL"] = "1"
+
+            result = subprocess.run(
+                [
+                    str(fixture),
+                    str(final_file),
+                    str(kinds_file),
+                    str(scratch),
+                    str(diagnostics),
+                    str(root),
+                ],
+                cwd=str(root),
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            return result.stdout.strip()
+
+    # ---- the three incidents -------------------------------------------
+
+    def test_incident_one_py_test_only_survivor_skips(self):
+        """The manual-tagged cc_test is not in the final list, so it cannot vote."""
+        verdict = self._decide(
+            label_kinds=[
+                "cc_test rule //donner/svg:renderer_manual_test",
+                "py_test rule //tools:filter_coverage_tests",
+            ],
+            final_targets=["//tools:filter_coverage_tests"],
+            host_compat=["@@//tools:filter_coverage_tests HOST_COMPATIBLE"],
+        )
+        self.assertEqual("skip", verdict)
+
+    def test_incident_two_macos_only_cc_tests_skip(self):
+        """A cc_test is not automatically host code; the cquery decides."""
+        labels = [
+            "//donner/svg/renderer/metal:metal_device_tests",
+            "//donner/svg/renderer/metal:metal_pipeline_tests",
+            "//donner/svg/renderer/metal:metal_surface_tests",
+        ]
+        verdict = self._decide(
+            label_kinds=["cc_test rule %s" % label for label in labels],
+            final_targets=labels,
+            host_compat=["@@%s HOST_INCOMPATIBLE" % label for label in labels],
+        )
+        self.assertEqual("skip", verdict)
+
+    def test_incident_three_playwright_wrappers_skip(self):
+        """The exact set from the run that sailed through both earlier fixes.
+
+        The `__entry_point` helper is host-compatible and is NOT a test, so it
+        never reaches the final list; the two `js_test` wrappers are unknown by
+        kind (fail-open) but the cquery proves both host-incompatible.
+        """
+        tests = [
+            "//donner/editor/wasm/tests:browser_presentation_regression_test",
+            "//donner/editor/wasm/tests:chromium_remote_smoke",
+        ]
+        verdict = self._decide(
+            label_kinds=[
+                "js_test rule %s" % tests[0],
+                "directory_path rule //donner/editor/wasm/tests:"
+                "browser_presentation_regression_test__entry_point",
+                "js_test rule %s" % tests[1],
+            ],
+            final_targets=tests,
+            host_compat=["@@%s HOST_INCOMPATIBLE" % label for label in tests],
+        )
+        self.assertEqual("skip", verdict)
+
+    def test_incident_three_pre_narrowing_helper_no_longer_votes(self):
+        """The direct cause: judged on the wider set, the same inputs say run.
+
+        This is the asymmetry the consolidation removes. Keeping it as an
+        executable statement means a future refactor that quietly widens the
+        decided-on set fails here instead of in CI.
+        """
+        entry_point = (
+            "//donner/editor/wasm/tests:"
+            "browser_presentation_regression_test__entry_point"
+        )
+        tests = [
+            "//donner/editor/wasm/tests:browser_presentation_regression_test",
+            "//donner/editor/wasm/tests:chromium_remote_smoke",
+        ]
+        verdict = self._decide(
+            label_kinds=[
+                "js_test rule %s" % tests[0],
+                "directory_path rule %s" % entry_point,
+                "js_test rule %s" % tests[1],
+            ],
+            final_targets=tests + [entry_point],
+            host_compat=[
+                "@@%s HOST_INCOMPATIBLE" % tests[0],
+                "@@%s HOST_COMPATIBLE" % entry_point,
+                "@@%s HOST_INCOMPATIBLE" % tests[1],
+            ],
+        )
+        self.assertEqual("run", verdict)
+
+    # ---- positive control and fail-open paths ---------------------------
+
+    def test_mixed_set_with_host_compatible_cc_test_runs(self):
+        """A real C++ test in the final list must still produce coverage."""
+        verdict = self._decide(
+            label_kinds=[
+                "cc_test rule //donner/base:string_utils_tests",
+                "js_test rule //donner/editor/wasm/tests:chromium_remote_smoke",
+                "py_test rule //tools:filter_coverage_tests",
+            ],
+            final_targets=[
+                "//donner/base:string_utils_tests",
+                "//donner/editor/wasm/tests:chromium_remote_smoke",
+                "//tools:filter_coverage_tests",
+            ],
+            host_compat=[
+                "@@//donner/base:string_utils_tests HOST_COMPATIBLE",
+                "@@//donner/editor/wasm/tests:chromium_remote_smoke HOST_INCOMPATIBLE",
+                "@@//tools:filter_coverage_tests HOST_COMPATIBLE",
+            ],
+        )
+        self.assertEqual("run", verdict)
+
+    def test_cquery_failure_keeps_the_coverage_run(self):
+        verdict = self._decide(
+            label_kinds=["py_test rule //tools:filter_coverage_tests"],
+            final_targets=["//tools:filter_coverage_tests"],
+            host_compat=[],
+            cquery_fails=True,
+        )
+        self.assertEqual("run", verdict)
+
+    def test_final_label_without_a_kind_line_keeps_the_coverage_run(self):
+        """`tests()` can name a test_suite member the kind query never saw."""
+        verdict = self._decide(
+            label_kinds=["py_test rule //tools:filter_coverage_tests"],
+            final_targets=[
+                "//tools:filter_coverage_tests",
+                "//donner/svg:suite_member_tests",
+            ],
+            host_compat=[
+                "@@//tools:filter_coverage_tests HOST_COMPATIBLE",
+                "@@//donner/svg:suite_member_tests HOST_COMPATIBLE",
+            ],
+        )
+        self.assertEqual("run", verdict)
+
+    # ---- workflow shape: one decision, after every narrowing step -------
+
+    def test_the_workflow_classifies_exactly_once(self):
+        """Three calls was the bug. Any number but one invites a fourth."""
+        self.assertEqual(
+            1,
+            self.workflow.count("python3 tools/coverage_instrumentable_targets.py"),
+            "coverage.yml classifies instrumentability more than once; the "
+            "second call is how the sets drifted apart",
+        )
+        self.assertEqual(
+            1,
+            self.workflow.count("bazelisk cquery"),
+            "coverage.yml runs more than one host-compatibility cquery",
+        )
+
+    def test_the_decision_names_the_final_list_and_the_cquery_answer(self):
+        """Both criteria, one call, on the narrowed list."""
+        self.assertIn('--restrict-to-file "$final_file"', self.decision)
+        self.assertIn('--host-incompatible-file "$incompatible_file"', self.decision)
+        # The retired two-phase handshake must not come back.
+        self.assertNotIn("--instrumentable-out", self.workflow)
+
+    def test_the_decision_runs_after_every_narrowing_step(self):
+        """Order is the invariant: narrow, then decide, then emit."""
+        test_query = self.workflow.index(
+            'affected_tests_file="$work_dir/affected-tests.txt"'
+        )
+        variant_trim = self.workflow.index(
+            "# Representative-variant trim", test_query
+        )
+        final_file = self.workflow.index(
+            'final_file="$work_dir/final-targets.txt"', variant_trim
+        )
+        decide = self.workflow.index("coverage_final_decision \\", final_file)
+        emit = self.workflow.index(
+            'emit_targets false bazel_diff "$affected"', decide
+        )
+        self.assertLess(test_query, variant_trim)
+        self.assertLess(variant_trim, final_file)
+        self.assertLess(final_file, decide)
+        self.assertLess(decide, emit)
+
+    def test_a_skip_uses_the_established_reason(self):
+        start = self.workflow.index('if [[ "$final_decision" == "skip" ]]')
+        skip_block = self.workflow[start : self.workflow.index("\n          fi", start)]
+        self.assertIn('emit_targets true no_instrumentable_targets ""', skip_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The PR coverage lane has now failed three times the same way, each time because its "is this subset worth instrumenting?" decision was taken about a different set of targets than the one `bazel coverage` actually ran. This replaces the three accreted guards with one decision point placed after every narrowing step, and separately fixes a desync between `tools/coverage.sh`'s graceful all-skipped path and the upload steps that consume its output.

## The three failures

1. A diff whose surviving tests were only a `py_test` passed the instrumentability check, because that check ran on the pre-narrowing affected set where a `manual`-tagged `cc_test` made the subset look instrumentable. The coverage command's own `--test_tag_filters` then removed that `cc_test`, coverage ran on nothing, and the lane died on the empty-report guard. Fixed at the time by adding a surviving-set recheck after the test-presence gate.
2. A diff selecting three macOS-only Metal `cc_test`s passed everything, because the host-compatibility recheck was scoped to `cc_binary`-only sets on the assumption that a `cc_test` is always host code. `--skip_incompatible_explicit_targets` dropped all three on the Linux lane and the run died the same way. Fixed at the time by generalizing that recheck beyond `cc_binary`.
3. A diff selecting two macOS-only playwright wrapper tests sailed through both of those fixes.

The third one is diagnosed from the failing run's own target-selection diagnostics artifact, and neither guard was broken in isolation:

* The kind query reported `js_test` for the two playwright tests and `directory_path` for the generated `..._test__entry_point` helper. `js_test` is a kind the classifier has never heard of, so it fails open to instrumentable by design. Kind classification alone can therefore never skip this shape.
* The host-compatibility cquery did run, and it was correct: it reported both `js_test` targets `HOST_INCOMPATIBLE` and the `directory_path` helper `HOST_COMPATIBLE`. But it was applied to the pre-narrowing affected set, where that one host-compatible helper kept `instrumentable_present=true`.
* The surviving-set recheck then re-asked only the kind question about the two surviving `js_test`s, without the host-incompatibility answer, and got `instrumentable_present=true` again.

So the helper voted in a decision about targets it was not part of (it is not a test and never reached the coverage command), and the recheck that saw the right target list threw away the fact that decided the question. Replaying the run's exact recorded artifacts through the classifier reproduces this: the pre-narrowing set plus the cquery answer says run, the surviving set without the cquery answer says run, and the final list with the cquery answer says skip.

## One decision point

`determine-targets` now computes the final target list first (affected, then tests only, then tag-filtered, then variant-trimmed), and only then decides. That decision asks both questions about exactly that list: rule kind classification and the host-compatibility cquery, in one classifier call, with the cquery run unconditionally rather than gated on a partial earlier verdict. The fail-closed-for-skipping and fail-open-for-running behavior each guard intended individually is preserved: a kind-query, cquery, kind-lookup, or classifier failure keeps the coverage run with the guard intact, and only a positively proven all-non-instrumentable-or-host-incompatible final list skips, with the established `no_instrumentable_targets` reason.

`tools/coverage_instrumentable_targets.py` grows a `--restrict-to-file` flag for the final list (a final label with no kind line fails closed) and loses the `--instrumentable-out` handshake, which existed only to feed the second decision that no longer exists. The hard-won reasoning in the replaced guards, including the earlier false RUN, its `cc_test` sibling, and the surviving-set rationale, is carried into the consolidated block's comment so the history of why survives. The infra-change and smoke fallback paths and the diagnostics artifacts are untouched; `surviving-label-kind.txt` is replaced by `final-targets.txt`, which together with the existing `affected-label-kind.txt` says exactly what was classified.

## The second desync

The same run then hit an unrelated contract break. When the build event stream proves every selected target was skipped as incompatible with the lane's platform, `tools/coverage.sh` correctly treats the lane as satisfied. That path exited its inner subshell with 0, after which the tail of the script unconditionally printed `Filtered coverage report saved to coverage-report/filtered_report.dat` for a file it had just decided not to write. The upload step believed it, looked for that exact path with `if-no-files-found: error`, and failed the job.

The script now records the outcome instead of pretending, and the outcome is plumbed rather than inferred: the generate step publishes `report_written`, and every consumer of the report honors it. That is the hosted Codecov upload, the self-hosted artifact upload, and the cross-job Codecov upload, which reads it as a job output. `if-no-files-found: error` stays as it is, because with the gate in place a missing report there is a real defect rather than a legitimate skip.

## Verification

* All three incident shapes replayed against the consolidated logic in `tools/coverage_selection_decision_tests.py`, which extracts the decision block from the workflow itself and runs it with the real classifier and a stubbed cquery, asserting skip for each. Plus a positive control (a mixed set holding a host-compatible `cc_test` keeps coverage), an executable statement of the third failure (the same inputs judged on the wider set still say run), and fail-open controls for a cquery failure and for a final label with no kind line.
* Workflow shape pinned: exactly one classifier call, exactly one cquery, both after every narrowing step, and the skip using the established reason.
* `tools/ci_runtime_workflow_tests.py` discovers every step that consumes `filtered_report.dat` and asserts each is gated on the report outcome, plus the marker guarding the report announcement. Both new assertions were confirmed red against the pre-change files.
* `bazel test --config=re //tools/...` green (36 of 36, including the new test). `bazel test --config=re //...` completed its full build and link phase and reached 329 of 393 tests with zero failures on two separate runs before the local run had to be stopped for host disk headroom; the remaining targets are editor, wasm, and GL tests that this diff cannot reach, and CI runs them here. Workflow YAML parses; `actionlint` clean; `buildifier --mode=check` clean; `shellcheck tools/coverage.sh` reports only the three findings already present on the parent revision.

Coverage routing for this PR itself: the diff touches workflow and tooling files plus `tools/BUILD.bazel`, so it does not qualify for the coverage-tooling smoke path. bazel-diff produces a genuine affected set, the narrowed final list is entirely Python test targets, and the new consolidated decision skips PR coverage with `no_instrumentable_targets`, which exercises the new path end to end on the right answer. The main-push baseline covers the lines, and the full-coverage infra-change fallback is untouched by this change.
