### PR TITLE
docs: correct the design 0053 update date

### DIFF
--- a/docs/design_docs/0053-native_gpu_hal.md
+++ b/docs/design_docs/0053-native_gpu_hal.md
@@ -2,7 +2,7 @@
 
 **Status:** Design\
 **Created:** 2026-07-05\
-**Updated:** 2026-08-27\
+**Updated:** 2026-09-03\
 **Author:** Claude Fable 5.1\
 **Drafted by:** GPT-5.6 Sol
 


### PR DESCRIPTION
The amendment to design 0053 that merged as PR 1091 was authored on 2026-09-03, but its header carried an update date of 2026-08-27 from a stale session clock. This corrects the date to the day the amendment was made. No other change.
