### PR TITLE
Fail closed the two Metal fixtures that silently skipped without a device

### DIFF
--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -20,6 +20,18 @@ donner_cc_library(
     ],
 )
 
+# Drives DONNER_REQUIRE_METAL_DEVICE directly: no Metal device involved, so unlike the three
+# fixtures below this runs on every lane and exercises the missing-device branches deterministically
+# rather than only when a runner has actually lost its device.
+donner_cc_test(
+    name = "metal_device_gate_tests",
+    srcs = ["MetalDeviceGate_tests.cc"],
+    deps = [
+        ":metal_device_gate",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 # The Metal solid-fill vertical slice: donner::gpu + emitted MSL only (no
 # wgpu-based dependencies, not geode-gated). Metal API validation is enabled
 # so validation issues abort loudly.
@@ -33,6 +45,8 @@ donner_cc_test(
     },
     # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
     # the no-device rule can never see one and this slice keeps skipping into a green report.
+    # MetalDeviceGate_tests.cc checks the macro's own logic without a device; it cannot see this
+    # list, so removing an entry here is a silent regression only review catches.
     env_inherit = [
         "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
         "GITHUB_ACTIONS",
@@ -67,6 +81,8 @@ donner_cc_test(
     },
     # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
     # the no-device rule can never see one and this slice keeps skipping into a green report.
+    # MetalDeviceGate_tests.cc checks the macro's own logic without a device; it cannot see this
+    # list, so removing an entry here is a silent regression only review catches.
     env_inherit = [
         "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
         "GITHUB_ACTIONS",
@@ -96,6 +112,8 @@ donner_cc_test(
     },
     # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
     # the no-device rule can never see one and this slice keeps skipping into a green report.
+    # MetalDeviceGate_tests.cc checks the macro's own logic without a device; it cannot see this
+    # list, so removing an entry here is a silent regression only review catches.
     env_inherit = [
         "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
         "GITHUB_ACTIONS",

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -1,9 +1,24 @@
-load("//build_defs:rules.bzl", "donner_cc_test")
+load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:visibility.bzl", "donner_internal_visibility")
 
 # Tests for the Metal vertical slices: the solid-fill pixel comparison against
 # the frozen per-adapter baseline the production renderer wrote, and the
 # color-matrix compute test.
+
+# The missing-device fixture preamble every Metal vertical slice below needs: fail closed on an
+# automated lane, skip on a developer machine. A library rather than a third hand copy once the
+# sub-rectangle-copy slice needed the same rule as solid-fill and color-matrix.
+donner_cc_library(
+    name = "metal_device_gate",
+    testonly = 1,
+    hdrs = ["MetalDeviceGate.h"],
+    visibility = donner_internal_visibility(),
+    deps = [
+        "//donner/gpu/baseline:frozen_baseline_policy",
+        "@com_google_gtest//:gtest",
+    ],
+)
 
 # The Metal solid-fill vertical slice: donner::gpu + emitted MSL only (no
 # wgpu-based dependencies, not geode-gated). Metal API validation is enabled
@@ -24,6 +39,7 @@ donner_cc_test(
     ],
     target_compatible_with = ["@platforms//os:macos"],
     deps = [
+        ":metal_device_gate",
         "//donner/base:base_test_utils",
         "//donner/editor/tests:bitmap_golden_compare",
         "//donner/gpu",
@@ -49,8 +65,15 @@ donner_cc_test(
         "MTL_DEBUG_LAYER": "1",
         "MTL_SHADER_VALIDATION": "1",
     },
+    # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
+    # the no-device rule can never see one and this slice keeps skipping into a green report.
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
     target_compatible_with = ["@platforms//os:macos"],
     deps = [
+        ":metal_device_gate",
         "//donner/gpu",
         "//donner/gpu:color_matrix_slice",
         "//donner/gpu/metal:metal_device",
@@ -71,8 +94,15 @@ donner_cc_test(
         "MTL_DEBUG_LAYER": "1",
         "MTL_SHADER_VALIDATION": "1",
     },
+    # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
+    # the no-device rule can never see one and this slice keeps skipping into a green report.
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
     target_compatible_with = ["@platforms//os:macos"],
     deps = [
+        ":metal_device_gate",
         "//donner/gpu",
         "//donner/gpu:sub_rectangle_copy_scene",
         "//donner/gpu/metal:metal_device",

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -28,6 +28,7 @@ donner_cc_test(
     srcs = ["MetalDeviceGate_tests.cc"],
     deps = [
         ":metal_device_gate",
+        "//donner/base:base_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
+++ b/donner/gpu/metal/tests/MetalColorMatrix_tests.cc
@@ -16,6 +16,7 @@
 
 #include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
 #include "donner/gpu/shader/ModuleInterface.h"
 #include "donner/gpu/shader/MslEmitter.h"
 #include "donner/gpu/shader/programs/ColorMatrix.h"
@@ -51,9 +52,7 @@ class MetalColorMatrixTest : public testing::Test {
 protected:
   void SetUp() override {
     device_ = MetalDevice::Create();
-    if (!device_) {
-      GTEST_SKIP() << "No Metal device available";
-    }
+    DONNER_REQUIRE_METAL_DEVICE(device_, "the Metal color-matrix slice");
   }
 
   /// Unwraps an RHI result, failing the test on error.

--- a/donner/gpu/metal/tests/MetalDeviceGate.h
+++ b/donner/gpu/metal/tests/MetalDeviceGate.h
@@ -1,0 +1,37 @@
+#pragma once
+/// @file
+/// Gates a Metal test fixture's SetUp() on having created a device: skip on a developer machine,
+/// fail on an automated lane. Every Metal vertical slice in this package needs this, so it is a
+/// shared macro rather than a third hand copy of the frozen pixel gate's fixture preamble.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "donner/gpu/baseline/FrozenBaselinePolicy.h"
+
+/**
+ * Gates a fixture's SetUp() on \p device having been created, ending the case when it was not:
+ * skipped on a developer machine, failed on an automated lane.
+ *
+ * Use directly in SetUp(). Placed in a helper function, GTEST_SKIP()/FAIL() would return out of
+ * the helper rather than SetUp(), and the fixture would go on to run its cases without a device.
+ *
+ * @param device Pointer-like value that is null when no device was created.
+ * @param gateLabel What the gate is, for a reader who sees only this line.
+ */
+#define DONNER_REQUIRE_METAL_DEVICE(device, gateLabel)                                           \
+  do {                                                                                           \
+    if (!(device)) {                                                                             \
+      const ::donner::gpu::baseline::MissingComparisonDisposition donnerMetalDeviceDisposition = \
+          ::donner::gpu::baseline::DispositionForMissingAdapter(                                 \
+              ::donner::gpu::baseline::RunningUnderContinuousIntegration());                     \
+      const std::string donnerMetalDeviceMessage =                                               \
+          ::donner::gpu::baseline::NoAdapterMessage((gateLabel), donnerMetalDeviceDisposition);  \
+      if (donnerMetalDeviceDisposition ==                                                        \
+          ::donner::gpu::baseline::MissingComparisonDisposition::FailClosed) {                   \
+        FAIL() << donnerMetalDeviceMessage;                                                      \
+      }                                                                                          \
+      GTEST_SKIP() << donnerMetalDeviceMessage;                                                  \
+    }                                                                                            \
+  } while (false)

--- a/donner/gpu/metal/tests/MetalDeviceGate_tests.cc
+++ b/donner/gpu/metal/tests/MetalDeviceGate_tests.cc
@@ -1,0 +1,111 @@
+/// @file
+/// Covers what DONNER_REQUIRE_METAL_DEVICE does when a fixture's device is null. The macro's
+/// missing-device branches are exercised only when a runner actually loses its Metal device; every
+/// case on a working lane takes the non-null path, so a regression in the macro itself would
+/// otherwise reach production only when a runner failed. Checked here directly, with no device
+/// needed, the same way ExternalToolGate_tests.cc checks DONNER_REQUIRE_EXTERNAL_TOOL.
+
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace donner::gpu::metal::tests {
+namespace {
+
+using testing::HasSubstr;
+using testing::Not;
+
+/// Sets an environment variable for one test and restores the previous state afterwards, so the
+/// cases can force the automated-lane path without depending on where they are run.
+///
+/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
+/// (shader-validators-fail-closed-on-ci) hoists this into
+/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
+/// it does, both copies should move onto the shared helper instead of a third one appearing here.
+class ScopedEnvironmentVariable {
+public:
+  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
+    if (const char* previous = std::getenv(name); previous != nullptr) {
+      previous_ = previous;
+      hadPrevious_ = true;
+    }
+    if (value != nullptr) {
+      setenv(name, value, 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  ~ScopedEnvironmentVariable() {
+    if (hadPrevious_) {
+      setenv(name_.c_str(), previous_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
+
+private:
+  std::string name_;
+  std::string previous_;
+  bool hadPrevious_ = false;
+};
+
+/// Invokes the macro the way a fixture's SetUp() does, then records that control continued past
+/// it.
+/// @param device Pointer-like value the macro gates on; null exercises the missing-device path.
+/// @param reachedEnd Set true when the macro let the case continue.
+void RunGate(const void* device, bool* reachedEnd) {
+  DONNER_REQUIRE_METAL_DEVICE(device, "the fixture under test");
+  *reachedEnd = true;
+}
+
+TEST(MetalDeviceGateTests, AnAvailableDeviceLetsTheCaseRun) {
+  const int fakeDevice = 0;
+  bool reachedEnd = false;
+  RunGate(&fakeDevice, &reachedEnd);
+
+  EXPECT_TRUE(reachedEnd);
+}
+
+TEST(MetalDeviceGateTests, AnAutomatedLaneFailsAndStopsTheCase) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "true");
+
+  // EXPECT_FATAL_FAILURE's statement cannot name a non-static local.
+  static bool reachedEnd;
+  reachedEnd = false;
+
+  EXPECT_FATAL_FAILURE(RunGate(nullptr, &reachedEnd), "Failing rather than skipping");
+  EXPECT_FALSE(reachedEnd);
+}
+
+TEST(MetalDeviceGateTests, ADeveloperMachineSkipsAndStopsTheCase) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  bool reachedEnd = false;
+  // Intercepted rather than allowed to land, so this case reports its assertions instead of
+  // reporting itself as skipped.
+  testing::TestPartResultArray results;
+  {
+    const testing::ScopedFakeTestPartResultReporter reporter(
+        testing::ScopedFakeTestPartResultReporter::INTERCEPT_ONLY_CURRENT_THREAD, &results);
+    RunGate(nullptr, &reachedEnd);
+  }
+
+  EXPECT_FALSE(reachedEnd);
+  ASSERT_THAT(results.size(), testing::Eq(1));
+  EXPECT_THAT(results.GetTestPartResult(0).type(), testing::Eq(testing::TestPartResult::kSkip));
+  EXPECT_THAT(results.GetTestPartResult(0).message(), HasSubstr("the fixture under test"));
+  EXPECT_THAT(results.GetTestPartResult(0).message(), Not(HasSubstr("Failing rather than")));
+}
+
+}  // namespace
+}  // namespace donner::gpu::metal::tests

--- a/donner/gpu/metal/tests/MetalDeviceGate_tests.cc
+++ b/donner/gpu/metal/tests/MetalDeviceGate_tests.cc
@@ -11,52 +11,13 @@
 #include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
-#include <cstdlib>
-#include <string>
+#include "donner/base/tests/ScopedEnvironmentVariable.h"
 
 namespace donner::gpu::metal::tests {
 namespace {
 
 using testing::HasSubstr;
 using testing::Not;
-
-/// Sets an environment variable for one test and restores the previous state afterwards, so the
-/// cases can force the automated-lane path without depending on where they are run.
-///
-/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
-/// (shader-validators-fail-closed-on-ci) hoists this into
-/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
-/// it does, both copies should move onto the shared helper instead of a third one appearing here.
-class ScopedEnvironmentVariable {
-public:
-  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
-    if (const char* previous = std::getenv(name); previous != nullptr) {
-      previous_ = previous;
-      hadPrevious_ = true;
-    }
-    if (value != nullptr) {
-      setenv(name, value, 1);
-    } else {
-      unsetenv(name);
-    }
-  }
-
-  ~ScopedEnvironmentVariable() {
-    if (hadPrevious_) {
-      setenv(name_.c_str(), previous_.c_str(), 1);
-    } else {
-      unsetenv(name_.c_str());
-    }
-  }
-
-  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
-  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
-
-private:
-  std::string name_;
-  std::string previous_;
-  bool hadPrevious_ = false;
-};
 
 /// Invokes the macro the way a fixture's SetUp() does, then records that control continued past
 /// it.

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -32,6 +32,7 @@
 #include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/baseline/FrozenBaselinePolicy.h"
 #include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
 #include "donner/gpu/shader/MslEmitter.h"
 #include "donner/gpu/shader/programs/SolidFill.h"
 #include "donner/gpu/shader/tests/StageIoTestModules.h"
@@ -90,18 +91,9 @@ class MetalSolidFillTest : public testing::Test {
 protected:
   void SetUp() override {
     device_ = MetalDevice::Create();
-    if (!device_) {
-      // Same rule the frozen pixel gate uses: a lane that selected this target and then created
-      // no device has disabled the comparison, and reporting that as a pass hides it.
-      const baseline::MissingComparisonDisposition disposition =
-          baseline::DispositionForMissingAdapter(baseline::RunningUnderContinuousIntegration());
-      const std::string message =
-          baseline::NoAdapterMessage("the Metal solid-fill slice", disposition);
-      if (disposition == baseline::MissingComparisonDisposition::FailClosed) {
-        FAIL() << message;
-      }
-      GTEST_SKIP() << message;
-    }
+    // Same rule the frozen pixel gate uses: a lane that selected this target and then created no
+    // device has disabled the comparison, and reporting that as a pass hides it.
+    DONNER_REQUIRE_METAL_DEVICE(device_, "the Metal solid-fill slice");
   }
 
   /**

--- a/donner/gpu/metal/tests/MetalSubRectangleCopy_tests.cc
+++ b/donner/gpu/metal/tests/MetalSubRectangleCopy_tests.cc
@@ -14,6 +14,7 @@
 
 #include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
 #include "donner/gpu/tests/SubRectangleCopyScene.h"
 
 namespace donner::gpu::metal::tests {
@@ -35,9 +36,7 @@ class MetalSubRectangleCopyTest : public testing::Test {
 protected:
   void SetUp() override {
     device_ = MetalDevice::Create();
-    if (!device_) {
-      GTEST_SKIP() << "No Metal device available";
-    }
+    DONNER_REQUIRE_METAL_DEVICE(device_, "the Metal sub-rectangle-copy slice");
   }
 
   /// Unwraps an RHI result, failing the test on error.


### PR DESCRIPTION
Two Metal test fixtures silently skipped rather than failed when `MetalDevice::Create()` returned null, so a CI lane that lost its GPU adapter reported `metal_color_matrix_tests` and `metal_sub_rectangle_copy_tests` as green while asserting nothing in 5 cases combined. Their sibling `metal_solid_fill_tests` already applies the frozen-pixel gate's disposition rule instead: skip on a developer machine, fail closed on an automated lane (named via `env_inherit`, since Bazel scrubs the test environment).

This extracts that rule into a `DONNER_REQUIRE_METAL_DEVICE` macro in a new `donner/gpu/metal/tests/MetalDeviceGate.h` (a macro rather than a function, so the early return lands in the fixture's `SetUp()` and not in a helper), switches all three fixtures onto it once a third copy would have violated rule-of-three, and wires the two previously skip-shaped targets' `BUILD.bazel` entries with the same `env_inherit` list and the dependency the macro needs. The solid-fill fixture's message and disposition are unchanged.

Verified: forcing the device null and setting `GITHUB_ACTIONS=true` fails both targets naming the missing-device rule (bazel exit 3); the same forced state without the marker reports a visible skip (exit 0); unforced on the CI macOS config all cases run against a real device; `bazel test --config=re //donner/gpu/metal/...`, `tools/lint.sh`, `clang-format`, and `buildifier` are all green. No test assertion changed.
