### PR TITLE
Fail rather than skip when a declared runfile is missing

### DIFF
--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -125,6 +125,7 @@ donner_cc_library(
     hdrs = [
         "tests/BaseTestUtils.h",
         "tests/ParseResultTestUtils.h",
+        "tests/RunfileGate.h",
         "tests/Runfiles.h",
         "tests/TestTempDir.h",
     ],
@@ -132,6 +133,7 @@ donner_cc_library(
     # helpers (TestTempDir) as //donner tests.
     visibility = donner_internal_visibility() + ["//tools:__subpackages__"],
     deps = [
+        ":base",
         "@com_google_gtest//:gtest",
         "@rules_cc//cc/runfiles",
     ],
@@ -196,6 +198,7 @@ donner_cc_test(
         "tests/Path_tests.cc",
         "tests/RcStringOrRef_tests.cc",
         "tests/RcString_tests.cc",
+        "tests/RunfileGate_tests.cc",
         "tests/Runfiles_tests.cc",
         "tests/SmallVector_tests.cc",
         "tests/StringUtils_tests.cc",

--- a/donner/base/tests/RunfileGate.h
+++ b/donner/base/tests/RunfileGate.h
@@ -150,8 +150,8 @@ inline RequiredRunfile ReadRequiredRunfile(std::string_view runfilePath) {
  *
  * @param runfile A donner::tests::RequiredRunfile.
  */
-#define DONNER_REQUIRE_RUNFILE(runfile)                                       \
-  do {                                                                        \
+#define DONNER_REQUIRE_RUNFILE(runfile)                                        \
+  do {                                                                         \
     const ::donner::tests::RequiredRunfile& donnerRequiredRunfile = (runfile); \
     if (!donnerRequiredRunfile.ok()) {                                         \
       FAIL() << donnerRequiredRunfile.error;                                   \

--- a/donner/base/tests/RunfileGate.h
+++ b/donner/base/tests/RunfileGate.h
@@ -1,0 +1,159 @@
+#pragma once
+/// @file
+/// What a test does when a file it declared in `data` is not in its runfiles.
+///
+/// Unlike a missing GPU adapter or an uninstalled command-line tool, this is never a property of
+/// the machine: the runfiles tree is generated from the target's `data` attribute, so an entry that
+/// does not resolve is a build-graph defect on every lane and every host. gtest reports a run whose
+/// every case skipped as a pass, so skipping on a missing data file hides that defect behind a
+/// green result.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include "donner/base/tests/Runfiles.h"
+
+namespace donner::tests {
+
+/// A file the test target lists in `data`, with its location and contents, or the reason it is
+/// unusable.
+struct RequiredRunfile {
+  /// Path as the test asked for it, relative to the workspace root.
+  std::string requestedPath;
+
+  /// Location the file was found at. Empty when it was not found.
+  std::string path;
+
+  /// File contents. Populated only by ReadRequiredRunfile(), and only when \ref error is empty.
+  std::string contents;
+
+  /// Why the file is unusable, naming the path, the target that should carry it, and every
+  /// resolution attempted. Empty when the file is usable.
+  std::string error;
+
+  /// Whether the file resolved, and was read when reading was asked for.
+  bool ok() const { return error.empty(); }
+};
+
+/**
+ * Label of the target under test, as Bazel reports it.
+ *
+ * @return The label, or a description of it when the process was not launched by Bazel.
+ */
+inline std::string TestTargetLabel() {
+  const char* label = std::getenv("TEST_TARGET");
+  if (label != nullptr && *label != '\0') {
+    return label;
+  }
+  return "the test target that owns this case";
+}
+
+/**
+ * The failure text for a runfile that did not resolve.
+ *
+ * @param requestedPath Path as the test asked for it.
+ * @param targetLabel Target whose `data` attribute should carry the path.
+ * @param manifestPath What the runfiles manifest mapped the path to, empty when it mapped nothing.
+ * @param workingDirectoryPath What the path resolves to against the test's working directory.
+ * @return A message naming the path, the target, and both resolutions attempted.
+ */
+inline std::string MissingRunfileMessage(std::string_view requestedPath,
+                                         std::string_view targetLabel,
+                                         std::string_view manifestPath,
+                                         std::string_view workingDirectoryPath) {
+  std::string message =
+      "Required runfile \"" + std::string(requestedPath) + "\" is not in the runfiles tree.\n";
+  message += "Add it to the `data` attribute of " + std::string(targetLabel) + ".\n";
+  message +=
+      "Failing rather than skipping: a runfiles tree is generated from `data`, so a path that "
+      "does not resolve is a build-graph defect on every lane and every host, not something this "
+      "machine lacks. gtest reports a run whose every case skipped as a pass, so skipping here "
+      "would report success without exercising anything.\n";
+  message += "Resolution attempted:\n";
+  message += "  runfiles manifest -> " +
+             (manifestPath.empty() ? std::string("(unmapped)") : std::string(manifestPath)) + "\n";
+  message += "  test working directory -> " + std::string(workingDirectoryPath);
+  return message;
+}
+
+/**
+ * Locates a file the test target lists in `data`, without reading it.
+ *
+ * Resolves through the runfiles manifest, then against the test's working directory, which is the
+ * runfiles root under Bazel.
+ *
+ * @param runfilePath Path relative to the workspace root, as it appears in `data`.
+ * @return The resolved location, or a populated RequiredRunfile::error.
+ */
+inline RequiredRunfile ResolveRequiredRunfile(std::string_view runfilePath) {
+  RequiredRunfile result;
+  result.requestedPath = std::string(runfilePath);
+
+  const std::string manifestPath = Runfiles::instance().Rlocation(result.requestedPath);
+  if (!manifestPath.empty() && std::filesystem::exists(manifestPath)) {
+    result.path = manifestPath;
+    return result;
+  }
+
+  std::error_code ignored;
+  const std::string workingDirectoryPath =
+      (std::filesystem::current_path(ignored) / result.requestedPath).string();
+  if (std::filesystem::exists(workingDirectoryPath)) {
+    result.path = workingDirectoryPath;
+    return result;
+  }
+
+  result.error = MissingRunfileMessage(result.requestedPath, TestTargetLabel(), manifestPath,
+                                       workingDirectoryPath);
+  return result;
+}
+
+/**
+ * Reads a file the test target lists in `data`.
+ *
+ * @param runfilePath Path relative to the workspace root, as it appears in `data`.
+ * @return The file's contents, or a populated RequiredRunfile::error.
+ */
+inline RequiredRunfile ReadRequiredRunfile(std::string_view runfilePath) {
+  RequiredRunfile result = ResolveRequiredRunfile(runfilePath);
+  if (!result.ok()) {
+    return result;
+  }
+
+  std::ifstream stream(result.path, std::ios::binary);
+  if (!stream.is_open()) {
+    result.error = "Required runfile \"" + result.requestedPath + "\" resolved to " + result.path +
+                   " but could not be opened for reading.";
+    return result;
+  }
+
+  std::ostringstream buffer;
+  buffer << stream.rdbuf();
+  result.contents = buffer.str();
+  return result;
+}
+
+}  // namespace donner::tests
+
+/**
+ * Ends the current test case when \p runfile did not resolve, reporting the path, the target that
+ * should carry it in `data`, and every resolution attempted.
+ *
+ * Use directly in a `TEST` body, a fixture method, or a void helper. In a helper that returns a
+ * value the fatal failure would not stop the caller, so check RequiredRunfile::ok() there instead.
+ *
+ * @param runfile A donner::tests::RequiredRunfile.
+ */
+#define DONNER_REQUIRE_RUNFILE(runfile)                                       \
+  do {                                                                        \
+    const ::donner::tests::RequiredRunfile& donnerRequiredRunfile = (runfile); \
+    if (!donnerRequiredRunfile.ok()) {                                         \
+      FAIL() << donnerRequiredRunfile.error;                                   \
+    }                                                                          \
+  } while (false)

--- a/donner/base/tests/RunfileGate_tests.cc
+++ b/donner/base/tests/RunfileGate_tests.cc
@@ -1,0 +1,81 @@
+#include "donner/base/tests/RunfileGate.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+namespace donner::tests {
+namespace {
+
+using testing::HasSubstr;
+
+constexpr const char* kPresentRunfile = "donner/base/tests/testdata/test.txt";
+constexpr const char* kAbsentRunfile = "donner/base/tests/testdata/no_such_entry.txt";
+
+/// Free function so EXPECT_FATAL_FAILURE, which cannot see a caller's locals, can drive the gate.
+void RequireAbsentRunfile() {
+  const RequiredRunfile runfile = ReadRequiredRunfile(kAbsentRunfile);
+  DONNER_REQUIRE_RUNFILE(runfile);
+}
+
+}  // namespace
+
+TEST(RunfileGate, ResolvesAFileTheTargetCarriesInData) {
+  const RequiredRunfile runfile = ResolveRequiredRunfile(kPresentRunfile);
+
+  ASSERT_TRUE(runfile.ok()) << runfile.error;
+  EXPECT_EQ(runfile.requestedPath, kPresentRunfile);
+  EXPECT_TRUE(std::filesystem::exists(runfile.path)) << runfile.path;
+}
+
+TEST(RunfileGate, ReadsAFileTheTargetCarriesInData) {
+  const RequiredRunfile runfile = ReadRequiredRunfile(kPresentRunfile);
+
+  ASSERT_TRUE(runfile.ok()) << runfile.error;
+  EXPECT_FALSE(runfile.contents.empty());
+}
+
+TEST(RunfileGate, ReportsAnAbsentEntryRatherThanResolvingIt) {
+  const RequiredRunfile runfile = ReadRequiredRunfile(kAbsentRunfile);
+
+  EXPECT_FALSE(runfile.ok());
+  EXPECT_TRUE(runfile.path.empty());
+  EXPECT_TRUE(runfile.contents.empty());
+  EXPECT_THAT(runfile.error, HasSubstr(kAbsentRunfile));
+}
+
+TEST(RunfileGate, LabelsTheTargetBazelIsRunning) {
+  EXPECT_THAT(TestTargetLabel(), HasSubstr("//donner/base"));
+}
+
+TEST(RunfileGate, MessageNamesThePathTheTargetAndEveryResolutionAttempted) {
+  const std::string message = MissingRunfileMessage("some/data/file.svg", "//some:target",
+                                                    "/runfiles/some/data/file.svg", "/cwd/file.svg");
+
+  EXPECT_THAT(message, HasSubstr("some/data/file.svg"));
+  EXPECT_THAT(message, HasSubstr("`data` attribute of //some:target"));
+  EXPECT_THAT(message, HasSubstr("runfiles manifest -> /runfiles/some/data/file.svg"));
+  EXPECT_THAT(message, HasSubstr("test working directory -> /cwd/file.svg"));
+}
+
+TEST(RunfileGate, MessageSaysSoWhenTheManifestMappedNothing) {
+  const std::string message =
+      MissingRunfileMessage("some/data/file.svg", "//some:target", "", "/cwd/file.svg");
+
+  EXPECT_THAT(message, HasSubstr("runfiles manifest -> (unmapped)"));
+}
+
+TEST(RunfileGate, GateLetsAResolvedRunfileThrough) {
+  const RequiredRunfile runfile = ReadRequiredRunfile(kPresentRunfile);
+  DONNER_REQUIRE_RUNFILE(runfile);
+
+  EXPECT_FALSE(runfile.contents.empty());
+}
+
+TEST(RunfileGate, GateFailsRatherThanSkipsOnAnAbsentEntry) {
+  EXPECT_FATAL_FAILURE(RequireAbsentRunfile(), "is not in the runfiles tree");
+}
+
+}  // namespace donner::tests

--- a/donner/base/tests/RunfileGate_tests.cc
+++ b/donner/base/tests/RunfileGate_tests.cc
@@ -51,8 +51,8 @@ TEST(RunfileGate, LabelsTheTargetBazelIsRunning) {
 }
 
 TEST(RunfileGate, MessageNamesThePathTheTargetAndEveryResolutionAttempted) {
-  const std::string message = MissingRunfileMessage("some/data/file.svg", "//some:target",
-                                                    "/runfiles/some/data/file.svg", "/cwd/file.svg");
+  const std::string message = MissingRunfileMessage(
+      "some/data/file.svg", "//some:target", "/runfiles/some/data/file.svg", "/cwd/file.svg");
 
   EXPECT_THAT(message, HasSubstr("some/data/file.svg"));
   EXPECT_THAT(message, HasSubstr("`data` attribute of //some:target"));

--- a/donner/editor/repro/tests/BUILD.bazel
+++ b/donner/editor/repro/tests/BUILD.bazel
@@ -9,6 +9,7 @@ donner_cc_test(
     ],
     deps = [
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/editor:editor_app",
         "//donner/editor:viewport_state",
         "//donner/editor/repro:repro_file",

--- a/donner/editor/repro/tests/ReproDecodeClicks_test.cc
+++ b/donner/editor/repro/tests/ReproDecodeClicks_test.cc
@@ -73,6 +73,11 @@ TEST(ReproDecodeClicks, MapClicksToDocumentElements) {
   const char* kReproPath = "/tmp/clouds_bug.donner-repro";
   const char* kSvgPath = "donner_splash.svg";
 
+  // The SVG is declared in `data`, so require it before the optional recording check can end the
+  // case. Gating it later would let a removed or misdeclared entry ride out as a green skip.
+  const donner::tests::RequiredRunfile svgFile = donner::tests::ReadRequiredRunfile(kSvgPath);
+  DONNER_REQUIRE_RUNFILE(svgFile);
+
   // The recording is a developer artifact under /tmp, not something the target carries in `data`,
   // so its absence stays a skip.
   auto file = ReadReproFile(kReproPath);
@@ -94,9 +99,7 @@ TEST(ReproDecodeClicks, MapClicksToDocumentElements) {
   std::fprintf(stderr, "[decode] render pane: origin=(%.1f, %.1f) size=(%.1f, %.1f)\n",
                layout.origin.x, layout.origin.y, layout.size.x, layout.size.y);
 
-  // Load the SVG the user was editing.
-  const donner::tests::RequiredRunfile svgFile = donner::tests::ReadRequiredRunfile(kSvgPath);
-  DONNER_REQUIRE_RUNFILE(svgFile);
+  // Parse the SVG the user was editing.
   const std::string& svgSource = svgFile.contents;
   ParseWarningSink sink;
   auto parseResult = svg::parser::SVGParser::ParseSVG(svgSource, sink);

--- a/donner/editor/repro/tests/ReproDecodeClicks_test.cc
+++ b/donner/editor/repro/tests/ReproDecodeClicks_test.cc
@@ -23,14 +23,13 @@
 
 #include <cstdio>
 #include <filesystem>
-#include <fstream>
 #include <optional>
-#include <sstream>
 #include <string>
 
 #include "donner/base/Box.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/ViewportState.h"
 #include "donner/editor/repro/ReproFile.h"
@@ -68,20 +67,14 @@ PaneLayout computeRenderPaneLayout(Vector2d windowSize) {
   };
 }
 
-std::string loadFile(const std::filesystem::path& path) {
-  std::ifstream is(path, std::ios::binary);
-  if (!is) return {};
-  std::ostringstream ss;
-  ss << is.rdbuf();
-  return ss.str();
-}
-
 }  // namespace
 
 TEST(ReproDecodeClicks, MapClicksToDocumentElements) {
   const char* kReproPath = "/tmp/clouds_bug.donner-repro";
   const char* kSvgPath = "donner_splash.svg";
 
+  // The recording is a developer artifact under /tmp, not something the target carries in `data`,
+  // so its absence stays a skip.
   auto file = ReadReproFile(kReproPath);
   if (!file.has_value()) {
     GTEST_SKIP() << "could not load " << kReproPath
@@ -101,12 +94,10 @@ TEST(ReproDecodeClicks, MapClicksToDocumentElements) {
   std::fprintf(stderr, "[decode] render pane: origin=(%.1f, %.1f) size=(%.1f, %.1f)\n",
                layout.origin.x, layout.origin.y, layout.size.x, layout.size.y);
 
-  // Load the SVG the user was editing. Resolve against bazel runfiles
-  // (splash lives at repo root in runfiles).
-  const std::string svgSource = loadFile(kSvgPath);
-  if (svgSource.empty()) {
-    GTEST_SKIP() << "could not load " << kSvgPath << " (expected in runfiles)";
-  }
+  // Load the SVG the user was editing.
+  const donner::tests::RequiredRunfile svgFile = donner::tests::ReadRequiredRunfile(kSvgPath);
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svgSource = svgFile.contents;
   ParseWarningSink sink;
   auto parseResult = svg::parser::SVGParser::ParseSVG(svgSource, sink);
   ASSERT_FALSE(parseResult.hasError()) << parseResult.error().reason;

--- a/donner/editor/tests/AsyncRendererFilterGroupCorrectness_tests.cc
+++ b/donner/editor/tests/AsyncRendererFilterGroupCorrectness_tests.cc
@@ -13,6 +13,7 @@ namespace {
 TEST(AsyncRendererPerfCorrectnessTest, FilterGroupSubtreeDragHitsTranslationFastPathCounters) {
   FilterGroupSubtreeDragPerfResult result;
   RunFilterGroupSubtreeDragPerfScenario(&result);
+  ASSERT_FALSE(HasFatalFailure());
 
   EXPECT_GE(result.fastPathFrames, static_cast<uint64_t>(result.dragFrames))
       << "filter-group subtree drag is not hitting the translation-only fast "

--- a/donner/editor/tests/AsyncRendererFilterGroupPerfTestUtils.cc
+++ b/donner/editor/tests/AsyncRendererFilterGroupPerfTestUtils.cc
@@ -3,16 +3,15 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <fstream>
 #include <iostream>
 #include <optional>
 #include <ratio>
-#include <sstream>
 #include <string>
 #include <thread>
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/Transform.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/editor/AsyncRenderer.h"
 #include "donner/editor/AsyncSVGDocument.h"
 #include "donner/svg/SVGGraphicsElement.h"
@@ -48,14 +47,10 @@ std::optional<RenderResult> WaitForResult(AsyncRenderer* asyncRenderer) {
 void RunFilterGroupSubtreeDragPerfScenario(FilterGroupSubtreeDragPerfResult* result) {
   ASSERT_NE(result, nullptr);
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;

--- a/donner/editor/tests/AsyncRendererFilterGroupPerfTestUtils.h
+++ b/donner/editor/tests/AsyncRendererFilterGroupPerfTestUtils.h
@@ -13,6 +13,11 @@ struct FilterGroupSubtreeDragPerfResult {
   uint64_t slowPathFramesWithDirty = 0;
 };
 
+/// Replay the filter-group subtree drag and populate `result`.
+///
+/// Uses `ASSERT_*` internally, including on the splash the target declares in `data` when it
+/// is not in the runfiles tree. Callers must therefore check `HasFatalFailure()` before
+/// reading `result`.
 void RunFilterGroupSubtreeDragPerfScenario(FilterGroupSubtreeDragPerfResult* result);
 
 }  // namespace donner::editor

--- a/donner/editor/tests/AsyncRendererFilterGroupWallclock_tests.cc
+++ b/donner/editor/tests/AsyncRendererFilterGroupWallclock_tests.cc
@@ -9,6 +9,7 @@ namespace {
 TEST(AsyncRendererPerfWallclockTest, FilterGroupSubtreeDragStaysUnderNightlyWallclockBudget) {
   FilterGroupSubtreeDragPerfResult result;
   RunFilterGroupSubtreeDragPerfScenario(&result);
+  ASSERT_FALSE(HasFatalFailure());
 
   EXPECT_LT(result.avgDragFrameMs, 100.0) << "average filter-group drag frame far above even the "
                                              "widened CI runner budget - something is doing a "

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -6,7 +6,6 @@
 #include <array>
 #include <atomic>
 #include <chrono>
-#include <fstream>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -18,6 +17,7 @@
 #include <vector>
 
 #include "donner/base/Transform.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/editor/AsyncSVGDocument.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/EditorApp.h"
@@ -637,14 +637,11 @@ TEST(AsyncRendererTest, FilterOnlyRestrictsMandatoryHintsButKeepsSelectionLayer)
 }
 
 TEST(AsyncRendererE2ETest, FilterOnlyPublishesSplashBlurGroupsAsSeparateLayers) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuffer;
-  splashBuffer << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
-  svg::SVGDocument document = svg::instantiateSubtree(splashBuffer.str());
+  svg::SVGDocument document = svg::instantiateSubtree(splashFile.contents);
   document.setCanvasSize(892, 512);
   const std::array<std::string_view, 3> filterSelectors = {
       "#Lightning_glow_dark",
@@ -1205,15 +1202,12 @@ TEST(AsyncRendererTest, PendingParentDemotionDoesNotClaimMovableChildCoverage) {
 }
 
 TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(splashBuf.str()));
+  ASSERT_TRUE(app.loadFromString(splashFile.contents));
   auto donnerD = app.document().document().querySelector("#Donner_D");
   ASSERT_TRUE(donnerD.has_value());
   ASSERT_TRUE(app.unbundleCompoundPath(*donnerD));
@@ -1422,15 +1416,12 @@ TEST(AsyncRendererTest, SimpleIdleSelectionPublishesThreeImmediateLayers) {
 }
 
 TEST(AsyncRendererE2ETest, SplashDonnerSelectionExposesEligibleStaticSpansForLayerPanel) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(splashBuf.str()));
+  ASSERT_TRUE(app.loadFromString(splashFile.contents));
   const EditorRasterViewport rasterViewport = SplashDonnerHighZoomRasterViewport();
   app.document().document().setCanvasSize(rasterViewport.semanticCanvasSizePx.x,
                                           rasterViewport.semanticCanvasSizePx.y);
@@ -1486,15 +1477,12 @@ TEST(AsyncRendererE2ETest, SplashDonnerSelectionExposesEligibleStaticSpansForLay
 }
 
 TEST(AsyncRendererE2ETest, SplashDonnerNDragPublishesImmediateLayerForLayerPanel) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(splashBuf.str()));
+  ASSERT_TRUE(app.loadFromString(splashFile.contents));
   const EditorRasterViewport rasterViewport =
       SplashDonnerHighZoomRasterViewport(Vector2d(435.0, 350.0));
   app.document().document().setCanvasSize(rasterViewport.semanticCanvasSizePx.x,
@@ -3307,13 +3295,10 @@ TEST(AsyncRendererTest, SelectedPathStyleChangePublishesFreshPromotedLayerPixels
 }
 
 TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGenerations) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
 
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(splashSource));
@@ -3484,15 +3469,12 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
 }
 
 TEST(AsyncRendererE2ETest, BackgroundStickerDragPresentsLiveDeltaFromStaleCache) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(splashBuf.str()));
+  ASSERT_TRUE(app.loadFromString(splashFile.contents));
   app.document().document().setCanvasSize(1784, 1024);
 
   std::optional<svg::SVGElement> backgroundPath =
@@ -4257,13 +4239,10 @@ TEST(AsyncRendererE2ETest, ClickThenDragOnSplashShapeMeetsLatencyBudget) {
   // groups with real geometry - not a simplified stub). This is the
   // document the user is interacting with in the editor; test numbers
   // must match editor reality.
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4388,13 +4367,10 @@ TEST(AsyncRendererE2ETest, EndToEndDragHarnessOnRealSplash) {
                     "target //donner/editor/tests:async_renderer_wallclock_tests.";
   }
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4443,13 +4419,10 @@ TEST(AsyncRendererE2ETest, FaithfulFrameDragOnRealSplashBreaksDownPerFrameCost) 
                     "target //donner/editor/tests:async_renderer_wallclock_tests.";
   }
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4522,13 +4495,10 @@ TEST(AsyncRendererE2ETest, FaithfulFrameDragOnRealSplashBlueCenterBurstBreaksDow
                     "target //donner/editor/tests:async_renderer_wallclock_tests.";
   }
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4587,13 +4557,10 @@ TEST(AsyncRendererE2ETest, RawSelectedZoomRenderOnRealSplashBreaksDownPerFrameCo
                     "target //donner/editor/tests:async_renderer_wallclock_tests.";
   }
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4732,13 +4699,10 @@ TEST(AsyncRendererE2ETest, MultiShapeClickDragHiDpiRepro) {
                     "target //donner/editor/tests:async_renderer_wallclock_tests.";
   }
 
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;
@@ -4907,13 +4871,10 @@ TEST(AsyncRendererE2ETest, MultiShapeClickDragHiDpiRepro) {
 // contain real pixels, while a split preview may omit that redundant full-frame
 // copy only when its current tiles resolve to retained non-transparent pixels.
 TEST(AsyncRendererE2ETest, PresentationStaysNonTransparentAcrossDragTargetSwap) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   AsyncSVGDocument asyncDoc;

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -305,6 +305,7 @@ donner_cc_test(
     srcs = ["SourceSelection_tests.cc"],
     data = ["//:donner_splash.svg"],
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/base/xml",
         "//donner/editor:editor_app",
         "//donner/editor:source_selection",
@@ -482,6 +483,7 @@ donner_perf_cc_test(
     ],
     wallclock_srcs = ["FilterDragReproWallclock_tests.cc"],
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/base",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
@@ -507,6 +509,7 @@ donner_cc_test(
     # separate async_renderer_wallclock_tests target); shard for parallelism.
     shard_count = 4,
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:command_queue",
@@ -553,6 +556,7 @@ donner_cc_test(
         "perf",
     ],
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:command_queue",
@@ -716,6 +720,7 @@ donner_perf_cc_test(
     ],
     wallclock_srcs = ["AsyncRendererFilterGroupWallclock_tests.cc"],
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/svg/compositor",
@@ -729,6 +734,7 @@ donner_cc_test(
     srcs = ["EditorApp_tests.cc"],
     data = ["//:donner_splash.svg"],
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/editor:editor_app",
         "//donner/editor:viewport_geometry",
         "//donner/svg",

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -483,8 +483,8 @@ donner_perf_cc_test(
     ],
     wallclock_srcs = ["FilterDragReproWallclock_tests.cc"],
     deps = [
-        "//donner/base:base_test_utils",
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:editor_app",

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -2481,13 +2481,11 @@ TEST(EditorAppGroupTest, UngroupAvailabilityReportsEachRejectionReason) {
   auto attrs = app.document().document().querySelector("#attrs");
   ASSERT_TRUE(attrs.has_value());
   app.setSelection(*attrs);
-  EXPECT_EQ(app.ungroupSelectionAvailability().reason,
-            "Remove group attributes before ungrouping");
+  EXPECT_EQ(app.ungroupSelectionAvailability().reason, "Remove group attributes before ungrouping");
 
   // An empty attribute-free group has nothing to ungroup. It carries no id, so
   // it is selected via the document tree rather than a query.
-  ASSERT_TRUE(app.loadFromString(
-      R"svg(<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>)svg"));
+  ASSERT_TRUE(app.loadFromString(R"svg(<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>)svg"));
   const auto emptyGroup = app.document().document().svgElement().firstChild();
   ASSERT_TRUE(emptyGroup.has_value());
   ASSERT_EQ(emptyGroup->tryType(), svg::ElementType::G);

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1,14 +1,13 @@
 #include "donner/editor/EditorApp.h"
 
-#include <fstream>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "donner/base/Path.h"
 #include "donner/base/RcString.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/base/xml/XMLQualifiedName.h"
 #include "donner/editor/ViewportGeometry.h"
 #include "donner/svg/SVGElement.h"
@@ -44,17 +43,6 @@ void ExpectBoxInside(const Box2d& inner, const Box2d& outer, double tolerance) {
       << inner << " not inside " << outer;
   EXPECT_LE(inner.bottomRight.y, outer.bottomRight.y + tolerance)
       << inner << " not inside " << outer;
-}
-
-std::optional<std::string> ReadDonnerSplash() {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    return std::nullopt;
-  }
-
-  std::ostringstream buffer;
-  buffer << splashStream.rdbuf();
-  return buffer.str();
 }
 
 bool GeometryContainsDocumentPoint(const svg::SVGElement& element, const Vector2d& point) {
@@ -953,11 +941,12 @@ TEST(EditorAppTest, UnbundleCompoundPathReleasesNestedHoleContours) {
 }
 
 TEST(EditorAppTest, UnbundleCompoundPathSupportsDonnerDWithCounter) {
-  const std::optional<std::string> splash = ReadDonnerSplash();
-  ASSERT_TRUE(splash.has_value());
+  const donner::tests::RequiredRunfile splash =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splash);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(*splash));
+  ASSERT_TRUE(app.loadFromString(splash.contents));
 
   auto donnerD = app.document().document().querySelector("#Donner_D");
   ASSERT_TRUE(donnerD.has_value());
@@ -1389,13 +1378,12 @@ TEST(EditorAppTest, PathOperationConvertsDocumentResultThroughRootViewBox) {
 }
 
 TEST(EditorAppTest, HitTestFindsDonnerLetterAtSolidStem) {
-  const std::optional<std::string> splashSource = ReadDonnerSplash();
-  if (!splashSource.has_value()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
+  const donner::tests::RequiredRunfile splashSource =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashSource);
 
   EditorApp app;
-  ASSERT_TRUE(app.loadFromString(*splashSource));
+  ASSERT_TRUE(app.loadFromString(splashSource.contents));
 
   const std::optional<svg::SVGGraphicsElement> hit = app.hitTest(Vector2d(281.0, 395.0));
   ASSERT_TRUE(hit.has_value());
@@ -1403,14 +1391,13 @@ TEST(EditorAppTest, HitTestFindsDonnerLetterAtSolidStem) {
 }
 
 TEST(EditorAppTest, PathOperationsHandleOverlappingDonnerLetters) {
-  const std::optional<std::string> splashSource = ReadDonnerSplash();
-  if (!splashSource.has_value()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
+  const donner::tests::RequiredRunfile splashSource =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashSource);
 
   const auto applyOperation = [&](PathOperationKind operation) {
     EditorApp app;
-    EXPECT_TRUE(app.loadFromString(*splashSource));
+    EXPECT_TRUE(app.loadFromString(splashSource.contents));
 
     auto donnerD = app.document().document().querySelector("#Donner_D");
     auto donnerO = app.document().document().querySelector("#Donner_O");

--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -2040,6 +2040,12 @@ TEST(EditorWindowTest, WgpuPresentsZoomedCompositedBlurredLayerWithoutDarkening)
 }
 
 TEST(EditorWindowTest, WgpuPresentsZoomedDonnerSplashFilteredLayerWithoutDarkening) {
+  // Required before the device check: a host without WebGPU still has the runfiles tree, so a
+  // removed or misdeclared entry must not ride out as a green skip on that host.
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+
   EditorWindow window(EditorWindowOptions{
       .title = "Zoomed Donner Splash Premultiplied WGPU Presentation Test",
       .initialWidth = 760,
@@ -2052,9 +2058,6 @@ TEST(EditorWindowTest, WgpuPresentsZoomedDonnerSplashFilteredLayerWithoutDarkeni
     GTEST_SKIP() << "WebGPU editor window is unavailable on this host";
   }
 
-  const donner::tests::RequiredRunfile splashFile =
-      donner::tests::ReadRequiredRunfile("donner_splash.svg");
-  DONNER_REQUIRE_RUNFILE(splashFile);
   std::optional<svg::SVGDocument> document = ParseDonnerSplashDocument(splashFile.contents);
   ASSERT_TRUE(document.has_value());
 

--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -24,6 +24,7 @@
 #include "backends/imgui_impl_wgpu.h"
 #include "donner/base/Box.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/base/tests/Runfiles.h"
 #include "donner/css/Color.h"
 #include "donner/editor/AsyncRenderer.h"
@@ -177,16 +178,9 @@ std::shared_ptr<const svg::RendererTextureSnapshot> RenderPremultipliedRedTextur
   return source.takeTextureSnapshot();
 }
 
-std::optional<svg::SVGDocument> LoadDonnerSplashDocument() {
-  std::ifstream splashStream(donner::Runfiles::instance().Rlocation("donner_splash.svg"));
-  if (!splashStream.is_open()) {
-    return std::nullopt;
-  }
-
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+std::optional<svg::SVGDocument> ParseDonnerSplashDocument(std::string_view source) {
   ParseWarningSink warningSink = ParseWarningSink::Disabled();
-  auto parsed = svg::parser::SVGParser::ParseSVG(splashBuf.str(), warningSink);
+  auto parsed = svg::parser::SVGParser::ParseSVG(source, warningSink);
   EXPECT_FALSE(parsed.hasError()) << parsed.error();
   if (parsed.hasError()) {
     return std::nullopt;
@@ -2058,10 +2052,11 @@ TEST(EditorWindowTest, WgpuPresentsZoomedDonnerSplashFilteredLayerWithoutDarkeni
     GTEST_SKIP() << "WebGPU editor window is unavailable on this host";
   }
 
-  std::optional<svg::SVGDocument> document = LoadDonnerSplashDocument();
-  if (!document.has_value()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  std::optional<svg::SVGDocument> document = ParseDonnerSplashDocument(splashFile.contents);
+  ASSERT_TRUE(document.has_value());
 
   std::optional<svg::SVGElement> target = document->querySelector("#Big_lightning_glow");
   ASSERT_TRUE(target.has_value());

--- a/donner/editor/tests/FilterDragReproCorrectness_tests.cc
+++ b/donner/editor/tests/FilterDragReproCorrectness_tests.cc
@@ -55,9 +55,7 @@ MATCHER(SingleTargetDragUsedFastPath, "") {
 TEST(FilterDragReproCorrectnessTest, ReplayReSelectsAndHitsFastPathWhenEligible) {
   FilterDragReproResult r;
   RunFilterDragReproScenario(&r, FilterDragReproReplayMode::CompactCorrectness);
-  if (r.skipped) {
-    GTEST_SKIP() << "Required data files not available in runfiles";
-  }
+  ASSERT_FALSE(HasFatalFailure());
 
   // Selection invariant: after the first mouse-up, ONE element must be
   // selected (the first drag's target). The second mouse-down in the

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -114,7 +114,7 @@ Vector2d RenderPaneSizeForWindow(double windowW, double windowH) {
                   std::max(0.0, windowH - kMenuBarHeight));
 }
 
-std::string LoadFileOrSkip(const std::filesystem::path& path) {
+std::string LoadFileOrEmpty(const std::filesystem::path& path) {
   std::ifstream file(path, std::ios::binary);
   if (!file.is_open()) return {};
   std::ostringstream buf;
@@ -189,7 +189,7 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
                           const std::filesystem::path& svgPath, FilterDragReproReplayMode mode) {
   ReplayResults results;
 
-  const std::string svgSource = LoadFileOrSkip(svgPath);
+  const std::string svgSource = LoadFileOrEmpty(svgPath);
   [&]() { ASSERT_FALSE(svgSource.empty()) << "svg source missing: " << svgPath; }();
   auto reproOpt = repro::ReadReproFile(reproPath);
   [&]() { ASSERT_TRUE(reproOpt.has_value()) << "repro file parse failed: " << reproPath; }();

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -35,6 +35,7 @@
 #include "donner/base/EcsRegistry_fwd.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/base/xml/XMLQualifiedName.h"
 #include "donner/editor/AsyncRenderer.h"
 #include "donner/editor/EditorApp.h"
@@ -417,15 +418,14 @@ void DumpFirstFiveFrames(const ReplayResults& r, uint64_t fromFrame, uint64_t to
 }  // namespace
 
 void RunFilterDragReproScenario(FilterDragReproResult* out, FilterDragReproReplayMode mode) {
-  const std::filesystem::path reproPath = "donner/editor/tests/filter_drag_repro.rnr";
-  const std::filesystem::path svgPath = "donner_splash.svg";
+  const donner::tests::RequiredRunfile reproFile =
+      donner::tests::ResolveRequiredRunfile("donner/editor/tests/filter_drag_repro.rnr");
+  DONNER_REQUIRE_RUNFILE(reproFile);
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ResolveRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
 
-  if (!std::filesystem::exists(reproPath) || !std::filesystem::exists(svgPath)) {
-    out->skipped = true;
-    return;
-  }
-
-  ReplayResults r = ReplayRepro(reproPath, svgPath, mode);
+  ReplayResults r = ReplayRepro(reproFile.path, svgFile.path, mode);
   ASSERT_FALSE(r.frames.empty()) << "repro produced zero frames";
   ASSERT_EQ(r.mouseDownFrameIndices.size(), 2u)
       << "expected exactly two mouse-down events in the repro (first drag, second drag)";

--- a/donner/editor/tests/FilterDragReproTestUtils.h
+++ b/donner/editor/tests/FilterDragReproTestUtils.h
@@ -35,12 +35,8 @@ struct DragCounterStats {
 };
 
 /// Aggregated result of replaying `filter_drag_repro.rnr` through the
-/// real editor stack. `skipped == true` means required data files were
-/// missing in runfiles and the caller should `GTEST_SKIP()` - the other
-/// fields are meaningless in that case.
+/// real editor stack.
 struct FilterDragReproResult {
-  bool skipped = false;
-
   // Per-gesture drag stats, computed over the frames strictly between
   // the mouse-down and mouse-up of each gesture (so cold mouse-down /
   // mouse-up frames are excluded).
@@ -88,10 +84,9 @@ enum class FilterDragReproReplayMode {
 /// 5 frames, fast-path counters, selection ids) to `std::cerr` so both
 /// paired tests produce the same operator-facing log output.
 ///
-/// Uses `ASSERT_*` internally; if an assertion trips, `out->skipped`
-/// stays false and the caller's test is halted by the assertion flow.
-/// On genuine "files missing in runfiles", sets `out->skipped = true`
-/// and returns without asserting - the caller issues `GTEST_SKIP()`.
+/// Uses `ASSERT_*` internally, including on a recording or splash the
+/// target declared in `data` that is not in the runfiles tree. Callers
+/// must therefore check `HasFatalFailure()` before reading `out`.
 void RunFilterDragReproScenario(FilterDragReproResult* out,
                                 FilterDragReproReplayMode mode = FilterDragReproReplayMode::Full);
 

--- a/donner/editor/tests/FilterDragReproWallclock_tests.cc
+++ b/donner/editor/tests/FilterDragReproWallclock_tests.cc
@@ -21,9 +21,7 @@ namespace {
 TEST(FilterDragReproWallclockTest, DragFramesStayUnderNightlyWallclockBudget) {
   FilterDragReproResult r;
   RunFilterDragReproScenario(&r);
-  if (r.skipped) {
-    GTEST_SKIP() << "Required data files not available in runfiles";
-  }
+  ASSERT_FALSE(HasFatalFailure());
 
   // Budgets tuned for the nightly lane where we can assume roughly
   // dev-machine-class runners. The numbers here are intentionally

--- a/donner/editor/tests/SourceSelection_tests.cc
+++ b/donner/editor/tests/SourceSelection_tests.cc
@@ -2,14 +2,13 @@
 
 #include <gtest/gtest.h>
 
-#include <fstream>
 #include <optional>
 #include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/base/xml/XMLNode.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/TextEditor.h"
@@ -401,14 +400,10 @@ TEST(SourceSelectionTest, CursorImmediatelyAfterGroupClosingTagSelectsGroup) {
 }
 
 TEST(SourceSelectionTest, HighlightsEachDonnerSplashLetterNode) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-
-  std::ostringstream splashBuffer;
-  splashBuffer << splashStream.rdbuf();
-  const std::string source = splashBuffer.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& source = splashFile.contents;
 
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(source));

--- a/donner/svg/compositor/BUILD.bazel
+++ b/donner/svg/compositor/BUILD.bazel
@@ -219,6 +219,7 @@ donner_cc_test(
     deps = [
         ":compositor",
         ":dual_path_verifier",
+        "//donner/base:base_test_utils",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
         "@com_google_gtest//:gtest_main",
@@ -242,6 +243,7 @@ donner_cc_test(
     deps = [
         ":compositor",
         ":dual_path_verifier",
+        "//donner/base:base_test_utils",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
         "@com_google_gtest//:gtest_main",

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -5,7 +5,6 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
-#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
@@ -14,6 +13,7 @@
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
@@ -1017,14 +1017,10 @@ TEST_F(CompositorGoldenTest, FilteredLayerBoundsStopAtLayerSubtree) {
 }
 
 TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   SVGDocument document = parseDocument(splashSource);
@@ -2398,14 +2394,10 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsSurviveExplicitDragTargetPromot
 // outside `worldBounds()` (blur radius spilling past geometry, clip-
 // path-expanded bounds, etc.) reproduce here.
 TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDrag) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   SVGDocument document = parseDocument(splashSource);
@@ -2472,13 +2464,10 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
 // retained-texture sequence: render the real Splash, prewarm one letter as an ActiveDrag layer at
 // identity, then move it and compare the flattened compositor target with a full DOM render.
 TEST_F(CompositorGoldenTest, RealSplashRetainedLetterMovesInFlattenedDragFrame) {
-  std::ifstream splashStream("donner_splash.svg");
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  SVGDocument document = parseDocument(splashBuf.str());
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  SVGDocument document = parseDocument(splashFile.contents);
 
   auto letter = document.querySelector("#Donner path");
   ASSERT_TRUE(letter.has_value());
@@ -2533,14 +2522,10 @@ TEST_F(CompositorGoldenTest, RealSplashRetainedLetterMovesInFlattenedDragFrame) 
 // that reshape the visible area, the diff will show up here but not
 // in the synthetic scenes.
 TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplash) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty());
 
   SVGDocument document = parseDocument(splashSource);
@@ -2967,14 +2952,10 @@ TEST_F(CompositorGoldenTest, TightBoundsRotatedEllipseWithRotatingGradient) {
 // of two different entities. Assert the compositor render matches a
 // reference full-render, within premul noise.
 TEST_F(CompositorGoldenTest, SplashLetterThenCloudOrbSelection) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
 
   RenderViewport vp;
   vp.size = Vector2d(892, 512);
@@ -3125,14 +3106,10 @@ TEST_F(CompositorGoldenTest, SplashLetterThenCloudOrbSelection) {
 // reported artifact was crescent-shaped color drift at the top of the
 // cls-8 radial-gradient cloud orb.
 TEST_F(CompositorGoldenTest, SplashCloudsDragMatchesReference) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
 
   RenderViewport vp;
   vp.size = Vector2d(892, 512);
@@ -3199,15 +3176,11 @@ TEST_F(CompositorGoldenTest, SplashCloudsDragMatchesReference) {
 }
 
 TEST_F(CompositorGoldenTest, SplashDonnerLetterDragKeepsCheapGradientSpansImmediate) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
-  SVGDocument document = parseDocument(splashBuf.str());
+  SVGDocument document = parseDocument(splashFile.contents);
   document.setCanvasSize(892, 512);
   auto target = document.querySelector("#Donner_D");
   ASSERT_TRUE(target.has_value());
@@ -4101,18 +4074,10 @@ TEST_F(CompositorGoldenTest, SplashPrewarmMakesFirstDragFree) {
 // The test file is in the `data` array of the `compositor_golden_tests`
 // target; bazel materializes it under the test's runfiles directory.
 TEST_F(CompositorGoldenTest, RealSplashDragLatencyOnTinySkia) {
-  // Load the splash file from the Bazel runfiles. If the path can't be
-  // opened the test skips - a dev running the test outside bazel (e.g.
-  // via an IDE runner that bypasses runfiles plumbing) shouldn't see a
-  // spurious failure.
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles - skipping splash perf test";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);
@@ -4197,14 +4162,10 @@ TEST_F(CompositorGoldenTest, RealSplashDragLatencyOnTinySkia) {
 }
 
 TEST_F(CompositorGoldenTest, RealSplashBlueCenterBurstEllipseDragLatency) {
-  const char* kSplashPath = "donner_splash.svg";
-  std::ifstream splashStream(kSplashPath);
-  if (!splashStream.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles - skipping splash perf test";
-  }
-  std::ostringstream splashBuf;
-  splashBuf << splashStream.rdbuf();
-  const std::string splashSource = splashBuf.str();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& splashSource = splashFile.contents;
   ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -789,6 +789,7 @@ donner_cc_test(
         ":geode_counters",
         ":geode_device",
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/base:gtest_timeout_main",
         "//donner/svg",
         "//donner/svg/parser",

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -29,6 +28,7 @@
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/RendererGeode.h"
@@ -116,18 +116,6 @@ void printCounters(const char* label, const geode::GeodeCounters& c) {
                label, c.pathEncodes, c.bufferCreates, c.bindgroupCreates, c.textureCreates,
                c.submits, c.drawCalls, c.pipelineSwitches, c.sameSourceDrawPairs, c.bufferWrites,
                c.bufferWriteBytes, c.textureWriteBytes);
-}
-
-/// Read a file from disk. Returns the empty string on any I/O error -
-/// callers treat that as "fixture not available" and skip.
-std::string readFile(const std::string& path) {
-  std::ifstream f(path);
-  if (!f) {
-    return {};
-  }
-  std::ostringstream ss;
-  ss << f.rdbuf();
-  return ss.str();
 }
 
 /// Fully render `svgSource` through a RendererGeode backed by a shared
@@ -384,20 +372,16 @@ TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {
 
 // ---------------------------------------------------------------------------
 // Fixture: lion.svg - the workhorse SVG used across Donner test suites.
-// Skipped gracefully if the file is not bundled (e.g. unit test run without
-// testdata deps).
 // ---------------------------------------------------------------------------
 
 TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
-  if (svg.empty()) {
-    GTEST_SKIP() << "testdata/lion.svg not readable - ensure the test target "
-                 << "has testdata as a data dep.";
-    return;
-  }
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ReadRequiredRunfile("donner/svg/renderer/testdata/lion.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svg = svgFile.contents;
 
   geode::GeodeCounters c = renderAndGetCounters(svg, device);
 
@@ -644,12 +628,10 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
-  if (svg.empty()) {
-    GTEST_SKIP() << "testdata/lion.svg not readable - ensure the test target "
-                 << "has testdata as a data dep.";
-    return;
-  }
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ReadRequiredRunfile("donner/svg/renderer/testdata/lion.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svg = svgFile.contents;
 
   const geode::GeodeCounters c = countersForSecondRender(svg, device);
   printCounters("Lion_NoDirtyPath_ZeroEncodes (frame2)", c);
@@ -684,12 +666,10 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
-  if (svg.empty()) {
-    GTEST_SKIP() << "testdata/Ghostscript_Tiger.svg not readable - ensure the "
-                 << "test target has testdata as a data dep.";
-    return;
-  }
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ReadRequiredRunfile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svg = svgFile.contents;
 
   const geode::GeodeCounters c = countersForSecondRender(svg, device);
   printCounters("GhostscriptTiger_NoDirtyPath_ZeroEncodes (frame2)", c);
@@ -817,11 +797,10 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
-  if (svg.empty()) {
-    GTEST_SKIP() << "testdata/lion.svg not readable.";
-    return;
-  }
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ReadRequiredRunfile("donner/svg/renderer/testdata/lion.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svg = svgFile.contents;
 
   const geode::GeodeCounters c = countersForSecondRender(svg, device);
   printCounters("Lion_NoDirtyPath_ZeroTextures (frame2)", c);
@@ -833,11 +812,10 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
-  if (svg.empty()) {
-    GTEST_SKIP() << "testdata/Ghostscript_Tiger.svg not readable.";
-    return;
-  }
+  const donner::tests::RequiredRunfile svgFile =
+      donner::tests::ReadRequiredRunfile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  DONNER_REQUIRE_RUNFILE(svgFile);
+  const std::string& svg = svgFile.contents;
 
   const geode::GeodeCounters c = countersForSecondRender(svg, device);
   printCounters("GhostscriptTiger_NoDirtyPath_ZeroTextures (frame2)", c);

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -305,6 +305,7 @@ donner_cc_test(
     # self-hosted RE lane (CI baseline, 2026-07-01).
     shard_count = 4,
     deps = [
+        "//donner/base:base_test_utils",
         "//donner/svg",
         "//donner/svg/parser",
         "//donner/svg/renderer",

--- a/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
+++ b/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
@@ -49,11 +49,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
-#include <sstream>
 #include <string>
 
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
@@ -62,16 +61,6 @@
 
 namespace donner::svg {
 namespace {
-
-std::string LoadSplash() {
-  std::ifstream stream("donner_splash.svg");
-  if (!stream.is_open()) {
-    return {};
-  }
-  std::ostringstream buf;
-  buf << stream.rdbuf();
-  return buf.str();
-}
 
 constexpr std::string_view kTinySvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -172,10 +161,10 @@ TEST(ZoomFilterRepro, SplashAtEditorClampBoundaryRenders) {
   // `takeSnapshot` returned an empty bitmap, and the editor (which doesn't
   // propagate the failure) ended up showing a stale or empty rendered
   // image.
-  const std::string source = LoadSplash();
-  if (source.empty()) {
-    GTEST_SKIP() << "donner_splash.svg not in runfiles";
-  }
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& source = splashFile.contents;
   const RendererBitmap snapshot = RenderAt(std::string_view{source}, 8192, 4708);
   const bool dimensionsOk = snapshot.dimensions.x == 8192 && snapshot.dimensions.y >= 4700 &&
                             snapshot.dimensions.y <= 4708;
@@ -201,10 +190,10 @@ TEST(ZoomFilterRepro, SplashHaloSurvivesHighZoom) {
   // disappears while every other element renders normally. This produces a
   // luma swing of ~37+ at the Lightning_glow_dark halo probe; with the
   // blur intact, the delta is ~9.
-  const std::string source = LoadSplash();
-  if (source.empty()) {
-    GTEST_SKIP() << "donner_splash.svg not in runfiles";
-  }
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
+  const std::string& source = splashFile.contents;
   const RendererBitmap lo = RenderAt(std::string_view{source}, 892, 512);
   ASSERT_FALSE(lo.empty());
   // 5x splash: ~182 MB float SourceGraphic buffer, 2.8x above the broken

--- a/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
+++ b/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
@@ -44,11 +44,11 @@
 /// SplashAtEditorClampBoundaryRenders above.
 
 #include <array>
-#include <span>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <span>
 #include <string>
 
 #include "donner/base/ParseWarningSink.h"

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -8,14 +8,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <initializer_list>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "donner/base/tests/RunfileGate.h"
 #include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/repro/ReplayResourceBudget.h"
 #include "donner/editor/repro/ReproFile.h"
@@ -459,15 +458,12 @@ TEST(EditorControlSessionTest, ClickLayerVisibilityButtonCapturesImmediateAndSet
 }
 
 TEST(EditorControlSessionTest, HidingSplashBackgroundDropsGhostPixelsFromSettledFrame) {
-  std::ifstream splash("donner_splash.svg", std::ios::binary);
-  if (!splash.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream buffer;
-  buffer << splash.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorControlSession session;
-  ToolCallResult load = session.handleToolCall("load_svg", json{{"svg_source", buffer.str()},
+  ToolCallResult load = session.handleToolCall("load_svg", json{{"svg_source", splashFile.contents},
                                                                 {"canvas_width", 892},
                                                                 {"canvas_height", 512},
                                                                 {"render_after_load", true}});
@@ -511,15 +507,12 @@ TEST(EditorControlSessionTest, HidingSplashBackgroundDropsGhostPixelsFromSettled
 }
 
 TEST(EditorControlSessionTest, DraggingSplashBackgroundDropsGhostPixelsFromPresentedFrame) {
-  std::ifstream splash("donner_splash.svg", std::ios::binary);
-  if (!splash.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream buffer;
-  buffer << splash.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorControlSession session;
-  ToolCallResult load = session.handleToolCall("load_svg", json{{"svg_source", buffer.str()},
+  ToolCallResult load = session.handleToolCall("load_svg", json{{"svg_source", splashFile.contents},
                                                                 {"canvas_width", 892},
                                                                 {"canvas_height", 512},
                                                                 {"render_after_load", true}});
@@ -804,16 +797,13 @@ TEST(EditorControlSessionTest, TransformSelectorResizesThroughHandleAndExposesAf
 }
 
 TEST(EditorControlSessionTest, LargeScaleDragKeepsPresentedTileTransformAlignedWithHandle) {
-  std::ifstream splash("donner_splash.svg", std::ios::binary);
-  if (!splash.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream buffer;
-  buffer << splash.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorControlSession session;
   ASSERT_TRUE(session
-                  .handleToolCall("load_svg", json{{"svg_source", buffer.str()},
+                  .handleToolCall("load_svg", json{{"svg_source", splashFile.contents},
                                                    {"canvas_width", 892},
                                                    {"canvas_height", 512},
                                                    {"render_after_load", true}})
@@ -1019,16 +1009,13 @@ TEST(EditorControlSessionTest, HeadlessTileCompositionPreservesAffinePlacementAn
 }
 
 TEST(EditorControlSessionTest, SplashOThenRDragKeepsStableSplitLayerPaintOrder) {
-  std::ifstream splash("donner_splash.svg", std::ios::binary);
-  if (!splash.is_open()) {
-    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
-  }
-  std::ostringstream buffer;
-  buffer << splash.rdbuf();
+  const donner::tests::RequiredRunfile splashFile =
+      donner::tests::ReadRequiredRunfile("donner_splash.svg");
+  DONNER_REQUIRE_RUNFILE(splashFile);
 
   EditorControlSession session;
   ASSERT_TRUE(session
-                  .handleToolCall("load_svg", json{{"svg_source", buffer.str()},
+                  .handleToolCall("load_svg", json{{"svg_source", splashFile.contents},
                                                    {"canvas_width", 892},
                                                    {"canvas_height", 512},
                                                    {"render_after_load", true}})


### PR DESCRIPTION
A test that skips because a file it declared in `data` is not in its runfiles reports success without running. gtest counts a run whose every case skipped as a pass, so those skips hid a build-graph defect behind a green result on every lane. Unlike a missing GPU adapter or an uninstalled command-line tool, an unresolvable runfile is never a property of the host: the runfiles tree is generated from the target's `data` attribute, so the entry is either declared or it is a bug. This converts every such skip into a failure.

The gate is one shared helper, `donner/base/tests/RunfileGate.h`, in the same test-utility library as `Runfiles.h` and `TestTempDir.h` because the sites span four packages. `ResolveRequiredRunfile` locates a path and `ReadRequiredRunfile` reads it, each returning the location, the contents, or an explanation. `DONNER_REQUIRE_RUNFILE` ends the case on that explanation. There is no CI-marker gating: the failure is the same on a developer machine as on an automated lane, because the defect is the same.

The failure text names what a reader needs to fix it: the path, the target whose `data` should carry it (from Bazel's own `TEST_TARGET`, so no site hand-maintains a label), and both resolutions attempted, the runfiles manifest and the test's working directory.

```
Required runfile "donner_splash.svg" is not in the runfiles tree.
Add it to the `data` attribute of //donner/svg/compositor:compositor_golden_tests.
Failing rather than skipping: a runfiles tree is generated from `data`, so a path that does not
resolve is a build-graph defect on every lane and every host, not something this machine lacks.
gtest reports a run whose every case skipped as a pass, so skipping here would report success
without exercising anything.
Resolution attempted:
  runfiles manifest -> .../compositor_golden_tests.runfiles/_main/donner_splash.svg
  test working directory -> .../compositor_golden_tests.runfiles/_main/donner_splash.svg
```

Converted sites, 41 skips across 11 files:

| File | Sites | Data |
| --- | --- | --- |
| `donner/svg/compositor/CompositorGolden_tests.cc` | 9 | `donner_splash.svg` |
| `donner/editor/tests/AsyncRenderer_tests.cc` | 13 | `donner_splash.svg` |
| `donner/editor/tests/AsyncRendererFilterGroupPerfTestUtils.cc` | 1 | `donner_splash.svg` |
| `donner/editor/tests/EditorApp_tests.cc` | 2 | `donner_splash.svg` |
| `donner/editor/tests/EditorWindow_tests.cc` | 1 | `donner_splash.svg` |
| `donner/editor/tests/SourceSelection_tests.cc` | 1 | `donner_splash.svg` |
| `donner/editor/tests/FilterDragReproTestUtils.{h,cc}` plus both callers | 2 | `filter_drag_repro.rnr`, `donner_splash.svg` |
| `donner/svg/renderer/geode/tests/GeodePerf_tests.cc` | 5 | `lion.svg`, `Ghostscript_Tiger.svg` |
| `donner/svg/renderer/tests/ZoomFilterRepro_tests.cc` | 2 | `donner_splash.svg` |
| `tools/mcp-servers/editor-control/EditorControlSession_tests.cc` | 4 | `donner_splash.svg` |
| `donner/editor/repro/tests/ReproDecodeClicks_test.cc` | 1 | `donner_splash.svg` |

Every converted target already declared the file in `data`, so no site turned out to be a legitimately optional asset needing a `select()` and a variant exclusion.

Two of these helpers are void functions that raise the gate's fatal failure on behalf of their callers, which does not by itself stop the caller. Both pairs of call sites check `HasFatalFailure()` before reading the result, and both declarations say so.

No test's assertions changed once its data resolves. The incidental assertion-count deltas are all the gate itself: `EditorApp_tests.cc` drops an `ASSERT_TRUE(splash.has_value())` the gate replaces; `EditorWindow_tests.cc` gains an `ASSERT_TRUE(document.has_value())` where a parse failure previously skipped behind a misleading "not found in runfiles" message that its own `EXPECT_FALSE(parsed.hasError())` had already flagged; and the four perf-helper callers gain `ASSERT_FALSE(HasFatalFailure())` now that those void helpers fail instead of setting a `skipped` flag.

`ReproDecodeClicks.MapClicksToDocumentElements` still skips when its `.donner-repro` recording is absent. That file is a developer artifact recorded into a temporary directory, not something the target carries in `data`, so its absence really is a host property. Its second guard, on the splash, is converted. A comment at the site records the distinction.

Out of scope and untouched: host and device capability skips (hidden editor window, Metal device, GL context, installed fonts, pseudo-terminal), the `resvg` `Params::Skip` mechanism, renderer-variant conditionals, the wall-clock budget cases that route to a manual perf target, the golden-regeneration escape hatches, and the environment-conditional security tests around symlink creation and document save.

Verification, red then green in five packages by removing the `data` entry and restoring it, each removal failing with the path named and Bazel exiting 3: the compositor golden tests without the splash; the geode perf tests without the renderer testdata; the editor-control session tests without the splash; the filter-drag repro correctness tests without the recording, which also covers the resolve-without-reading path; and the filter-group perf correctness tests without the splash, which also shows the caller-side guard stopping the case before its counter assertions. Unforced, all 13 converted targets pass with zero skips of this class; the 14 gtest skips that remain across them are 7 wall-clock budget cases routing to the manual perf target, 6 Geode-only presentation cases without a GL context, and the one deliberate recording skip. `bazel test //donner/... //tools/...` is green; `tools/lint.sh`, `clang-format`, and `buildifier` are clean. `RunfileGate_tests.cc` covers the helper itself: resolving and reading a declared file, reporting an absent one, the message naming path, target, and both attempts, and the gate failing rather than skipping.
