### PR TITLE
Fail closed on CI when a security test cannot create the symlink it checks

### DIFF
--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -128,6 +128,7 @@ donner_cc_library(
         "tests/EnvironmentCapabilityGate.h",
         "tests/ParseResultTestUtils.h",
         "tests/Runfiles.h",
+        "tests/ScopedEnvironmentVariable.h",
         "tests/TestTempDir.h",
     ],
     # //tools tests (MCP servers, build tooling) share the same test-hygiene

--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -124,6 +124,7 @@ donner_cc_library(
     testonly = 1,
     hdrs = [
         "tests/BaseTestUtils.h",
+        "tests/EnvironmentCapabilityGate.h",
         "tests/ParseResultTestUtils.h",
         "tests/Runfiles.h",
         "tests/TestTempDir.h",
@@ -184,6 +185,7 @@ donner_cc_test(
         "tests/ChunkedString_tests.cc",
         "tests/CompileTimeMap_tests.cc",
         "tests/DiagnosticRenderer_tests.cc",
+        "tests/EnvironmentCapabilityGate_tests.cc",
         "tests/FileUtils_tests.cc",
         "tests/Length_tests.cc",
         "tests/MathUtils_tests.cc",

--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -124,6 +124,7 @@ donner_cc_library(
     testonly = 1,
     hdrs = [
         "tests/BaseTestUtils.h",
+        "tests/ContinuousIntegrationMarkers.h",
         "tests/EnvironmentCapabilityGate.h",
         "tests/ParseResultTestUtils.h",
         "tests/Runfiles.h",
@@ -184,6 +185,7 @@ donner_cc_test(
         "tests/Box_tests.cc",
         "tests/ChunkedString_tests.cc",
         "tests/CompileTimeMap_tests.cc",
+        "tests/ContinuousIntegrationMarkers_tests.cc",
         "tests/DiagnosticRenderer_tests.cc",
         "tests/EnvironmentCapabilityGate_tests.cc",
         "tests/FileUtils_tests.cc",

--- a/donner/base/tests/ContinuousIntegrationMarkers.h
+++ b/donner/base/tests/ContinuousIntegrationMarkers.h
@@ -1,0 +1,51 @@
+#pragma once
+/// @file
+/// The environment markers that identify an automated lane, and the two questions every
+/// fail-closed test gate in this repo needs answered from them: which marker is set, and is any
+/// of them.
+///
+/// This is the single definition. donner/gpu/baseline/FrozenBaselinePolicy.{h,cc} delegates its
+/// same-named public functions here rather than keeping its own copy of the list, and
+/// donner/base/tests/EnvironmentCapabilityGate.h calls straight through to these.
+
+#include <array>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+namespace donner::tests {
+
+/**
+ * The environment variables whose presence marks an automated lane, in the order checked.
+ *
+ * `GITHUB_ACTIONS` is set by the hosted runner itself. The Donner-specific name lets any other
+ * automated lane opt in without this list having to learn every runner's convention.
+ */
+inline constexpr std::array<std::string_view, 2> kContinuousIntegrationMarkers = {
+    "GITHUB_ACTIONS",
+    "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+};
+
+/**
+ * The name of the environment marker that identified this process as running on an automated
+ * lane, for a message that has to say which one did.
+ *
+ * @return The marker's name, aliasing static storage that outlives every caller, or an empty view
+ *   when no marker is set.
+ */
+inline std::string_view FirstContinuousIntegrationMarkerSet() {
+  for (const std::string_view name : kContinuousIntegrationMarkers) {
+    const char* value = std::getenv(std::string(name).c_str());
+    if (value != nullptr && value[0] != '\0') {
+      return name;
+    }
+  }
+  return {};
+}
+
+/// Whether this process is running on an automated lane. @return True on such a lane.
+inline bool RunningUnderContinuousIntegration() {
+  return !FirstContinuousIntegrationMarkerSet().empty();
+}
+
+}  // namespace donner::tests

--- a/donner/base/tests/ContinuousIntegrationMarkers_tests.cc
+++ b/donner/base/tests/ContinuousIntegrationMarkers_tests.cc
@@ -1,0 +1,103 @@
+/// @file
+/// Covers the single definition of the automated-lane markers. Both
+/// donner/gpu/baseline/FrozenBaselinePolicy.{h,cc} and
+/// donner/base/tests/EnvironmentCapabilityGate.h delegate to these functions rather than keeping
+/// their own copy, so a marker dropped here silently drops the automated-lane detection for both
+/// a pixel-baseline gate and a symlink-capability gate at once. Checked directly, the same way
+/// FrozenBaselinePolicy_tests.cc used to check its own local copy of this logic.
+
+#include "donner/base/tests/ContinuousIntegrationMarkers.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace donner::tests {
+namespace {
+
+using testing::Eq;
+using testing::IsEmpty;
+
+/// Sets an environment variable for one test and restores the previous state afterwards, so the
+/// cases can force the automated-lane path without depending on where they are run.
+///
+/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
+/// (shader-validators-fail-closed-on-ci) hoists this into
+/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
+/// it does, every local copy of this class, including this one, should move onto it.
+class ScopedEnvironmentVariable {
+public:
+  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
+    if (const char* previous = std::getenv(name); previous != nullptr) {
+      previous_ = previous;
+      hadPrevious_ = true;
+    }
+    if (value != nullptr) {
+      setenv(name, value, 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  ~ScopedEnvironmentVariable() {
+    if (hadPrevious_) {
+      setenv(name_.c_str(), previous_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
+
+private:
+  std::string name_;
+  std::string previous_;
+  bool hadPrevious_ = false;
+};
+
+TEST(ContinuousIntegrationMarkersTests, NoMarkerMeansNoAutomatedLane) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), IsEmpty());
+  EXPECT_FALSE(RunningUnderContinuousIntegration());
+}
+
+TEST(ContinuousIntegrationMarkersTests, TheHostedRunnerMarkerIsDetected) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "true");
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), Eq("GITHUB_ACTIONS"));
+  EXPECT_TRUE(RunningUnderContinuousIntegration());
+}
+
+TEST(ContinuousIntegrationMarkersTests, TheExplicitOverrideMarkerIsDetected) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", "1");
+
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), Eq("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER"));
+  EXPECT_TRUE(RunningUnderContinuousIntegration());
+}
+
+TEST(ContinuousIntegrationMarkersTests, AnEmptyMarkerDoesNotCountAsSet) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "");
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), IsEmpty());
+  EXPECT_FALSE(RunningUnderContinuousIntegration());
+}
+
+TEST(ContinuousIntegrationMarkersTests, TheHostedRunnerMarkerIsCheckedFirst) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "true");
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", "1");
+
+  // Both markers are set; the reported one is whichever this list checks first, so a message
+  // naming it stays consistent regardless of which lane variables happen to be present together.
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), Eq(kContinuousIntegrationMarkers[0]));
+}
+
+}  // namespace
+}  // namespace donner::tests

--- a/donner/base/tests/ContinuousIntegrationMarkers_tests.cc
+++ b/donner/base/tests/ContinuousIntegrationMarkers_tests.cc
@@ -11,52 +11,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstdlib>
-#include <string>
+#include "donner/base/tests/ScopedEnvironmentVariable.h"
 
 namespace donner::tests {
 namespace {
 
 using testing::Eq;
 using testing::IsEmpty;
-
-/// Sets an environment variable for one test and restores the previous state afterwards, so the
-/// cases can force the automated-lane path without depending on where they are run.
-///
-/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
-/// (shader-validators-fail-closed-on-ci) hoists this into
-/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
-/// it does, every local copy of this class, including this one, should move onto it.
-class ScopedEnvironmentVariable {
-public:
-  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
-    if (const char* previous = std::getenv(name); previous != nullptr) {
-      previous_ = previous;
-      hadPrevious_ = true;
-    }
-    if (value != nullptr) {
-      setenv(name, value, 1);
-    } else {
-      unsetenv(name);
-    }
-  }
-
-  ~ScopedEnvironmentVariable() {
-    if (hadPrevious_) {
-      setenv(name_.c_str(), previous_.c_str(), 1);
-    } else {
-      unsetenv(name_.c_str());
-    }
-  }
-
-  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
-  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
-
-private:
-  std::string name_;
-  std::string previous_;
-  bool hadPrevious_ = false;
-};
 
 TEST(ContinuousIntegrationMarkersTests, NoMarkerMeansNoAutomatedLane) {
   const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);

--- a/donner/base/tests/EnvironmentCapabilityGate.h
+++ b/donner/base/tests/EnvironmentCapabilityGate.h
@@ -132,23 +132,23 @@ inline std::string MissingEnvironmentCapabilityMessage(
  * @param capabilityLabel What the capability is, for a reader who sees only the failure or skip
  *   line.
  */
-#define DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(condition, capabilityLabel)                        \
-  do {                                                                                           \
-    const std::string donnerEnvironmentCapabilityReason = (condition);                           \
-    if (!donnerEnvironmentCapabilityReason.empty()) {                                            \
-      const ::donner::tests::MissingEnvironmentCapabilityDisposition                             \
-          donnerEnvironmentCapabilityDisposition =                                               \
-              ::donner::tests::DispositionForMissingEnvironmentCapability(                       \
-                  ::donner::tests::RunningUnderContinuousIntegration());                         \
-      const std::string donnerEnvironmentCapabilityMessage =                                     \
-          ::donner::tests::MissingEnvironmentCapabilityMessage(                                  \
-              (capabilityLabel), donnerEnvironmentCapabilityReason,                               \
-              ::donner::tests::FirstContinuousIntegrationMarkerSet(),                             \
-              donnerEnvironmentCapabilityDisposition);                                            \
-      if (donnerEnvironmentCapabilityDisposition ==                                              \
-          ::donner::tests::MissingEnvironmentCapabilityDisposition::FailClosed) {                \
-        FAIL() << donnerEnvironmentCapabilityMessage;                                            \
-      }                                                                                          \
-      GTEST_SKIP() << donnerEnvironmentCapabilityMessage;                                        \
-    }                                                                                             \
+#define DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(condition, capabilityLabel)         \
+  do {                                                                            \
+    const std::string donnerEnvironmentCapabilityReason = (condition);            \
+    if (!donnerEnvironmentCapabilityReason.empty()) {                             \
+      const ::donner::tests::MissingEnvironmentCapabilityDisposition              \
+          donnerEnvironmentCapabilityDisposition =                                \
+              ::donner::tests::DispositionForMissingEnvironmentCapability(        \
+                  ::donner::tests::RunningUnderContinuousIntegration());          \
+      const std::string donnerEnvironmentCapabilityMessage =                      \
+          ::donner::tests::MissingEnvironmentCapabilityMessage(                   \
+              (capabilityLabel), donnerEnvironmentCapabilityReason,               \
+              ::donner::tests::FirstContinuousIntegrationMarkerSet(),             \
+              donnerEnvironmentCapabilityDisposition);                            \
+      if (donnerEnvironmentCapabilityDisposition ==                               \
+          ::donner::tests::MissingEnvironmentCapabilityDisposition::FailClosed) { \
+        FAIL() << donnerEnvironmentCapabilityMessage;                             \
+      }                                                                           \
+      GTEST_SKIP() << donnerEnvironmentCapabilityMessage;                         \
+    }                                                                             \
   } while (false)

--- a/donner/base/tests/EnvironmentCapabilityGate.h
+++ b/donner/base/tests/EnvironmentCapabilityGate.h
@@ -12,18 +12,17 @@
 /// reports the same green as a lane that exercised the protection, so on an automated lane this
 /// fails closed instead, naming the capability and the marker that identified the lane.
 ///
-/// Checks the same automated-lane markers as donner/gpu/baseline/FrozenBaselinePolicy.h. This
-/// header lives in donner/base, which donner/gpu depends on and not the reverse, so the check
-/// here is a local copy rather than a call into that policy; keep the marker names identical if
-/// either list changes.
+/// Checks the same automated-lane markers as donner/gpu/baseline/FrozenBaselinePolicy.h, by
+/// calling the single definition in donner/base/tests/ContinuousIntegrationMarkers.h rather than
+/// keeping a copy: that policy delegates to the same functions.
 
 #include <gtest/gtest.h>
 
-#include <array>
-#include <cstdlib>
 #include <ostream>
 #include <string>
 #include <string_view>
+
+#include "donner/base/tests/ContinuousIntegrationMarkers.h"
 
 namespace donner::tests {
 
@@ -41,35 +40,6 @@ inline std::ostream& operator<<(std::ostream& os,
     case MissingEnvironmentCapabilityDisposition::FailClosed: return os << "FailClosed";
   }
   return os << "MissingEnvironmentCapabilityDisposition(unknown)";
-}
-
-/**
- * The name of the environment marker that identified this process as running on an automated
- * lane, for a message that has to say which one did.
- *
- * `GITHUB_ACTIONS` is set by the hosted runner itself. The Donner-specific name lets any other
- * automated lane opt in without this list having to learn every runner's convention.
- *
- * @return The marker's name, aliasing static storage that outlives every caller, or an empty view
- *   when no marker is set.
- */
-inline std::string_view FirstContinuousIntegrationMarkerSet() {
-  static constexpr std::array<std::string_view, 2> kContinuousIntegrationMarkers = {
-      "GITHUB_ACTIONS",
-      "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
-  };
-  for (const std::string_view name : kContinuousIntegrationMarkers) {
-    const char* value = std::getenv(std::string(name).c_str());
-    if (value != nullptr && value[0] != '\0') {
-      return name;
-    }
-  }
-  return {};
-}
-
-/// Whether this process is running on an automated lane. @return True on such a lane.
-inline bool RunningUnderContinuousIntegration() {
-  return !FirstContinuousIntegrationMarkerSet().empty();
 }
 
 /**

--- a/donner/base/tests/EnvironmentCapabilityGate.h
+++ b/donner/base/tests/EnvironmentCapabilityGate.h
@@ -1,0 +1,154 @@
+#pragma once
+/// @file
+/// What a test does when an environment capability it needs (a filesystem or sandbox operation,
+/// not a build artifact or a piece of hardware) is unavailable: creating a symlink, for example,
+/// on a filesystem or sandbox that forbids it.
+///
+/// That is not a property every machine has, so a developer machine in that state should skip
+/// visibly and go on to the rest of the suite. An automated lane is not "some machine in that
+/// state" though: it is where a case exercising a security protection (path-escape rejection
+/// through a symlink, a save that refuses to follow one) is supposed to run on every commit, and
+/// gtest reports a run whose every case skipped as a pass. A lane that never had the capability
+/// reports the same green as a lane that exercised the protection, so on an automated lane this
+/// fails closed instead, naming the capability and the marker that identified the lane.
+///
+/// Checks the same automated-lane markers as donner/gpu/baseline/FrozenBaselinePolicy.h. This
+/// header lives in donner/base, which donner/gpu depends on and not the reverse, so the check
+/// here is a local copy rather than a call into that policy; keep the marker names identical if
+/// either list changes.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace donner::tests {
+
+/// What a run should do when the environment capability it needs is unavailable.
+enum class MissingEnvironmentCapabilityDisposition {
+  Skip,        //!< Report the case as skipped, naming the capability that is unavailable.
+  FailClosed,  //!< Fail: skipping here would silently retire the case that checks it.
+};
+
+/// Streams the disposition name. @param os Stream. @param disposition Value. @return `os`.
+inline std::ostream& operator<<(std::ostream& os,
+                                MissingEnvironmentCapabilityDisposition disposition) {
+  switch (disposition) {
+    case MissingEnvironmentCapabilityDisposition::Skip: return os << "Skip";
+    case MissingEnvironmentCapabilityDisposition::FailClosed: return os << "FailClosed";
+  }
+  return os << "MissingEnvironmentCapabilityDisposition(unknown)";
+}
+
+/**
+ * The name of the environment marker that identified this process as running on an automated
+ * lane, for a message that has to say which one did.
+ *
+ * `GITHUB_ACTIONS` is set by the hosted runner itself. The Donner-specific name lets any other
+ * automated lane opt in without this list having to learn every runner's convention.
+ *
+ * @return The marker's name, aliasing static storage that outlives every caller, or an empty view
+ *   when no marker is set.
+ */
+inline std::string_view FirstContinuousIntegrationMarkerSet() {
+  static constexpr std::array<std::string_view, 2> kContinuousIntegrationMarkers = {
+      "GITHUB_ACTIONS",
+      "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+  };
+  for (const std::string_view name : kContinuousIntegrationMarkers) {
+    const char* value = std::getenv(std::string(name).c_str());
+    if (value != nullptr && value[0] != '\0') {
+      return name;
+    }
+  }
+  return {};
+}
+
+/// Whether this process is running on an automated lane. @return True on such a lane.
+inline bool RunningUnderContinuousIntegration() {
+  return !FirstContinuousIntegrationMarkerSet().empty();
+}
+
+/**
+ * The disposition for a run whose needed environment capability is unavailable.
+ *
+ * @param underContinuousIntegration Whether this process is on an automated lane.
+ * @return What the run should do.
+ */
+inline MissingEnvironmentCapabilityDisposition DispositionForMissingEnvironmentCapability(
+    bool underContinuousIntegration) {
+  return underContinuousIntegration ? MissingEnvironmentCapabilityDisposition::FailClosed
+                                    : MissingEnvironmentCapabilityDisposition::Skip;
+}
+
+/**
+ * The message a run reports when an environment capability it needs is unavailable.
+ *
+ * @param capabilityLabel What the capability is, for a reader who sees only this line.
+ * @param unavailableReason What the probe found, for example a `std::error_code`'s message.
+ * @param laneMarker Marker that identified the lane, empty when there is none.
+ * @param disposition What the run is about to do.
+ * @return A message naming the capability and, when failing, the marker and why skipping was not
+ *   an option.
+ */
+inline std::string MissingEnvironmentCapabilityMessage(
+    std::string_view capabilityLabel, std::string_view unavailableReason,
+    std::string_view laneMarker, MissingEnvironmentCapabilityDisposition disposition) {
+  std::string message(capabilityLabel);
+  message += " is unavailable: ";
+  message += unavailableReason;
+
+  if (disposition == MissingEnvironmentCapabilityDisposition::FailClosed) {
+    message +=
+        "\nFailing rather than skipping: this lane selected a target whose case checks this "
+        "capability, and gtest reports a run whose every case skipped as a pass, so skipping "
+        "here would report success without exercising the protection it checks.";
+    if (!laneMarker.empty()) {
+      message += "\nAutomated lane identified by ";
+      message += laneMarker;
+      message += ".";
+    }
+  }
+
+  return message;
+}
+
+}  // namespace donner::tests
+
+/**
+ * Gates a test case on an environment capability being available, ending the case when it is not:
+ * skipped on a developer machine, failed on an automated lane.
+ *
+ * Use directly in a `TEST` or `TEST_F` body. Placed in a helper that returns a value, the skip or
+ * fatal failure would end the helper rather than the case, and the case would go on to run
+ * without the capability.
+ *
+ * @param condition An expression producing a value contextually convertible to `std::string`
+ *   (matching `std::error_code::message()`), empty when the capability is available and, when
+ *   not, the reason it is unavailable. Evaluated once.
+ * @param capabilityLabel What the capability is, for a reader who sees only the failure or skip
+ *   line.
+ */
+#define DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(condition, capabilityLabel)                        \
+  do {                                                                                           \
+    const std::string donnerEnvironmentCapabilityReason = (condition);                           \
+    if (!donnerEnvironmentCapabilityReason.empty()) {                                            \
+      const ::donner::tests::MissingEnvironmentCapabilityDisposition                             \
+          donnerEnvironmentCapabilityDisposition =                                               \
+              ::donner::tests::DispositionForMissingEnvironmentCapability(                       \
+                  ::donner::tests::RunningUnderContinuousIntegration());                         \
+      const std::string donnerEnvironmentCapabilityMessage =                                     \
+          ::donner::tests::MissingEnvironmentCapabilityMessage(                                  \
+              (capabilityLabel), donnerEnvironmentCapabilityReason,                               \
+              ::donner::tests::FirstContinuousIntegrationMarkerSet(),                             \
+              donnerEnvironmentCapabilityDisposition);                                            \
+      if (donnerEnvironmentCapabilityDisposition ==                                              \
+          ::donner::tests::MissingEnvironmentCapabilityDisposition::FailClosed) {                \
+        FAIL() << donnerEnvironmentCapabilityMessage;                                            \
+      }                                                                                          \
+      GTEST_SKIP() << donnerEnvironmentCapabilityMessage;                                        \
+    }                                                                                             \
+  } while (false)

--- a/donner/base/tests/EnvironmentCapabilityGate_tests.cc
+++ b/donner/base/tests/EnvironmentCapabilityGate_tests.cc
@@ -12,8 +12,9 @@
 #include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
-#include <cstdlib>
 #include <string>
+
+#include "donner/base/tests/ScopedEnvironmentVariable.h"
 
 namespace donner::tests {
 namespace {
@@ -21,44 +22,6 @@ namespace {
 using testing::Eq;
 using testing::HasSubstr;
 using testing::Not;
-
-/// Sets an environment variable for one test and restores the previous state afterwards, so the
-/// cases can force the automated-lane path without depending on where they are run.
-///
-/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
-/// (shader-validators-fail-closed-on-ci) hoists this into
-/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
-/// it does, this copy should move onto the shared helper instead of a third one existing.
-class ScopedEnvironmentVariable {
-public:
-  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
-    if (const char* previous = std::getenv(name); previous != nullptr) {
-      previous_ = previous;
-      hadPrevious_ = true;
-    }
-    if (value != nullptr) {
-      setenv(name, value, 1);
-    } else {
-      unsetenv(name);
-    }
-  }
-
-  ~ScopedEnvironmentVariable() {
-    if (hadPrevious_) {
-      setenv(name_.c_str(), previous_.c_str(), 1);
-    } else {
-      unsetenv(name_.c_str());
-    }
-  }
-
-  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
-  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
-
-private:
-  std::string name_;
-  std::string previous_;
-  bool hadPrevious_ = false;
-};
 
 /// Invokes the macro the way a test case does, then records that control continued past it.
 /// @param unavailableReason Reason string the macro gates on; non-empty exercises the

--- a/donner/base/tests/EnvironmentCapabilityGate_tests.cc
+++ b/donner/base/tests/EnvironmentCapabilityGate_tests.cc
@@ -95,8 +95,9 @@ TEST(EnvironmentCapabilityGateTests, ADeveloperMachineSkipsAndStopsTheCase) {
   // Intercepted rather than allowed to land, so this case reports its assertions instead of
   // reporting itself as skipped. This is the check that would catch a mutant collapsing the
   // automated-lane branch onto this one: it fails unless the intercepted result is exactly one
-  // kSkip part, so a mutant that skips under the marker too would flip AnAutomatedLaneFailsAndStopsTheCase
-  // instead, and a mutant that fails here too would flip this one.
+  // kSkip part, so a mutant that skips under the marker too would flip
+  // AnAutomatedLaneFailsAndStopsTheCase instead, and a mutant that fails here too would flip this
+  // one.
   testing::TestPartResultArray results;
   {
     const testing::ScopedFakeTestPartResultReporter reporter(
@@ -157,7 +158,8 @@ TEST(EnvironmentCapabilityGateTests, TheMessageNamesTheCapability) {
   EXPECT_THAT(message, Not(HasSubstr("Failing rather than skipping")));
 }
 
-TEST(EnvironmentCapabilityGateTests, TheFailingMessageExplainsWhySkippingWasNotAnOptionAndNamesTheMarker) {
+TEST(EnvironmentCapabilityGateTests,
+     TheFailingMessageExplainsWhySkippingWasNotAnOptionAndNamesTheMarker) {
   const std::string message = MissingEnvironmentCapabilityMessage(
       "the ability to create filesystem symlinks", "permission denied", "GITHUB_ACTIONS",
       MissingEnvironmentCapabilityDisposition::FailClosed);

--- a/donner/base/tests/EnvironmentCapabilityGate_tests.cc
+++ b/donner/base/tests/EnvironmentCapabilityGate_tests.cc
@@ -1,0 +1,180 @@
+/// @file
+/// Covers what DONNER_REQUIRE_ENVIRONMENT_CAPABILITY does when the capability it gates is
+/// unavailable. The macro's missing-capability branches are exercised only when a lane actually
+/// lacks the capability (a sandbox that forbids symlink creation, say); every case on a working
+/// lane takes the available path, so a regression in the macro itself would otherwise reach
+/// production only when a lane lost the capability. Checked here directly, with no such lane
+/// needed, the same way MetalDeviceGate_tests.cc checks DONNER_REQUIRE_METAL_DEVICE.
+
+#include "donner/base/tests/EnvironmentCapabilityGate.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace donner::tests {
+namespace {
+
+using testing::Eq;
+using testing::HasSubstr;
+using testing::Not;
+
+/// Sets an environment variable for one test and restores the previous state afterwards, so the
+/// cases can force the automated-lane path without depending on where they are run.
+///
+/// Copied from donner/gpu/baseline/FrozenBaselinePolicy_tests.cc rather than shared: PR 1095
+/// (shader-validators-fail-closed-on-ci) hoists this into
+/// donner/base/tests/ScopedEnvironmentVariable, but that branch has not landed on main yet. Once
+/// it does, this copy should move onto the shared helper instead of a third one existing.
+class ScopedEnvironmentVariable {
+public:
+  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
+    if (const char* previous = std::getenv(name); previous != nullptr) {
+      previous_ = previous;
+      hadPrevious_ = true;
+    }
+    if (value != nullptr) {
+      setenv(name, value, 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  ~ScopedEnvironmentVariable() {
+    if (hadPrevious_) {
+      setenv(name_.c_str(), previous_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
+
+private:
+  std::string name_;
+  std::string previous_;
+  bool hadPrevious_ = false;
+};
+
+/// Invokes the macro the way a test case does, then records that control continued past it.
+/// @param unavailableReason Reason string the macro gates on; non-empty exercises the
+///   missing-capability path.
+/// @param reachedEnd Set true when the macro let the case continue.
+void RunGate(const std::string& unavailableReason, bool* reachedEnd) {
+  DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(unavailableReason, "the capability under test");
+  *reachedEnd = true;
+}
+
+TEST(EnvironmentCapabilityGateTests, AnAvailableCapabilityLetsTheCaseRun) {
+  bool reachedEnd = false;
+  RunGate(/*unavailableReason=*/"", &reachedEnd);
+
+  EXPECT_TRUE(reachedEnd);
+}
+
+TEST(EnvironmentCapabilityGateTests, AnAutomatedLaneFailsAndStopsTheCase) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "true");
+
+  // EXPECT_FATAL_FAILURE's statement cannot name a non-static local.
+  static bool reachedEnd;
+  reachedEnd = false;
+
+  EXPECT_FATAL_FAILURE(RunGate("permission denied", &reachedEnd), "Failing rather than skipping");
+  EXPECT_FALSE(reachedEnd);
+}
+
+TEST(EnvironmentCapabilityGateTests, ADeveloperMachineSkipsAndStopsTheCase) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  bool reachedEnd = false;
+  // Intercepted rather than allowed to land, so this case reports its assertions instead of
+  // reporting itself as skipped. This is the check that would catch a mutant collapsing the
+  // automated-lane branch onto this one: it fails unless the intercepted result is exactly one
+  // kSkip part, so a mutant that skips under the marker too would flip AnAutomatedLaneFailsAndStopsTheCase
+  // instead, and a mutant that fails here too would flip this one.
+  testing::TestPartResultArray results;
+  {
+    const testing::ScopedFakeTestPartResultReporter reporter(
+        testing::ScopedFakeTestPartResultReporter::INTERCEPT_ONLY_CURRENT_THREAD, &results);
+    RunGate("permission denied", &reachedEnd);
+  }
+
+  EXPECT_FALSE(reachedEnd);
+  ASSERT_THAT(results.size(), Eq(1));
+  EXPECT_THAT(results.GetTestPartResult(0).type(), Eq(testing::TestPartResult::kSkip));
+  EXPECT_THAT(results.GetTestPartResult(0).message(), HasSubstr("the capability under test"));
+  EXPECT_THAT(results.GetTestPartResult(0).message(), HasSubstr("permission denied"));
+  EXPECT_THAT(results.GetTestPartResult(0).message(), Not(HasSubstr("Failing rather than")));
+}
+
+TEST(EnvironmentCapabilityGateTests, TheHostedRunnerMarkerSelectsTheFailClosedDisposition) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "true");
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_TRUE(RunningUnderContinuousIntegration());
+  EXPECT_THAT(DispositionForMissingEnvironmentCapability(RunningUnderContinuousIntegration()),
+              Eq(MissingEnvironmentCapabilityDisposition::FailClosed));
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), Eq("GITHUB_ACTIONS"));
+}
+
+TEST(EnvironmentCapabilityGateTests, TheExplicitOverrideSelectsTheFailClosedDisposition) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", "1");
+
+  EXPECT_TRUE(RunningUnderContinuousIntegration());
+  EXPECT_THAT(FirstContinuousIntegrationMarkerSet(), Eq("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER"));
+}
+
+TEST(EnvironmentCapabilityGateTests, NoMarkerMeansNoAutomatedLane) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", nullptr);
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_FALSE(RunningUnderContinuousIntegration());
+  EXPECT_THAT(DispositionForMissingEnvironmentCapability(RunningUnderContinuousIntegration()),
+              Eq(MissingEnvironmentCapabilityDisposition::Skip));
+  EXPECT_TRUE(FirstContinuousIntegrationMarkerSet().empty());
+}
+
+TEST(EnvironmentCapabilityGateTests, AnEmptyMarkerDoesNotCountAsAnAutomatedLane) {
+  const ScopedEnvironmentVariable githubActions("GITHUB_ACTIONS", "");
+  const ScopedEnvironmentVariable donnerOverride("DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER", nullptr);
+
+  EXPECT_FALSE(RunningUnderContinuousIntegration());
+}
+
+TEST(EnvironmentCapabilityGateTests, TheMessageNamesTheCapability) {
+  const std::string message = MissingEnvironmentCapabilityMessage(
+      "the ability to create filesystem symlinks", "permission denied", "",
+      MissingEnvironmentCapabilityDisposition::Skip);
+
+  EXPECT_THAT(message, HasSubstr("the ability to create filesystem symlinks"));
+  EXPECT_THAT(message, HasSubstr("permission denied"));
+  EXPECT_THAT(message, Not(HasSubstr("Failing rather than skipping")));
+}
+
+TEST(EnvironmentCapabilityGateTests, TheFailingMessageExplainsWhySkippingWasNotAnOptionAndNamesTheMarker) {
+  const std::string message = MissingEnvironmentCapabilityMessage(
+      "the ability to create filesystem symlinks", "permission denied", "GITHUB_ACTIONS",
+      MissingEnvironmentCapabilityDisposition::FailClosed);
+
+  EXPECT_THAT(message, HasSubstr("the ability to create filesystem symlinks"));
+  EXPECT_THAT(message, HasSubstr("Failing rather than skipping"));
+  EXPECT_THAT(message, HasSubstr("Automated lane identified by GITHUB_ACTIONS"));
+}
+
+TEST(EnvironmentCapabilityGateTests, TheFailingMessageOmitsTheMarkerLineWhenThereIsNone) {
+  const std::string message = MissingEnvironmentCapabilityMessage(
+      "the ability to create filesystem symlinks", "permission denied", "",
+      MissingEnvironmentCapabilityDisposition::FailClosed);
+
+  EXPECT_THAT(message, HasSubstr("Failing rather than skipping"));
+  EXPECT_THAT(message, Not(HasSubstr("Automated lane identified by")));
+}
+
+}  // namespace
+}  // namespace donner::tests

--- a/donner/base/tests/ScopedEnvironmentVariable.h
+++ b/donner/base/tests/ScopedEnvironmentVariable.h
@@ -1,0 +1,52 @@
+#pragma once
+/// @file
+
+#include <cstdlib>
+#include <string>
+
+namespace donner {
+
+/**
+ * Sets or unsets an environment variable for one test and restores the previous state afterwards.
+ *
+ * Tests whose behavior depends on an ambient marker need to force both answers, and Bazel scrubs
+ * the test environment, so neither answer can be relied on to be the ambient one.
+ */
+class ScopedEnvironmentVariable {
+public:
+  /**
+   * Sets \p name to \p value, or unsets it when \p value is null.
+   *
+   * @param name Environment variable name.
+   * @param value Value to set, or nullptr to unset.
+   */
+  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
+    if (const char* previous = std::getenv(name); previous != nullptr) {
+      previous_ = previous;
+      hadPrevious_ = true;
+    }
+    if (value != nullptr) {
+      setenv(name, value, 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  ~ScopedEnvironmentVariable() {
+    if (hadPrevious_) {
+      setenv(name_.c_str(), previous_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
+
+private:
+  std::string name_;
+  std::string previous_;
+  bool hadPrevious_ = false;
+};
+
+}  // namespace donner

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -248,6 +248,13 @@ donner_cc_test(
 donner_cc_test(
     name = "document_save_tests",
     srcs = ["DocumentSave_tests.cc"],
+    # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
+    # the symlink-destination fail-closed rule can never see one and the case keeps skipping into
+    # a green report.
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
     deps = [
         ":bitmap_golden_compare",
         "//donner/base",

--- a/donner/editor/tests/DocumentSave_tests.cc
+++ b/donner/editor/tests/DocumentSave_tests.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 
+#include "donner/base/tests/EnvironmentCapabilityGate.h"
 #include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/DocumentSyncController.h"
 #include "donner/editor/EditorApp.h"
@@ -184,9 +185,8 @@ TEST(DocumentSaveTest, RejectsSymlinkDestinationWithoutTouchingTarget) {
 
   std::error_code ec;
   std::filesystem::create_symlink(target, symlink, ec);
-  if (ec) {
-    GTEST_SKIP() << "Could not create symlink in test output dir: " << ec.message();
-  }
+  DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(ec ? ec.message() : std::string(),
+                                        "the ability to create filesystem symlinks");
 
   const DocumentSaveResult result = SaveSourceToPath(symlink, "<svg id=\"replaced\"/>");
   EXPECT_EQ(result.status, DocumentSaveStatus::OpenFailed);

--- a/donner/gpu/baseline/BUILD.bazel
+++ b/donner/gpu/baseline/BUILD.bazel
@@ -31,6 +31,10 @@ donner_cc_library(
     srcs = ["FrozenBaselinePolicy.cc"],
     hdrs = ["FrozenBaselinePolicy.h"],
     visibility = donner_internal_visibility(),
+    deps = [
+        # Delegates its automated-lane marker check to the single definition there.
+        "//donner/base:base_test_utils",
+    ],
 )
 
 donner_cc_test(

--- a/donner/gpu/baseline/BUILD.bazel
+++ b/donner/gpu/baseline/BUILD.bazel
@@ -42,6 +42,7 @@ donner_cc_test(
     srcs = ["FrozenBaselinePolicy_tests.cc"],
     deps = [
         ":frozen_baseline_policy",
+        "//donner/base:base_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/gpu/baseline/FrozenBaselinePolicy.cc
+++ b/donner/gpu/baseline/FrozenBaselinePolicy.cc
@@ -1,7 +1,6 @@
 #include "donner/gpu/baseline/FrozenBaselinePolicy.h"
 
 #include <cctype>
-#include <cstdlib>
 
 #include "donner/base/tests/ContinuousIntegrationMarkers.h"
 
@@ -13,22 +12,6 @@ std::ostream& operator<<(std::ostream& os, MissingComparisonDisposition disposit
     case MissingComparisonDisposition::FailClosed: return os << "FailClosed";
   }
   return os << "MissingComparisonDisposition(unknown)";
-}
-
-// Delegates to the single definition in donner/base/tests/ContinuousIntegrationMarkers.h rather
-// than keeping its own copy of the marker list.
-std::span<const std::string_view> ContinuousIntegrationMarkers() {
-  return ::donner::tests::kContinuousIntegrationMarkers;
-}
-
-bool AnyEnvironmentVariableIsSet(std::span<const std::string_view> names) {
-  for (const std::string_view name : names) {
-    const char* value = std::getenv(std::string(name).c_str());
-    if (value != nullptr && value[0] != '\0') {
-      return true;
-    }
-  }
-  return false;
 }
 
 // Delegates to the single definition in donner/base/tests/ContinuousIntegrationMarkers.h so a

--- a/donner/gpu/baseline/FrozenBaselinePolicy.cc
+++ b/donner/gpu/baseline/FrozenBaselinePolicy.cc
@@ -1,18 +1,11 @@
 #include "donner/gpu/baseline/FrozenBaselinePolicy.h"
 
-#include <array>
 #include <cctype>
 #include <cstdlib>
 
+#include "donner/base/tests/ContinuousIntegrationMarkers.h"
+
 namespace donner::gpu::baseline {
-namespace {
-
-constexpr std::array<std::string_view, 2> kContinuousIntegrationMarkers = {
-    "GITHUB_ACTIONS",
-    "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
-};
-
-}  // namespace
 
 std::ostream& operator<<(std::ostream& os, MissingComparisonDisposition disposition) {
   switch (disposition) {
@@ -22,8 +15,10 @@ std::ostream& operator<<(std::ostream& os, MissingComparisonDisposition disposit
   return os << "MissingComparisonDisposition(unknown)";
 }
 
+// Delegates to the single definition in donner/base/tests/ContinuousIntegrationMarkers.h rather
+// than keeping its own copy of the marker list.
 std::span<const std::string_view> ContinuousIntegrationMarkers() {
-  return kContinuousIntegrationMarkers;
+  return ::donner::tests::kContinuousIntegrationMarkers;
 }
 
 bool AnyEnvironmentVariableIsSet(std::span<const std::string_view> names) {
@@ -36,8 +31,11 @@ bool AnyEnvironmentVariableIsSet(std::span<const std::string_view> names) {
   return false;
 }
 
+// Delegates to the single definition in donner/base/tests/ContinuousIntegrationMarkers.h so a
+// marker dropped from the shared list is caught by that header's own tests as well as this
+// policy's.
 bool RunningUnderContinuousIntegration() {
-  return AnyEnvironmentVariableIsSet(ContinuousIntegrationMarkers());
+  return ::donner::tests::RunningUnderContinuousIntegration();
 }
 
 MissingComparisonDisposition DispositionForUnbaselinedAdapter(bool underContinuousIntegration) {

--- a/donner/gpu/baseline/FrozenBaselinePolicy.h
+++ b/donner/gpu/baseline/FrozenBaselinePolicy.h
@@ -9,7 +9,6 @@
 /// exercised without a device on every platform.
 
 #include <ostream>
-#include <span>
 #include <string>
 #include <string_view>
 
@@ -23,24 +22,6 @@ enum class MissingComparisonDisposition {
 
 /// Streams the disposition name. @param os Stream. @param disposition Value. @return `os`.
 std::ostream& operator<<(std::ostream& os, MissingComparisonDisposition disposition);
-
-/**
- * Environment variables whose presence marks an automated lane.
- *
- * `GITHUB_ACTIONS` is set by the hosted runner itself. The Donner-specific name lets any other
- * automated lane opt in without this list having to learn every runner's convention.
- *
- * @return The marker names, in a stable order.
- */
-std::span<const std::string_view> ContinuousIntegrationMarkers();
-
-/**
- * Whether any of `names` is set to a non-empty value in the process environment.
- *
- * @param names Environment variable names to check.
- * @return True when at least one is present and non-empty.
- */
-bool AnyEnvironmentVariableIsSet(std::span<const std::string_view> names);
 
 /// Whether this process is running on an automated lane. @return True on such a lane.
 bool RunningUnderContinuousIntegration();

--- a/donner/gpu/baseline/FrozenBaselinePolicy_tests.cc
+++ b/donner/gpu/baseline/FrozenBaselinePolicy_tests.cc
@@ -8,47 +8,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstdlib>
 #include <string>
+
+#include "donner/base/tests/ScopedEnvironmentVariable.h"
 
 namespace donner::gpu::baseline {
 namespace {
 
 using testing::HasSubstr;
 using testing::Not;
-
-/// Sets an environment variable for one test and restores the previous state afterwards, so the
-/// cases can force the automated-lane path without depending on where they are run.
-class ScopedEnvironmentVariable {
-public:
-  ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
-    if (const char* previous = std::getenv(name); previous != nullptr) {
-      previous_ = previous;
-      hadPrevious_ = true;
-    }
-    if (value != nullptr) {
-      setenv(name, value, 1);
-    } else {
-      unsetenv(name);
-    }
-  }
-
-  ~ScopedEnvironmentVariable() {
-    if (hadPrevious_) {
-      setenv(name_.c_str(), previous_.c_str(), 1);
-    } else {
-      unsetenv(name_.c_str());
-    }
-  }
-
-  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
-  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
-
-private:
-  std::string name_;
-  std::string previous_;
-  bool hadPrevious_ = false;
-};
 
 TEST(FrozenBaselinePolicyTests, AnAutomatedLaneFailsInsteadOfSkipping) {
   EXPECT_THAT(DispositionForUnbaselinedAdapter(/*underContinuousIntegration=*/true),

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -164,6 +164,13 @@ donner_cc_test(
     srcs = [
         "ImageComparisonTestFixture_tests.cc",
     ],
+    # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
+    # the symlink-resolution fail-closed rule can never see one and the case keeps skipping into
+    # a green report.
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
     deps = [
         ":image_comparison_test_fixture",
         "//donner/base:base_test_utils",

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture_tests.cc
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture_tests.cc
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <string>
 
+#include "donner/base/tests/EnvironmentCapabilityGate.h"
 #include "donner/base/tests/TestTempDir.h"
 
 namespace donner::svg {
@@ -51,9 +52,8 @@ TEST(ImageComparisonTestFixtureTests, ResolvesSymlinkedRunfilesRootToCanonicalDo
 
   std::error_code error;
   std::filesystem::create_directory_symlink(canonicalRoot, runfilesRoot, error);
-  if (error) {
-    GTEST_SKIP() << "Could not create test symlink: " << error.message();
-  }
+  DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(error ? error.message() : std::string(),
+                                        "the ability to create filesystem symlinks");
 
   EXPECT_EQ(ResolveRunfilesResourceRootForTesting(runfilesRoot, runfilesRoot / "document.svg"),
             canonicalRoot);

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -283,6 +283,13 @@ donner_cc_test(
         "tests/NullResourceLoader_tests.cc",
         "tests/SandboxedFileResourceLoader_tests.cc",
     ],
+    # Bazel scrubs the test environment, so the automated-lane markers have to be named here or
+    # the symlink-escape fail-closed rule can never see one and the case keeps skipping into a
+    # green report.
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
     # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
     # wrappers run automatically under `bazel test //...`.
     variants = [
@@ -293,6 +300,7 @@ donner_cc_test(
     deps = [
         ":resource_loader_interface",
         ":sandboxed_file_resource_loader",
+        "//donner/base:base_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
+++ b/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
@@ -5,6 +5,8 @@
 
 #include <fstream>
 
+#include "donner/base/tests/EnvironmentCapabilityGate.h"
+
 #ifndef _WIN32
 #include <sys/stat.h>
 #endif
@@ -138,9 +140,8 @@ TEST_F(SandboxedFileResourceLoaderTests, RejectsSymlinkThatEscapesRoot) {
   createTestFileUnder(secondaryDir_, "secret.txt");
   std::error_code error;
   std::filesystem::create_directory_symlink(secondaryDir_, root_ / "escape", error);
-  if (error) {
-    GTEST_SKIP() << "Could not create test symlink: " << error.message();
-  }
+  DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(error ? error.message() : std::string(),
+                                        "the ability to create filesystem symlinks");
 
   SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
   EXPECT_THAT(loader.fetchExternalResource("escape/secret.txt"),


### PR DESCRIPTION
Three security-relevant tests (symlink-escape rejection in the sandboxed file loader, symlinked-runfiles-root resolution in the image comparison fixture, and symlink-destination rejection in document save) silently skipped whenever `std::filesystem::create_symlink` failed, and gtest reports a run whose every case skipped as a pass. On a developer machine without symlink-creation permission that skip is correct; on an automated lane it hides the very protection each case exists to check.

This adds `DONNER_REQUIRE_ENVIRONMENT_CAPABILITY(condition, capabilityLabel)` in `donner/base/tests/EnvironmentCapabilityGate.h`, matching the shape of the existing device and tool gates: skip visibly on a developer machine, fail closed naming the capability and the automated-lane marker otherwise. It is wired into the three symlink-dependent skips, with `env_inherit` on each target so Bazel's environment scrubbing does not defeat the marker check, and ships a test suite for the gate itself, including a case that catches a mutant collapsing the fail-closed branch onto the skip branch. The compile-time `O_NOFOLLOW` skip in the document-save tests is a platform macro check, not an environment probe, and is unchanged.

The automated-lane markers themselves now have one definition. `donner/base/tests/ContinuousIntegrationMarkers.h` holds the list, the lookup returning the first marker set, and the running-under-CI predicate, with its own tests; the frozen-baseline policy delegates to it with its public declarations unchanged, and this gate consumes it, so a marker cannot be added or dropped in one place without the other noticing: removing one from the list turns a policy test and a gate test red together.

Verification: with symlink creation forced to fail, the three targets fail closed under the automated-lane marker (exit 3) and skip visibly without it, and the marker reaches the test through `env_inherit` alone, proven by exporting it in the shell with no test-env flag; unforced runs on the remote-execution config show all three cases running, so the sandbox can create symlinks and the real symlink-escape, resolution, and rejection logic is exercised. `bazel test` across the affected packages plus the base and baseline test suites, `tools/lint.sh`, `clang-format`, and `buildifier` are green.
