### PR TITLE
Keep canvas shortcuts out of active Inspector inputs

### DIFF
--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2603,6 +2603,36 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   }
 }
 
+void EditorShell::handleFileShortcuts(bool anyPopupOpen, bool cmd, bool shift) {
+  if (anyPopupOpen || !cmd) {
+    return;
+  }
+
+  if (!shift && ImGui::IsKeyPressed(ImGuiKey_N, /*repeat=*/false)) {
+    cancelSampleThumbnailGeneration();
+    cancelPendingSampleLoad();
+    requestNewDocument();
+  }
+
+  if (ShouldRequestOpenShortcut(options_.allowFileSystemActions, anyPopupOpen, cmd, shift,
+                                ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false))) {
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+  }
+
+  if (!shift && ImGui::IsKeyPressed(ImGuiKey_Q, /*repeat=*/false)) {
+    glfwSetWindowShouldClose(window_.rawHandle(), GLFW_TRUE);
+  }
+
+  if (ShouldRequestSaveShortcut(options_.allowFileSystemActions, anyPopupOpen, cmd,
+                                ImGui::IsKeyPressed(ImGuiKey_S, /*repeat=*/false))) {
+    if (shift) {
+      requestSaveAs();
+    } else {
+      requestSave();
+    }
+  }
+}
+
 void EditorShell::handleGlobalShortcuts() {
   const bool anyPopupOpen = ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
   const bool cmd = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
@@ -2624,29 +2654,7 @@ void EditorShell::handleGlobalShortcuts() {
     return;
   }
 
-  if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_N, /*repeat=*/false)) {
-    cancelSampleThumbnailGeneration();
-    cancelPendingSampleLoad();
-    requestNewDocument();
-  }
-
-  if (ShouldRequestOpenShortcut(options_.allowFileSystemActions, anyPopupOpen, cmd, shift,
-                                ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false))) {
-    dialogPresenter_.requestOpenFile(app_.currentFilePath());
-  }
-
-  if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_Q, /*repeat=*/false)) {
-    glfwSetWindowShouldClose(window_.rawHandle(), GLFW_TRUE);
-  }
-
-  if (ShouldRequestSaveShortcut(options_.allowFileSystemActions, anyPopupOpen, cmd,
-                                ImGui::IsKeyPressed(ImGuiKey_S, /*repeat=*/false))) {
-    if (shift) {
-      requestSaveAs();
-    } else {
-      requestSave();
-    }
-  }
+  handleFileShortcuts(anyPopupOpen, cmd, shift);
 
   // Active inspector fields own editing shortcuts, including select-all, clipboard, and undo.
   if (ImGui::GetIO().WantTextInput && !sourcePaneFocused) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2648,6 +2648,11 @@ void EditorShell::handleGlobalShortcuts() {
     }
   }
 
+  // Active inspector fields own editing shortcuts, including select-all, clipboard, and undo.
+  if (ImGui::GetIO().WantTextInput && !sourcePaneFocused) {
+    return;
+  }
+
   if (!sourcePaneFocused) {
     if (pressedZ && cmd && !shift) {
       requestHistoryAction(HistoryAction::Undo);

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -407,6 +407,7 @@ private:
   /// input and presentation passes.
   [[nodiscard]] bool formatBarShouldShow() const;
   void handleGlobalShortcuts();
+  void handleFileShortcuts(bool anyPopupOpen, bool cmd, bool shift);
   /// True when the document has at least one selectable element (the canonical marquee/Select-All
   /// set). Gates whether Cmd+A / the Edit menu's "Select All" act on the canvas.
   [[nodiscard]] bool canvasHasSelectableElements();

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -1548,7 +1548,7 @@ bool WaitForStyleSourceDecorations(EditorShell& shell) {
 }
 
 void DriveGlobalShortcut(EditorShell& shell, const std::vector<ImGuiKey>& keys, bool ctrl = false,
-                         bool shift = false, bool super = false) {
+                         bool shift = false, bool super = false, bool textInputActive = false) {
   ImGuiIO& io = ImGui::GetIO();
   io.DisplaySize = ImVec2(640.0f, 480.0f);
   io.ConfigMacOSXBehaviors = false;
@@ -1569,6 +1569,9 @@ void DriveGlobalShortcut(EditorShell& shell, const std::vector<ImGuiKey>& keys, 
   }
 
   ImGui::NewFrame();
+  if (textInputActive) {
+    io.WantTextInput = true;
+  }
   EditorShellTestAccess::HandleGlobalShortcuts(shell);
   ImGui::Render();
 
@@ -3886,6 +3889,25 @@ TEST(EditorShellTest, SelectAllCanvasAndTextSelectionPreconditions) {
   EXPECT_FALSE(EditorShellTestAccess::CanvasHasSelectableElements(invalidShell));
   EditorShellTestAccess::SelectAllCanvasElements(invalidShell);
   EXPECT_TRUE(EditorShellTestAccess::App(invalidShell).selectedElements().empty());
+}
+
+TEST(EditorShellTest, InspectorTextInputKeepsSelectAllFromChangingCanvasSelection) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorApp& app = EditorShellTestAccess::App(shell);
+  const auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  app.setSelection(*target);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_A}, /*ctrl=*/false, /*shift=*/false, /*super=*/true,
+                      /*textInputActive=*/true);
+
+  ASSERT_THAT(app.selectedElements(), testing::SizeIs(1));
+  EXPECT_THAT(app.selectedElement()->id(), testing::Eq("target"));
 }
 
 TEST(EditorShellTest, ConvertSelectedTextToOutlinesGuardsNonTextSelection) {

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -1562,6 +1562,7 @@ TEST(EditorControlSessionTest, InspectorTextInputReplay) {
   replay.metadata.windowWidth = 1100;
   replay.metadata.windowHeight = 720;
   replay.metadata.displayScale = 1.0;
+  const int selectAllModifiers = ImGuiIO{}.ConfigMacOSXBehaviors ? (1 << 3) : (1 << 0);
   for (std::uint64_t index = 0; index <= 44; ++index) {
     repro::ReproFrame frame;
     frame.index = index;
@@ -1579,7 +1580,7 @@ TEST(EditorControlSessionTest, InspectorTextInputReplay) {
     } else if (index == 11 || index == 22 || index == 24) {
       frame.events.push_back({.kind = repro::ReproEvent::Kind::MouseUp});
     } else if (index == 28) {
-      frame.modifiers = 1 << 3;
+      frame.modifiers = selectAllModifiers;
       frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyDown, .key = ImGuiKey_A});
     } else if (index == 29) {
       frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyUp, .key = ImGuiKey_A});

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -16,6 +16,7 @@
 
 #include "donner/base/tests/RunfileGate.h"
 #include "donner/base/tests/TestTempDir.h"
+#include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/repro/ReplayResourceBudget.h"
 #include "donner/editor/repro/ReproFile.h"
 #include "donner/editor/tests/BitmapGoldenCompare.h"
@@ -1548,6 +1549,80 @@ TEST(EditorControlSessionTest, BoundsCaptureItemsAndBytesBeforeEncoding) {
   EXPECT_EQ(AttachPngBytes(&byteLimited, "oversized", oversizedPng, false, &byteMetadata), -1);
   EXPECT_TRUE(byteLimited.captureBudgetExceeded);
   EXPECT_TRUE(byteLimited.images.empty());
+}
+
+TEST(EditorControlSessionTest, InspectorTextInputReplay) {
+  repro::ReproFile replay;
+  replay.metadata.svgPath = "inspector.svg";
+  replay.metadata.svgSource =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400">
+<rect id="target" x="32" y="32" width="180" height="120" fill="#2563eb"/>
+<rect id="other" x="300" y="32" width="80" height="80" fill="#f97316"/>
+</svg>)svg";
+  replay.metadata.windowWidth = 1100;
+  replay.metadata.windowHeight = 720;
+  replay.metadata.displayScale = 1.0;
+  for (std::uint64_t index = 0; index <= 44; ++index) {
+    repro::ReproFrame frame;
+    frame.index = index;
+    frame.timestampSeconds = static_cast<double>(index) / 60.0;
+    frame.deltaMs = 1000.0 / 60.0;
+    frame.mouseX = 200;
+    frame.mouseY = 240;
+    if (index >= 21) {
+      frame.mouseX = 868;
+      frame.mouseY = 375;
+    }
+    if (index == 10 || index == 21 || index == 23) {
+      frame.mouseButtonMask = 1;
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::MouseDown});
+    } else if (index == 11 || index == 22 || index == 24) {
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::MouseUp});
+    } else if (index == 28) {
+      frame.modifiers = 1 << 3;
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyDown, .key = ImGuiKey_A});
+    } else if (index == 29) {
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyUp, .key = ImGuiKey_A});
+    } else if (index == 30 || index == 31) {
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::Char,
+                              .codepoint = static_cast<std::uint32_t>(index == 30 ? '6' : '4')});
+    } else if (index == 32) {
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyDown, .key = ImGuiKey_Enter});
+    } else if (index == 33) {
+      frame.events.push_back({.kind = repro::ReproEvent::Kind::KeyUp, .key = ImGuiKey_Enter});
+    }
+    replay.frames.push_back(std::move(frame));
+  }
+  const std::filesystem::path rnrPath = TestScratchDir() / "inspector_input.rnr";
+  ASSERT_EQ(repro::WriteReproFile(rnrPath, replay), true);
+  EditorControlSession session;
+  const ToolCallResult result =
+      session.handleToolCall("replay_rnr", json{{"rnr_path", rnrPath.string()},
+                                                {"gl_readback", true},
+                                                {"gl_capture_frame", 44},
+                                                {"gl_pace", true},
+                                                {"gl_timeout_ms", 5000},
+                                                {"include_gl_images", false}});
+  ASSERT_EQ(result.isError, false) << result.body.dump(2);
+  EXPECT_EQ(result.body.value("capture_count", 0), 1) << result.body.dump(2);
+
+  repro::GlRnrReplayOptions options;
+  options.rnrPath = rnrPath;
+  options.captureFrames = {44};
+  options.outputDir = TestScratchDir();
+  repro::GlRnrReplayResult replayResult;
+  std::string error;
+  ASSERT_EQ(repro::RunGlRnrReplay(options, &replayResult, &error), true) << error;
+  ASSERT_THAT(replayResult.finalDocumentSource, ::testing::Optional(::testing::_));
+  const ToolCallResult load = session.handleToolCall(
+      "load_svg",
+      json{{"svg_source", *replayResult.finalDocumentSource}, {"render_after_load", false}});
+  ASSERT_EQ(load.isError, false) << load.body.dump(2);
+  const ToolCallResult selection = session.handleToolCall(
+      "select_by_selector", json{{"selector", "#target"}, {"render", false}});
+  ASSERT_EQ(selection.isError, false) << selection.body.dump(2);
+  EXPECT_THAT(selection.body.at("selection_bounds_doc").at("top_left"),
+              ::testing::Eq(json{{"x", 64.0}, {"y", 32.0}}));
 }
 
 TEST(EditorControlSessionTest, RejectsExcessiveGlReplayTimeoutBeforeLaunchingHelper) {


### PR DESCRIPTION
Command/Ctrl+A while editing an Inspector value selected canvas elements instead of the field's text. Keep canvas editing shortcuts from consuming keys owned by text inputs, while preserving file shortcuts.

Add coverage through the shortcut handler and an editor-control replay that changes X from 32 to 64 and checks the resulting document geometry. Extract file-shortcut handling into a small helper to keep the routing readable.

Validation: the full repository test gate passes (479 targets passed; 30 platform/configuration skips), including the EditorShell and editor-control suites. The same recorded interaction fails before the fix and passes afterward. CMake generator validation, formatting, and scoped lint pass.
