### PR TITLE
Preserve native GPU upload and resource ordering

### DIFF
--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -423,7 +423,16 @@ void Device::recycleRetiredSlot(ResourceKind kind, uint32_t slotIndex) {
   }
 }
 
+void Device::onRetireBuffer(uint32_t) {}
+
+void Device::onRetireTexture(uint32_t) {}
+
 void Device::retireResource(ResourceKind kind, uint32_t slotIndex, uint64_t lastUseSerial) {
+  if (kind == ResourceKind::Buffer) {
+    onRetireBuffer(slotIndex);
+  } else if (kind == ResourceKind::Texture) {
+    onRetireTexture(slotIndex);
+  }
   if (lastUseSerial <= completedSerial()) {
     recycleRetiredSlot(kind, slotIndex);
   } else {

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1840,6 +1840,14 @@ void Device::markSubmissionUses(std::span<const SubmissionUse> uses, uint64_t su
   }
 }
 
+uint64_t Device::bufferLastUseSerial(uint32_t slotIndex) const {
+  return buffers_.lastUseOf(slotIndex);
+}
+
+uint64_t Device::textureLastUseSerial(uint32_t slotIndex) const {
+  return textures_.lastUseOf(slotIndex);
+}
+
 Status Device::validateBufferHandleForBackend(const Buffer& buffer) const {
   auto record = resolve(buffers_, buffer, BufferTag::kName);
   if (record.hasError()) {

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -581,7 +581,15 @@ protected:
   virtual Status onCreateComputePipeline(uint32_t slotIndex,
                                          const ComputePipelineDescriptor& descriptor) = 0;
 
-  /// Backend hook: a validated resource was destroyed.
+  /// Backend hook: a buffer handle was retired. Discard unsubmitted work, but keep native
+  /// resources alive until \ref onDestroyResource. @param slotIndex Retired buffer slot.
+  virtual void onRetireBuffer(uint32_t slotIndex);
+
+  /// Backend hook: a texture handle was retired. Discard unsubmitted work, but keep native
+  /// resources alive until \ref onDestroyResource. @param slotIndex Retired texture slot.
+  virtual void onRetireTexture(uint32_t slotIndex);
+
+  /// Backend hook: a retired resource is no longer used by submitted work and can be released.
   /// @param resourceName Resource type name, e.g. `"buffer"`.
   /// @param slotIndex Slot index of the destroyed resource.
   virtual void onDestroyResource(std::string_view resourceName, uint32_t slotIndex) = 0;

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -534,6 +534,14 @@ protected:
   /// Constructor for backends; assigns the process-unique device identity.
   Device();
 
+  /// Last accepted submission referencing a buffer slot already validated by the caller.
+  /// @param slotIndex A validated live buffer slot.
+  uint64_t bufferLastUseSerial(uint32_t slotIndex) const;
+
+  /// Last accepted submission referencing a texture slot already validated by the caller.
+  /// @param slotIndex A validated live texture slot.
+  uint64_t textureLastUseSerial(uint32_t slotIndex) const;
+
   /// Backend hook: a buffer passed validation and occupies \p slotIndex.
   /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
   virtual Status onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) = 0;

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -36,8 +36,10 @@ namespace donner::gpu::metal {
  * allocation and no queue submission; Metal retains the staging buffer and destinations until
  * completion. Queued and in-flight uploads share a configurable byte budget, defaulting to
  * \ref kMaxBufferByteSize; at most 16,384 writes may await submission. Excess writes return
- * `LimitExceeded` without changing the batch. The budget counts logical upload bytes; packing
- * temporarily retains both the host payload and native staging buffer. Managed resources may
+ * `LimitExceeded` without changing the batch. The budget counts logical upload bytes, excluding
+ * row and alignment padding. Combined queued and in-flight packed staging also stays within
+ * the larger of this budget and \ref kMaxBufferByteSize. Packing temporarily retains both the
+ * host payload and native staging buffer. Managed resources may
  * have separate host and device backing, so physical RAM/VRAM usage also includes those copies
  * and driver overhead. Destroyed destinations drop unsubmitted writes; completion returns the
  * in-flight byte reservation.
@@ -76,7 +78,7 @@ public:
    *
    * @param memoryModel Which memory model to build resources for; production leaves this
    *   detected, and a test forces the non-unified path to cover it on unified hardware.
-   * @param uploadStagingByteBudget Maximum combined queued and in-flight upload staging bytes.
+   * @param uploadStagingByteBudget Maximum combined queued and in-flight logical payload bytes.
    *   Zero is invalid and returns nullptr. Each individual batch also fits \ref kMaxBufferByteSize.
    * @param unalignedWriteTimeout Maximum CPU wait for an unaligned write to a busy buffer.
    *   Must be between zero and five seconds; invalid budgets return nullptr.
@@ -106,7 +108,7 @@ public:
   /// Snapshot of upload bookkeeping for tests and performance measurements.
   struct WriteStats {
     size_t pendingWrites = 0;             //!< Coalesced writes awaiting a normal submission.
-    uint64_t inFlightStagingBytes = 0;    //!< Upload bytes reserved until GPU completion.
+    uint64_t inFlightStagingBytes = 0;    //!< Packed staging bytes retained until GPU completion.
     uint64_t pendingStagingBytes = 0;     //!< Packed staging bytes reserved for those writes.
     uint64_t stagingAllocations = 0;      //!< Native upload staging allocations attempted.
     uint64_t submittedUploadBatches = 0;  //!< Ordinary submissions containing queued writes.
@@ -182,6 +184,8 @@ protected:
                                 const RenderPipelineDescriptor& descriptor) override;
   Status onCreateComputePipeline(uint32_t slotIndex,
                                  const ComputePipelineDescriptor& descriptor) override;
+  void onRetireBuffer(uint32_t slotIndex) override;
+  void onRetireTexture(uint32_t slotIndex) override;
   void onDestroyResource(std::string_view resourceName, uint32_t slotIndex) override;
   Status onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
                        std::span<const uint8_t> data) override;

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -84,6 +84,13 @@ public:
   /// accessor, for the same reason as above but in the other direction.
   [[nodiscard]] uint64_t deviceWritePublishCountForTest() const;
 
+  /// Pauses submitted GPU work at a shared event until \ref resumeSubmissionsForTest is called.
+  /// A deterministic test seam for writes issued while an earlier submission is in flight.
+  Status pauseSubmissionsForTest();
+
+  /// Releases the event installed by \ref pauseSubmissionsForTest. Safe when no pause is active.
+  void resumeSubmissionsForTest();
+
   /// Destructor; releases all Metal objects still alive.
   ~MetalDevice() override;
 

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -2,12 +2,15 @@
 /// @file
 /// \c donner::gpu::metal::MetalDevice - the Metal backend for the Donner GPU runtime.
 
+#include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "donner/gpu/Device.h"
+#include "donner/gpu/GpuLimits.h"
 
 namespace donner::gpu::metal {
 
@@ -27,15 +30,26 @@ namespace donner::gpu::metal {
  * texture and sampler bindings map directly, and stage-in vertex data occupies vertex buffer
  * index 30.
  *
- * Memory model: the storage mode of host-visible resources follows what the device reports
- * rather than an assumption about it. Where the CPU and GPU address one copy of a resource
- * (`hasUnifiedMemory`), resources are `MTLStorageModeShared` and queue writes (`memcpy` /
- * `replaceRegion`) and buffer readback need no staging and no publication step. Where they do
- * not, resources are `MTLStorageModeManaged` and each side's changes must be published to the
- * other explicitly: a host buffer write publishes its range, and every submission ends by
- * publishing the device's changes back before it completes, since afterwards there is no encoder
- * left to do it with. Neither omission is an API error, so a missing publication is not reported
- * by validation - it shows up only as the host reading whatever its copy last held.
+ * Queue writes update idle resources directly. Writes to resources an earlier submission still
+ * uses are copied into bounded host storage and uploaded at the beginning of the next ordinary
+ * submission. Repeated writes of the same resource range are coalesced. A batch adds one staging
+ * allocation and no queue submission; Metal retains the staging buffer and destinations until
+ * completion. Queued and in-flight uploads share a configurable byte budget, defaulting to
+ * \ref kMaxBufferByteSize; at most 16,384 writes may await submission. Excess writes return
+ * `LimitExceeded` without changing the batch. The budget counts logical upload bytes; packing
+ * temporarily retains both the host payload and native staging buffer. Managed resources may
+ * have separate host and device backing, so physical RAM/VRAM usage also includes those copies
+ * and driver overhead. Destroyed destinations drop unsubmitted writes; completion returns the
+ * in-flight byte reservation.
+ *
+ * macOS buffer blits require four-byte-aligned offsets and sizes. An unaligned update instead
+ * waits at most five seconds for that buffer's last use, returning an error on timeout; it never
+ * waits for unrelated later submissions.
+ *
+ * Memory model: unified-memory resources use `MTLStorageModeShared`; other devices use
+ * `MTLStorageModeManaged`. Managed CPU writes publish their ranges, and every submission
+ * synchronizes its GPU-written buffers before reporting completion to host readers. Textures
+ * reach the CPU through readback buffers, so unrelated buffers and textures need no scan.
  *
  * Threading: single-threaded use, matching \ref donner::gpu::Device's thread affinity. The one
  * exception is command-buffer completion handlers, which Metal invokes on an internal queue;
@@ -62,18 +76,23 @@ public:
    *
    * @param memoryModel Which memory model to build resources for; production leaves this
    *   detected, and a test forces the non-unified path to cover it on unified hardware.
+   * @param uploadStagingByteBudget Maximum combined queued and in-flight upload staging bytes.
+   *   Zero is invalid and returns nullptr. Each individual batch also fits \ref kMaxBufferByteSize.
+   * @param unalignedWriteTimeout Maximum CPU wait for an unaligned write to a busy buffer.
+   *   Must be between zero and five seconds; invalid budgets return nullptr.
    */
-  static std::unique_ptr<MetalDevice> Create(MemoryModel memoryModel = MemoryModel::Detected);
+  static std::unique_ptr<MetalDevice> Create(
+      MemoryModel memoryModel = MemoryModel::Detected,
+      uint64_t uploadStagingByteBudget = kMaxBufferByteSize,
+      std::chrono::milliseconds unalignedWriteTimeout = std::chrono::seconds(5));
 
   /// Whether this device's resources are built for unified memory. Test accessor.
   [[nodiscard]] bool usesUnifiedMemoryForTest() const;
 
   /// How many buffer writes have published their range to the device copy. Test accessor.
   ///
-  /// Counts the buffer path only, where the write is a `memcpy` through the host pointer and the
-  /// range has to be published after it. Texture writes go through `replaceRegion`, which
-  /// publishes what it wrote on its own, so they are deliberately absent from this count rather
-  /// than missing from it.
+  /// Counts CPU-written buffer ranges, including packed staging for buffer or texture uploads.
+  /// Direct texture writes publish through `replaceRegion` and need no buffer-range publication.
   ///
   /// On unified memory nothing is published and this stays zero. The count exists because
   /// hardware that addresses one copy produces correct results whether or not the publication
@@ -83,6 +102,19 @@ public:
   /// How many submissions have published the device's changes back to the host copy. Test
   /// accessor, for the same reason as above but in the other direction.
   [[nodiscard]] uint64_t deviceWritePublishCountForTest() const;
+
+  /// Snapshot of upload bookkeeping for tests and performance measurements.
+  struct WriteStats {
+    size_t pendingWrites = 0;             //!< Coalesced writes awaiting a normal submission.
+    uint64_t inFlightStagingBytes = 0;    //!< Upload bytes reserved until GPU completion.
+    uint64_t pendingStagingBytes = 0;     //!< Packed staging bytes reserved for those writes.
+    uint64_t stagingAllocations = 0;      //!< Native upload staging allocations attempted.
+    uint64_t submittedUploadBatches = 0;  //!< Ordinary submissions containing queued writes.
+    uint64_t unalignedWriteWaits = 0;     //!< Resource waits needed by unaligned buffer writes.
+  };
+
+  /// Current queue-write counters. Does not wait or change device state.
+  WriteStats writeStatsForTest() const;
 
   /// Pauses submitted GPU work at a shared event until \ref resumeSubmissionsForTest is called.
   /// A deterministic test seam for writes issued while an earlier submission is in flight.
@@ -117,7 +149,8 @@ public:
    * Test/readback convenience, pending a buffer mapping API: it validates device identity, slot
    * liveness, and the handle generation, then reads
    * the shared-storage Metal buffer contents directly. Callers must ensure relevant GPU work has
-   * completed first (see \ref waitForSerial).
+   * completed first (see \ref waitForSerial). Queued writes become visible after a subsequent
+   * ordinary submission completes; this accessor does not submit them.
    *
    * @param buffer Buffer to read back; must be a live buffer of this device.
    */

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -185,6 +185,7 @@ MTLPrimitiveType ToMtlPrimitiveType(PrimitiveTopology topology) {
 struct CompletionState {
   std::atomic<uint64_t> completedSerial{0};       //!< Highest completed submission serial.
   std::atomic<uint64_t> inFlightStagingBytes{0};  //!< Accepted uploads awaiting completion.
+  std::atomic<uint64_t> inFlightPayloadBytes{0};  //!< Logical bytes charged to the upload budget.
   std::atomic<bool> hadError{false};  //!< True once any command buffer reported an error.
   std::mutex mutex;                   //!< Guards errorMessage.
   std::string errorMessage;           //!< Message of the first captured execution error.
@@ -245,6 +246,7 @@ struct MetalDevice::Impl {
     uint64_t offsetBytes = 0;
     Extent2d size;
     uint32_t bytesPerRow = 0;
+    uint64_t payloadBytes = 0;
     std::vector<uint8_t> bytes;
   };
 
@@ -254,6 +256,7 @@ struct MetalDevice::Impl {
   uint64_t uploadStagingByteBudget = kMaxBufferByteSize;
   std::chrono::milliseconds unalignedWriteTimeout = std::chrono::seconds(5);
   uint64_t pendingStagingBytes = 0;
+  uint64_t pendingPayloadBytes = 0;
   uint64_t stagingAllocations = 0;
   uint64_t submittedUploadBatches = 0;
   uint64_t unalignedWriteWaits = 0;
@@ -275,26 +278,38 @@ struct MetalDevice::Impl {
              pending.offsetBytes == write.offsetBytes && pending.size == write.size &&
              pending.bytes.size() == byteCount;
     });
-    const uint64_t replacedBytes =
+    const uint64_t replacedStagingBytes =
         previous == pendingWrites.end() ? 0 : StagingSize(previous->bytes.size());
-    const uint64_t queuedBytes = pendingStagingBytes - replacedBytes + StagingSize(byteCount);
-    const uint64_t inFlightBytes =
+    const uint64_t replacedPayloadBytes =
+        previous == pendingWrites.end() ? 0 : previous->payloadBytes;
+    const uint64_t queuedStagingBytes =
+        pendingStagingBytes - replacedStagingBytes + StagingSize(byteCount);
+    const uint64_t queuedPayloadBytes =
+        pendingPayloadBytes - replacedPayloadBytes + write.payloadBytes;
+    const uint64_t inFlightPayloadBytes =
+        completionState->inFlightPayloadBytes.load(std::memory_order_acquire);
+    const uint64_t inFlightStagingBytes =
         completionState->inFlightStagingBytes.load(std::memory_order_acquire);
-    if (queuedBytes > kMaxBufferByteSize || queuedBytes > uploadStagingByteBudget ||
-        inFlightBytes > uploadStagingByteBudget - queuedBytes ||
+    const uint64_t packedBudget = std::max(kMaxBufferByteSize, uploadStagingByteBudget);
+    if (queuedStagingBytes > kMaxBufferByteSize || queuedPayloadBytes > uploadStagingByteBudget ||
+        inFlightPayloadBytes > uploadStagingByteBudget - queuedPayloadBytes ||
+        inFlightStagingBytes > packedBudget - queuedStagingBytes ||
         (previous == pendingWrites.end() && pendingWrites.size() >= 16'384)) {
       return GpuError{
           GpuErrorType::LimitExceeded,
-          std::format("Metal upload budget exceeded: {} queued bytes, {} in-flight "
-                      "bytes, {} byte budget, {} pending writes",
-                      queuedBytes, inFlightBytes, uploadStagingByteBudget, pendingWrites.size())};
+          std::format(
+              "Metal upload budget exceeded: {} queued / {} in-flight payload bytes "
+              "(limit {}), {} queued / {} in-flight packed bytes (limit {}), {} pending writes",
+              queuedPayloadBytes, inFlightPayloadBytes, uploadStagingByteBudget, queuedStagingBytes,
+              inFlightStagingBytes, packedBudget, pendingWrites.size())};
     }
     if (previous != pendingWrites.end()) {
       write.bytes = std::move(previous->bytes);
       pendingWrites.erase(previous);
     }
     write.bytes.resize(byteCount);
-    pendingStagingBytes = pendingStagingBytes - replacedBytes + StagingSize(byteCount);
+    pendingStagingBytes = queuedStagingBytes;
+    pendingPayloadBytes = queuedPayloadBytes;
     pendingWrites.push_back(std::move(write));
     return &pendingWrites.back();
   }
@@ -305,6 +320,7 @@ struct MetalDevice::Impl {
         return false;
       }
       pendingStagingBytes -= StagingSize(write.bytes.size());
+      pendingPayloadBytes -= write.payloadBytes;
       return true;
     });
   }
@@ -875,14 +891,20 @@ Status MetalDevice::onCreateComputePipeline(uint32_t slotIndex,
   return OkStatus();
 }
 
+void MetalDevice::onRetireBuffer(uint32_t slotIndex) {
+  impl_->discardPendingWrites(GetSlot(impl_->buffers, slotIndex), nil);
+}
+
+void MetalDevice::onRetireTexture(uint32_t slotIndex) {
+  impl_->discardPendingWrites(nil, GetSlot(impl_->textures, slotIndex));
+}
+
 void MetalDevice::onDestroyResource(std::string_view resourceName, uint32_t slotIndex) {
   // Clearing a slot to nil / nullopt releases the ObjC object under ARC. Unknown resource names
   // are ignored; the base class owns their bookkeeping.
   if (resourceName == "buffer") {
-    impl_->discardPendingWrites(GetSlot(impl_->buffers, slotIndex), nil);
     SetSlot(impl_->buffers, slotIndex, id<MTLBuffer>(nil));
   } else if (resourceName == "texture") {
-    impl_->discardPendingWrites(nil, GetSlot(impl_->textures, slotIndex));
     SetSlot(impl_->textures, slotIndex, id<MTLTexture>(nil));
   } else if (resourceName == "textureView") {
     SetSlot(impl_->textureViewToTexture, slotIndex, std::optional<uint32_t>());
@@ -936,9 +958,11 @@ Status MetalDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
       std::max(bufferLastUseSerial(slotIndex), GetSlot(impl_->bufferUploadSerials, slotIndex));
   if (lastUse > completedSerial() || impl_->hasPendingWrite(buffer, nil)) {
     if (offsetBytes % 4 == 0 && data.size() % 4 == 0) {
-      auto queued = impl_->queueWrite(
-          Impl::PendingWrite{.slotIndex = slotIndex, .buffer = buffer, .offsetBytes = offsetBytes},
-          data.size());
+      auto queued = impl_->queueWrite(Impl::PendingWrite{.slotIndex = slotIndex,
+                                                         .buffer = buffer,
+                                                         .offsetBytes = offsetBytes,
+                                                         .payloadBytes = data.size()},
+                                      data.size());
       if (queued.hasError()) {
         return std::move(queued).error();
       }
@@ -975,10 +999,13 @@ Status MetalDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> 
     const uint32_t texelBytes = texture.pixelFormat == MTLPixelFormatR8Unorm ? 1 : 4;
     const uint32_t rowBytes = writeSize.width * texelBytes;
     const uint32_t rowPitch = static_cast<uint32_t>(Impl::StagingSize(rowBytes));
-    auto queued = impl_->queueWrite(
-        Impl::PendingWrite{
-            .slotIndex = slotIndex, .texture = texture, .size = writeSize, .bytesPerRow = rowPitch},
-        uint64_t{rowPitch} * writeSize.height);
+    auto queued =
+        impl_->queueWrite(Impl::PendingWrite{.slotIndex = slotIndex,
+                                             .texture = texture,
+                                             .size = writeSize,
+                                             .bytesPerRow = rowPitch,
+                                             .payloadBytes = uint64_t{rowBytes} * writeSize.height},
+                          uint64_t{rowPitch} * writeSize.height);
     if (queued.hasError()) {
       return std::move(queued).error();
     }
@@ -1401,7 +1428,9 @@ Status MetalDevice::Impl::encodeCommand(EncodingState& state, const Command& com
 void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t submissionSerial) {
   std::shared_ptr<CompletionState> sharedState = completionState;
   const uint64_t uploadBytes = pendingStagingBytes;
+  const uint64_t payloadBytes = pendingPayloadBytes;
   sharedState->inFlightStagingBytes.fetch_add(uploadBytes, std::memory_order_relaxed);
+  sharedState->inFlightPayloadBytes.fetch_add(payloadBytes, std::memory_order_relaxed);
   [state.commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> completedBuffer) {
     if (completedBuffer.error != nil) {
       sharedState->hadError.store(true, std::memory_order_release);
@@ -1414,6 +1443,7 @@ void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t s
 
     // Make the reservation available before a completion waiter observes this serial.
     sharedState->inFlightStagingBytes.fetch_sub(uploadBytes, std::memory_order_release);
+    sharedState->inFlightPayloadBytes.fetch_sub(payloadBytes, std::memory_order_release);
 
     // Monotonic max: handlers may complete out of order across command buffers.
     uint64_t previous = sharedState->completedSerial.load(std::memory_order_relaxed);
@@ -1528,6 +1558,7 @@ void MetalDevice::Impl::didSubmitWrites(uint64_t submissionSerial) {
     ++submittedUploadBatches;
     pendingWrites.clear();
     pendingStagingBytes = 0;
+    pendingPayloadBytes = 0;
   }
 }
 

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -7,6 +7,7 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -19,6 +20,7 @@
 #include <vector>
 
 #include "donner/base/Utils.h"
+#include "donner/gpu/GpuLimits.h"
 #include "donner/gpu/metal/MetalDevice.h"
 #include "donner/gpu/shader/MslBindingMap.h"
 
@@ -181,10 +183,11 @@ MTLPrimitiveType ToMtlPrimitiveType(PrimitiveTopology topology) {
 /// State shared with Metal command-buffer completion handlers, which run on a Metal-internal
 /// thread. Held by shared_ptr so a handler that outlives the device touches valid memory.
 struct CompletionState {
-  std::atomic<uint64_t> completedSerial{0};  //!< Highest completed submission serial.
-  std::atomic<bool> hadError{false};         //!< True once any command buffer reported an error.
-  std::mutex mutex;                          //!< Guards errorMessage.
-  std::string errorMessage;                  //!< Message of the first captured execution error.
+  std::atomic<uint64_t> completedSerial{0};       //!< Highest completed submission serial.
+  std::atomic<uint64_t> inFlightStagingBytes{0};  //!< Accepted uploads awaiting completion.
+  std::atomic<bool> hadError{false};  //!< True once any command buffer reported an error.
+  std::mutex mutex;                   //!< Guards errorMessage.
+  std::string errorMessage;           //!< Message of the first captured execution error.
 };
 
 }  // namespace
@@ -234,6 +237,78 @@ struct MetalDevice::Impl {
   std::shared_ptr<CompletionState> completionState =
       std::make_shared<CompletionState>();  //!< Shared with completion handlers.
 
+  /// A host write waiting for the queue, retaining its exact native destination.
+  struct PendingWrite {
+    uint32_t slotIndex = 0;
+    id<MTLBuffer> buffer = nil;
+    id<MTLTexture> texture = nil;
+    uint64_t offsetBytes = 0;
+    Extent2d size;
+    uint32_t bytesPerRow = 0;
+    std::vector<uint8_t> bytes;
+  };
+
+  std::vector<PendingWrite> pendingWrites;
+  std::vector<uint64_t> bufferUploadSerials;
+  std::vector<uint64_t> textureUploadSerials;
+  uint64_t uploadStagingByteBudget = kMaxBufferByteSize;
+  std::chrono::milliseconds unalignedWriteTimeout = std::chrono::seconds(5);
+  uint64_t pendingStagingBytes = 0;
+  uint64_t stagingAllocations = 0;
+  uint64_t submittedUploadBatches = 0;
+  uint64_t unalignedWriteWaits = 0;
+
+  static constexpr uint64_t StagingSize(uint64_t byteCount) {
+    return (byteCount + 255u) & ~uint64_t{255};
+  }
+
+  bool hasPendingWrite(id<MTLBuffer> buffer, id<MTLTexture> texture) const {
+    return std::ranges::any_of(pendingWrites, [&](const PendingWrite& write) {
+      return write.buffer == buffer && write.texture == texture;
+    });
+  }
+
+  /// Reuses an identical destination range while keeping the newest write last in queue order.
+  Result<PendingWrite*> queueWrite(PendingWrite write, size_t byteCount) {
+    const auto previous = std::ranges::find_if(pendingWrites, [&](const PendingWrite& pending) {
+      return pending.buffer == write.buffer && pending.texture == write.texture &&
+             pending.offsetBytes == write.offsetBytes && pending.size == write.size &&
+             pending.bytes.size() == byteCount;
+    });
+    const uint64_t replacedBytes =
+        previous == pendingWrites.end() ? 0 : StagingSize(previous->bytes.size());
+    const uint64_t queuedBytes = pendingStagingBytes - replacedBytes + StagingSize(byteCount);
+    const uint64_t inFlightBytes =
+        completionState->inFlightStagingBytes.load(std::memory_order_acquire);
+    if (queuedBytes > kMaxBufferByteSize || queuedBytes > uploadStagingByteBudget ||
+        inFlightBytes > uploadStagingByteBudget - queuedBytes ||
+        (previous == pendingWrites.end() && pendingWrites.size() >= 16'384)) {
+      return GpuError{
+          GpuErrorType::LimitExceeded,
+          std::format("Metal upload budget exceeded: {} queued bytes, {} in-flight "
+                      "bytes, {} byte budget, {} pending writes",
+                      queuedBytes, inFlightBytes, uploadStagingByteBudget, pendingWrites.size())};
+    }
+    if (previous != pendingWrites.end()) {
+      write.bytes = std::move(previous->bytes);
+      pendingWrites.erase(previous);
+    }
+    write.bytes.resize(byteCount);
+    pendingStagingBytes = pendingStagingBytes - replacedBytes + StagingSize(byteCount);
+    pendingWrites.push_back(std::move(write));
+    return &pendingWrites.back();
+  }
+
+  void discardPendingWrites(id<MTLBuffer> buffer, id<MTLTexture> texture) {
+    std::erase_if(pendingWrites, [&](const PendingWrite& write) {
+      if (write.buffer != buffer || write.texture != texture) {
+        return false;
+      }
+      pendingStagingBytes -= StagingSize(write.bytes.size());
+      return true;
+    });
+  }
+
   /// Mutable state threaded through the encoding of one command stream.
   struct EncodingState {
     id<MTLCommandBuffer> commandBuffer = nil;           //!< Command buffer being encoded.
@@ -244,6 +319,7 @@ struct MetalDevice::Impl {
     PrimitiveTopology currentTopology = PrimitiveTopology::TriangleList;
     /// Threadgroup shape of the bound compute pipeline, applied at dispatch.
     WorkgroupSize currentWorkgroupSize;
+    std::vector<id<MTLBuffer>> hostReadBuffers;  //!< GPU-written buffers needing CPU visibility.
   };
 
   /// Opens a render encoder for a recorded pass and configures its color attachments.
@@ -379,13 +455,36 @@ struct MetalDevice::Impl {
   /// Whether host-visible resources need explicit publication in both directions.
   bool needsExplicitHostCoherency() const { return !unifiedMemory; }
 
-  /// Publishes every live host-visible resource's device-side changes back to the host copy, for
-  /// a memory model that keeps the two apart. A no-op where the two are one copy.
+  /// Records a GPU-written buffer whose host copy must be current after completion.
+  void requireHostSync(EncodingState& state, id<MTLBuffer> buffer);
+
+  /// Publishes the GPU-written buffers needed by the host, once per distinct buffer.
   /// @param state Encoding state.
   Status encodeHostCoherencySync(EncodingState& state);
+
+  /// Encodes all queued writes ahead of this submission without submitting separate work.
+  Status encodePendingWrites(EncodingState& state);
+
+  /// Creates a command buffer and encodes its optional pause and queued uploads.
+  Status beginSubmission(EncodingState& state);
+
+  /// Copies host bytes into an idle buffer and publishes managed-memory changes.
+  void writeIdleBuffer(id<MTLBuffer> buffer, uint64_t offsetBytes, std::span<const uint8_t> bytes);
+
+  /// Applies queued writes after this buffer's GPU uses have completed.
+  void flushIdleBufferWrites(id<MTLBuffer> buffer);
+
+  /// Records upload-only resource uses and consumes a successfully submitted upload batch.
+  void didSubmitWrites(uint64_t submissionSerial);
 };
 
-std::unique_ptr<MetalDevice> MetalDevice::Create(MemoryModel memoryModel) {
+std::unique_ptr<MetalDevice> MetalDevice::Create(MemoryModel memoryModel,
+                                                 uint64_t uploadStagingByteBudget,
+                                                 std::chrono::milliseconds unalignedWriteTimeout) {
+  if (uploadStagingByteBudget == 0 || unalignedWriteTimeout < std::chrono::milliseconds::zero() ||
+      unalignedWriteTimeout > std::chrono::seconds(5)) {
+    return nullptr;
+  }
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   if (device == nil) {
     return nullptr;
@@ -393,6 +492,8 @@ std::unique_ptr<MetalDevice> MetalDevice::Create(MemoryModel memoryModel) {
 
   std::unique_ptr<MetalDevice> result(new MetalDevice());
   result->impl_->device = device;
+  result->impl_->uploadStagingByteBudget = uploadStagingByteBudget;
+  result->impl_->unalignedWriteTimeout = unalignedWriteTimeout;
   // Ask the device rather than assuming. On a unified-memory device the CPU and GPU address one
   // copy of a shared resource and nothing has to be moved between them; on a device without it,
   // a shared resource is not the same bytes on both sides, and reading GPU output through the
@@ -416,6 +517,15 @@ uint64_t MetalDevice::deviceWritePublishCountForTest() const {
 }
 
 MetalDevice::MetalDevice() : impl_(std::make_unique<Impl>()) {}
+
+MetalDevice::WriteStats MetalDevice::writeStatsForTest() const {
+  return WriteStats{impl_->pendingWrites.size(),
+                    impl_->completionState->inFlightStagingBytes.load(std::memory_order_acquire),
+                    impl_->pendingStagingBytes,
+                    impl_->stagingAllocations,
+                    impl_->submittedUploadBatches,
+                    impl_->unalignedWriteWaits};
+}
 
 Status MetalDevice::pauseSubmissionsForTest() {
   if (impl_->submissionGate != nil) {
@@ -510,6 +620,7 @@ Status MetalDevice::onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& d
   }
 
   SetSlot(impl_->buffers, slotIndex, buffer);
+  SetSlot(impl_->bufferUploadSerials, slotIndex, uint64_t{0});
   return OkStatus();
 }
 
@@ -545,6 +656,7 @@ Status MetalDevice::onCreateTexture(uint32_t slotIndex, const TextureDescriptor&
   }
 
   SetSlot(impl_->textures, slotIndex, texture);
+  SetSlot(impl_->textureUploadSerials, slotIndex, uint64_t{0});
   return OkStatus();
 }
 
@@ -767,8 +879,10 @@ void MetalDevice::onDestroyResource(std::string_view resourceName, uint32_t slot
   // Clearing a slot to nil / nullopt releases the ObjC object under ARC. Unknown resource names
   // are ignored; the base class owns their bookkeeping.
   if (resourceName == "buffer") {
+    impl_->discardPendingWrites(GetSlot(impl_->buffers, slotIndex), nil);
     SetSlot(impl_->buffers, slotIndex, id<MTLBuffer>(nil));
   } else if (resourceName == "texture") {
+    impl_->discardPendingWrites(nil, GetSlot(impl_->textures, slotIndex));
     SetSlot(impl_->textures, slotIndex, id<MTLTexture>(nil));
   } else if (resourceName == "textureView") {
     SetSlot(impl_->textureViewToTexture, slotIndex, std::optional<uint32_t>());
@@ -789,6 +903,24 @@ void MetalDevice::onDestroyResource(std::string_view resourceName, uint32_t slot
   }
 }
 
+void MetalDevice::Impl::writeIdleBuffer(id<MTLBuffer> buffer, uint64_t offsetBytes,
+                                        std::span<const uint8_t> bytes) {
+  std::memcpy(static_cast<uint8_t*>(buffer.contents) + offsetBytes, bytes.data(), bytes.size());
+  if (needsExplicitHostCoherency()) {
+    [buffer didModifyRange:NSMakeRange(offsetBytes, bytes.size())];
+    ++hostWritePublishCount;
+  }
+}
+
+void MetalDevice::Impl::flushIdleBufferWrites(id<MTLBuffer> buffer) {
+  for (const PendingWrite& pending : pendingWrites) {
+    if (pending.buffer == buffer) {
+      writeIdleBuffer(buffer, pending.offsetBytes, pending.bytes);
+    }
+  }
+  discardPendingWrites(buffer, nil);
+}
+
 Status MetalDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
                                   std::span<const uint8_t> data) {
   id<MTLBuffer> buffer = GetSlot(impl_->buffers, slotIndex);
@@ -797,15 +929,34 @@ Status MetalDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
                     std::format("buffer slot {} has no Metal buffer", slotIndex)};
   }
 
-  if (!data.empty()) {
-    std::memcpy(static_cast<uint8_t*>(buffer.contents) + offsetBytes, data.data(), data.size());
-    if (impl_->needsExplicitHostCoherency()) {
-      // The write landed in the host's copy; the GPU reads its own until the range is published.
-      [buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(offsetBytes),
-                                         static_cast<NSUInteger>(data.size()))];
-      ++impl_->hostWritePublishCount;
-    }
+  if (data.empty()) {
+    return OkStatus();
   }
+  const uint64_t lastUse =
+      std::max(bufferLastUseSerial(slotIndex), GetSlot(impl_->bufferUploadSerials, slotIndex));
+  if (lastUse > completedSerial() || impl_->hasPendingWrite(buffer, nil)) {
+    if (offsetBytes % 4 == 0 && data.size() % 4 == 0) {
+      auto queued = impl_->queueWrite(
+          Impl::PendingWrite{.slotIndex = slotIndex, .buffer = buffer, .offsetBytes = offsetBytes},
+          data.size());
+      if (queued.hasError()) {
+        return std::move(queued).error();
+      }
+      std::memcpy(queued.result()->bytes.data(), data.data(), data.size());
+      return OkStatus();
+    }
+    if (lastUse > completedSerial()) {
+      ++impl_->unalignedWriteWaits;
+      if (!waitForSerial(lastUse,
+                         std::chrono::duration<double>(impl_->unalignedWriteTimeout).count())) {
+        return GpuError{
+            GpuErrorType::InvalidState,
+            std::format("Metal unaligned buffer write could not complete submission {}", lastUse)};
+      }
+    }
+    impl_->flushIdleBufferWrites(buffer);
+  }
+  impl_->writeIdleBuffer(buffer, offsetBytes, data);
   return OkStatus();
 }
 
@@ -816,6 +967,27 @@ Status MetalDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> 
   if (texture == nil) {
     return GpuError{GpuErrorType::InvalidState,
                     std::format("texture slot {} has no Metal texture", slotIndex)};
+  }
+
+  const uint64_t lastUse =
+      std::max(textureLastUseSerial(slotIndex), GetSlot(impl_->textureUploadSerials, slotIndex));
+  if (lastUse > completedSerial() || impl_->hasPendingWrite(nil, texture)) {
+    const uint32_t texelBytes = texture.pixelFormat == MTLPixelFormatR8Unorm ? 1 : 4;
+    const uint32_t rowBytes = writeSize.width * texelBytes;
+    const uint32_t rowPitch = static_cast<uint32_t>(Impl::StagingSize(rowBytes));
+    auto queued = impl_->queueWrite(
+        Impl::PendingWrite{
+            .slotIndex = slotIndex, .texture = texture, .size = writeSize, .bytesPerRow = rowPitch},
+        uint64_t{rowPitch} * writeSize.height);
+    if (queued.hasError()) {
+      return std::move(queued).error();
+    }
+    for (uint32_t row = 0; row < writeSize.height; ++row) {
+      std::memcpy(queued.result()->bytes.data() + uint64_t{row} * rowPitch,
+                  data.data() + dataLayout.offsetBytes + uint64_t{row} * dataLayout.bytesPerRow,
+                  rowBytes);
+    }
+    return OkStatus();
   }
 
   [texture replaceRegion:MTLRegionMake2D(0, 0, writeSize.width, writeSize.height)
@@ -1085,6 +1257,7 @@ Status MetalDevice::Impl::encodeCopyTextureToBuffer(EncodingState& state,
         destinationBytesPerRow:copy.layout.bytesPerRow
       destinationBytesPerImage:static_cast<uint64_t>(copy.layout.bytesPerRow) *
                                copy.layout.rowsPerImage];
+  requireHostSync(state, buffer);
   [blitEncoder endEncoding];
   return OkStatus();
 }
@@ -1227,6 +1400,8 @@ Status MetalDevice::Impl::encodeCommand(EncodingState& state, const Command& com
 
 void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t submissionSerial) {
   std::shared_ptr<CompletionState> sharedState = completionState;
+  const uint64_t uploadBytes = pendingStagingBytes;
+  sharedState->inFlightStagingBytes.fetch_add(uploadBytes, std::memory_order_relaxed);
   [state.commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> completedBuffer) {
     if (completedBuffer.error != nil) {
       sharedState->hadError.store(true, std::memory_order_release);
@@ -1237,6 +1412,9 @@ void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t s
       }
     }
 
+    // Make the reservation available before a completion waiter observes this serial.
+    sharedState->inFlightStagingBytes.fetch_sub(uploadBytes, std::memory_order_release);
+
     // Monotonic max: handlers may complete out of order across command buffers.
     uint64_t previous = sharedState->completedSerial.load(std::memory_order_relaxed);
     while (previous < submissionSerial &&
@@ -1245,50 +1423,121 @@ void MetalDevice::Impl::attachCompletionHandler(EncodingState& state, uint64_t s
   }];
 }
 
-Status MetalDevice::Impl::encodeHostCoherencySync(EncodingState& state) {
-  if (!needsExplicitHostCoherency()) {
-    return OkStatus();  // One copy addressed from both sides; nothing to publish.
+void MetalDevice::Impl::requireHostSync(EncodingState& state, id<MTLBuffer> buffer) {
+  if (needsExplicitHostCoherency() &&
+      std::ranges::find(state.hostReadBuffers, buffer) == state.hostReadBuffers.end()) {
+    state.hostReadBuffers.push_back(buffer);
   }
+}
 
+Status MetalDevice::Impl::encodeHostCoherencySync(EncodingState& state) {
+  if (state.hostReadBuffers.empty()) {
+    return OkStatus();
+  }
   id<MTLBlitCommandEncoder> blitEncoder = [state.commandBuffer blitCommandEncoder];
   if (blitEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState,
                     "Metal blit command encoder creation failed for the host-coherency sync"};
   }
-  for (id<MTLBuffer> buffer : buffers) {
-    if (buffer != nil) {
-      [blitEncoder synchronizeResource:buffer];
-    }
-  }
-  for (id<MTLTexture> texture : textures) {
-    if (texture != nil) {
-      [blitEncoder synchronizeResource:texture];
-    }
+  for (id<MTLBuffer> buffer : state.hostReadBuffers) {
+    [blitEncoder synchronizeResource:buffer];
   }
   [blitEncoder endEncoding];
   ++deviceWritePublishCount;
   return OkStatus();
 }
 
-Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
-                             std::span<const Command> commands) {
-  (void)commandBufferSlotIndex;
+Status MetalDevice::Impl::encodePendingWrites(EncodingState& state) {
+  if (pendingWrites.empty()) {
+    return OkStatus();
+  }
+  const MTLResourceOptions options =
+      unifiedMemory ? MTLResourceStorageModeShared : MTLResourceStorageModeManaged;
+  id<MTLBuffer> staging = [device newBufferWithLength:pendingStagingBytes options:options];
+  ++stagingAllocations;
+  if (staging == nil) {
+    return GpuError{GpuErrorType::InvalidState, "Metal queue-write staging allocation failed"};
+  }
+  uint64_t sourceOffset = 0;
+  for (const PendingWrite& write : pendingWrites) {
+    std::memcpy(static_cast<uint8_t*>(staging.contents) + sourceOffset, write.bytes.data(),
+                write.bytes.size());
+    sourceOffset += StagingSize(write.bytes.size());
+  }
+  if (needsExplicitHostCoherency()) {
+    [staging didModifyRange:NSMakeRange(0, pendingStagingBytes)];
+    ++hostWritePublishCount;
+  }
+  id<MTLBlitCommandEncoder> blit = [state.commandBuffer blitCommandEncoder];
+  if (blit == nil) {
+    return GpuError{GpuErrorType::InvalidState, "Metal queue-write blit encoder creation failed"};
+  }
+  sourceOffset = 0;
+  for (const PendingWrite& write : pendingWrites) {
+    if (write.buffer != nil) {
+      [blit copyFromBuffer:staging
+               sourceOffset:sourceOffset
+                   toBuffer:write.buffer
+          destinationOffset:write.offsetBytes
+                       size:write.bytes.size()];
+      requireHostSync(state, write.buffer);
+    } else {
+      [blit copyFromBuffer:staging
+                 sourceOffset:sourceOffset
+            sourceBytesPerRow:write.bytesPerRow
+          sourceBytesPerImage:0
+                   sourceSize:MTLSizeMake(write.size.width, write.size.height, 1)
+                    toTexture:write.texture
+             destinationSlice:0
+             destinationLevel:0
+            destinationOrigin:MTLOriginMake(0, 0, 0)];
+    }
+    sourceOffset += StagingSize(write.bytes.size());
+  }
+  [blit endEncoding];
+  return OkStatus();
+}
 
-  if (impl_->commandQueue == nil) {
-    impl_->commandQueue = [impl_->device newCommandQueue];
-    if (impl_->commandQueue == nil) {
+Status MetalDevice::Impl::beginSubmission(EncodingState& state) {
+  if (commandQueue == nil) {
+    commandQueue = [device newCommandQueue];
+    if (commandQueue == nil) {
       return GpuError{GpuErrorType::InvalidState, "Metal command queue creation failed"};
     }
   }
 
-  Impl::EncodingState state;
-  state.commandBuffer = [impl_->commandQueue commandBuffer];
+  state.commandBuffer = [commandQueue commandBuffer];
   if (state.commandBuffer == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal command buffer creation failed"};
   }
 
-  if (impl_->submissionGate != nil) {
-    [state.commandBuffer encodeWaitForEvent:impl_->submissionGate value:1];
+  if (submissionGate != nil) {
+    [state.commandBuffer encodeWaitForEvent:submissionGate value:1];
+  }
+
+  return encodePendingWrites(state);
+}
+
+void MetalDevice::Impl::didSubmitWrites(uint64_t submissionSerial) {
+  if (!pendingWrites.empty()) {
+    // Upload destinations need ordering even when the caller's command stream never names them.
+    for (const PendingWrite& write : pendingWrites) {
+      SetSlot(write.buffer != nil ? bufferUploadSerials : textureUploadSerials, write.slotIndex,
+              submissionSerial);
+    }
+    ++submittedUploadBatches;
+    pendingWrites.clear();
+    pendingStagingBytes = 0;
+  }
+}
+
+Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
+                             std::span<const Command> commands) {
+  (void)commandBufferSlotIndex;
+
+  Impl::EncodingState state;
+  if (Status status = impl_->beginSubmission(state); status.hasError()) {
+    return status;
   }
 
   // On any encoding failure, close an open encoder before returning so the un-committed command
@@ -1318,18 +1567,14 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
         GpuError{GpuErrorType::InvalidState, "submitted command stream left a pass open"});
   }
 
-  // Publish every host-visible resource's GPU-side changes before the buffer completes, so a
-  // host read after the completion sees them. Only a device without unified memory needs this,
-  // and there it has to happen inside the submission: once the command buffer has completed
-  // there is no encoder left to do it with. It covers every live resource rather than tracking
-  // which this stream touched - the cost falls only on the path that already needs the copy, and
-  // a missed resource here is silently wrong data rather than a reported failure.
+  // Queued buffer uploads and readback copies are the only GPU buffer writers.
   if (Status status = impl_->encodeHostCoherencySync(state); status.hasError()) {
     return failEncoding(std::move(status));
   }
 
   impl_->attachCompletionHandler(state, submissionSerial);
   [state.commandBuffer commit];
+  impl_->didSubmitWrites(submissionSerial);
 
   return OkStatus();
 }

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -192,8 +192,9 @@ struct CompletionState {
 /// Objective-C++ state of a MetalDevice: the Metal device and queue plus per-resource slot
 /// tables mirroring the validated slot indices handed to the `on*` hooks.
 struct MetalDevice::Impl {
-  id<MTLDevice> device = nil;              //!< The Metal device; set by Create.
-  id<MTLCommandQueue> commandQueue = nil;  //!< Lazily created on first submit.
+  id<MTLDevice> device = nil;               //!< The Metal device; set by Create.
+  id<MTLCommandQueue> commandQueue = nil;   //!< Lazily created on first submit.
+  id<MTLSharedEvent> submissionGate = nil;  //!< Optional test-controlled execution pause.
 
   /// A bind group plus the layout slot it was created against (for per-binding visibility).
   struct BindGroupRecord {
@@ -416,7 +417,26 @@ uint64_t MetalDevice::deviceWritePublishCountForTest() const {
 
 MetalDevice::MetalDevice() : impl_(std::make_unique<Impl>()) {}
 
+Status MetalDevice::pauseSubmissionsForTest() {
+  if (impl_->submissionGate != nil) {
+    return GpuError{GpuErrorType::InvalidState, "a Metal submission pause is already active"};
+  }
+  impl_->submissionGate = [impl_->device newSharedEvent];
+  if (impl_->submissionGate == nil) {
+    return GpuError{GpuErrorType::Unsupported, "Metal shared events are unavailable"};
+  }
+  return OkStatus();
+}
+
+void MetalDevice::resumeSubmissionsForTest() {
+  if (impl_->submissionGate != nil) {
+    impl_->submissionGate.signaledValue = 1;
+    impl_->submissionGate = nil;
+  }
+}
+
 MetalDevice::~MetalDevice() {
+  resumeSubmissionsForTest();
   // Wait for in-flight submissions so deferred destructions drain before Impl teardown releases
   // the remaining Metal objects. On timeout (a hung submission) teardown proceeds anyway: Metal
   // itself retains every resource referenced by a committed command buffer until it completes,
@@ -1265,6 +1285,10 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
   state.commandBuffer = [impl_->commandQueue commandBuffer];
   if (state.commandBuffer == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal command buffer creation failed"};
+  }
+
+  if (impl_->submissionGate != nil) {
+    [state.commandBuffer encodeWaitForEvent:impl_->submissionGate value:1];
   }
 
   // On any encoding failure, close an open encoder before returning so the un-committed command

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -129,4 +129,26 @@ donner_cc_test(
     ],
 )
 
+donner_cc_test(
+    name = "metal_queue_writes_tests",
+    srcs = ["MetalQueueWrites_tests.cc"],
+    env = {
+        "MTL_DEBUG_LAYER": "1",
+        "MTL_SHADER_VALIDATION": "1",
+    },
+    env_inherit = [
+        "DONNER_BASELINE_REQUIRE_FROZEN_ADAPTER",
+        "GITHUB_ACTIONS",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_device_gate",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/gpu",
+        "//donner/gpu:gpu_test_utils",
+        "//donner/gpu/metal:metal_device",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
+++ b/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
@@ -4,7 +4,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -23,6 +25,7 @@ namespace {
 struct Capture {
   Buffer readback;
   uint64_t serial = 0;
+  Extent2d size{1, 1};
 };
 
 class MetalQueueWritesTest : public testing::Test {
@@ -38,13 +41,14 @@ protected:
     }
   }
 
-  Capture captureTexture(const Texture& texture) {
+  Capture captureTexture(const Texture& texture, Extent2d size = {1, 1}) {
     Capture capture;
-    capture.readback = GetResultOrFail(device_->createBuffer(
-        BufferDescriptor{"capture", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
+    capture.size = size;
+    capture.readback = GetResultOrFail(device_->createBuffer(BufferDescriptor{
+        "capture", uint64_t{256} * size.height, BufferUsage::CopyDst | BufferUsage::MapRead}));
     auto encoder = GetResultOrFail(device_->createCommandEncoder());
     EXPECT_THAT(encoder->copyTextureToBuffer(TexelCopyTextureInfo{texture}, capture.readback,
-                                             TexelCopyBufferLayout{0, 256, 1}, Extent2d{1, 1}),
+                                             TexelCopyBufferLayout{0, 256, size.height}, size),
                 IsOk());
     capture.serial = GetResultOrFail(device_->submit(GetResultOrFail(encoder->finish())));
     return capture;
@@ -98,15 +102,32 @@ kernel void cs_main(constant float4& color [[buffer(1)]],
     return capture;
   }
 
-  void expectPixel(const Capture& capture, std::array<uint8_t, 4> expected, const char* label) {
+  void expectPixels(const Capture& capture, std::span<const uint8_t> expected, const char* label) {
     const auto bytes = GetResultOrFail(device_->readBackBuffer(capture.readback));
-    ASSERT_GE(bytes.size(), 4u);
-    const svg::RendererBitmap actual{
-        .dimensions = {1, 1}, .pixels = {bytes[0], bytes[1], bytes[2], bytes[3]}, .rowBytes = 4};
-    const svg::RendererBitmap reference{
-        .dimensions = {1, 1}, .pixels = {expected.begin(), expected.end()}, .rowBytes = 4};
+    ASSERT_GE(bytes.size(), uint64_t{256} * capture.size.height);
+    const Vector2i dimensions{static_cast<int>(capture.size.width),
+                              static_cast<int>(capture.size.height)};
+    const svg::RendererBitmap actual{.dimensions = dimensions, .pixels = bytes, .rowBytes = 256};
+    const size_t rowBytes = size_t{capture.size.width} * 4;
+    ASSERT_EQ(expected.size(), rowBytes * capture.size.height);
+    svg::RendererBitmap reference{
+        .dimensions = dimensions, .pixels = std::vector<uint8_t>(bytes.size()), .rowBytes = 256};
+    for (uint32_t row = 0; row < capture.size.height; ++row) {
+      std::copy_n(expected.begin() + row * rowBytes, rowBytes,
+                  reference.pixels.begin() + row * 256);
+    }
     editor::tests::CompareBitmapToBitmap(actual, reference, label,
                                          editor::tests::PixelmatchIdentityParams());
+  }
+
+  void expectPixel(const Capture& capture, std::array<uint8_t, 4> expected, const char* label) {
+    expectPixels(capture, expected, label);
+  }
+
+  Status writeColor(const Buffer& buffer, const std::array<float, 4>& color) {
+    return device_->writeBuffer(
+        buffer, 0,
+        std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(color.data()), sizeof(color)));
   }
 
   std::unique_ptr<MetalDevice> device_;
@@ -152,6 +173,203 @@ TEST_F(MetalQueueWritesTest, TextureUpdateDoesNotChangeAnEarlierSubmission) {
   ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
   expectPixel(first, red, "texture_before_update");
   expectPixel(second, blue, "texture_after_update");
+}
+
+TEST_F(MetalQueueWritesTest, RepeatedWritesCoalesceAndOverlapsKeepQueueOrder) {
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  for (int i = 0; i < 32; ++i) {
+    ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  }
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 1u);
+  const float redChannel = 1.0f;
+  ASSERT_THAT(
+      device_->writeBuffer(uniform, 0,
+                           std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&redChannel),
+                                                    sizeof(redChannel))),
+      IsOk());
+  const Capture second = captureUniform(uniform);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "coalesced_before_update");
+  expectPixel(second, {255, 0, 255, 255}, "coalesced_after_update");
+  const MetalDevice::WriteStats stats = device_->writeStatsForTest();
+  EXPECT_EQ(stats.pendingWrites, 0u);
+  EXPECT_EQ(stats.pendingStagingBytes, 0u);
+  EXPECT_EQ(stats.stagingAllocations, 1u);
+  EXPECT_EQ(stats.submittedUploadBatches, 1u);
+  EXPECT_EQ(stats.unalignedWriteWaits, 0u);
+  EXPECT_EQ(device_->lastSubmittedSerial(), 2u);
+}
+
+TEST_F(MetalQueueWritesTest, PartialTextureUploadsPreserveOtherPixelsAndCallerPitch) {
+  const Texture texture = GetResultOrFail(
+      device_->createTexture(TextureDescriptor{"source", Extent2d{2, 2}, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopySrc | TextureUsage::CopyDst}));
+  std::array<uint8_t, 512> initial{};
+  for (size_t offset : {0u, 4u, 256u, 260u}) {
+    initial[offset] = 255;
+    initial[offset + 3] = 255;
+  }
+  ASSERT_THAT(device_->writeTexture(texture, initial, TexelCopyBufferLayout{0, 256, 2}, {2, 2}),
+              IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureTexture(texture, {2, 2});
+  std::array<uint8_t, 1024> update{};
+  for (size_t offset : {4u, 516u}) {
+    update[offset + 2] = 255;
+    update[offset + 3] = 255;
+  }
+  ASSERT_THAT(device_->writeTexture(texture, update, TexelCopyBufferLayout{4, 512, 2}, {1, 2}),
+              IsOk());
+  const Capture second = captureTexture(texture, {2, 2});
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  const std::array<uint8_t, 16> red = {255, 0, 0, 255, 255, 0, 0, 255,
+                                       255, 0, 0, 255, 255, 0, 0, 255};
+  const std::array<uint8_t, 16> columns = {0, 0, 255, 255, 255, 0, 0, 255,
+                                           0, 0, 255, 255, 255, 0, 0, 255};
+  expectPixels(first, red, "partial_texture_before_update");
+  expectPixels(second, columns, "partial_texture_after_update");
+}
+
+TEST_F(MetalQueueWritesTest, AnUploadOnlySubmissionStillProtectsItsDestination) {
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  device_->resumeSubmissionsForTest();
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  auto empty = GetResultOrFail(device_->createCommandEncoder());
+  const uint64_t uploadSerial = GetResultOrFail(device_->submit(GetResultOrFail(empty->finish())));
+  ASSERT_TRUE(device_->waitForSerial(first.serial, 5.0)) << device_->lastErrorForTest();
+  ASSERT_THAT(device_->completedSerial(), testing::Lt(uploadSerial));
+  ASSERT_THAT(writeColor(uniform, {0, 1, 0, 1}), IsOk());
+  const Capture third = captureUniform(uniform);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(third.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "upload_only_before_update");
+  expectPixel(third, {0, 255, 0, 255}, "upload_only_after_update");
+  EXPECT_EQ(device_->writeStatsForTest().submittedUploadBatches, 2u);
+}
+
+TEST_F(MetalQueueWritesTest, RetiringADestinationDiscardsItsUnsubmittedWrite) {
+  Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  ASSERT_THAT(device_->destroyBuffer(std::move(uniform)), IsOk());
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(first.serial, 5.0)) << device_->lastErrorForTest();
+  device_->poll();
+  expectPixel(first, {255, 0, 0, 255}, "retired_destination");
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 0u);
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 0u);
+}
+
+TEST_F(MetalQueueWritesTest, ManagedMemoryPublishesTheBatchedUpload) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::ForceNonUnified);
+  ASSERT_NE(device_, nullptr);
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  const Capture second = captureUniform(uniform);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "managed_before_update");
+  expectPixel(second, {0, 0, 255, 255}, "managed_after_update");
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 1u);
+  EXPECT_EQ(device_->hostWritePublishCountForTest(), 2u);
+}
+
+TEST_F(MetalQueueWritesTest, ManagedUploadOnlySubmissionPublishesItsHostBuffer) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::ForceNonUnified);
+  ASSERT_NE(device_, nullptr);
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  const std::array<float, 4> blue = {0, 0, 1, 1};
+  ASSERT_THAT(writeColor(uniform, blue), IsOk());
+  auto empty = GetResultOrFail(device_->createCommandEncoder());
+  const uint64_t serial = GetResultOrFail(device_->submit(GetResultOrFail(empty->finish())));
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "managed_upload_only_before_update");
+  EXPECT_THAT(
+      GetResultOrFail(device_->readBackBuffer(uniform)),
+      testing::ElementsAreArray(reinterpret_cast<const uint8_t*>(blue.data()), sizeof(blue)));
+  EXPECT_EQ(device_->deviceWritePublishCountForTest(), 2u);
+}
+
+TEST_F(MetalQueueWritesTest, UploadBudgetRefusesAndRecoversAcrossInFlightSubmissions) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, 256);
+  ASSERT_NE(device_, nullptr);
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  const Capture second = captureUniform(uniform);
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 256u);
+  EXPECT_THAT(writeColor(uniform, {0, 1, 0, 1}), IsGpuError(GpuErrorType::LimitExceeded));
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 0u);
+  expectPixel(first, {255, 0, 0, 255}, "budget_first_submission");
+  expectPixel(second, {0, 0, 255, 255}, "budget_refused_write");
+
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture third = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 1, 0, 1}), IsOk());
+  const Capture fourth = captureUniform(uniform);
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 256u);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(fourth.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(third, {0, 0, 255, 255}, "budget_recovery_before_update");
+  expectPixel(fourth, {0, 255, 0, 255}, "budget_recovery_after_update");
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 0u);
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 2u);
+}
+
+TEST_F(MetalQueueWritesTest, UnalignedWriteTimesOutWithoutOverwritingTheBusyBuffer) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, kMaxBufferByteSize,
+                                std::chrono::milliseconds(20));
+  ASSERT_NE(device_, nullptr);
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  const std::array<uint8_t, 1> zero = {0};
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_THAT(device_->writeBuffer(uniform, 3, zero), IsGpuError(GpuErrorType::InvalidState));
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(elapsed, std::chrono::seconds(1));
+  RecordProperty("unaligned_wait_ms",
+                 std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(first.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "unaligned_timeout_before_update");
+  ASSERT_THAT(device_->writeBuffer(uniform, 3, zero), IsOk());
+  const Capture second = captureUniform(uniform);
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(second, {0, 0, 0, 255}, "unaligned_after_completion");
+  EXPECT_EQ(device_->writeStatsForTest().unalignedWriteWaits, 1u);
 }
 
 }  // namespace

--- a/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
+++ b/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
@@ -1,0 +1,158 @@
+/// @file
+/// Queue writes preserve earlier submissions while later submissions observe the new contents.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+namespace donner::gpu::metal::tests {
+namespace {
+
+struct Capture {
+  Buffer readback;
+  uint64_t serial = 0;
+};
+
+class MetalQueueWritesTest : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = MetalDevice::Create();
+    DONNER_REQUIRE_METAL_DEVICE(device_, "Metal queue write ordering");
+  }
+
+  void TearDown() override {
+    if (device_) {
+      device_->resumeSubmissionsForTest();
+    }
+  }
+
+  Capture captureTexture(const Texture& texture) {
+    Capture capture;
+    capture.readback = GetResultOrFail(device_->createBuffer(
+        BufferDescriptor{"capture", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
+    auto encoder = GetResultOrFail(device_->createCommandEncoder());
+    EXPECT_THAT(encoder->copyTextureToBuffer(TexelCopyTextureInfo{texture}, capture.readback,
+                                             TexelCopyBufferLayout{0, 256, 1}, Extent2d{1, 1}),
+                IsOk());
+    capture.serial = GetResultOrFail(device_->submit(GetResultOrFail(encoder->finish())));
+    return capture;
+  }
+
+  Capture captureUniform(const Buffer& uniform) {
+    const ShaderModule module = GetResultOrFail(device_->createShaderModule(
+        ShaderModuleDescriptor{"captureUniform",
+                               RcString(R"msl(#include <metal_stdlib>
+using namespace metal;
+kernel void cs_main(constant float4& color [[buffer(1)]],
+                    texture2d<float, access::write> output [[texture(1)]]) {
+  output.write(color, uint2(0));
+}
+)msl"),
+                               ShaderSourceKind::Msl,
+                               {},
+                               {ComputeEntryPointInfo{"cs_main", WorkgroupSize{1, 1, 1}}}}));
+    const BindGroupLayout layout =
+        GetResultOrFail(device_->createBindGroupLayout(BindGroupLayoutDescriptor{
+            "captureLayout",
+            {{0, ShaderStage::Compute, BindingType::UniformBuffer},
+             {1, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
+    const PipelineLayout pipelineLayout = GetResultOrFail(
+        device_->createPipelineLayout(PipelineLayoutDescriptor{"capturePipelineLayout", {layout}}));
+    const ComputePipeline pipeline = GetResultOrFail(device_->createComputePipeline(
+        ComputePipelineDescriptor{"capturePipeline", pipelineLayout,
+                                  ComputeState{module, "cs_main"}, WorkgroupSize{1, 1, 1}}));
+    const Texture output = GetResultOrFail(device_->createTexture(
+        TextureDescriptor{"captureOutput", Extent2d{1, 1}, TextureFormat::RGBA8Unorm,
+                          TextureUsage::StorageBinding | TextureUsage::CopySrc}));
+    const TextureView view =
+        GetResultOrFail(device_->createTextureView(output, TextureViewDescriptor{"captureView"}));
+    const BindGroup group = GetResultOrFail(device_->createBindGroup(
+        BindGroupDescriptor{"captureGroup",
+                            layout,
+                            {{0, BufferBinding{uniform, 0, 16}}, {1, TextureViewBinding{view}}}}));
+    Capture capture;
+    capture.readback = GetResultOrFail(device_->createBuffer(
+        BufferDescriptor{"capture", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
+    auto encoder = GetResultOrFail(device_->createCommandEncoder());
+    ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({"capture"}));
+    EXPECT_THAT(pass->setPipeline(pipeline), IsOk());
+    EXPECT_THAT(pass->setBindGroup(0, group), IsOk());
+    EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    EXPECT_THAT(pass->end(), IsOk());
+    EXPECT_THAT(encoder->copyTextureToBuffer(TexelCopyTextureInfo{output}, capture.readback,
+                                             TexelCopyBufferLayout{0, 256, 1}, Extent2d{1, 1}),
+                IsOk());
+    capture.serial = GetResultOrFail(device_->submit(GetResultOrFail(encoder->finish())));
+    return capture;
+  }
+
+  void expectPixel(const Capture& capture, std::array<uint8_t, 4> expected, const char* label) {
+    const auto bytes = GetResultOrFail(device_->readBackBuffer(capture.readback));
+    ASSERT_GE(bytes.size(), 4u);
+    const svg::RendererBitmap actual{
+        .dimensions = {1, 1}, .pixels = {bytes[0], bytes[1], bytes[2], bytes[3]}, .rowBytes = 4};
+    const svg::RendererBitmap reference{
+        .dimensions = {1, 1}, .pixels = {expected.begin(), expected.end()}, .rowBytes = 4};
+    editor::tests::CompareBitmapToBitmap(actual, reference, label,
+                                         editor::tests::PixelmatchIdentityParams());
+  }
+
+  std::unique_ptr<MetalDevice> device_;
+};
+
+TEST_F(MetalQueueWritesTest, UniformUpdateDoesNotChangeAnEarlierSubmission) {
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  const std::array<float, 4> red = {1.0f, 0.0f, 0.0f, 1.0f};
+  const std::array<float, 4> blue = {0.0f, 0.0f, 1.0f, 1.0f};
+  ASSERT_THAT(
+      device_->writeBuffer(
+          uniform, 0, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(red.data()), 16)),
+      IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(device_->completedSerial(), testing::Lt(first.serial));
+  ASSERT_THAT(
+      device_->writeBuffer(
+          uniform, 0, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(blue.data()), 16)),
+      IsOk());
+  const Capture second = captureUniform(uniform);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "uniform_before_update");
+  expectPixel(second, {0, 0, 255, 255}, "uniform_after_update");
+}
+
+TEST_F(MetalQueueWritesTest, TextureUpdateDoesNotChangeAnEarlierSubmission) {
+  const Texture texture = GetResultOrFail(
+      device_->createTexture(TextureDescriptor{"source", Extent2d{1, 1}, TextureFormat::RGBA8Unorm,
+                                               TextureUsage::CopySrc | TextureUsage::CopyDst}));
+  const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+  const std::array<uint8_t, 4> blue = {0, 0, 255, 255};
+  const TexelCopyBufferLayout layout{0, 256, 1};
+  ASSERT_THAT(device_->writeTexture(texture, red, layout, Extent2d{1, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureTexture(texture);
+  ASSERT_THAT(device_->completedSerial(), testing::Lt(first.serial));
+  ASSERT_THAT(device_->writeTexture(texture, blue, layout, Extent2d{1, 1}), IsOk());
+  const Capture second = captureTexture(texture);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, red, "texture_before_update");
+  expectPixel(second, blue, "texture_after_update");
+}
+
+}  // namespace
+}  // namespace donner::gpu::metal::tests

--- a/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
+++ b/donner/gpu/metal/tests/MetalQueueWrites_tests.cc
@@ -1,5 +1,6 @@
 /// @file
-/// Queue writes preserve earlier submissions while later submissions observe the new contents.
+/// Queue writes preserve earlier submissions while later submissions observe
+/// the new contents.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -266,8 +267,14 @@ TEST_F(MetalQueueWritesTest, RetiringADestinationDiscardsItsUnsubmittedWrite) {
   const Capture first = captureUniform(uniform);
   ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
   ASSERT_THAT(device_->destroyBuffer(std::move(uniform)), IsOk());
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 0u);
+  auto empty = GetResultOrFail(device_->createCommandEncoder());
+  const uint64_t unrelatedSerial =
+      GetResultOrFail(device_->submit(GetResultOrFail(empty->finish())));
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 0u);
   device_->resumeSubmissionsForTest();
-  ASSERT_TRUE(device_->waitForSerial(first.serial, 5.0)) << device_->lastErrorForTest();
+  ASSERT_TRUE(device_->waitForSerial(unrelatedSerial, 5.0)) << device_->lastErrorForTest();
   device_->poll();
   expectPixel(first, {255, 0, 0, 255}, "retired_destination");
   EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
@@ -315,7 +322,7 @@ TEST_F(MetalQueueWritesTest, ManagedUploadOnlySubmissionPublishesItsHostBuffer) 
 }
 
 TEST_F(MetalQueueWritesTest, UploadBudgetRefusesAndRecoversAcrossInFlightSubmissions) {
-  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, 256);
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, 16);
   ASSERT_NE(device_, nullptr);
   const Buffer uniform = GetResultOrFail(device_->createBuffer(
       BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
@@ -344,6 +351,121 @@ TEST_F(MetalQueueWritesTest, UploadBudgetRefusesAndRecoversAcrossInFlightSubmiss
   expectPixel(fourth, {0, 255, 0, 255}, "budget_recovery_after_update");
   EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 0u);
   EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 2u);
+}
+
+TEST_F(MetalQueueWritesTest, RaiiRetirementDiscardsABusyBuffersUnsubmittedWrite) {
+  Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  ASSERT_THAT(writeColor(uniform, {0, 0, 1, 1}), IsOk());
+  uniform = Buffer{};
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 0u);
+  auto empty = GetResultOrFail(device_->createCommandEncoder());
+  const uint64_t serial = GetResultOrFail(device_->submit(GetResultOrFail(empty->finish())));
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 0u);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "raii_retired_buffer");
+}
+
+TEST_F(MetalQueueWritesTest, TextureRetirementDiscardsWritesBeforeTheEarlierSubmissionCompletes) {
+  for (bool explicitDestroy : {true, false}) {
+    SCOPED_TRACE(explicitDestroy);
+    Texture texture =
+        GetResultOrFail(device_->createTexture({"source",
+                                                {1, 1},
+                                                TextureFormat::RGBA8Unorm,
+                                                TextureUsage::CopySrc | TextureUsage::CopyDst}));
+    const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+    const std::array<uint8_t, 4> blue = {0, 0, 255, 255};
+    ASSERT_THAT(device_->writeTexture(texture, red, {0, 256, 1}, {1, 1}), IsOk());
+    ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+    const Capture first = captureTexture(texture);
+    ASSERT_THAT(device_->writeTexture(texture, blue, {0, 256, 1}, {1, 1}), IsOk());
+    if (explicitDestroy) {
+      ASSERT_THAT(device_->destroyTexture(std::move(texture)), IsOk());
+    } else {
+      texture = Texture{};
+    }
+    EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+    EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 0u);
+    auto empty = GetResultOrFail(device_->createCommandEncoder());
+    const uint64_t serial = GetResultOrFail(device_->submit(GetResultOrFail(empty->finish())));
+    EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 0u);
+    device_->resumeSubmissionsForTest();
+    ASSERT_TRUE(device_->waitForSerial(serial, 5.0)) << device_->lastErrorForTest();
+    expectPixel(first, red, explicitDestroy ? "explicit_retired_texture" : "raii_retired_texture");
+  }
+}
+
+TEST_F(MetalQueueWritesTest, SmallPayloadsShareTheLogicalBudgetDespiteStagingAlignment) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, 16);
+  ASSERT_NE(device_, nullptr);
+  const Buffer uniform = GetResultOrFail(device_->createBuffer(
+      BufferDescriptor{"color", 32, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(writeColor(uniform, {1, 0, 0, 1}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureUniform(uniform);
+  const std::array<float, 2> zeros = {0, 0};
+  const std::array<float, 2> ones = {1, 1};
+  const std::array<float, 2> redGreen = {1, 0};
+  const auto bytes = [](const auto& value) {
+    return std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(value.data()), sizeof(value));
+  };
+  ASSERT_THAT(device_->writeBuffer(uniform, 0, bytes(zeros)), IsOk());
+  ASSERT_THAT(device_->writeBuffer(uniform, 8, bytes(ones)), IsOk());
+  ASSERT_THAT(device_->writeBuffer(uniform, 0, bytes(redGreen)), IsOk());
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 2u);
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 512u);
+  EXPECT_THAT(device_->writeBuffer(uniform, 16, bytes(zeros)),
+              IsGpuError(GpuErrorType::LimitExceeded));
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 2u);
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 512u);
+  const Capture second = captureUniform(uniform);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  expectPixel(first, {255, 0, 0, 255}, "logical_budget_before_update");
+  expectPixel(second, {255, 0, 255, 255}, "logical_budget_coalesced_ranges");
+  EXPECT_EQ(device_->writeStatsForTest().stagingAllocations, 1u);
+}
+
+TEST_F(MetalQueueWritesTest, TextureBudgetCountsTexelsInsteadOfCallerOrStagingRowPadding) {
+  device_ = MetalDevice::Create(MetalDevice::MemoryModel::Detected, 8);
+  ASSERT_NE(device_, nullptr);
+  const Texture texture =
+      GetResultOrFail(device_->createTexture({"source",
+                                              {1, 2},
+                                              TextureFormat::RGBA8Unorm,
+                                              TextureUsage::CopySrc | TextureUsage::CopyDst}));
+  std::array<uint8_t, 268> pixels{};
+  for (size_t row : {0u, 1u}) {
+    pixels[4 + row * 256] = 255;
+    pixels[7 + row * 256] = 255;
+  }
+  ASSERT_THAT(device_->writeTexture(texture, pixels, {4, 256, 2}, {1, 2}), IsOk());
+  ASSERT_THAT(device_->pauseSubmissionsForTest(), IsOk());
+  const Capture first = captureTexture(texture, {1, 2});
+  for (size_t row : {0u, 1u}) {
+    pixels[4 + row * 256] = 0;
+    pixels[6 + row * 256] = 255;
+  }
+  ASSERT_THAT(device_->writeTexture(texture, pixels, {4, 256, 2}, {1, 2}), IsOk());
+  EXPECT_EQ(device_->writeStatsForTest().pendingStagingBytes, 512u);
+  const Capture second = captureTexture(texture, {1, 2});
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 512u);
+  EXPECT_THAT(device_->writeTexture(texture, pixels, {4, 256, 2}, {1, 2}),
+              IsGpuError(GpuErrorType::LimitExceeded));
+  EXPECT_EQ(device_->writeStatsForTest().pendingWrites, 0u);
+  device_->resumeSubmissionsForTest();
+  ASSERT_TRUE(device_->waitForSerial(second.serial, 5.0)) << device_->lastErrorForTest();
+  const std::array<uint8_t, 8> red = {255, 0, 0, 255, 255, 0, 0, 255};
+  const std::array<uint8_t, 8> blue = {0, 0, 255, 255, 0, 0, 255, 255};
+  expectPixels(first, red, "logical_texture_budget_before_update");
+  expectPixels(second, blue, "logical_texture_budget_after_update");
+  EXPECT_EQ(device_->writeStatsForTest().inFlightStagingBytes, 0u);
 }
 
 TEST_F(MetalQueueWritesTest, UnalignedWriteTimesOutWithoutOverwritingTheBusyBuffer) {

--- a/donner/gpu/vulkan/BUILD.bazel
+++ b/donner/gpu/vulkan/BUILD.bazel
@@ -12,7 +12,7 @@ load("//build_defs:package.bzl", "donner_package")
 # build needs no Vulkan library present and a machine without one reports it
 # at device creation. Execution is gated to Linux in tests/BUILD.bazel.
 
-# The tracked resource-state model every barrier and subpass dependency is derived from.
+# The tracked resource-state model every image barrier is derived from.
 # Deliberately its own target: it is pure state machinery over Vulkan enums that opens no device
 # and calls no entry point, so it builds and its tests run on every platform, not only where a
 # Vulkan loader exists.
@@ -22,7 +22,6 @@ donner_cc_library(
     hdrs = ["VulkanResourceState.h"],
     visibility = donner_internal_visibility(),
     deps = [
-        "//donner/gpu",
         "@vulkan_headers",
     ],
 )

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -11,6 +11,7 @@
 #include <vulkan/vulkan.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdio>
@@ -1037,7 +1038,8 @@ struct VulkanDevice::Impl {
     const RenderPipelineRecord* currentPipeline = nullptr;  //!< Pipeline bound in the pass.
     /// Compute pipeline bound in the active compute pass.
     const ComputePipelineRecord* currentComputePipeline = nullptr;
-    std::vector<VkDescriptorSet> boundSets;  //!< Descriptor sets bound by index.
+    /// Groups bound by index; their records remain live throughout command encoding.
+    std::array<const BindGroupRecord*, kMaxBindGroups> boundGroups = {};
   };
 
   /// Records the barrier that puts \p textureSlot into \p usage, if one is needed, and stages
@@ -1059,15 +1061,19 @@ struct VulkanDevice::Impl {
   /// @param state Encoding state.
   void destroyTransientEncodingObjects(EncodingState& state);
 
-  /// Transitions every texture the upcoming pass binds to the layout its descriptors declare:
-  /// sampled textures to SHADER_READ_ONLY_OPTIMAL and storage textures to GENERAL. Barriers are
-  /// illegal inside a render pass, so this pre-scans the pass's commands and records the
-  /// transitions before the pass begins.
+  /// Transitions the textures in one bind group to their descriptor layouts.
+  /// @param state Encoding state.
+  /// @param group Bind group whose textures are about to be used.
+  void transitionBoundTextures(EncodingState& state, const BindGroupRecord& group);
+
+  /// Transitions every texture the upcoming render pass binds to its descriptor layout:
+  /// sampled textures to SHADER_READ_ONLY_OPTIMAL and storage textures to GENERAL. These layout
+  /// changes must precede vkCmdBeginRenderPass, so the render commands are scanned in advance.
   /// @param state Encoding state.
   /// @param commands Full command stream.
   /// @param beginIndex Index of the begin-pass command.
-  void transitionPassBoundTextures(EncodingState& state, std::span<const Command> commands,
-                                   size_t beginIndex);
+  void transitionRenderPassBoundTextures(EncodingState& state, std::span<const Command> commands,
+                                         size_t beginIndex);
 
   /// Creates the pass's render pass and framebuffer, transitions its attachments, and begins it
   /// with the WebGPU-style full-attachment viewport and scissor.
@@ -1162,10 +1168,8 @@ struct VulkanDevice::Impl {
   /// only once its submission reached the queue.
   TextureSyncStateTable syncStates;
 
-  /// Every image barrier recorded, and the most recent render pass's entry dependency. Test
-  /// observation only; nothing in the backend reads these back.
-  std::vector<RecordedImageBarrierForTest> recordedBarriers;
-  std::optional<RecordedSubpassDependencyForTest> lastEntryDependency;
+  /// Opt-in image barrier history. Disengaged during normal device use.
+  std::optional<std::vector<RecordedImageBarrierForTest>> recordedBarriers;
   /// Set by the test seam; makes the next internal upload report failure at the named point.
   std::optional<UploadFailureModeForTest> uploadFailureMode;
 
@@ -1450,17 +1454,17 @@ Result<VulkanDevice::TrackedTextureLayout> VulkanDevice::trackedTextureLayoutFor
   }
 }
 
-std::vector<VulkanDevice::RecordedImageBarrierForTest> VulkanDevice::recordedImageBarriersForTest()
-    const {
-  return impl_->recordedBarriers;
+void VulkanDevice::setImageBarrierRecordingForTest(bool enabled) {
+  if (enabled) {
+    impl_->recordedBarriers.emplace();
+  } else {
+    impl_->recordedBarriers.reset();
+  }
 }
 
-Result<VulkanDevice::RecordedSubpassDependencyForTest>
-VulkanDevice::lastRenderPassEntryDependencyForTest() const {
-  if (!impl_->lastEntryDependency.has_value()) {
-    return GpuError{GpuErrorType::InvalidState, "no render pass has been created"};
-  }
-  return *impl_->lastEntryDependency;
+std::vector<VulkanDevice::RecordedImageBarrierForTest> VulkanDevice::recordedImageBarriersForTest()
+    const {
+  return impl_->recordedBarriers.value_or(std::vector<RecordedImageBarrierForTest>{});
 }
 
 void VulkanDevice::failNextTextureUploadForTest(UploadFailureModeForTest mode) {
@@ -2353,10 +2357,12 @@ void VulkanDevice::Impl::transitionTexture(VkCommandBuffer commandBuffer, uint32
     return;  // Same layout and nothing to make available: no hazard to order.
   }
   RecordImageBarrier(*api, commandBuffer, record.image, params);
-  recordedBarriers.push_back(RecordedImageBarrierForTest{
-      textureSlot, static_cast<uint32_t>(params.srcStage), static_cast<uint32_t>(params.dstStage),
-      static_cast<uint32_t>(params.srcAccess), static_cast<uint32_t>(params.dstAccess),
-      static_cast<int32_t>(params.oldLayout), static_cast<int32_t>(params.newLayout)});
+  if (recordedBarriers) {
+    recordedBarriers->push_back(RecordedImageBarrierForTest{
+        textureSlot, static_cast<uint32_t>(params.srcStage), static_cast<uint32_t>(params.dstStage),
+        static_cast<uint32_t>(params.srcAccess), static_cast<uint32_t>(params.dstAccess),
+        static_cast<int32_t>(params.oldLayout), static_cast<int32_t>(params.newLayout)});
+  }
   syncStates.stage(textureSlot, StateAfterUsage(usage));
 }
 
@@ -2371,22 +2377,26 @@ void VulkanDevice::Impl::destroyTransientEncodingObjects(EncodingState& state) {
   api->vkFreeCommandBuffers(device, commandPool, 1, &state.commandBuffer);
 }
 
-void VulkanDevice::Impl::transitionPassBoundTextures(EncodingState& state,
-                                                     std::span<const Command> commands,
-                                                     size_t beginIndex) {
-  // An UNDEFINED oldLayout for a never-written texture is valid; its contents are undefined
-  // either way.
+void VulkanDevice::Impl::transitionBoundTextures(EncodingState& state,
+                                                 const BindGroupRecord& group) {
   const auto transitionTo = [&](uint32_t textureSlot, TextureUsageKind usage) {
-    const TextureRecord* texture = FindRecord(textures, textureSlot);
-    if (texture == nullptr) {
-      return;  // Submit-time re-validation makes this unreachable.
+    if (const TextureRecord* texture = FindRecord(textures, textureSlot)) {
+      transitionTexture(state.commandBuffer, textureSlot, *texture, usage);
     }
-    transitionTexture(state.commandBuffer, textureSlot, *texture, usage);
   };
+  for (const uint32_t sampledSlot : group.sampledTextureSlots) {
+    transitionTo(sampledSlot, TextureUsageKind::SampledRead);
+  }
+  for (const uint32_t storageSlot : group.storageTextureSlots) {
+    transitionTo(storageSlot, TextureUsageKind::StorageWrite);
+  }
+}
 
+void VulkanDevice::Impl::transitionRenderPassBoundTextures(EncodingState& state,
+                                                           std::span<const Command> commands,
+                                                           size_t beginIndex) {
   for (size_t scanIndex = beginIndex + 1; scanIndex < commands.size(); ++scanIndex) {
-    if (std::get_if<EndRenderPassCommand>(&commands[scanIndex]) != nullptr ||
-        std::get_if<EndComputePassCommand>(&commands[scanIndex]) != nullptr) {
+    if (std::get_if<EndRenderPassCommand>(&commands[scanIndex]) != nullptr) {
       break;
     }
     const auto* scannedBindGroup = std::get_if<SetBindGroupCommand>(&commands[scanIndex]);
@@ -2398,12 +2408,7 @@ void VulkanDevice::Impl::transitionPassBoundTextures(EncodingState& state,
     if (scannedGroup == nullptr) {
       continue;  // The SetBindGroupCommand handler below fails closed on this.
     }
-    for (const uint32_t sampledSlot : scannedGroup->sampledTextureSlots) {
-      transitionTo(sampledSlot, TextureUsageKind::SampledRead);
-    }
-    for (const uint32_t storageSlot : scannedGroup->storageTextureSlots) {
-      transitionTo(storageSlot, TextureUsageKind::StorageWrite);
-    }
+    transitionBoundTextures(state, *scannedGroup);
   }
 }
 
@@ -2416,13 +2421,6 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   std::vector<VkAttachmentReference> colorRefs;
   std::vector<VkImageView> attachmentViews;
   std::vector<VkClearValue> clearValues;
-  // The pass's external dependencies are derived from the same model the barriers are: what last
-  // touched the attachments on the way in, and what their declared usage says can consume them on
-  // the way out. One edge serves every attachment, so every attachment's prior state feeds it -
-  // keeping only the last one's would let a pass that loads an attachment a dispatch wrote be
-  // ordered as though nothing had ever written it.
-  std::vector<TextureSyncState> entryStates;
-  TextureUsage attachmentUsage = TextureUsage::None;
 
   for (size_t i = 0; i < attachmentDescriptors.size(); ++i) {
     const RenderPassColorAttachment& attachment = attachmentDescriptors[i];
@@ -2436,8 +2434,6 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
 
     // Explicit transition to the attachment layout; the pass then begins and ends in
     // COLOR_ATTACHMENT_OPTIMAL, so the pass itself performs no layout transition.
-    entryStates.push_back(syncStates.stateOf(view->textureSlot));
-    attachmentUsage = attachmentUsage | texture->usage;
     transitionTexture(state.commandBuffer, view->textureSlot, *texture,
                       TextureUsageKind::ColorAttachment);
 
@@ -2472,38 +2468,13 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   subpass.colorAttachmentCount = static_cast<uint32_t>(colorRefs.size());
   subpass.pColorAttachments = colorRefs.data();
 
-  // Explicit external dependencies; the implicit defaults do not cover memory access. Both come
-  // from the resource-state model, because a precise image barrier behind a pass edge that still
-  // said ALL_COMMANDS would order nothing narrower than before.
-  const SubpassDependencyParams entryDependency = AttachmentEntryDependency(entryStates);
-  lastEntryDependency =
-      RecordedSubpassDependencyForTest{static_cast<uint32_t>(entryDependency.srcStage),
-                                       static_cast<uint32_t>(entryDependency.dstStage),
-                                       static_cast<uint32_t>(entryDependency.srcAccess),
-                                       static_cast<uint32_t>(entryDependency.dstAccess)};
-  const SubpassDependencyParams exitDependency = AttachmentExitDependency(attachmentUsage);
-  VkSubpassDependency dependencies[2] = {};
-  dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-  dependencies[0].dstSubpass = 0;
-  dependencies[0].srcStageMask = entryDependency.srcStage;
-  dependencies[0].srcAccessMask = entryDependency.srcAccess;
-  dependencies[0].dstStageMask = entryDependency.dstStage;
-  dependencies[0].dstAccessMask = entryDependency.dstAccess;
-  dependencies[1].srcSubpass = 0;
-  dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-  dependencies[1].srcStageMask = exitDependency.srcStage;
-  dependencies[1].srcAccessMask = exitDependency.srcAccess;
-  dependencies[1].dstStageMask = exitDependency.dstStage;
-  dependencies[1].dstAccessMask = exitDependency.dstAccess;
-
+  // Per-image barriers provide synchronization without changing pipeline render-pass compatibility.
   VkRenderPassCreateInfo renderPassInfo = {};
   renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
   renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
   renderPassInfo.pAttachments = attachments.data();
   renderPassInfo.subpassCount = 1;
   renderPassInfo.pSubpasses = &subpass;
-  renderPassInfo.dependencyCount = 2;
-  renderPassInfo.pDependencies = dependencies;
 
   VkRenderPass renderPass = VK_NULL_HANDLE;
   if (const VkResult result =
@@ -2555,7 +2526,7 @@ Status VulkanDevice::Impl::beginEncodedRenderPass(EncodingState& state,
 
   // Fresh pass state, matching WebGPU render pass semantics.
   state.currentPipeline = nullptr;
-  std::fill(state.boundSets.begin(), state.boundSets.end(), VK_NULL_HANDLE);
+  state.boundGroups.fill(nullptr);
   return OkStatus();
 }
 
@@ -2584,7 +2555,7 @@ Status VulkanDevice::Impl::encodeSetBindGroup(EncodingState& state,
   }
   // Descriptor sets bind lazily at draw: vkCmdBindDescriptorSets needs the pipeline layout,
   // and the RHI allows setBindGroup before setPipeline.
-  state.boundSets[setBindGroup.index] = bindGroup->set;
+  state.boundGroups[setBindGroup.index] = bindGroup;
   return OkStatus();
 }
 
@@ -2639,14 +2610,15 @@ Status VulkanDevice::Impl::encodeDraw(EncodingState& state, const DrawCommand& d
   // guarantees each declared group index is bound; this re-check fails closed anyway.
   for (uint32_t setIndex = 0; setIndex < state.currentPipeline->layout->descriptorSetCount;
        ++setIndex) {
-    if (state.boundSets[setIndex] == VK_NULL_HANDLE) {
+    const BindGroupRecord* group = state.boundGroups[setIndex];
+    if (group == nullptr) {
       return GpuError{
           GpuErrorType::InvalidState,
           std::format("draw: pipeline layout requires bind group {} but none is bound", setIndex)};
     }
     api->vkCmdBindDescriptorSets(state.commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                 state.currentPipeline->layout->layout, setIndex, 1,
-                                 &state.boundSets[setIndex], 0, nullptr);
+                                 state.currentPipeline->layout->layout, setIndex, 1, &group->set, 0,
+                                 nullptr);
   }
   api->vkCmdDraw(state.commandBuffer, draw.vertexCount, draw.instanceCount, draw.firstVertex,
                  draw.firstInstance);
@@ -2660,7 +2632,7 @@ Status VulkanDevice::Impl::encodeEndRenderPass(EncodingState& state) {
   api->vkCmdEndRenderPass(state.commandBuffer);
   state.inRenderPass = false;
   state.currentPipeline = nullptr;
-  std::fill(state.boundSets.begin(), state.boundSets.end(), VK_NULL_HANDLE);
+  state.boundGroups.fill(nullptr);
   return OkStatus();
 }
 
@@ -2723,7 +2695,7 @@ std::optional<Status> VulkanDevice::Impl::encodeRenderCommand(EncodingState& sta
                                                               size_t commandIndex) {
   const Command& command = commands[commandIndex];
   if (const auto* beginPass = std::get_if<BeginRenderPassCommand>(&command)) {
-    transitionPassBoundTextures(state, commands, commandIndex);
+    transitionRenderPassBoundTextures(state, commands, commandIndex);
     return beginEncodedRenderPass(state, *beginPass);
   } else if (const auto* setPipeline = std::get_if<SetPipelineCommand>(&command)) {
     return encodeSetPipeline(state, *setPipeline);
@@ -2746,7 +2718,7 @@ std::optional<Status> VulkanDevice::Impl::encodeRenderCommand(EncodingState& sta
 Status VulkanDevice::Impl::beginEncodedComputePass(EncodingState& state) {
   state.inComputePass = true;
   state.currentComputePipeline = nullptr;
-  std::fill(state.boundSets.begin(), state.boundSets.end(), VK_NULL_HANDLE);
+  state.boundGroups.fill(nullptr);
   return OkStatus();
 }
 
@@ -2774,15 +2746,17 @@ Status VulkanDevice::Impl::encodeDispatchWorkgroups(EncodingState& state,
   // guarantees each declared group index is bound; this re-check fails closed anyway.
   for (uint32_t setIndex = 0; setIndex < state.currentComputePipeline->layout->descriptorSetCount;
        ++setIndex) {
-    if (state.boundSets[setIndex] == VK_NULL_HANDLE) {
+    const BindGroupRecord* group = state.boundGroups[setIndex];
+    if (group == nullptr) {
       return GpuError{GpuErrorType::InvalidState,
                       std::format("dispatchWorkgroups: pipeline layout requires bind group {} but "
                                   "none is bound",
                                   setIndex)};
     }
+    transitionBoundTextures(state, *group);
     api->vkCmdBindDescriptorSets(state.commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                                  state.currentComputePipeline->layout->layout, setIndex, 1,
-                                 &state.boundSets[setIndex], 0, nullptr);
+                                 &group->set, 0, nullptr);
   }
   api->vkCmdDispatch(state.commandBuffer, dispatch.workgroupCountX, dispatch.workgroupCountY,
                      dispatch.workgroupCountZ);
@@ -2815,7 +2789,7 @@ Status VulkanDevice::Impl::encodeEndComputePass(EncodingState& state) {
 
   state.inComputePass = false;
   state.currentComputePipeline = nullptr;
-  std::fill(state.boundSets.begin(), state.boundSets.end(), VK_NULL_HANDLE);
+  state.boundGroups.fill(nullptr);
   return OkStatus();
 }
 
@@ -2824,9 +2798,6 @@ std::optional<Status> VulkanDevice::Impl::encodeComputeCommand(EncodingState& st
                                                                size_t commandIndex) {
   const Command& command = commands[commandIndex];
   if (std::get_if<BeginComputePassCommand>(&command) != nullptr) {
-    // Symmetric with the render path: barriers cannot be recorded inside a pass, so the textures
-    // this pass binds are transitioned into the layouts its descriptors declare before it opens.
-    transitionPassBoundTextures(state, commands, commandIndex);
     return beginEncodedComputePass(state);
   } else if (const auto* setPipeline = std::get_if<SetComputePipelineCommand>(&command)) {
     return encodeSetComputePipeline(state, *setPipeline);
@@ -2909,7 +2880,6 @@ Status VulkanDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferS
   // and are destroyed when the fence signals, on failure they are destroyed here.
   Impl::EncodingState state;
   state.commandBuffer = commandBufferResult.result();
-  state.boundSets.assign(kMaxBindGroups, VK_NULL_HANDLE);
   const auto failEncoding = [&](Status error) -> Status {
     // Nothing recorded into this command buffer will execute, so the transitions staged while
     // encoding it must not survive into the tracked state.

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -43,12 +43,11 @@ namespace donner::gpu::vulkan {
  * DEVICE_LOCAL (when available) with staged uploads through a transient host-visible buffer and
  * explicit image layout transitions.
  *
- * Synchronization is tracked per resource rather than assumed: every image barrier and both of
- * every render pass's external dependencies are derived from the state model in
- * VulkanResourceState.h, which records the stage and access that last touched each texture and
- * names both ends of the transition to whatever uses it next. A pattern the model does not
- * describe falls back to the maximal ALL_COMMANDS barrier, so an unrecognised usage costs
- * precision and never correctness. Readback copies still end in a HOST-domain buffer barrier.
+ * Synchronization is tracked per image: barriers before and after render passes, dispatches,
+ * and copies come from VulkanResourceState.h. Render-pass attachment layouts stay fixed, so
+ * explicit image barriers provide the dependencies without varying render-pass compatibility.
+ * Unknown usage falls back to an ALL_COMMANDS barrier. Readback copies also end in a HOST-domain
+ * buffer barrier.
  *
  * Barrier elision - dropping a barrier the model says is needed - is still not attempted; that
  * would need counter and timing evidence naming the bottleneck it removes.
@@ -141,21 +140,13 @@ public:
     int32_t newLayout = 0;     //!< Layout the image moved to.
   };
 
-  /// Every image barrier recorded since the device was created, oldest first. Test accessor.
+  /// Enables an empty barrier history or disables recording and releases the history.
+  /// Recording is disabled by default.
+  /// @param enabled Whether subsequent image barriers should be retained for inspection.
+  void setImageBarrierRecordingForTest(bool enabled);
+
+  /// Image barriers since recording was last enabled, oldest first; empty while disabled.
   [[nodiscard]] std::vector<RecordedImageBarrierForTest> recordedImageBarriersForTest() const;
-
-  /// The two halves of a render pass external dependency, as plain numbers. Test accessor.
-  struct RecordedSubpassDependencyForTest {
-    uint32_t srcStage = 0;   //!< Source pipeline stage mask.
-    uint32_t dstStage = 0;   //!< Destination pipeline stage mask.
-    uint32_t srcAccess = 0;  //!< Access made available.
-    uint32_t dstAccess = 0;  //!< Access made visible.
-  };
-
-  /// The entry-side external dependency of the most recently created render pass. Fails closed
-  /// when no render pass has been created. Test accessor.
-  [[nodiscard]] Result<RecordedSubpassDependencyForTest> lastRenderPassEntryDependencyForTest()
-      const;
 
   /// Where an injected upload failure happens, which is what decides whether the transitions it
   /// recorded describe anything the GPU will run.

--- a/donner/gpu/vulkan/VulkanResourceState.cc
+++ b/donner/gpu/vulkan/VulkanResourceState.cc
@@ -7,11 +7,10 @@ namespace donner::gpu::vulkan {
 
 namespace {
 
-/// The stages a sampled read can happen in. A sampled texture is readable from the fragment
-/// stage of a render pass and from a compute dispatch, and the backend does not record which of
-/// the two a given binding will be read from, so the destination scope names both.
-constexpr VkPipelineStageFlags kSampledReadStages =
-    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+/// Sampled bindings can be visible in every supported shader stage.
+constexpr VkPipelineStageFlags kSampledReadStages = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                                    VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
 /// The access bits that need an availability operation. Only writes have to be made available;
 /// a read that happened before needs no flushing, so naming it in a source scope would order

--- a/donner/gpu/vulkan/VulkanResourceState.cc
+++ b/donner/gpu/vulkan/VulkanResourceState.cc
@@ -63,12 +63,6 @@ std::ostream& operator<<(std::ostream& os, const ImageBarrierParams& value) {
             << ", conservative=" << (value.conservative ? "true" : "false") << "}";
 }
 
-std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value) {
-  return os << "{srcStage=0x" << std::hex << value.srcStage << ", dstStage=0x" << value.dstStage
-            << ", srcAccess=0x" << value.srcAccess << ", dstAccess=0x" << value.dstAccess
-            << std::dec << ", conservative=" << (value.conservative ? "true" : "false") << "}";
-}
-
 namespace {
 
 /// The one maximal scope every conservative fallback uses: wait for everything, make every write
@@ -79,17 +73,6 @@ constexpr VkPipelineStageFlags kStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 constexpr VkAccessFlags kSrcAccess = VK_ACCESS_MEMORY_WRITE_BIT;
 constexpr VkAccessFlags kDstAccess = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
 }  // namespace maximal
-
-/// The maximal subpass dependency, for a pass whose scope cannot be narrowed.
-SubpassDependencyParams ConservativeSubpassDependency() {
-  SubpassDependencyParams params;
-  params.srcStage = maximal::kStage;
-  params.dstStage = maximal::kStage;
-  params.srcAccess = maximal::kSrcAccess;
-  params.dstAccess = maximal::kDstAccess;
-  params.conservative = true;
-  return params;
-}
 
 }  // namespace
 
@@ -123,9 +106,9 @@ TextureSyncState StateAfterUsage(TextureUsageKind usage) {
       // Nothing has touched the image, so a barrier out of this state waits for nothing.
       return TextureSyncState{VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0};
     case TextureUsageKind::ColorAttachment:
-      return TextureSyncState{VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT};
+      return TextureSyncState{
+          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+          VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT};
     case TextureUsageKind::SampledRead:
       return TextureSyncState{VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, kSampledReadStages,
                               VK_ACCESS_SHADER_READ_BIT};
@@ -158,70 +141,6 @@ ImageBarrierParams TransitionFor(const TextureSyncState& current, TextureUsageKi
   params.dstStage = next.stage;
   params.srcAccess = current.access & kWriteAccessMask;
   params.dstAccess = next.access;
-  params.conservative = false;
-  return params;
-}
-
-SubpassDependencyParams AttachmentEntryDependency(
-    std::span<const TextureSyncState> attachmentStates) {
-  if (attachmentStates.empty()) {
-    return ConservativeSubpassDependency();
-  }
-
-  SubpassDependencyParams params;
-  params.srcStage = 0;
-  params.srcAccess = 0;
-  for (const TextureSyncState& state : attachmentStates) {
-    if (!IsTrackedLayout(state.layout)) {
-      return ConservativeSubpassDependency();
-    }
-    // One edge serves every attachment, so it must wait for the widest thing any of them was
-    // last touched by. Narrowing to a single attachment would drop another's prior write: a pass
-    // that loads one attachment a dispatch wrote and clears another still has to wait for that
-    // write to be both available and visible to the load.
-    params.srcStage |= state.stage;
-    params.srcAccess |= state.access & kWriteAccessMask;
-  }
-  params.dstStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  params.dstAccess = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  params.conservative = false;
-  return params;
-}
-
-SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage) {
-  VkPipelineStageFlags dstStage = 0;
-  VkAccessFlags dstAccess = 0;
-  if (HasAllFlags(declaredUsage, TextureUsage::Sampled)) {
-    dstStage |= kSampledReadStages;
-    dstAccess |= VK_ACCESS_SHADER_READ_BIT;
-  }
-  if (HasAllFlags(declaredUsage, TextureUsage::StorageBinding)) {
-    dstStage |= VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-    dstAccess |= VK_ACCESS_SHADER_WRITE_BIT;
-  }
-  if (HasAllFlags(declaredUsage, TextureUsage::CopySrc)) {
-    dstStage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
-    dstAccess |= VK_ACCESS_TRANSFER_READ_BIT;
-  }
-  if (HasAllFlags(declaredUsage, TextureUsage::CopyDst)) {
-    dstStage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
-    dstAccess |= VK_ACCESS_TRANSFER_WRITE_BIT;
-  }
-  if (HasAllFlags(declaredUsage, TextureUsage::RenderAttachment)) {
-    dstStage |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dstAccess |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  }
-
-  if (dstStage == 0) {
-    // The attachment declares no consumer this table models, so nothing narrower than the
-    // maximal edge can be justified.
-    return ConservativeSubpassDependency();
-  }
-  SubpassDependencyParams params;
-  params.srcStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  params.srcAccess = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  params.dstStage = dstStage;
-  params.dstAccess = dstAccess;
   params.conservative = false;
   return params;
 }

--- a/donner/gpu/vulkan/VulkanResourceState.h
+++ b/donner/gpu/vulkan/VulkanResourceState.h
@@ -3,11 +3,8 @@
 /// \c donner::gpu::vulkan::VulkanResourceState - the tracked per-texture synchronization state
 /// the Vulkan backend derives its barriers from.
 ///
-/// Every barrier this backend records, and every render pass external dependency it declares,
-/// is derived here from one table so the two cannot disagree. A precise image barrier sitting
-/// behind a render pass dependency that still says ALL_COMMANDS buys nothing: the dependency is
-/// the edge that orders an attachment write against whatever reads it next, so both halves read
-/// from the same source of truth.
+/// Each barrier names the stage and access that last touched the image and its next use.
+/// Render passes keep attachment layouts fixed; the barriers around them carry synchronization.
 ///
 /// This is pure state machinery over Vulkan enums: it opens no device, calls no entry point, and
 /// records nothing. That keeps it testable on every platform the project builds on, rather than
@@ -23,9 +20,6 @@
 #include <cstdint>
 #include <map>
 #include <ostream>
-#include <span>
-
-#include "donner/gpu/Descriptors.h"
 
 namespace donner::gpu::vulkan {
 
@@ -38,7 +32,7 @@ namespace donner::gpu::vulkan {
 /// host-mapped and a kernel write to one would otherwise be invisible to the mapping.
 enum class TextureUsageKind : uint8_t {
   Undefined,        //!< Never used; contents undefined.
-  ColorAttachment,  //!< Written as a render pass color attachment.
+  ColorAttachment,  //!< Read and written as a render pass color attachment.
   SampledRead,      //!< Read through a sampled-texture binding.
   StorageWrite,     //!< Written through a write-only storage-texture binding.
   TransferRead,     //!< Read as the source of a copy.
@@ -84,22 +78,6 @@ struct ImageBarrierParams {
 /// Ostream output operator. @param os Output stream. @param value Value to output.
 std::ostream& operator<<(std::ostream& os, const ImageBarrierParams& value);
 
-/// The two halves of a render pass external subpass dependency.
-struct SubpassDependencyParams {
-  VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Source stage scope.
-  VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  //!< Destination scope.
-  VkAccessFlags srcAccess = 0;                                         //!< Access made available.
-  VkAccessFlags dstAccess = 0;                                         //!< Access made visible.
-  /// True when the declared usage implied nothing tracked and the maximal edge was used.
-  bool conservative = false;
-
-  /// Equality operator. @param other Parameters to compare against.
-  bool operator==(const SubpassDependencyParams& other) const = default;
-};
-
-/// Ostream output operator. @param os Output stream. @param value Value to output.
-std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value);
-
 /// The maximal barrier: ALL_COMMANDS to ALL_COMMANDS with memory availability and visibility.
 ///
 /// The fallback for any usage pair the table does not name. VK_ACCESS_MEMORY_* is valid with any
@@ -129,30 +107,6 @@ std::ostream& operator<<(std::ostream& os, const SubpassDependencyParams& value)
 /// @param usage Usage the texture is about to be put to.
 [[nodiscard]] ImageBarrierParams TransitionFor(const TextureSyncState& current,
                                                TextureUsageKind usage);
-
-/// The external dependency into a render pass, ordering whatever touched the attachments before
-/// it against the pass's color output.
-///
-/// One edge covers every attachment, so the source scope is the union across all of them: a pass
-/// that loads one attachment a compute dispatch wrote and clears another must still wait for
-/// that write, and taking any single attachment's prior state would lose it. A pass with no
-/// attachments, or one whose attachment reached its layout through a path the model does not
-/// describe, falls back to the maximal edge.
-///
-/// @param attachmentStates State each attachment texture is tracked in, in any order.
-[[nodiscard]] SubpassDependencyParams AttachmentEntryDependency(
-    std::span<const TextureSyncState> attachmentStates);
-
-/// The external dependency out of a render pass, ordering the pass's color output against
-/// whatever the attachment's declared usage says can consume it next.
-///
-/// The consumer is read from the texture's declared usage set rather than by scanning ahead: a
-/// texture declared Sampled gets the shader-read edge, one declared CopySrc the transfer-read
-/// edge, and one declaring several gets their union. A usage set naming no tracked consumer
-/// falls back to the maximal edge.
-///
-/// @param declaredUsage Usage flags the attachment texture was created with.
-[[nodiscard]] SubpassDependencyParams AttachmentExitDependency(TextureUsage declaredUsage);
 
 /**
  * Tracked state for a set of textures, under the discipline the backend records against.

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -139,6 +139,7 @@ donner_cc_test(
         "//donner/gpu/shader:module_interface",
         "//donner/gpu/shader:programs",
         "//donner/gpu/vulkan:vulkan_device",
+        "//donner/gpu/vulkan:vulkan_resource_state",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/gpu/vulkan/tests/VulkanColorMatrix_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanColorMatrix_tests.cc
@@ -101,6 +101,12 @@ protected:
     }
   }
 
+  void TearDown() override {
+    if (device_) {
+      EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+    }
+  }
+
   /// Unwraps an RHI result, failing the test on error.
   template <typename T>
   T unwrap(Result<T>&& result, const char* what) {
@@ -228,6 +234,7 @@ protected:
     if (HasFatalFailure() || IsSkipped()) {
       return;
     }
+    device_->setImageBarrierRecordingForTest(true);
 
     shader::ShaderResult<shader::IrModule> module = shader::programs::BuildColorMatrixModule();
     ASSERT_FALSE(module.hasError()) << module.error();

--- a/donner/gpu/vulkan/tests/VulkanColorMatrix_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanColorMatrix_tests.cc
@@ -22,6 +22,7 @@
 #include "donner/gpu/shader/programs/ColorMatrix.h"
 #include "donner/gpu/tests/ColorMatrixSlice.h"
 #include "donner/gpu/vulkan/VulkanDevice.h"
+#include "donner/gpu/vulkan/VulkanResourceState.h"
 
 namespace donner::gpu::vulkan::tests {
 namespace {
@@ -217,6 +218,128 @@ TEST_F(VulkanColorMatrixTest, ComputePassTransitionsAFreshStorageTextureToGenera
   EXPECT_EQ(afterLayout.result(), TrackedLayout::General)
       << "the compute pass bound this texture through a storage-texture descriptor, which "
          "declares GENERAL, so the pass must have transitioned it there";
+}
+
+/// Two groups share an intermediate texture as the first dispatch's output and the second's input.
+class VulkanDispatchStateTest : public VulkanColorMatrixTest {
+protected:
+  void SetUp() override {
+    VulkanColorMatrixTest::SetUp();
+    if (HasFatalFailure() || IsSkipped()) {
+      return;
+    }
+
+    shader::ShaderResult<shader::IrModule> module = shader::programs::BuildColorMatrixModule();
+    ASSERT_FALSE(module.hasError()) << module.error();
+    shader::ShaderResult<std::vector<uint32_t>> spirv = shader::EmitSpirv(module.result());
+    ASSERT_FALSE(spirv.hasError()) << spirv.error();
+    shaderModule_ = unwrap(device_->createShaderModule(ShaderModuleDescriptor{
+                               "dispatch", "", ShaderSourceKind::Spirv, std::move(spirv).result(),
+                               shader::ComputeEntryPointsOf(module.result())}),
+                           "createShaderModule");
+    groupLayout_ = unwrap(device_->createBindGroupLayout(
+                              BindGroupLayoutDescriptor{"dispatch", ColorMatrixLayoutEntries()}),
+                          "createBindGroupLayout");
+    pipelineLayout_ =
+        unwrap(device_->createPipelineLayout(PipelineLayoutDescriptor{"dispatch", {groupLayout_}}),
+               "createPipelineLayout");
+    pipeline_ = unwrap(device_->createComputePipeline(ComputePipelineDescriptor{
+                           "dispatch", pipelineLayout_, ComputeState{shaderModule_, "cs_main"},
+                           WorkgroupSize{kColorMatrixWorkgroupSize, kColorMatrixWorkgroupSize, 1}}),
+                       "createComputePipeline");
+
+    for (size_t i = 0; i < textures_.size(); ++i) {
+      textures_[i] = unwrap(device_->createTexture(TextureDescriptor{
+                                "dispatch",
+                                {1, 1},
+                                TextureFormat::RGBA8Unorm,
+                                TextureUsage::Sampled | TextureUsage::StorageBinding}),
+                            "createTexture");
+      views_[i] = unwrap(device_->createTextureView(textures_[i], TextureViewDescriptor{}),
+                         "createTextureView");
+    }
+    params_ = unwrap(device_->createBuffer(BufferDescriptor{"params", sizeof(ColorMatrixParams),
+                                                            BufferUsage::Uniform}),
+                     "createBuffer params");
+    bias_ = unwrap(
+        device_->createBuffer(BufferDescriptor{"bias", sizeof(float) * 8, BufferUsage::Storage}),
+        "createBuffer bias");
+    for (size_t i = 0; i < groups_.size(); ++i) {
+      groups_[i] = unwrap(device_->createBindGroup(BindGroupDescriptor{
+                              "dispatch", groupLayout_,
+                              ColorMatrixBindGroupEntries(views_[i], views_[i + 1], params_, bias_,
+                                                          sizeof(float) * 8)}),
+                          "createBindGroup");
+    }
+    encoder_ = unwrap(device_->createCommandEncoder(), "createCommandEncoder");
+    pass_ = unwrap(encoder_->beginComputePass(ComputePassDescriptor{}), "beginComputePass");
+    ASSERT_FALSE(pass_->setPipeline(pipeline_).hasError());
+  }
+
+  void submitPass() {
+    ASSERT_FALSE(pass_->end().hasError());
+    Result<CommandBuffer> commands = encoder_->finish();
+    ASSERT_FALSE(commands.hasError()) << commands.error();
+    Result<uint64_t> serial = device_->submit(std::move(commands).result());
+    ASSERT_FALSE(serial.hasError()) << serial.error();
+    ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/5.0))
+        << device_->lastErrorForTest();
+    EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+  }
+
+  ShaderModule shaderModule_;
+  BindGroupLayout groupLayout_;
+  PipelineLayout pipelineLayout_;
+  ComputePipeline pipeline_;
+  std::array<Texture, 3> textures_;
+  std::array<TextureView, 3> views_;
+  Buffer params_;
+  Buffer bias_;
+  std::array<BindGroup, 2> groups_;
+  std::unique_ptr<CommandEncoder> encoder_;
+  ComputePassEncoder* pass_ = nullptr;
+};
+
+TEST_F(VulkanDispatchStateTest, StorageWriteThenSampleInOnePassUsesEachDispatchLayout) {
+  ASSERT_FALSE(pass_->setBindGroup(0, groups_[0]).hasError());
+  ASSERT_FALSE(pass_->dispatchWorkgroups(1).hasError());
+  ASSERT_FALSE(pass_->setBindGroup(0, groups_[1]).hasError());
+  ASSERT_FALSE(pass_->dispatchWorkgroups(1).hasError());
+  submitPass();
+
+  EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(textures_[1]), "intermediate layout"),
+            TrackedLayout::ShaderReadOnly);
+}
+
+TEST_F(VulkanDispatchStateTest, RepeatedDispatchWithoutRebindingOrdersStorageWrites) {
+  ASSERT_FALSE(pass_->setBindGroup(0, groups_[0]).hasError());
+  ASSERT_FALSE(pass_->dispatchWorkgroups(1).hasError());
+  ASSERT_FALSE(pass_->dispatchWorkgroups(1).hasError());
+  submitPass();
+
+  using Barrier = VulkanDevice::RecordedImageBarrierForTest;
+  EXPECT_THAT(
+      device_->recordedImageBarriersForTest(),
+      testing::Contains(testing::AllOf(
+          testing::Field("textureSlot", &Barrier::textureSlot, textures_[1].slotIndex()),
+          testing::Field("oldLayout", &Barrier::oldLayout, int32_t{VK_IMAGE_LAYOUT_GENERAL}),
+          testing::Field("newLayout", &Barrier::newLayout, int32_t{VK_IMAGE_LAYOUT_GENERAL}),
+          testing::Field("srcStage", &Barrier::srcStage,
+                         uint32_t{VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT}),
+          testing::Field("dstStage", &Barrier::dstStage,
+                         uint32_t{VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT}),
+          testing::Field("srcAccess", &Barrier::srcAccess, uint32_t{VK_ACCESS_SHADER_WRITE_BIT}),
+          testing::Field("dstAccess", &Barrier::dstAccess, uint32_t{VK_ACCESS_SHADER_WRITE_BIT}))));
+}
+
+TEST_F(VulkanDispatchStateTest, AGroupReplacedBeforeDispatchDoesNotTransitionItsTextures) {
+  ASSERT_FALSE(pass_->setBindGroup(0, groups_[0]).hasError());
+  ASSERT_FALSE(pass_->setBindGroup(0, groups_[1]).hasError());
+  ASSERT_FALSE(pass_->dispatchWorkgroups(1).hasError());
+  submitPass();
+
+  EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(textures_[0]), "unused input layout"),
+            TrackedLayout::Undefined);
 }
 
 TEST_F(VulkanColorMatrixTest, DispatchMatchesTheHostComputedResult) {

--- a/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
@@ -83,6 +83,20 @@ protected:
   std::unique_ptr<VulkanDevice> device_;
 };
 
+TEST_F(VulkanResourceStateDeviceTest, BarrierHistoryIsDisabledByDefault) {
+  device_ = VulkanDevice::Create();
+  ASSERT_NE(device_, nullptr);
+  Texture texture = makeTexture("uploaded", TextureUsage::CopyDst);
+  for (int upload = 0; upload < 2; ++upload) {
+    Status status =
+        device_->writeTexture(texture, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+    ASSERT_FALSE(status.hasError()) << status.error();
+  }
+  EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(texture), "uploaded layout"),
+            VulkanDevice::TrackedTextureLayout::TransferDst);
+  EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::IsEmpty());
+}
+
 TEST_F(VulkanResourceStateDeviceTest, AFailedUploadLeavesNoStateForALaterSubmitToPromote) {
   // Not Sampled, so a completed upload would leave this texture in the transfer-destination
   // layout and a failed one must leave it untouched - a difference the tracker can show.
@@ -184,7 +198,8 @@ TEST_F(VulkanResourceStateDeviceTest, ThePassEntryEdgeCoversAnAttachmentThatIsNo
   ASSERT_FALSE(commands.hasError()) << commands.error();
   Result<uint64_t> serial = device_->submit(std::move(commands).result());
   ASSERT_FALSE(serial.hasError()) << serial.error();
-  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0));
+  ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0))
+      << device_->lastErrorForTest();
 
   const VulkanDevice::RecordedSubpassDependencyForTest entry =
       unwrap(device_->lastRenderPassEntryDependencyForTest(), "entry dependency");

--- a/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceStateDevice_tests.cc
@@ -1,6 +1,5 @@
 /// @file
-/// Device-level regressions for the resource-state wiring: the barriers and render pass
-/// dependencies the backend actually emits, and what it leaves in the tracker when work fails.
+/// Device-level regressions for the barriers the backend emits and the state left after failure.
 ///
 /// The model's own suite covers the table. These cover the code that feeds it, which is where
 /// both of the defects this file exists for lived. They need a real device, so unlike the model
@@ -40,6 +39,13 @@ protected:
         FAIL() << "DONNER_REQUIRE_VULKAN=1 is set but no Vulkan 1.1 device is available";
       }
       GTEST_SKIP() << "No Vulkan 1.1 device available";
+    }
+    device_->setImageBarrierRecordingForTest(true);
+  }
+
+  void TearDown() override {
+    if (device_) {
+      EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
     }
   }
 
@@ -94,6 +100,28 @@ TEST_F(VulkanResourceStateDeviceTest, BarrierHistoryIsDisabledByDefault) {
   }
   EXPECT_EQ(unwrap(device_->trackedTextureLayoutForTest(texture), "uploaded layout"),
             VulkanDevice::TrackedTextureLayout::TransferDst);
+  EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::IsEmpty());
+}
+
+TEST_F(VulkanResourceStateDeviceTest, BarrierRecordingCanBeRestartedAndDisabled) {
+  Texture texture = makeTexture("uploaded", TextureUsage::CopyDst);
+  Status status =
+      device_->writeTexture(texture, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(status.hasError()) << status.error();
+  ASSERT_THAT(device_->recordedImageBarriersForTest(), testing::SizeIs(1));
+
+  device_->setImageBarrierRecordingForTest(true);
+  EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::IsEmpty());
+  status =
+      device_->writeTexture(texture, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(status.hasError()) << status.error();
+  EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::SizeIs(1));
+
+  device_->setImageBarrierRecordingForTest(false);
+  EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::IsEmpty());
+  status =
+      device_->writeTexture(texture, uploadBytes(), uploadLayout(), Extent2d{kExtent, kExtent});
+  ASSERT_FALSE(status.hasError()) << status.error();
   EXPECT_THAT(device_->recordedImageBarriersForTest(), testing::IsEmpty());
 }
 
@@ -163,11 +191,8 @@ TEST_F(VulkanResourceStateDeviceTest, AnUploadTheQueueTookKeepsItsStateWhenTheWa
   EXPECT_EQ(next.srcStage, uint32_t{VK_PIPELINE_STAGE_TRANSFER_BIT});
 }
 
-TEST_F(VulkanResourceStateDeviceTest, ThePassEntryEdgeCoversAnAttachmentThatIsNotTheLast) {
-  // One attachment carries a prior write, the other is untouched, and the written one is not
-  // last: deriving the edge from a single attachment picks up the untouched one and orders
-  // nothing. A transfer stands in for the producing write here; which stage and access a given
-  // producer contributes is what the model suite covers.
+TEST_F(VulkanResourceStateDeviceTest, AttachmentTransitionsCoverEveryAttachment) {
+  // The written attachment is not last, so handling only the final attachment loses its write.
   Texture producedFirst =
       makeTexture("producedFirst", TextureUsage::RenderAttachment | TextureUsage::CopyDst);
   Texture freshSecond = makeTexture("freshSecond", TextureUsage::RenderAttachment);
@@ -201,13 +226,25 @@ TEST_F(VulkanResourceStateDeviceTest, ThePassEntryEdgeCoversAnAttachmentThatIsNo
   ASSERT_TRUE(device_->waitForSerial(serial.result(), /*timeoutSeconds=*/30.0))
       << device_->lastErrorForTest();
 
-  const VulkanDevice::RecordedSubpassDependencyForTest entry =
-      unwrap(device_->lastRenderPassEntryDependencyForTest(), "entry dependency");
-  EXPECT_TRUE((entry.srcStage & VK_PIPELINE_STAGE_TRANSFER_BIT) != 0)
-      << "the load of the written attachment must be ordered after the write that produced it";
-  EXPECT_TRUE((entry.srcAccess & VK_ACCESS_TRANSFER_WRITE_BIT) != 0)
-      << "that write must be made available to the load";
-  EXPECT_EQ(entry.dstStage, uint32_t{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT});
+  const auto writtenBarriers = barriersFor(producedFirst.slotIndex());
+  ASSERT_THAT(writtenBarriers, testing::SizeIs(2));
+  const VulkanDevice::RecordedImageBarrierForTest& writtenBarrier = writtenBarriers.back();
+  EXPECT_EQ(writtenBarrier.oldLayout, int32_t{VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL});
+  EXPECT_EQ(writtenBarrier.newLayout, int32_t{VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
+  EXPECT_EQ(writtenBarrier.srcStage, uint32_t{VK_PIPELINE_STAGE_TRANSFER_BIT});
+  EXPECT_EQ(writtenBarrier.srcAccess, uint32_t{VK_ACCESS_TRANSFER_WRITE_BIT});
+  EXPECT_EQ(writtenBarrier.dstStage, uint32_t{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT});
+  EXPECT_EQ(writtenBarrier.dstAccess,
+            uint32_t{VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT});
+
+  const auto freshBarriers = barriersFor(freshSecond.slotIndex());
+  ASSERT_THAT(freshBarriers, testing::SizeIs(1));
+  EXPECT_EQ(freshBarriers[0].oldLayout, int32_t{VK_IMAGE_LAYOUT_UNDEFINED});
+  EXPECT_EQ(freshBarriers[0].newLayout, int32_t{VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
+  EXPECT_EQ(freshBarriers[0].srcAccess, 0u);
+  EXPECT_EQ(freshBarriers[0].dstStage, uint32_t{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT});
+  EXPECT_EQ(freshBarriers[0].dstAccess,
+            uint32_t{VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT});
 }
 
 TEST_F(VulkanResourceStateDeviceTest, WritingOneTextureTwiceInALayoutThatDoesNotChangeStillWaits) {

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -18,6 +18,20 @@ namespace {
 constexpr VkPipelineStageFlags kSampledReadStages =
     VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
+TEST(VulkanResourceStateTests, UploadVisibilityIncludesVertexTextureReads) {
+  const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::TransferWrite),
+                                                   TextureUsageKind::SampledRead);
+  EXPECT_EQ(barrier.dstStage & VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+            VkPipelineStageFlags{VK_PIPELINE_STAGE_VERTEX_SHADER_BIT});
+}
+
+TEST(VulkanResourceStateTests, ATransferWriteWaitsForEarlierVertexTextureReads) {
+  const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::SampledRead),
+                                                   TextureUsageKind::TransferWrite);
+  EXPECT_EQ(barrier.srcStage & VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+            VkPipelineStageFlags{VK_PIPELINE_STAGE_VERTEX_SHADER_BIT});
+}
+
 TEST(VulkanResourceStateTests, AttachmentTransitionCoversLoadsAndWrites) {
   const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::TransferWrite),
                                                    TextureUsageKind::ColorAttachment);

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -16,7 +16,8 @@ namespace donner::gpu::vulkan {
 namespace {
 
 constexpr VkPipelineStageFlags kSampledReadStages =
-    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+    VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
 TEST(VulkanResourceStateTests, UploadVisibilityIncludesVertexTextureReads) {
   const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::TransferWrite),

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -1,6 +1,6 @@
 /// @file
 /// Model tests for the Vulkan backend's tracked resource-state machine: the exact barriers and
-/// subpass dependencies each recorded usage pattern produces, the conservative fallback for
+/// transitions each recorded usage pattern produces, the conservative fallback for
 /// patterns outside the tracked set, and the staged-then-committed discipline that keeps the
 /// table from claiming transitions the GPU never ran.
 ///
@@ -11,8 +11,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <array>
 
 namespace donner::gpu::vulkan {
 namespace {
@@ -132,52 +130,6 @@ TEST(VulkanResourceStateTests, EveryTrackedUsageRoundTripsThroughItsLayout) {
   }
 }
 
-TEST(VulkanResourceStateTests, ThePassEntryEdgeNamesWhatLastTouchedTheAttachment) {
-  const std::array<TextureSyncState, 1> attachments = {
-      StateAfterUsage(TextureUsageKind::TransferWrite)};
-  const SubpassDependencyParams entry = AttachmentEntryDependency(attachments);
-
-  EXPECT_EQ(entry.srcStage, VK_PIPELINE_STAGE_TRANSFER_BIT);
-  EXPECT_EQ(entry.srcAccess, VK_ACCESS_TRANSFER_WRITE_BIT);
-  EXPECT_EQ(entry.dstStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-  EXPECT_FALSE(entry.conservative);
-}
-
-TEST(VulkanResourceStateTests, ThePassEntryEdgeCoversEveryAttachmentNotJustOne) {
-  // The shape the backend actually produces: one attachment a compute dispatch wrote and is
-  // about to be loaded, and one fresh attachment that will simply be cleared. A single edge
-  // serves both, so it has to wait for the dispatch even though the other attachment has never
-  // been touched.
-  const std::array<TextureSyncState, 2> attachments = {
-      StateAfterUsage(TextureUsageKind::StorageWrite), TextureSyncState{}};
-  const SubpassDependencyParams entry = AttachmentEntryDependency(attachments);
-
-  EXPECT_TRUE((entry.srcStage & VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT) != 0)
-      << "the load of the written attachment must be ordered after the dispatch that wrote it";
-  EXPECT_TRUE((entry.srcAccess & VK_ACCESS_SHADER_WRITE_BIT) != 0)
-      << "the dispatch's write must be made available to that load";
-  EXPECT_EQ(entry.dstStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-  EXPECT_FALSE(entry.conservative);
-
-  // Order must not matter: the union is the same whichever attachment comes first.
-  const std::array<TextureSyncState, 2> reversed = {
-      TextureSyncState{}, StateAfterUsage(TextureUsageKind::StorageWrite)};
-  EXPECT_EQ(AttachmentEntryDependency(reversed), entry);
-}
-
-TEST(VulkanResourceStateTests, ThePassEntryEdgeIsMaximalWhenAnyAttachmentIsUnmodelled) {
-  TextureSyncState fromElsewhere;
-  fromElsewhere.layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-  const std::array<TextureSyncState, 2> attachments = {
-      StateAfterUsage(TextureUsageKind::ColorAttachment), fromElsewhere};
-
-  EXPECT_TRUE(AttachmentEntryDependency(attachments).conservative)
-      << "one attachment the model cannot describe makes the whole edge unnarrowable";
-
-  const std::array<TextureSyncState, 0> none = {};
-  EXPECT_TRUE(AttachmentEntryDependency(none).conservative);
-}
-
 TEST(VulkanResourceStateTests, WritingAStorageTextureTwiceStillNeedsABarrier) {
   // Both dispatches leave the image in GENERAL, so a layout-only comparison would see no change
   // and order nothing between them.
@@ -191,32 +143,6 @@ TEST(VulkanResourceStateTests, WritingAStorageTextureTwiceStillNeedsABarrier) {
   EXPECT_EQ(barrier.dstStage, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
   EXPECT_EQ(barrier.dstAccess, VK_ACCESS_SHADER_WRITE_BIT);
   EXPECT_FALSE(barrier.conservative);
-}
-
-TEST(VulkanResourceStateTests, ThePassExitEdgeComesFromTheAttachmentsDeclaredConsumers) {
-  const SubpassDependencyParams sampled =
-      AttachmentExitDependency(TextureUsage::RenderAttachment | TextureUsage::Sampled);
-  EXPECT_EQ(sampled.srcStage, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-  EXPECT_EQ(sampled.srcAccess, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-  EXPECT_EQ(sampled.dstStage, kSampledReadStages | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-  EXPECT_EQ(sampled.dstAccess, VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-  EXPECT_FALSE(sampled.conservative)
-      << "a precise barrier behind an ALL_COMMANDS pass edge would buy nothing";
-
-  const SubpassDependencyParams readback =
-      AttachmentExitDependency(TextureUsage::RenderAttachment | TextureUsage::CopySrc);
-  EXPECT_TRUE((readback.dstStage & VK_PIPELINE_STAGE_TRANSFER_BIT) != 0);
-  EXPECT_TRUE((readback.dstAccess & VK_ACCESS_TRANSFER_READ_BIT) != 0);
-  EXPECT_FALSE(readback.conservative);
-}
-
-TEST(VulkanResourceStateTests, AnAttachmentWithNoModelledConsumerFallsBackToTheMaximalEdge) {
-  const SubpassDependencyParams edge = AttachmentExitDependency(TextureUsage::None);
-
-  EXPECT_TRUE(edge.conservative);
-  EXPECT_EQ(edge.dstStage, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-  EXPECT_EQ(edge.dstAccess, VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
 }
 
 // ----------------------------------------------------------------------------

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -15,9 +15,9 @@
 namespace donner::gpu::vulkan {
 namespace {
 
-constexpr VkPipelineStageFlags kSampledReadStages =
-    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
-    VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+constexpr VkPipelineStageFlags kSampledReadStages = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                                    VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
 TEST(VulkanResourceStateTests, UploadVisibilityIncludesVertexTextureReads) {
   const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::TransferWrite),

--- a/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanResourceState_tests.cc
@@ -20,6 +20,13 @@ namespace {
 constexpr VkPipelineStageFlags kSampledReadStages =
     VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
+TEST(VulkanResourceStateTests, AttachmentTransitionCoversLoadsAndWrites) {
+  const ImageBarrierParams barrier = TransitionFor(StateAfterUsage(TextureUsageKind::TransferWrite),
+                                                   TextureUsageKind::ColorAttachment);
+  EXPECT_EQ(barrier.dstAccess, VkAccessFlags{VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT});
+}
+
 TEST(VulkanResourceStateTests, AttachmentWriteThenSampledReadNamesBothEnds) {
   const TextureSyncState afterDraw = StateAfterUsage(TextureUsageKind::ColorAttachment);
   const ImageBarrierParams barrier = TransitionFor(afterDraw, TextureUsageKind::SampledRead);


### PR DESCRIPTION
Preserve native GPU operation ordering across uploads, dispatches, and rendering. Metal queues bounded upload batches so an earlier submission cannot observe a later host write. Vulkan transitions images at their actual uses and includes attachment loads and vertex texture reads in the required access scopes.

Coalesce repeated Metal writes, discard unsubmitted writes as soon as ordinary buffer or texture handles retire, and enforce the configured budget against logical payload bytes while separately bounding packed staging memory. Synchronize only GPU-written managed buffers. Remove incompatible aggregate render-pass dependencies and make Vulkan barrier history opt-in; the Vulkan production implementation loses 167 lines.

Add deterministic in-flight upload and dispatch-transition regressions, including unused/replaced bindings, repeated writes, explicit/RAII retirement, and padded texture rows. The initial full repository gate passed 480 targets with 30 platform/configuration skips. The retirement and budget follow-up passes 256 shared GPU and native Metal cases with no skips under Metal validation. CMake generation, formatting, and changed-method lint pass; native Vulkan comparisons were separately checked with synchronization validation enabled. Broader GPU hardening continues separately.
