### PR TITLE
Manage RcString storage lifetimes explicitly in C++20

### DIFF
--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -265,6 +265,25 @@ donner_cc_test(
     ],
 )
 
+config_setting(
+    name = "gcc_compiler",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "gcc"},
+)
+
+# GCC's uninitialized-storage analysis needs optimization to see through the inline moves.
+donner_cc_test(
+    name = "rcstring_compile_tests",
+    srcs = ["tests/RcStringCompile_tests.cc"],
+    copts = ["-O2"] + select({
+        ":gcc_compiler": ["-Werror=maybe-uninitialized"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":base",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_cc_fuzzer(
     name = "bezier_utils_fuzzer",
     srcs = [

--- a/donner/base/RcString.h
+++ b/donner/base/RcString.h
@@ -4,10 +4,12 @@
 #include <bit>
 #include <cassert>
 #include <compare>
+#include <cstring>
 #include <format>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include "donner/base/StringUtils.h"
@@ -31,8 +33,8 @@ namespace donner {
 class RcString {
 public:
   /*
-   * Since we use the low bit to indicate whether the string is a short or long string, aliasing the
-   * one-byte size in the first field of ShortStringData with size_t size of LongStringData.
+   * The first storage byte holds the short/long tag: either the short size byte or the low byte
+   * of the long size. Inspect its object representation without reading an inactive union member.
    *
    * On big-endian architectures, we would need to use the high bit instead. Since I don't have a
    * big-endian machine to test, only little-endian is currently supported.
@@ -315,16 +317,10 @@ private:
   static constexpr size_t kMaxSize = size_t(1) << ((sizeof(size_t) * 8) - 1);
 
   struct LongStringData {
-    struct InitOnlySharedPtr {};
-
-    // Only initialize the storage field, leave everything else unset.
-    // NOLINTNEXTLINE: Only one field is initialized as an optimization.
-    constexpr LongStringData(InitOnlySharedPtr) : storage(nullptr) {}
-
     LongStringData(std::shared_ptr<std::vector<char>> storageRef, std::string_view view)
         : shiftedSize((view.size() << 1) | 1), data(view.data()), storage(std::move(storageRef)) {}
 
-    ~LongStringData() { storage = nullptr; }
+    ~LongStringData() = default;
 
     // Default move and copy constructors.
     LongStringData(const LongStringData&) = default;
@@ -348,6 +344,11 @@ private:
     constexpr ShortStringData() {}  // NOLINT(cppcoreguidelines-pro-type-member-init): data is not
                                     // initialized by default due to use in union
 
+    explicit ShortStringData(std::string_view value)
+        : shiftedSizeByte(static_cast<uint8_t>(value.size()) << 1) {
+      std::char_traits<char>::copy(data, value.data(), value.size());
+    }
+
     uint8_t shiftedSizeByte = 0;
     char data[kShortStringCapacity];
 
@@ -355,6 +356,7 @@ private:
     std::string_view view() const { return std::string_view(&data[0], size()); }
   };
 
+  static_assert(std::is_trivially_copyable_v<ShortStringData>);
   static_assert(sizeof(LongStringData) == sizeof(ShortStringData),
                 "Long and short string data must be the same size.");
 
@@ -374,9 +376,10 @@ private:
     if (data.empty() || data.back() != '\0') {
       data.push_back('\0');
     }
-    data_.long_.shiftedSize = (originalSize << 1) | 1;
-    data_.long_.data = data.data();
-    data_.long_.storage = std::make_shared<std::vector<char>>(std::move(data));
+    auto storage = std::make_shared<std::vector<char>>(std::move(data));
+    const std::string_view view(storage->data(), originalSize);
+    data_.destroyActive();
+    std::construct_at(&data_.long_, std::move(storage), view);
   }
 
   /**
@@ -429,9 +432,8 @@ private:
       char buf[kShortStringCapacity];
       std::copy(data.begin(), data.end(), &buf[0]);
 
-      data_.clear();
-      data_.short_.shiftedSizeByte = static_cast<uint8_t>(size) << 1;
-      std::copy(&buf[0], &buf[size], &data_.short_.data[0]);
+      data_.destroyActive();
+      std::construct_at(&data_.short_, std::string_view(buf, size));
     } else {
       assert(size < kMaxSize);
 
@@ -445,10 +447,9 @@ private:
         (*storage)[size] = '\0';
       }
 
-      data_.clear();
-      data_.long_.shiftedSize = (size << 1) | 1;
-      data_.long_.data = storage->data();
-      data_.long_.storage = std::move(storage);
+      const std::string_view view(storage->data(), size);
+      data_.destroyActive();
+      std::construct_at(&data_.long_, std::move(storage), view);
     }
   }
 
@@ -456,48 +457,33 @@ private:
     LongStringData long_;
     ShortStringData short_;
 
-    Storage() : short_() {
-      // Call the empty LongStringData constructor, to clear the field containing the shared_ptr so
-      // we don't need to zero the entire short_ buffer.
-      new (&long_) LongStringData(LongStringData::InitOnlySharedPtr());
-    }
+    Storage() : short_() {}
     explicit Storage(std::shared_ptr<std::vector<char>> storage, std::string_view view)
         : long_(std::move(storage), view) {}
 
-    ~Storage() { clear(); }
+    ~Storage() { destroyActive(); }
 
     Storage(const Storage& other) {
       if (other.isLong()) {
-        // Specifically use the placement new operator since long_ has not been initialized yet.
-        new (&long_) LongStringData(other.long_);
+        std::construct_at(&long_, other.long_);
       } else {
-        short_ = other.short_;
+        constructShort(other.short_);
       }
     }
 
     Storage(Storage&& other) noexcept {
       if (other.isLong()) {
-        // Specifically use the placement new operator since long_ has not been initialized yet.
-        new (&long_) LongStringData(std::move(other.long_));
-        other.long_.storage = nullptr;
-
-        // Set length to zero, which also switches this to a short string.
-        other.short_.shiftedSizeByte = 0;
+        std::construct_at(&long_, std::move(other.long_));
       } else {
-        short_ = other.short_;
-        other.short_.shiftedSizeByte = 0;
+        constructShort(other.short_);
       }
+      other.clear();
     }
 
     Storage& operator=(const Storage& other) {
       if (this != &other) {
-        clear();
-
-        if (other.isLong()) {
-          long_ = other.long_;
-        } else {
-          short_ = other.short_;
-        }
+        std::destroy_at(this);
+        std::construct_at(this, other);
       }
 
       return *this;
@@ -505,33 +491,33 @@ private:
 
     Storage& operator=(Storage&& other) noexcept {
       if (this != &other) {
-        clear();
-
-        if (other.isLong()) {
-          long_ = std::move(other.long_);
-          other.long_.storage = nullptr;
-
-          // Set length to zero, which also switches this to a short string.
-          other.short_.shiftedSizeByte = 0;
-        } else {
-          short_ = other.short_;
-          other.short_.shiftedSizeByte = 0;
-        }
+        std::destroy_at(this);
+        std::construct_at(this, std::move(other));
       }
 
       return *this;
     }
 
-    void clear() {
-      if (isLong()) {
-        long_.~LongStringData();
-      }
-
-      // Initialize empty long string, to clear the shared_ptr.
-      new (&long_) LongStringData(LongStringData::InitOnlySharedPtr());
+    void constructShort(const ShortStringData& source) {
+      std::construct_at(&short_);
+      // Copy the representation without evaluating the unused, indeterminate character values.
+      std::memcpy(&short_, &source, sizeof(short_));
     }
 
-    bool isLong() const { return (short_.shiftedSizeByte & 1) == 1; }
+    void clear() {
+      destroyActive();
+      std::construct_at(&short_);
+    }
+
+    void destroyActive() {
+      if (isLong()) {
+        std::destroy_at(&long_);
+      } else {
+        std::destroy_at(&short_);
+      }
+    }
+
+    bool isLong() const { return (*reinterpret_cast<const unsigned char*>(this) & 1) != 0; }
   };
 
   Storage data_;

--- a/donner/base/tests/RcStringCompile_tests.cc
+++ b/donner/base/tests/RcStringCompile_tests.cc
@@ -1,0 +1,31 @@
+/// @file
+/// Optimized default-string moves must neither read uninitialized storage nor change values.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "donner/base/RcString.h"
+
+namespace donner {
+
+std::vector<RcString> MakeAlternatingStrings(unsigned count) {
+  std::vector<RcString> values;
+  for (unsigned index = 0; index < count; ++index) {
+    RcString empty;
+    values.push_back(std::move(empty));
+    values.emplace_back("test");
+  }
+  return values;
+}
+
+TEST(RcStringCompile, DefaultMovesSurviveVectorGrowth) {
+  const auto values = MakeAlternatingStrings(32);
+  ASSERT_EQ(values.size(), 64u);
+  for (size_t index = 0; index < values.size(); ++index) {
+    SCOPED_TRACE(index);
+    EXPECT_EQ(values[index], index % 2 == 0 ? "" : "test");
+  }
+}
+
+}  // namespace donner

--- a/donner/base/tests/RcString_tests.cc
+++ b/donner/base/tests/RcString_tests.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <unordered_map>
 
 #include "donner/base/Utils.h"
@@ -62,6 +63,77 @@ TEST(RcString, ConstructEmptyVector) {
   EXPECT_TRUE(str.empty());
   EXPECT_EQ(str.size(), 0u);
   EXPECT_EQ(str, "");
+}
+
+TEST(RcString, InlineBoundaryPreservesLayoutAndCopyOwnership) {
+  static_assert(sizeof(RcString) == 4 * sizeof(void*));
+  constexpr size_t kCapacity = sizeof(RcString) - 1;
+  for (size_t size : {size_t{0}, size_t{1}, kCapacity - 1, kCapacity, kCapacity + 1}) {
+    SCOPED_TRACE(size);
+    const std::string text(size, 'x');
+    const RcString original(text);
+    const RcString copy(original);  // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_EQ(copy, text);
+    EXPECT_EQ(original, text);
+    if (size <= kCapacity) {
+      EXPECT_NE(copy.data(), original.data());
+    } else {
+      EXPECT_EQ(copy.data(), original.data());
+    }
+  }
+}
+
+TEST(RcString, AssignmentTransitionsAndMovedFromReuse) {
+  constexpr size_t kCapacity = sizeof(RcString) - 1;
+  const std::array<std::string, 4> values = {"", "x", std::string(kCapacity, 's'),
+                                             std::string(kCapacity + 1, 'l')};
+  for (const std::string& before : values) {
+    for (const std::string& after : values) {
+      SCOPED_TRACE("before=" + std::to_string(before.size()) +
+                   " after=" + std::to_string(after.size()));
+      RcString source(after);
+      RcString destination(before);
+      destination = source;
+      EXPECT_EQ(destination, after);
+      EXPECT_EQ(source, after);
+
+      destination = before;
+      destination = std::move(source);
+      EXPECT_EQ(destination, after);
+      EXPECT_EQ(source, "");
+      source = before;
+      EXPECT_EQ(source, before);
+
+      RcString moved(std::move(destination));
+      EXPECT_EQ(moved, after);
+      EXPECT_EQ(destination, "");
+      destination = before;
+      EXPECT_EQ(destination, before);
+    }
+  }
+}
+
+TEST(RcString, AdoptedVectorAndSubstringKeepSharedOwnershipAcrossTransitions) {
+  const size_t length = 2 * sizeof(RcString);
+  std::vector<char> bytes(length, 'v');
+  bytes.reserve(length + 1);
+  const char* originalData = bytes.data();
+  RcString original = RcString::fromVector(std::move(bytes));
+  ASSERT_EQ(original.data(), originalData);
+  RcString copy = original;
+  RcString slice = original.substr(1);
+  EXPECT_EQ(copy.data(), originalData);
+  EXPECT_EQ(slice.data(), originalData + 1);
+
+  original = "short";
+  copy = "";
+  EXPECT_EQ(slice, std::string(length - 1, 'v'));
+  EXPECT_EQ(slice.data(), originalData + 1);
+  RcString moved(std::move(slice));
+  EXPECT_EQ(moved.data(), originalData + 1);
+  EXPECT_EQ(slice, "");
+  slice = "reused";
+  EXPECT_EQ(slice, "reused");
 }
 
 TEST(RcString, FromFormat) {


### PR DESCRIPTION
RcString could read an inactive union member or copy uninitialized short-string storage. GCC optimization exposed this as incorrect values when default strings moved during vector growth. Explicitly construct and destroy the active C++20 storage member, inspect the tag through its byte representation, and copy the trivial short representation without reading inactive members.

Add compiler and value regressions for empty moves, vector growth, storage transitions, and self-referencing assignments. Preserve the native and Wasm object layout, allocation counts, and short-string capacity while removing 14 implementation lines.

Validation: 767 ASan/UBSan cases and 25 optimized GCC cases pass; native/Wasm layout checks and paired allocation measurements are unchanged. The full repository gate passes on the current base (480 targets passed; 30 platform/configuration skips), along with formatting, banned-pattern and changed-method lint, and CMake generator validation.
