### PR TITLE
Validate Donner as a default tiny-skia Bazel dependency

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,6 @@
 .git
 examples/bazel-examples
+examples/bazel_consumer
 tools/python
 donner/editor/wasm/tests/node_modules
 

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,21 +1,8 @@
-# BCR presubmit configuration. Exercised when Publish-to-BCR opens a PR on
-# bazelbuild/bazel-central-registry for a new Donner release.
-#
-# IMPORTANT: The target allowlist below must only contain targets that are
-# buildable with the dependencies that BCR consumers see — i.e. NOT including
-# @harfbuzz, @woff2, @wgpu_native_*, @resvg-test-suite, or @bazel_clang_tidy
-# (all of which are hidden behind a dev_dependency module extension at
-# //third_party:bazel/non_bcr_deps.bzl). If you add a new top-level library
-# under //donner, add it here too; if your library references one of the
-# hidden deps, it must be guarded with `target_compatible_with` so BCR
-# consumers can skip it cleanly.
-#
-# See docs/design_docs/0018-bcr_release.md for the fuller release checklist.
-
+# Check the published C++20 library surface without development-only dependencies.
+# The separate consumer also compiles, links, and renders through the public API.
 matrix:
   platform:
-    - debian11
-    - ubuntu2204
+    - ubuntu2404
     - macos
   bazel:
     - 7.x
@@ -23,20 +10,31 @@ matrix:
 
 tasks:
   verify_targets:
-    name: "Build core Donner library (tiny-skia backend, text-base)"
+    name: "Build Donner with tiny-skia and base text support"
     platform: ${{ platform }}
     bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
     build_targets:
-      - "@donner//donner/base/..."
-      - "@donner//donner/css/..."
+      - "@donner//donner/base:base"
+      - "@donner//donner/css:css"
       - "@donner//donner/svg:svg"
-      - "@donner//donner/svg/parser/..."
-      - "@donner//donner/svg/components/..."
-      - "@donner//donner/svg/core/..."
-      - "@donner//donner/svg/properties/..."
-      - "@donner//donner/svg/graph/..."
-      - "@donner//donner/svg/resources/..."
-      - "@donner//donner/svg/renderer:rendering_context"
-      - "@donner//donner/svg/renderer:renderer_driver"
-      - "@donner//donner/svg/renderer:renderer_interface"
-      - "@donner//donner/svg/renderer:renderer_tiny_skia"
+      - "@donner//donner/svg/renderer:renderer"
+
+bcr_test_module:
+  module_path: examples/bazel_consumer
+  matrix:
+    platform:
+      - ubuntu2404
+      - macos
+    bazel:
+      - 7.x
+      - 8.x
+  tasks:
+    render_svg:
+      name: "Parse and render from a downstream module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//:render_svg"

--- a/docs/design_docs/0018-bcr_release.md
+++ b/docs/design_docs/0018-bcr_release.md
@@ -1,20 +1,16 @@
 # BCR Release Runbook
 
-**Status:** Active — blocked. The first BCR publish attempt, on the `v0.5.0`
-tag (2026-04-16), failed (see the
-[v0.5 retrospective](0011-v0_5_release.md#release-process-bugs-carry-to-v06)).
-Root-causing and re-running the publish flow is tracked as a release-blocking
-item in [0028-v1_0_release.md](0028-v1_0_release.md) Phase 1; no successful
-BCR publish has landed yet.
-**Last updated:** 2026-09-07.
+**Author:** Unknown; original provenance is not recorded.
+**Status:** Active release preparation. Downstream consumer validation is present; the first BCR
+publication awaits a maintainer-approved release.
 
 This doc is the single source of truth for cutting a new Donner release on the [Bazel Central Registry](https://registry.bazel.build/). It's tuned for quick execution, not exhaustive explanation — the "why" lives in the companion docs and PRs linked at the bottom.
 
-## TL;DR — the happy path
+## Release sequence
 
 1. Bump `module(name = "donner", version = "X.Y.Z")` in `MODULE.bazel`
 2. Run the pre-release checklist below, make sure it's green
-3. Merge the release PR, tag `vX.Y.Z`, push
+3. After maintainer approval, merge the release PR, create `vX.Y.Z`, and publish its GitHub Release
 4. `.github/workflows/release.yml` builds, verifies, and attests the CLI binaries once
 5. After the release artifacts are green, use the reviewed `.bcr/` templates to prepare the BCR PR manually
 6. Watch BCR presubmit CI on that PR, iterate on `.bcr/presubmit.yml` if anything fails, ping a BCR maintainer, wait for merge
@@ -47,7 +43,7 @@ Do these in order. Each step is either a command to run or a one-line visual che
 ### Pre-flight
 
 - [ ] Working tree on `main`, clean, up to date
-- [ ] `docs/design_docs/0011-v0_5_release.md` (or equivalent release doc) marks all release-blocking phases complete
+- [ ] `docs/release_checklist.md` and the current release scope have no unresolved release blockers
 - [ ] `RELEASE_NOTES.md` drafted for the version being cut
 
 ### Version bump
@@ -105,7 +101,7 @@ runs `examples/bazel_consumer` via the `bcr_test_module` section of `.bcr/presub
 - [ ] Ping a BCR maintainer in the PR comments when presubmit CI goes green
 - [ ] After BCR merge: `https://registry.bazel.build/modules/donner` shows the new version
 
-## Publish-to-BCR flow details
+## Registry submission
 
 BCR publication is intentionally separate from the credentialed release workflow. The release
 workflow produces and attests immutable CLI artifacts, but it does not rebuild source or invoke a
@@ -115,7 +111,7 @@ reviewed tag and the checked-in `.bcr/metadata.template.json`, `.bcr/source.temp
 opening the BCR pull request from the maintainer fork. This keeps registry publication operator-initiated and prevents a moved tag or
 workflow rerun from silently substituting source.
 
-### One-time Publish-to-BCR setup
+### Maintainer setup
 
 1. Fork `bazelbuild/bazel-central-registry` to
    `jwmcglynn/bazel-central-registry`.
@@ -134,16 +130,16 @@ Update this section with real-world lessons as they happen.
 
 | Symptom                                                        | Cause                                                                                      | Fix                                                                                         |
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| BCR PR presubmit: unmapped former full-Skia external dep       | A target referenced the former full-Skia repo but wasn't gated by `target_compatible_with` | Add the appropriate backend gating to the offending target                                  |
+| BCR presubmit: missing external repository | A public target or wildcard selects development-only dependencies | Use explicit public targets and keep optional features behind their configuration guards |
 | BCR PR presubmit: target not found                             | New top-level library added under `//donner` since last release                            | Add it to `.bcr/presubmit.yml` `build_targets`                                              |
 | BCR PR presubmit: integrity hash mismatch                      | GitHub regenerated the source tarball or the tag moved                                     | Re-upload the release tarball verbatim; never force-push tags                               |
-| `source.template.json` URL 404                                 | `strip_prefix` doesn't match GitHub's tarball layout                                       | Confirm pattern is `donner-{VERSION}` (GitHub uses repo name + version)                     |
+| `source.template.json` URL 404 | The source URL, tag, or release asset is missing | Verify the reviewed source URL and release asset; archive strip-prefix errors occur after download |
 
 ## Adding a new top-level library
 
 When you create a new top-level library under `//donner/...`, the BCR presubmit allowlist won't know about it automatically.
 
-1. Add `"@donner//donner/your/new/package/..."` (or the specific target) to `.bcr/presubmit.yml` `build_targets`.
+1. Add the specific public library target to `.bcr/presubmit.yml` `build_targets`. Do not use package wildcards that also select tests or fuzzers.
 2. Re-run the BCR-consumer simulation `cquery` above to confirm your new library doesn't transitively pull in any non-BCR dep.
 3. If it does (and that's intentional — e.g. it's text-full-specific), gate the offending target with `target_compatible_with` on the relevant config_setting, same as `text_backend_full` and `woff2_parser`.
 
@@ -154,11 +150,10 @@ Things that are deliberately out of scope for the first few BCR releases but may
 - **text-full on BCR** — vendor HarfBuzz + WOFF2 via `git subtree` (~1–2 days of `BUILD.harfbuzz` work), or ship a sibling `donner-text-full` module that layers on top of `donner` and brings its own HB/WOFF2. Blocked on: deciding whether to own an additional BCR module or vendor.
 - **Separate `tiny-skia-cpp` BCR module** — it already has its own `MODULE.bazel` in `third_party/tiny-skia-cpp`; could be published independently and then consumed as a BCR `bazel_dep` from Donner. Blocked on: deciding the dev vs publish trade-off.
 - **Geode / wgpu-native on BCR** — wgpu-native is distributed only as a prebuilt binary release (no upstream Bazel rules; no public source build on BCR), so the Geode backend stays `git_override`-only for the foreseeable future. Revisit post-v1.0 if someone puts up a `donner-geode` BCR module that pulls the `http_archive` in itself.
-- **Skia backend on BCR** — not realistic. Skia is a monorepo with a custom build. It will stay `git_override`-only for the foreseeable future.
 
 ## References
 
-- [Publish-to-BCR](https://github.com/bazel-contrib/publish-to-bcr) — the reusable workflow this runbook drives
+- [Publish-to-BCR](https://github.com/bazel-contrib/publish-to-bcr) — background on registry publication tooling
 - [bazelbuild/bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry) — the BCR repository
 - [rules_foreign_cc/.bcr/](https://github.com/bazelbuild/rules_foreign_cc/tree/main/.bcr) — reference `.bcr/` layout for a C++ library
 - `docs/design_docs/0011-v0_5_release.md` — v0.5 release scope

--- a/docs/design_docs/0018-bcr_release.md
+++ b/docs/design_docs/0018-bcr_release.md
@@ -6,7 +6,7 @@ tag (2026-04-16), failed (see the
 Root-causing and re-running the publish flow is tracked as a release-blocking
 item in [0028-v1_0_release.md](0028-v1_0_release.md) Phase 1; no successful
 BCR publish has landed yet.
-**Last updated:** 2026-04-08.
+**Last updated:** 2026-09-07.
 
 This doc is the single source of truth for cutting a new Donner release on the [Bazel Central Registry](https://registry.bazel.build/). It's tuned for quick execution, not exhaustive explanation — the "why" lives in the companion docs and PRs linked at the bottom.
 
@@ -21,7 +21,10 @@ This doc is the single source of truth for cutting a new Donner release on the [
 
 ## What's on BCR (and what isn't)
 
-Donner's BCR-published surface is a deliberate subset of the full library. The default build that BCR consumers get is **tiny-skia + text-base**:
+The initial BCR module is `donner`, with **tiny-skia + text-base** as its default. A separate
+`tiny-skia-cpp` module is outside this initial v0.8 scope. Consumers need a C++20 compiler and standard
+library, including `std::format`; the validation matrix uses Ubuntu 24.04 and macOS with Bazel 7 and 8.
+The intended published surface is:
 
 | Feature                                       | On BCR? | How BCR consumers get it                                                                                                                                                                  |
 | --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,27 +64,30 @@ Do these in order. Each step is either a command to run or a one-line visual che
 
 ### BCR-consumer simulation (most important)
 
-Simulate what a BCR downstream sees, where the `non_bcr_deps` dev extension is stripped and the former full-Skia repo / `@harfbuzz` / `@woff2` / `@wgpu_native_*` do not exist.
+Run from a separate module so Donner's development-only dependencies and root `.bazelrc` do not
+apply. The fixture supplies its own C++20 flags and compiles, links, and renders through the public API.
 
-- [ ] No `git_repository` / `new_git_repository` / non-dev `*_override` in top-level `MODULE.bazel` (grep for them):
+- [ ] Run the downstream smoke test for every BCR matrix entry:
       ```sh
-      grep -nE '^(git_repository|new_git_repository|git_override|archive_override)' MODULE.bazel
+      cd examples/bazel_consumer
+      bazel test //:render_svg
       ```
-      (Should return nothing. Dev-only entries live inside `use_extension(..., dev_dependency = True)` blocks or the extension .bzl file.)
-- [ ] No non-BCR repo labels reachable from the BCR target allowlist in default config:
+      The local source override permits testing before publication. Remove that override and add the
+      published version to `bazel_dep` when testing a registry entry.
+- [ ] Build the public base, CSS, SVG, and renderer target list in `.bcr/presubmit.yml` with its explicit
+      C++20 flags. Avoid package wildcards: they also select internal tests and fuzzers whose
+      dependencies are intentionally development-only.
+- [ ] Inspect the default renderer's configured dependency closure from the consumer module:
       ```sh
-      bazel cquery 'kind("source file", deps( \
-        //donner/base/... + //donner/css/... + //donner/svg:svg + \
-        //donner/svg/parser/... + //donner/svg/components/... + \
-        //donner/svg/core/... + //donner/svg/properties/... + \
-        //donner/svg/graph/... + //donner/svg/resources/... + \
-        //donner/svg/renderer:rendering_context + \
-        //donner/svg/renderer:renderer_tiny_skia))' \
-        | grep -E '^@(skia|harfbuzz|woff2|wgpu_native|resvg-test-suite|bazel_clang_tidy)'
+      bazel cquery 'deps(@donner//donner/svg/renderer:renderer)'
       ```
-      Must return **zero** matches. If there are matches, a target in that allowlist has a dep that needs `target_compatible_with` gating (or a new target was added and isn't on the `.bcr/presubmit.yml` allowlist).
-- [ ] `.bcr/presubmit.yml` `build_targets` cover every top-level library consumers might reasonably want. Add new libs here when you add them under `//donner`.
-- [ ] `.bcr/source.template.json` `strip_prefix` matches `donner-{VERSION}` (GitHub tarball convention).
+      It must include tiny-skia and exclude Geode, wgpu-native, HarfBuzz, WOFF2, and development fixtures.
+- [ ] Repeat the consumer check against the extracted source archive, including its vendored tiny-skia
+      sources. A checkout-only build does not qualify archive packaging.
+- [ ] `.bcr/source.template.json` integrity and strip prefix match the exact reviewed archive bytes.
+
+The [BCR test-module mechanism](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md#test-module)
+runs `examples/bazel_consumer` via the `bcr_test_module` section of `.bcr/presubmit.yml`.
 
 ### Scaffolding sanity
 
@@ -91,10 +97,10 @@ Simulate what a BCR downstream sees, where the `non_bcr_deps` dev extension is s
 ### Ship
 
 - [ ] **Root-cause the previous BCR attempt before retrying** — pull up the last release's BCR PR on `bazelbuild/bazel-central-registry` (`modules/donner/<prev>/`), identify exactly why it failed, and confirm the fix is already in the checked-in `.bcr/` templates and `presubmit.yml` targets. Do not retry blind. Cross-check the common-failures table below.
-- [ ] Merge release PR → push tag `vX.Y.Z` → GitHub Release auto-created
+- [ ] After explicit approval, merge the release PR and create the intended tag and GitHub Release; the release workflow runs when the release is published
 - [ ] Watch Actions tab: `linux` + `macos` CLI binary jobs run, then the verified artifact publication job
 - [ ] Prepare the BCR entry from the reviewed release source and `.bcr/` templates only after artifact publication is green
-- [ ] Watch `bazelbuild/bazel-central-registry` → `modules/donner/X.Y.Z/` for the new PR
+- [ ] Present the final registry diff and destination for explicit maintainer approval before submitting it
 - [ ] Iterate on BCR presubmit failures via the common-failures table below
 - [ ] Ping a BCR maintainer in the PR comments when presubmit CI goes green
 - [ ] After BCR merge: `https://registry.bazel.build/modules/donner` shows the new version
@@ -105,8 +111,8 @@ BCR publication is intentionally separate from the credentialed release workflow
 workflow produces and attests immutable CLI artifacts, but it does not rebuild source or invoke a
 third-party BCR publisher. After those artifacts are green, prepare the registry entry from the
 reviewed tag and the checked-in `.bcr/metadata.template.json`, `.bcr/source.template.json`, and
-`.bcr/presubmit.yml`. Verify the source archive digest, then open the BCR pull request from the
-maintainer fork. This keeps registry publication operator-initiated and prevents a moved tag or
+`.bcr/presubmit.yml`. Verify the source archive digest and obtain explicit approval of the final registry diff before
+opening the BCR pull request from the maintainer fork. This keeps registry publication operator-initiated and prevents a moved tag or
 workflow rerun from silently substituting source.
 
 ### One-time Publish-to-BCR setup

--- a/examples/bazel_consumer/.bazelrc
+++ b/examples/bazel_consumer/.bazelrc
@@ -1,0 +1,2 @@
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20

--- a/examples/bazel_consumer/BUILD.bazel
+++ b/examples/bazel_consumer/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "render_svg",
+    size = "small",
+    srcs = ["main.cc"],
+    deps = [
+        "@donner//donner/svg",
+        "@donner//donner/svg/renderer",
+    ],
+)

--- a/examples/bazel_consumer/MODULE.bazel
+++ b/examples/bazel_consumer/MODULE.bazel
@@ -1,0 +1,9 @@
+module(name = "donner_bazel_consumer")
+
+bazel_dep(name = "donner")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+
+local_path_override(
+    module_name = "donner",
+    path = "../..",
+)

--- a/examples/bazel_consumer/README.md
+++ b/examples/bazel_consumer/README.md
@@ -1,0 +1,9 @@
+# Bazel consumer smoke test
+
+This separate module parses and renders an SVG through Donner's public API using the default
+tiny-skia backend. It consumes the adjacent source tree as a dependency, so Donner's development
+module dependencies and root `.bazelrc` do not apply. Its own `.bazelrc` selects the required C++20
+language mode.
+
+From this directory, run `bazel test //:render_svg`. For a registry release, remove the
+`local_path_override` and add the published version to `bazel_dep`.

--- a/examples/bazel_consumer/main.cc
+++ b/examples/bazel_consumer/main.cc
@@ -1,0 +1,33 @@
+#include <cstdlib>
+#include <string_view>
+#include <utility>
+
+#include "donner/base/ParseResult.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/renderer/Renderer.h"
+
+int main() {
+  constexpr std::string_view kSvg = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+      <rect id="swatch" width="8" height="8" fill="#d33" />
+    </svg>
+  )svg";
+
+  donner::ParseWarningSink warnings;
+  donner::ParseResult<donner::svg::SVGDocument> maybeDocument =
+      donner::svg::parser::SVGParser::ParseSVG(kSvg, warnings);
+  if (maybeDocument.hasError()) {
+    return EXIT_FAILURE;
+  }
+
+  donner::svg::SVGDocument document = std::move(maybeDocument.result());
+  if (!document.querySelector("#swatch").has_value()) {
+    return EXIT_FAILURE;
+  }
+
+  donner::svg::Renderer renderer;
+  renderer.draw(document);
+
+  return renderer.width() == 8 && renderer.height() == 8 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/bazel_consumer/main.cc
+++ b/examples/bazel_consumer/main.cc
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <iostream>
 #include <string_view>
 #include <utility>
 
@@ -18,16 +19,23 @@ int main() {
   donner::ParseResult<donner::svg::SVGDocument> maybeDocument =
       donner::svg::parser::SVGParser::ParseSVG(kSvg, warnings);
   if (maybeDocument.hasError()) {
+    std::cerr << "SVG parse failed: " << maybeDocument.error() << '\n';
     return EXIT_FAILURE;
   }
 
   donner::svg::SVGDocument document = std::move(maybeDocument.result());
   if (!document.querySelector("#swatch").has_value()) {
+    std::cerr << "Selector lookup failed: expected #swatch in the parsed SVG\n";
     return EXIT_FAILURE;
   }
 
   donner::svg::Renderer renderer;
   renderer.draw(document);
 
-  return renderer.width() == 8 && renderer.height() == 8 ? EXIT_SUCCESS : EXIT_FAILURE;
+  if (renderer.width() != 8 || renderer.height() != 8) {
+    std::cerr << "Rendered dimensions: " << renderer.width() << "x" << renderer.height()
+              << "; expected 8x8\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Validate Donner as a downstream Bazel module using its default tiny-skia renderer and base text support. The previous BCR target wildcards selected internal tests whose dependencies are intentionally unavailable to consumers, and consumer builds need explicit C++20 settings.

Use four public library targets for presubmit and add a separate module that parses, queries, and renders an SVG through the public API. Keep development-only dependencies private to the root module, exclude the nested fixture from root Bazel traversal, and update the release runbook for the checked source archive and supported compiler matrix.

Validation: the exact source archive passes the downstream render test and public-target builds on macOS and Ubuntu 24.04 with Bazel 7.7.1 and 8.7.0. The configured default renderer closure contains tiny-skia and excludes Geode and development-only renderer dependencies. The full repository gate passes 479 targets with 30 platform/configuration skips; CMake generation, formatting, and lint pass.
