### PR TITLE
Validate PNG row strides within encoder arithmetic bounds

### DIFF
--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -19,6 +19,7 @@ donner_cc_library(
     # blessed pixelmatch comparator for their frozen-baseline comparisons.
     visibility = [
         "//donner/gpu:__subpackages__",
+        "//donner/svg/renderer/tests:__pkg__",
         "//tools/mcp-servers/editor-control:__pkg__",
     ],
     deps = [

--- a/donner/editor/tests/BitmapGoldenCompare.cc
+++ b/donner/editor/tests/BitmapGoldenCompare.cc
@@ -138,7 +138,8 @@ void CompareBitmapToGolden(const svg::RendererBitmap& bitmap, std::string_view g
     svg::RendererImageIO::writeRgbaPixelsToPngFile(diffPath.string().c_str(), diffImage, width,
                                                    height, strideInPixels);
     svg::RendererImageIO::writeRgbaPixelsToPngFile(sideBySidePath.string().c_str(), sideBySide,
-                                                   width * 2, height, strideInPixels * 2u);
+                                                   width * 2, height,
+                                                   static_cast<size_t>(width) * 2u);
     ADD_FAILURE() << "[" << testLabel << "] " << mismatched
                   << " pixels differ (max allowed: " << params.maxMismatchedPixels
                   << "). Golden: " << goldenPath << ". Actual: " << actualPath.string()
@@ -214,7 +215,8 @@ void CompareBitmapToBitmap(const svg::RendererBitmap& actual, const svg::Rendere
     svg::RendererImageIO::writeRgbaPixelsToPngFile(diffPath.string().c_str(), diffImage, width,
                                                    height, strideInPixels);
     svg::RendererImageIO::writeRgbaPixelsToPngFile(sideBySidePath.string().c_str(), sideBySide,
-                                                   width * 2, height, strideInPixels * 2u);
+                                                   width * 2, height,
+                                                   static_cast<size_t>(width) * 2u);
     ADD_FAILURE() << "[" << testLabel << "] " << mismatched
                   << " pixels differ (max allowed: " << params.maxMismatchedPixels
                   << "). Actual: " << actualPath.string() << ". Expected: " << expectedPath.string()

--- a/donner/svg/renderer/RendererImageIO.cc
+++ b/donner/svg/renderer/RendererImageIO.cc
@@ -2,11 +2,38 @@
 
 #include <stb/stb_image_write.h>
 
-#include <cassert>
 #include <fstream>
 #include <limits>
 
 namespace donner::svg {
+namespace {
+
+/// Returns the row stride in bytes, or zero if the span or encoder dimensions are invalid.
+int PngRowStride(std::span<const uint8_t> pixels, int width, int height, size_t strideInPixels) {
+  constexpr int kMaxInt = std::numeric_limits<int>::max();
+  // stb_image_write keeps row offsets, filter scores, filtered input sizes, and stretchy-buffer
+  // capacities in signed ints. Stay within every one of those arithmetic domains before calling it.
+  constexpr size_t kMaxFilteredBytes = (static_cast<size_t>(kMaxInt) - 32'766u) / 2u;
+  constexpr size_t kMaxScoredRowBytes = static_cast<size_t>(kMaxInt) / 128u;
+  if (width <= 0 || height <= 0 || static_cast<size_t>(width) > kMaxScoredRowBytes / 4u) {
+    return 0;
+  }
+  const size_t rowBytes = static_cast<size_t>(width) * 4;
+  const size_t stridePixels = strideInPixels ? strideInPixels : static_cast<size_t>(width);
+  if (stridePixels < static_cast<size_t>(width) || stridePixels > kMaxInt / 4) {
+    return 0;
+  }
+  const size_t strideBytes = stridePixels * 4;
+  if (static_cast<size_t>(height - 1) > static_cast<size_t>(kMaxInt) / strideBytes ||
+      static_cast<size_t>(height) > kMaxFilteredBytes / (rowBytes + 1u) ||
+      pixels.size() < rowBytes ||
+      static_cast<size_t>(height - 1) > (pixels.size() - rowBytes) / strideBytes) {
+    return 0;
+  }
+  return static_cast<int>(strideBytes);
+}
+
+}  // namespace
 
 bool RendererImageIO::writeRgbaPixelsToPngFile(const char* filename,
                                                std::span<const uint8_t> rgbaPixels, int width,
@@ -15,10 +42,10 @@ bool RendererImageIO::writeRgbaPixelsToPngFile(const char* filename,
     std::ofstream output;
   };
 
-  assert(width > 0);
-  assert(height > 0);
-  assert(strideInPixels <= std::numeric_limits<int>::max() / 4);
-  assert(rgbaPixels.size() == static_cast<size_t>(width) * height * 4);
+  const int rowStride = PngRowStride(rgbaPixels, width, height, strideInPixels);
+  if (rowStride == 0) {
+    return false;
+  }
 
   Context context;
   context.output = std::ofstream(filename, std::ofstream::out | std::ofstream::binary);
@@ -26,15 +53,15 @@ bool RendererImageIO::writeRgbaPixelsToPngFile(const char* filename,
     return false;
   }
 
-  stbi_write_png_to_func(
+  const int encoded = stbi_write_png_to_func(
       [](void* context, void* data, int len) {
         Context* contextObj = static_cast<Context*>(context);
         contextObj->output.write(static_cast<const char*>(data), len);
       },
-      &context, width, height, 4, rgbaPixels.data(),
-      /* stride in bytes */ strideInPixels ? static_cast<int>(strideInPixels * 4) : width * 4);
+      &context, width, height, 4, rgbaPixels.data(), rowStride);
 
-  return context.output.good();
+  context.output.flush();
+  return encoded != 0 && context.output.good();
 }
 
 std::vector<uint8_t> RendererImageIO::writeRgbaPixelsToPngMemory(
@@ -43,22 +70,24 @@ std::vector<uint8_t> RendererImageIO::writeRgbaPixelsToPngMemory(
     std::vector<uint8_t> buffer;
   };
 
-  assert(width > 0);
-  assert(height > 0);
-  assert(strideInPixels <= std::numeric_limits<int>::max() / 4);
-  assert(rgbaPixels.size() == static_cast<size_t>(width) * height * 4);
+  const int rowStride = PngRowStride(rgbaPixels, width, height, strideInPixels);
+  if (rowStride == 0) {
+    return {};
+  }
 
   Context context;
 
-  stbi_write_png_to_func(
+  const int encoded = stbi_write_png_to_func(
       [](void* context, void* data, int len) {
         Context* contextObj = static_cast<Context*>(context);
         const uint8_t* bytes = static_cast<const uint8_t*>(data);
         contextObj->buffer.insert(contextObj->buffer.end(), bytes, bytes + len);
       },
-      &context, width, height, 4, rgbaPixels.data(),
-      /* stride in bytes */ strideInPixels ? static_cast<int>(strideInPixels * 4) : width * 4);
+      &context, width, height, 4, rgbaPixels.data(), rowStride);
 
+  if (encoded == 0) {
+    return {};
+  }
   return context.buffer;
 }
 

--- a/donner/svg/renderer/RendererImageIO.h
+++ b/donner/svg/renderer/RendererImageIO.h
@@ -16,11 +16,12 @@ public:
    * Write raw RGBA pixel data to a PNG file.
    *
    * @param filename Filename to save to.
-   * @param rgbaPixels Span containing RGBA-ordered pixel data.
+   * @param rgbaPixels Span containing RGBA-ordered pixel data. Row padding is allowed;
+   *   the span must include every pixel of the final row.
    * @param width Width of the image.
    * @param height Height of the image.
    * @param strideInPixels Stride in pixels. Defaults to 0, which assumes a stride of width.
-   * @returns true if the image was written successfully.
+   * @returns true if the image was written successfully, false for an invalid layout or I/O error.
    */
   static bool writeRgbaPixelsToPngFile(const char* filename, std::span<const uint8_t> rgbaPixels,
                                        int width, int height, size_t strideInPixels = 0);
@@ -28,11 +29,12 @@ public:
   /**
    * Write raw RGBA pixel data to a PNG in memory.
    *
-   * @param rgbaPixels Span containing RGBA-ordered pixel data.
+   * @param rgbaPixels Span containing RGBA-ordered pixel data. Row padding is allowed;
+   *   the span must include every pixel of the final row.
    * @param width Width of the image.
    * @param height Height of the image.
    * @param strideInPixels Stride in pixels. Defaults to 0, which assumes a stride of width.
-   * @returns Vector containing the PNG-encoded data.
+   * @returns PNG-encoded data, or an empty vector for an invalid layout or encoder failure.
    */
   static std::vector<uint8_t> writeRgbaPixelsToPngMemory(std::span<const uint8_t> rgbaPixels,
                                                          int width, int height,

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -17,6 +17,17 @@ filegroup(
     visibility = ["//tools/resvg_parity:__pkg__"],
 )
 
+donner_cc_test(
+    name = "renderer_image_io_tests",
+    srcs = ["RendererImageIO_tests.cc"],
+    deps = [
+        ":renderer_image_test_utils",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/svg/renderer:renderer_image_io",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_cc_library(
     name = "rgba_test_matchers",
     testonly = 1,

--- a/donner/svg/renderer/tests/RendererImageIO_tests.cc
+++ b/donner/svg/renderer/tests/RendererImageIO_tests.cc
@@ -1,0 +1,129 @@
+/// @file
+/// PNG encoding and failure diagnostics preserve pixels with padded rows.
+
+#include "donner/svg/renderer/RendererImageIO.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/svg/renderer/tests/RendererImageTestUtils.h"
+
+namespace donner::svg {
+namespace {
+
+RendererBitmap ExpectedCorners() {
+  return {.dimensions = {2, 2},
+          .pixels = {255, 0, 0, 255, 0, 0, 255, 255, 0, 255, 0, 255, 255, 255, 255, 255},
+          .rowBytes = 8};
+}
+
+std::vector<uint8_t> PaddedCorners() {
+  return {255, 0,   0, 255, 0,   0,   255, 255, 17, 18, 19, 20,
+          0,   255, 0, 255, 255, 255, 255, 255, 21, 22, 23, 24};
+}
+
+void ExpectPng(const std::filesystem::path& filename, const RendererBitmap& expected) {
+  const auto image = RendererImageTestUtils::readRgbaImageFromPngFile(filename.string().c_str());
+  ASSERT_TRUE(image.has_value());
+  const RendererBitmap actual{.dimensions = {image->width, image->height},
+                              .pixels = image->data,
+                              .rowBytes = image->strideInPixels * 4};
+  editor::tests::CompareBitmapToBitmap(actual, expected, filename.filename().string(),
+                                       editor::tests::PixelmatchIdentityParams());
+}
+
+TEST(RendererImageIOTests, PaddedRowsRoundTripToFile) {
+  const auto filename = std::filesystem::path(testing::TempDir()) / "padded_file.png";
+  const auto pixels = PaddedCorners();
+  ASSERT_TRUE(
+      RendererImageIO::writeRgbaPixelsToPngFile(filename.string().c_str(), pixels, 2, 2, 3));
+  ExpectPng(filename, ExpectedCorners());
+}
+
+TEST(RendererImageIOTests, PaddedRowsWithoutFinalPaddingRoundTripToMemory) {
+  auto pixels = PaddedCorners();
+  pixels.resize(20);
+  const auto encoded = RendererImageIO::writeRgbaPixelsToPngMemory(pixels, 2, 2, 3);
+  ASSERT_THAT(encoded, testing::Not(testing::IsEmpty()));
+  const auto filename = std::filesystem::path(testing::TempDir()) / "padded_memory.png";
+  {
+    std::ofstream output(filename, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(encoded.data()), encoded.size());
+    ASSERT_TRUE(output.good());
+  }
+  ExpectPng(filename, ExpectedCorners());
+}
+
+TEST(RendererImageIOTests, RejectsInvalidLayoutsBeforeOpeningAFile) {
+  struct Layout {
+    int width;
+    int height;
+    size_t stride;
+    size_t bytes;
+  };
+  const std::array<uint8_t, 16> pixels{};
+  const auto filename = std::filesystem::path(testing::TempDir()) / "invalid_layout.png";
+  for (const Layout& layout :
+       {Layout{0, 1, 0, 4}, Layout{1, 0, 0, 4}, Layout{-1, 1, 0, 4}, Layout{1, -1, 0, 4},
+        Layout{1, 1, 0, 3}, Layout{2, 1, 1, 8}, Layout{1, 2, 4, 16},
+        Layout{1, 1, std::numeric_limits<size_t>::max(), 4},
+        Layout{std::numeric_limits<int>::max(), 1, 0, 4},
+        Layout{1, std::numeric_limits<int>::max(), 0, 4}}) {
+    SCOPED_TRACE(testing::Message() << layout.width << "x" << layout.height
+                                    << " stride=" << layout.stride << " bytes=" << layout.bytes);
+    const std::span<const uint8_t> data(pixels.data(), layout.bytes);
+    EXPECT_THAT(RendererImageIO::writeRgbaPixelsToPngMemory(data, layout.width, layout.height,
+                                                            layout.stride),
+                testing::IsEmpty());
+    EXPECT_FALSE(RendererImageIO::writeRgbaPixelsToPngFile(
+        filename.string().c_str(), data, layout.width, layout.height, layout.stride));
+    EXPECT_FALSE(std::filesystem::exists(filename));
+  }
+}
+
+TEST(RendererImageIOTests, PaddedMismatchProducesReadableDiagnosticImages) {
+  const char* outputDirectory = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+  ASSERT_NE(outputDirectory, nullptr);
+  RendererBitmap actual{.dimensions = {1, 2}, .pixels = std::vector<uint8_t>(512), .rowBytes = 256};
+  RendererBitmap expected = actual;
+  for (size_t row : {0u, 1u}) {
+    actual.pixels[row * 256 + 2] = 255;
+    actual.pixels[row * 256 + 3] = 255;
+    expected.pixels[row * 256] = 255;
+    expected.pixels[row * 256 + 3] = 255;
+  }
+  EXPECT_NONFATAL_FAILURE(
+      editor::tests::CompareBitmapToBitmap(actual, expected, "strided_png_diagnostics",
+                                           editor::tests::PixelmatchIdentityParams()),
+      "pixels differ");
+  const auto directory = std::filesystem::path(outputDirectory);
+  const RendererBitmap blue{
+      .dimensions = {1, 2}, .pixels = {0, 0, 255, 255, 0, 0, 255, 255}, .rowBytes = 4};
+  const RendererBitmap red{
+      .dimensions = {1, 2}, .pixels = {255, 0, 0, 255, 255, 0, 0, 255}, .rowBytes = 4};
+  const RendererBitmap sideBySide{
+      .dimensions = {2, 2},
+      .pixels = {255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255, 0, 0, 255, 255},
+      .rowBytes = 8};
+  ExpectPng(directory / "actual_strided_png_diagnostics.png", blue);
+  ExpectPng(directory / "expected_strided_png_diagnostics.png", red);
+  ExpectPng(directory / "side_by_side_strided_png_diagnostics.png", sideBySide);
+  const auto diff = RendererImageTestUtils::readRgbaImageFromPngFile(
+      (directory / "diff_strided_png_diagnostics.png").string().c_str());
+  ASSERT_TRUE(diff.has_value());
+  EXPECT_EQ(diff->width, 1);
+  EXPECT_EQ(diff->height, 2);
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererImageIO_tests.cc
+++ b/donner/svg/renderer/tests/RendererImageIO_tests.cc
@@ -64,6 +64,12 @@ TEST(RendererImageIOTests, PaddedRowsWithoutFinalPaddingRoundTripToMemory) {
   ExpectPng(filename, ExpectedCorners());
 }
 
+TEST(RendererImageIOTests, RejectsUnrepresentableEncoderFilterScores) {
+  constexpr int kWidth = std::numeric_limits<int>::max() / (4 * 128) + 1;
+  const std::vector<uint8_t> pixels(static_cast<size_t>(kWidth) * 4, 128);
+  EXPECT_THAT(RendererImageIO::writeRgbaPixelsToPngMemory(pixels, kWidth, 1), testing::IsEmpty());
+}
+
 TEST(RendererImageIOTests, RejectsInvalidLayoutsBeforeOpeningAFile) {
   struct Layout {
     int width;


### PR DESCRIPTION
PNG mismatch diagnostics accepted padded rows but asserted that the source span was tightly packed, aborting precisely when a GPU pixel comparison needed artifacts. Accept a valid padded layout and reject invalid dimensions or spans before opening an output file.

Bound every signed-integer domain used by the pinned encoder: row offsets, filter-score accumulation, filtered input size, zlib arithmetic, and stretchy-buffer growth. Propagate encoder and file errors, and write side-by-side diagnostic images using their actual tightly packed stride without changing pixelmatch acceptance.

Verification: the reviewed source passed normal and UBSan lanes over five focused cases, including padded file and memory round trips, readable mismatch artifacts, invalid layouts, and a bounded 16 MiB filter-score case, plus the full repository, CMake, formatting, BUILD formatting, and changed-method lint gates. The branch has since been rebased onto current main with no content change, so CI on this head is the gate for the rebased source.
