### PR TITLE
Wait before writing Vulkan buffers still in GPU use

### DIFF
--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -479,6 +479,13 @@ public:
    * Writes \p data into \p buffer at \p offsetBytes. Fails closed if the range does not fit
    * (checked arithmetic) or the buffer lacks \ref BufferUsage::CopyDst.
    *
+   * A write never changes bytes an already submitted command still reads, but backends reach
+   * that guarantee differently and the difference is visible to callers. MetalDevice queues an
+   * aligned write to a busy buffer behind the outstanding submission and returns success;
+   * VulkanDevice waits for that buffer's submission and returns a GpuErrorType::InvalidState
+   * error if the wait times out. Portable callers should either write buffers no in-flight
+   * submission references, or handle the busy-buffer failure.
+   *
    * @param buffer Destination buffer.
    * @param offsetBytes Destination byte offset.
    * @param data Payload bytes.

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -1308,6 +1308,14 @@ struct VulkanDevice::Impl {
 };
 
 std::unique_ptr<VulkanDevice> VulkanDevice::Create() {
+  return CreateImpl(false);
+}
+
+std::unique_ptr<VulkanDevice> VulkanDevice::CreateWithTimelineSemaphoreForTest() {
+  return CreateImpl(true);
+}
+
+std::unique_ptr<VulkanDevice> VulkanDevice::CreateImpl(bool enableTimelineSemaphoreForTest) {
   InstanceSetup setup = CreateInstance();
   if (setup.loader == nullptr) {
     return nullptr;
@@ -1352,6 +1360,16 @@ std::unique_ptr<VulkanDevice> VulkanDevice::Create() {
   deviceInfo.queueCreateInfoCount = 1;
   deviceInfo.pQueueCreateInfos = &queueInfo;
   deviceInfo.pEnabledFeatures = &enabledFeatures;
+
+  const char* timelineExtension = VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
+  VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelineFeatures = {};
+  timelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR;
+  timelineFeatures.timelineSemaphore = VK_TRUE;
+  if (enableTimelineSemaphoreForTest) {
+    deviceInfo.enabledExtensionCount = 1;
+    deviceInfo.ppEnabledExtensionNames = &timelineExtension;
+    deviceInfo.pNext = &timelineFeatures;
+  }
 
   VkDevice device = VK_NULL_HANDLE;
   if (api.vkCreateDevice(selectedDevice, &deviceInfo, nullptr, &device) != VK_SUCCESS) {
@@ -1416,6 +1434,10 @@ VulkanDevice::~VulkanDevice() {
     poll();
   }
   impl_->teardown();
+}
+
+VulkanDevice::NativeContextForTest VulkanDevice::nativeContextForTest() const {
+  return {impl_->api, impl_->device, impl_->queue, impl_->queueFamilyIndex};
 }
 
 uint64_t VulkanDevice::completedSerial() const {

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -2234,10 +2234,22 @@ Status VulkanDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
     return GpuError{GpuErrorType::InvalidState,
                     std::format("buffer slot {} has no Vulkan buffer", slotIndex)};
   }
-  if (!data.empty()) {
-    std::memcpy(static_cast<uint8_t*>(record->allocation.mapped) + offsetBytes, data.data(),
-                data.size());
+  if (impl_->hasError()) {
+    return GpuError{GpuErrorType::InvalidState, lastErrorForTest()};
   }
+  if (data.empty()) {
+    return OkStatus();
+  }
+  const uint64_t lastUse = bufferLastUseSerial(slotIndex);
+  if (lastUse > impl_->completedSerialValue && !waitForSerial(lastUse, 5.0)) {
+    const std::string error = lastErrorForTest();
+    return GpuError{GpuErrorType::InvalidState,
+                    error.empty()
+                        ? std::format("writeBuffer timed out waiting for submission {}", lastUse)
+                        : error};
+  }
+  std::memcpy(static_cast<uint8_t*>(record->allocation.mapped) + offsetBytes, data.data(),
+              data.size());
   return OkStatus();
 }
 

--- a/donner/gpu/vulkan/VulkanDevice.cc
+++ b/donner/gpu/vulkan/VulkanDevice.cc
@@ -43,6 +43,11 @@ constexpr uint32_t kTargetApiVersion = VK_API_VERSION_1_1;
 /// stuck driver fails closed with an error instead of hanging the caller forever.
 constexpr uint64_t kUploadFenceTimeoutNs = 60ull * 1000ull * 1000ull * 1000ull;
 
+/// How long \ref VulkanDevice::onWriteBuffer waits for a buffer's outstanding submission before
+/// refusing the write. Long enough for any legitimate frame, short enough to leave the device
+/// recoverable rather than wedging the calling thread.
+constexpr double kBusyBufferWriteTimeoutSeconds = 5.0;
+
 /// Validation layer enabled when the loader enumerates it (CI installs it explicitly; plain
 /// driver installs usually do not have it, and it is skipped silently then).
 constexpr const char* kValidationLayerName = "VK_LAYER_KHRONOS_validation";
@@ -1352,24 +1357,30 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateImpl(bool enableTimelineSemaph
   queueInfo.queueCount = 1;
   queueInfo.pQueuePriorities = &queuePriority;
 
-  // Vulkan 1.1 core only: no device extensions, and no optional features beyond the mandatory
-  // robustBufferAccess (read-only storage buffer access in the fragment stage and
-  // negative-height viewports are core).
+  // Vulkan 1.1 core for every production path: no device extensions, and no optional features
+  // beyond the mandatory robustBufferAccess (read-only storage buffer access in the fragment
+  // stage and negative-height viewports are core). Tests that need to hold a submission open ask
+  // for VK_KHR_timeline_semaphore through CreateWithTimelineSemaphoreForTest; that is the only
+  // extension this backend ever enables, and it is never enabled for a device the product uses.
   VkDeviceCreateInfo deviceInfo = {};
   deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   deviceInfo.queueCreateInfoCount = 1;
   deviceInfo.pQueueCreateInfos = &queueInfo;
   deviceInfo.pEnabledFeatures = &enabledFeatures;
 
-  const char* timelineExtension = VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME;
+  // Accumulate rather than assign, so enabling a second extension or chaining a second features
+  // struct later cannot silently drop the test-only one (or be dropped by it).
+  std::vector<const char*> deviceExtensions;
   VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelineFeatures = {};
   timelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR;
   timelineFeatures.timelineSemaphore = VK_TRUE;
   if (enableTimelineSemaphoreForTest) {
-    deviceInfo.enabledExtensionCount = 1;
-    deviceInfo.ppEnabledExtensionNames = &timelineExtension;
+    deviceExtensions.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+    timelineFeatures.pNext = const_cast<void*>(deviceInfo.pNext);
     deviceInfo.pNext = &timelineFeatures;
   }
+  deviceInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
+  deviceInfo.ppEnabledExtensionNames = deviceExtensions.empty() ? nullptr : deviceExtensions.data();
 
   VkDevice device = VK_NULL_HANDLE;
   if (api.vkCreateDevice(selectedDevice, &deviceInfo, nullptr, &device) != VK_SUCCESS) {
@@ -2234,14 +2245,14 @@ Status VulkanDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
     return GpuError{GpuErrorType::InvalidState,
                     std::format("buffer slot {} has no Vulkan buffer", slotIndex)};
   }
-  if (impl_->hasError()) {
-    return GpuError{GpuErrorType::InvalidState, lastErrorForTest()};
-  }
   if (data.empty()) {
     return OkStatus();
   }
+  // A latched device failure is reported through waitForSerial below, which fails closed on it.
+  // Writes to idle buffers stay unaffected by an unrelated earlier failure, exactly as before.
   const uint64_t lastUse = bufferLastUseSerial(slotIndex);
-  if (lastUse > impl_->completedSerialValue && !waitForSerial(lastUse, 5.0)) {
+  if (lastUse > impl_->completedSerialValue &&
+      !waitForSerial(lastUse, kBusyBufferWriteTimeoutSeconds)) {
     const std::string error = lastErrorForTest();
     return GpuError{GpuErrorType::InvalidState,
                     error.empty()

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -28,23 +28,32 @@ struct VulkanApi;
  * SPIR-V binding decorations (the SPIR-V emitter uses DescriptorSet 0 / Binding b).
  *
  * Targets Vulkan 1.1 core only: classic VkRenderPass + VkFramebuffer (no dynamic rendering),
- * per-submission VkFence completion tracking (no timeline semaphores), and the core
- * negative-viewport-height feature (VK_KHR_maintenance1, promoted to 1.1) to present WebGPU
- * clip-space semantics - identical SPIR-V positions land on identical pixels as the wgpu
- * baseline.
+ * per-submission VkFence completion tracking, and the core negative-viewport-height feature
+ * (VK_KHR_maintenance1, promoted to 1.1) to present WebGPU clip-space semantics - identical
+ * SPIR-V positions land on identical pixels as the wgpu baseline. No device extension is
+ * enabled on any production path; the sole exception is VK_KHR_timeline_semaphore, which
+ * \ref CreateWithTimelineSemaphoreForTest requests so a test can hold a submission open.
  *
  * Memory model (documented simplification for this slice): every buffer lives in
  * HOST_VISIBLE | HOST_COHERENT memory and stays persistently mapped. Queue writes wait up to
- * five seconds for that buffer's prior submission before copying; timeout leaves its bytes
- * unchanged. Idle buffers copy directly, and readback needs no staging. Which allocation a buffer
- * is bound into is the allocator's decision, behind the seam in VulkanBufferAllocator.h: one
- * dedicated allocation per buffer today, with a suballocating implementation replaceable there
- * rather than at every call site, once measurement says the driver's allocation-count cap is the
- * constraint worth spending complexity on. Such a memory type is guaranteed by the Vulkan
- * specification ("Device Memory": at least one memory type has both HOST_VISIBLE and
- * HOST_COHERENT), and both the CI software rasterizer and desktop GPUs expose it. Textures are
- * DEVICE_LOCAL (when available) with staged uploads through a transient host-visible buffer and
- * explicit image layout transitions.
+ * five seconds for that buffer's prior submission before copying; timeout refuses the write and
+ * leaves its bytes unchanged. Idle buffers copy directly.
+ *
+ * Two consequences of that simplification are worth stating, because callers cannot see them:
+ * this backend refuses a write to a busy buffer where MetalDevice queues an equivalent aligned
+ * write and returns success, so \ref donner::gpu::Device::writeBuffer can fail here and succeed
+ * there for the same call; and \ref readBackBuffer copies the mapping without consulting the
+ * buffer's last use, so a caller reading a buffer an unfinished submission still writes must
+ * wait for that submission itself. Both are tracked follow-ups, not intended end states.
+ *
+ * Which allocation a buffer is bound into is the allocator's decision, behind the seam in
+ * VulkanBufferAllocator.h: one dedicated allocation per buffer today, with a suballocating
+ * implementation replaceable there rather than at every call site, once measurement says the
+ * driver's allocation-count cap is the constraint worth spending complexity on. Such a memory type
+ * is guaranteed by the Vulkan specification ("Device Memory": at least one memory type has both
+ * HOST_VISIBLE and HOST_COHERENT), and both the CI software rasterizer and desktop GPUs expose it.
+ * Textures are DEVICE_LOCAL (when available) with staged uploads through a transient host-visible
+ * buffer and explicit image layout transitions.
  *
  * Synchronization is tracked per image: barriers before and after render passes, dispatches,
  * and copies come from VulkanResourceState.h. Render-pass attachment layouts stay fixed, so

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -11,6 +11,8 @@
 
 namespace donner::gpu::vulkan {
 
+struct VulkanApi;
+
 /**
  * Vulkan backend of the Donner GPU runtime.
  *
@@ -70,6 +72,10 @@ public:
    * Vulkan 1.1 instance or graphics-capable physical device is available.
    */
   static std::unique_ptr<VulkanDevice> Create();
+
+  /// Creates a device with VK_KHR_timeline_semaphore enabled solely for test-owned host gates.
+  /// Returns nullptr if the test extension/feature is unavailable; ordinary Create needs neither.
+  static std::unique_ptr<VulkanDevice> CreateWithTimelineSemaphoreForTest();
 
   /// Destructor; waits for in-flight submissions (vkDeviceWaitIdle), drains deferred
   /// destructions, then destroys all remaining Vulkan objects in dependency-safe order.
@@ -172,6 +178,19 @@ public:
   /// @param defer Whether to postpone upload completion observations.
   void deferTextureUploadPollingForTest(bool defer);
 
+  /// Borrowed native objects for tests that submit their own synchronization gate. Valid only
+  /// until this device is destroyed; callers must use the owning thread, release every gate, and
+  /// finish their native work before destroying any of these objects or the device.
+  struct NativeContextForTest {
+    const VulkanApi* api;       //!< Device entry points, owned by this device.
+    void* device;               //!< Borrowed VkDevice.
+    void* queue;                //!< Borrowed VkQueue.
+    uint32_t queueFamilyIndex;  //!< Family of the borrowed queue.
+  };
+
+  /// Returns borrowed native objects solely for deterministic backend synchronization tests.
+  NativeContextForTest nativeContextForTest() const;
+
   /// Message of the most recent asynchronous Vulkan failure observed while polling or waiting
   /// on fences (e.g. VK_ERROR_DEVICE_LOST), or an empty string if none occurred.
   /// Test/diagnostic accessor.
@@ -204,6 +223,9 @@ protected:
                   std::span<const Command> commands) override;
 
 private:
+  /// Creates the common backend, optionally enabling the extension used by native test gates.
+  static std::unique_ptr<VulkanDevice> CreateImpl(bool enableTimelineSemaphoreForTest);
+
   /// Constructs an empty device; \ref Create attaches the Vulkan instance/device.
   VulkanDevice();
 

--- a/donner/gpu/vulkan/VulkanDevice.h
+++ b/donner/gpu/vulkan/VulkanDevice.h
@@ -34,12 +34,13 @@ struct VulkanApi;
  * baseline.
  *
  * Memory model (documented simplification for this slice): every buffer lives in
- * HOST_VISIBLE | HOST_COHERENT memory and stays persistently mapped, so queue writes are a
- * `memcpy` and readback needs no staging. Which allocation a buffer is bound into is the
- * allocator's decision, behind the seam in VulkanBufferAllocator.h: one dedicated allocation per
- * buffer today, with a suballocating implementation replaceable there rather than at every call
- * site, once measurement says the driver's allocation-count cap is the constraint worth spending
- * complexity on. Such a memory type is guaranteed by the Vulkan
+ * HOST_VISIBLE | HOST_COHERENT memory and stays persistently mapped. Queue writes wait up to
+ * five seconds for that buffer's prior submission before copying; timeout leaves its bytes
+ * unchanged. Idle buffers copy directly, and readback needs no staging. Which allocation a buffer
+ * is bound into is the allocator's decision, behind the seam in VulkanBufferAllocator.h: one
+ * dedicated allocation per buffer today, with a suballocating implementation replaceable there
+ * rather than at every call site, once measurement says the driver's allocation-count cap is the
+ * constraint worth spending complexity on. Such a memory type is guaranteed by the Vulkan
  * specification ("Device Memory": at least one memory type has both HOST_VISIBLE and
  * HOST_COHERENT), and both the CI software rasterizer and desktop GPUs expose it. Textures are
  * DEVICE_LOCAL (when available) with staged uploads through a transient host-visible buffer and

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -172,4 +172,25 @@ donner_cc_test(
     ],
 )
 
+donner_cc_test(
+    name = "vulkan_buffer_writes_tests",
+    srcs = ["VulkanBufferWrites_tests.cc"],
+    env = {
+        "DONNER_REQUIRE_VULKAN": "1",
+        "XDG_RUNTIME_DIR": "/tmp",
+    },
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/gpu",
+        "//donner/gpu:gpu_test_utils",
+        "//donner/gpu/shader",
+        "//donner/gpu/shader:module_interface",
+        "//donner/gpu/shader:programs",
+        "//donner/gpu/shader:spirv_emitter",
+        "//donner/gpu/vulkan:vulkan_device",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/vulkan/tests/VulkanBufferWrites_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanBufferWrites_tests.cc
@@ -176,11 +176,18 @@ protected:
   void SetUp() override {
     device_ = VulkanDevice::CreateWithTimelineSemaphoreForTest();
     if (!device_) {
+      // DONNER_REQUIRE_VULKAN asserts that a baseline Vulkan 1.1 device exists, which is what the
+      // sibling targets need. This one additionally needs VK_KHR_timeline_semaphore to hold a
+      // submission open, and that extension is optional on a conforming 1.1 driver, so a device
+      // that runs every other Vulkan target may legitimately not offer it. Distinguish the two:
+      // no baseline device on a required runner is a failure, the missing extension is a skip.
       const char* required = std::getenv("DONNER_REQUIRE_VULKAN");
-      if (required && std::string_view(required) == "1") {
-        FAIL() << "A Vulkan 1.1 device with the test timeline-semaphore extension is required";
+      const bool requireVulkan = required != nullptr && std::string_view(required) == "1";
+      if (requireVulkan && VulkanDevice::Create() == nullptr) {
+        FAIL() << "DONNER_REQUIRE_VULKAN=1 but no Vulkan 1.1 device could be created";
       }
-      GTEST_SKIP() << "No Vulkan 1.1 device with test timeline-semaphore support available";
+      GTEST_SKIP() << "Vulkan device does not support the test-only VK_KHR_timeline_semaphore "
+                      "extension this deterministic ordering regression needs";
     }
     auto ir = BuildUniformReadModule();
     ASSERT_FALSE(ir.hasError()) << ir.error();

--- a/donner/gpu/vulkan/tests/VulkanBufferWrites_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanBufferWrites_tests.cc
@@ -1,0 +1,320 @@
+/// @file
+/// Host writes cannot change bytes an earlier Vulkan submission still needs.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/shader/ModuleInterface.h"
+#include "donner/gpu/shader/SpirvEmitter.h"
+#include "donner/gpu/shader/programs/ErrorLatch.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+#include "donner/gpu/vulkan/VulkanDevice.h"
+#include "donner/gpu/vulkan/VulkanLoader.h"
+
+namespace donner::gpu::vulkan {
+namespace {
+
+/// A test-owned timeline semaphore blocks later queue work until explicitly released.
+class NativeQueueGate {
+public:
+  explicit NativeQueueGate(VulkanDevice::NativeContextForTest context)
+      : api_(*context.api),
+        device_(static_cast<VkDevice>(context.device)),
+        queue_(static_cast<VkQueue>(context.queue)),
+        family_(context.queueFamilyIndex) {
+    createSemaphore_ = reinterpret_cast<PFN_vkCreateSemaphore>(
+        api_.vkGetDeviceProcAddr(device_, "vkCreateSemaphore"));
+    destroySemaphore_ = reinterpret_cast<PFN_vkDestroySemaphore>(
+        api_.vkGetDeviceProcAddr(device_, "vkDestroySemaphore"));
+    signalSemaphore_ = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(
+        api_.vkGetDeviceProcAddr(device_, "vkSignalSemaphoreKHR"));
+  }
+
+  ~NativeQueueGate() {
+    if (semaphore_ != VK_NULL_HANDLE) {
+      EXPECT_EQ(release(), VK_SUCCESS);
+    }
+    if (submitted_) {
+      const VkResult result = api_.vkWaitForFences(device_, 1, &fence_, VK_TRUE, 5'000'000'000);
+      if (result != VK_SUCCESS) {
+        ADD_FAILURE() << "Released native gate did not finish: " << result;
+        return;  // Retain possibly in-use objects until the device is destroyed.
+      }
+    }
+    if (pool_ != VK_NULL_HANDLE) api_.vkDestroyCommandPool(device_, pool_, nullptr);
+    if (fence_ != VK_NULL_HANDLE) api_.vkDestroyFence(device_, fence_, nullptr);
+    if (semaphore_ != VK_NULL_HANDLE) destroySemaphore_(device_, semaphore_, nullptr);
+  }
+
+  void start() {
+    ASSERT_NE(createSemaphore_, nullptr);
+    ASSERT_NE(destroySemaphore_, nullptr);
+    ASSERT_NE(signalSemaphore_, nullptr);
+    VkSemaphoreTypeCreateInfoKHR type = {};
+    type.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO_KHR;
+    type.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
+    VkSemaphoreCreateInfo semaphoreInfo = {};
+    semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    semaphoreInfo.pNext = &type;
+    ASSERT_EQ(createSemaphore_(device_, &semaphoreInfo, nullptr, &semaphore_), VK_SUCCESS);
+    VkCommandPoolCreateInfo poolInfo = {};
+    poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolInfo.queueFamilyIndex = family_;
+    ASSERT_EQ(api_.vkCreateCommandPool(device_, &poolInfo, nullptr, &pool_), VK_SUCCESS);
+    VkFenceCreateInfo fenceInfo = {};
+    fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    ASSERT_EQ(api_.vkCreateFence(device_, &fenceInfo, nullptr, &fence_), VK_SUCCESS);
+    recordAndSubmit();
+  }
+
+  VkResult release() {
+    if (released_) return VK_SUCCESS;
+    VkSemaphoreSignalInfoKHR signal = {};
+    signal.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO_KHR;
+    signal.semaphore = semaphore_;
+    signal.value = 1;
+    const VkResult result = signalSemaphore_(device_, &signal);
+    released_ = result == VK_SUCCESS;
+    return result;
+  }
+  bool submitted() const { return submitted_; }
+
+private:
+  void recordAndSubmit() {
+    VkCommandBufferAllocateInfo allocate = {};
+    allocate.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocate.commandPool = pool_;
+    allocate.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocate.commandBufferCount = 1;
+    VkCommandBuffer command = VK_NULL_HANDLE;
+    ASSERT_EQ(api_.vkAllocateCommandBuffers(device_, &allocate, &command), VK_SUCCESS);
+    VkCommandBufferBeginInfo begin = {};
+    begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    ASSERT_EQ(api_.vkBeginCommandBuffer(command, &begin), VK_SUCCESS);
+    VkMemoryBarrier barrier = {};
+    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT;
+    // The tested host write happens after queue submission, so it needs an explicit domain
+    // transfer.
+    api_.vkCmdPipelineBarrier(
+        command, VK_PIPELINE_STAGE_HOST_BIT | VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1, &barrier, 0, nullptr, 0, nullptr);
+    ASSERT_EQ(api_.vkEndCommandBuffer(command), VK_SUCCESS);
+    const uint64_t waitValue = 1;
+    VkTimelineSemaphoreSubmitInfoKHR timeline = {};
+    timeline.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR;
+    timeline.waitSemaphoreValueCount = 1;
+    timeline.pWaitSemaphoreValues = &waitValue;
+    const VkPipelineStageFlags waitStages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkSubmitInfo submit = {};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.pNext = &timeline;
+    submit.waitSemaphoreCount = 1;
+    submit.pWaitSemaphores = &semaphore_;
+    submit.pWaitDstStageMask = &waitStages;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &command;
+    ASSERT_EQ(api_.vkQueueSubmit(queue_, 1, &submit, fence_), VK_SUCCESS);
+    submitted_ = true;
+  }
+
+  const VulkanApi& api_;
+  VkDevice device_;
+  VkQueue queue_;
+  uint32_t family_;
+  PFN_vkCreateSemaphore createSemaphore_ = nullptr;
+  PFN_vkDestroySemaphore destroySemaphore_ = nullptr;
+  PFN_vkSignalSemaphoreKHR signalSemaphore_ = nullptr;
+  VkSemaphore semaphore_ = VK_NULL_HANDLE;
+  VkCommandPool pool_ = VK_NULL_HANDLE;
+  VkFence fence_ = VK_NULL_HANDLE;
+  bool submitted_ = false;
+  bool released_ = false;
+};
+
+shader::ShaderResult<shader::IrModule> BuildUniformReadModule() {
+  using namespace shader;
+  programs::ErrorLatch e;
+  ModuleBuilder builder;
+  const IrType params = e(IrType::Struct("Params", {{"color", IrType::Vec4f()}}));
+  e.ok(builder.addUniformBuffer(0, 0, "params", params));
+  e.ok(builder.addWriteOnlyStorageTexture2d(0, 1, "outputTexture",
+                                            StorageTextureFormat::Rgba8Unorm));
+  auto function = builder.createComputeEntryPoint("cs", {}, {1, 1, 1});
+  if (function.hasError()) return std::move(function).error();
+  FunctionBuilder entry = std::move(function).result();
+  e.ok(entry.textureStore(e(entry.ref("outputTexture")),
+                          e(ConstructVector(IrType::Vec2i(), {LiteralI32(0)})),
+                          e(Member(e(entry.ref("params")), "color"))));
+  e.ok(entry.finish());
+  if (e.error) return *e.error;
+  return builder.build();
+}
+
+template <typename T>
+std::span<const uint8_t> AsBytes(const T& value) {
+  return {reinterpret_cast<const uint8_t*>(&value), sizeof(value)};
+}
+
+constexpr std::array<float, 4> kRed{1, 0, 0, 1};
+constexpr std::array<float, 4> kBlue{0, 0, 1, 1};
+
+class VulkanBufferWritesTests : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = VulkanDevice::CreateWithTimelineSemaphoreForTest();
+    if (!device_) {
+      const char* required = std::getenv("DONNER_REQUIRE_VULKAN");
+      if (required && std::string_view(required) == "1") {
+        FAIL() << "A Vulkan 1.1 device with the test timeline-semaphore extension is required";
+      }
+      GTEST_SKIP() << "No Vulkan 1.1 device with test timeline-semaphore support available";
+    }
+    auto ir = BuildUniformReadModule();
+    ASSERT_FALSE(ir.hasError()) << ir.error();
+    auto spirv = shader::EmitSpirv(ir.result());
+    ASSERT_FALSE(spirv.hasError()) << spirv.error();
+    module_ =
+        GetResultOrFail(device_->createShaderModule({"uniform read",
+                                                     {},
+                                                     ShaderSourceKind::Spirv,
+                                                     std::move(spirv).result(),
+                                                     shader::ComputeEntryPointsOf(ir.result())}));
+    groupLayout_ = GetResultOrFail(device_->createBindGroupLayout(
+        {"uniform read",
+         {{0, ShaderStage::Compute, BindingType::UniformBuffer},
+          {1, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
+    layout_ = GetResultOrFail(device_->createPipelineLayout({"uniform read", {groupLayout_}}));
+    pipeline_ = GetResultOrFail(
+        device_->createComputePipeline({"uniform read", layout_, {module_, "cs"}, {1, 1, 1}}));
+    input_ = GetResultOrFail(device_->createBuffer(
+        {"params", sizeof(kRed), BufferUsage::Uniform | BufferUsage::CopyDst}));
+    ASSERT_THAT(device_->writeBuffer(input_, 0, AsBytes(kRed)), IsOk());
+    output_ = GetResultOrFail(
+        device_->createTexture({"output",
+                                {1, 1},
+                                TextureFormat::RGBA8Unorm,
+                                TextureUsage::StorageBinding | TextureUsage::CopySrc}));
+    view_ = GetResultOrFail(device_->createTextureView(output_, {}));
+    readback_ = GetResultOrFail(
+        device_->createBuffer({"readback", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
+  }
+
+  void TearDown() override {
+    if (device_) EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+  }
+
+  uint64_t submitRead(const Buffer& input) {
+    const BindGroup group = GetResultOrFail(device_->createBindGroup(
+        {"uniform read",
+         groupLayout_,
+         {{0, BufferBinding{input, 0, sizeof(kRed)}}, {1, TextureViewBinding{view_}}}}));
+    auto encoder = GetResultOrFail(device_->createCommandEncoder());
+    if (!encoder) return 0;
+    auto passResult = encoder->beginComputePass({});
+    EXPECT_THAT(passResult, HasResult());
+    if (passResult.hasError()) return 0;
+    ComputePassEncoder* pass = passResult.result();
+    EXPECT_THAT(pass->setPipeline(pipeline_), IsOk());
+    EXPECT_THAT(pass->setBindGroup(0, group), IsOk());
+    EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    EXPECT_THAT(pass->end(), IsOk());
+    EXPECT_THAT(encoder->copyTextureToBuffer({output_}, readback_, {0, 256, 1}, {1, 1}), IsOk());
+    return GetResultOrFail(device_->submit(GetResultOrFail(encoder->finish())));
+  }
+
+  void expectPixel(const std::array<uint8_t, 4>& expected) {
+    auto data = device_->readBackBuffer(readback_);
+    ASSERT_THAT(data, HasResult());
+    ASSERT_GE(data.result().size(), 4u);
+    data.result().resize(4);
+    const svg::RendererBitmap actual{
+        .dimensions = {1, 1}, .pixels = std::move(data).result(), .rowBytes = 4};
+    const svg::RendererBitmap reference{
+        .dimensions = {1, 1},
+        .pixels = std::vector<uint8_t>(expected.begin(), expected.end()),
+        .rowBytes = 4};
+    editor::tests::CompareBitmapToBitmap(actual, reference, "vulkan_buffer_write",
+                                         editor::tests::PixelmatchIdentityParams());
+  }
+
+  std::unique_ptr<VulkanDevice> device_;
+  ShaderModule module_;
+  BindGroupLayout groupLayout_;
+  PipelineLayout layout_;
+  ComputePipeline pipeline_;
+  Buffer input_;
+  Texture output_;
+  TextureView view_;
+  Buffer readback_;
+};
+
+TEST_F(VulkanBufferWritesTests, InFlightWriteRefusesWithoutChangingSubmittedBytes) {
+  NativeQueueGate gate(device_->nativeContextForTest());
+  gate.start();
+  ASSERT_THAT(gate.submitted(), testing::IsTrue());
+  const uint64_t serial = submitRead(input_);
+  ASSERT_NE(serial, 0u);
+  ASSERT_LT(device_->completedSerial(), serial);
+  const Status write = device_->writeBuffer(input_, 0, AsBytes(kBlue));
+  ASSERT_EQ(gate.release(), VK_SUCCESS);
+  ASSERT_THAT(device_->waitForSerial(serial, 5.0), testing::IsTrue());
+  EXPECT_THAT(write, IsGpuError(GpuErrorType::InvalidState));
+  expectPixel({255, 0, 0, 255});
+
+  // A timeout is recoverable, and the same write can succeed after the reader completes.
+  ASSERT_THAT(device_->writeBuffer(input_, 0, AsBytes(kBlue)), IsOk());
+  ASSERT_THAT(device_->waitForSerial(submitRead(input_), 5.0), testing::IsTrue());
+  expectPixel({0, 0, 255, 255});
+}
+
+TEST_F(VulkanBufferWritesTests, FreshAndCompletedBuffersDoNotWaitForUnrelatedWork) {
+  ASSERT_THAT(device_->waitForSerial(submitRead(input_), 5.0), testing::IsTrue());
+  const Buffer other = GetResultOrFail(
+      device_->createBuffer({"other", sizeof(kRed), BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(device_->writeBuffer(other, 0, AsBytes(kRed)), IsOk());
+  NativeQueueGate gate(device_->nativeContextForTest());
+  gate.start();
+  ASSERT_THAT(gate.submitted(), testing::IsTrue());
+  const uint64_t serial = submitRead(other);
+  ASSERT_LT(device_->completedSerial(), serial);
+  const Buffer fresh =
+      GetResultOrFail(device_->createBuffer({"fresh", sizeof(kRed), BufferUsage::CopyDst}));
+  EXPECT_THAT(device_->writeBuffer(input_, 0, AsBytes(kBlue)), IsOk());
+  EXPECT_THAT(device_->writeBuffer(fresh, 0, AsBytes(kBlue)), IsOk());
+  EXPECT_THAT(device_->writeBuffer(other, 0, {}), IsOk());
+  ASSERT_EQ(gate.release(), VK_SUCCESS);
+  ASSERT_THAT(device_->waitForSerial(serial, 5.0), testing::IsTrue());
+  expectPixel({255, 0, 0, 255});
+}
+
+TEST_F(VulkanBufferWritesTests, CompletedWritesReportHostCopyCost) {
+  ASSERT_THAT(device_->waitForSerial(submitRead(input_), 5.0), testing::IsTrue());
+  constexpr uint32_t kWrites = 20'000;
+  for (uint32_t sample = 0; sample < 7; ++sample) {
+    Status status = OkStatus();
+    const auto start = std::chrono::steady_clock::now();
+    for (uint32_t index = 0; index < kWrites; ++index) {
+      status = device_->writeBuffer(input_, 0, AsBytes(kBlue));
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_THAT(status, IsOk());
+    std::fprintf(stderr, "completed_buffer_write count=%u ns=%.3f\n", kWrites,
+                 std::chrono::duration<double, std::nano>(elapsed).count() / kWrites);
+  }
+}
+
+}  // namespace
+}  // namespace donner::gpu::vulkan


### PR DESCRIPTION
A Vulkan buffer write could overwrite persistently mapped coherent memory while an already submitted command still read the same allocation. Track the buffer's last-use serial and wait only when that specific buffer still has outstanding GPU work; a bounded timeout refuses the write before copying and leaves the device recoverable.

Fresh and completed buffers keep the direct-copy fast path. The deterministic regression holds a real earlier submission behind a test-owned timeline semaphore, proves the old write changes the earlier pixel, then verifies timeout recovery, post-completion retry, empty writes, and unrelated buffers. Normal device creation does not require the test-only timeline feature.

Verification: the reviewed source passed seven native Vulkan and shared targets under synchronization validation, 300 cases with no failures or skips, plus the full repository, CMake, formatting, BUILD formatting, and changed-method lint gates. Rebasing onto current main produced one additive conflict in the device test-accessor header against the upload-ownership changes in #1104; both sides were kept and no other content changed. CI on this head is the gate for the rebased source.

Independent review before opening this PR found three defects, now fixed here: the latched-error gate failed every later write including writes to idle buffers, two class comments claimed the backend enables no device extensions while the test seam enables VK_KHR_timeline_semaphore, and the device-create path assigned rather than accumulated the extension list and pNext chain. Two follow-ups are documented rather than fixed: this backend refuses a busy-buffer write where MetalDevice queues an equivalent aligned write and succeeds, and readBackBuffer still copies the mapping without consulting the buffer's last use.
