### PR TITLE
Describe shader buffer requirements from the typed IR

### DIFF
--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -574,6 +574,21 @@ struct ComputeEntryPointInfo {
   WorkgroupSize workgroupSize;  //!< Workgroup size compiled into that entry point.
 };
 
+/// One buffer statically used by an entry point, including uses through helper functions.
+/// Generated from the same IR as shader source; the runtime never parses shader source.
+struct ShaderBufferBindingInfo {
+  RcString entryPoint;                            //!< Entry point using this binding.
+  ShaderStage stage = ShaderStage::None;          //!< Single shader stage of that entry point.
+  uint32_t group = 0;                             //!< Bind group index.
+  uint32_t binding = 0;                           //!< Binding index within the group.
+  BindingType type = BindingType::UniformBuffer;  //!< Uniform or read-only storage buffer.
+  uint64_t minSizeBytes = 0;             //!< Fixed layout size, or one runtime-array element.
+  uint32_t runtimeArrayStrideBytes = 0;  //!< Runtime-array stride; zero for a fixed-size binding.
+
+  /// Equality comparison. @param other Facts to compare.
+  bool operator==(const ShaderBufferBindingInfo& other) const = default;
+};
+
 /// Descriptor for `Device::createShaderModule`. Source is trusted generated build output, never
 /// runtime input from documents. Exactly one source representation must be populated: text kinds
 /// (\ref ShaderSourceKind::Wgsl, \ref ShaderSourceKind::Msl) require nonempty `sourceText` and
@@ -589,6 +604,10 @@ struct ShaderModuleDescriptor {
   /// empty. \ref donner::gpu::shader::ComputeEntryPointsOf fills it from the IR module the
   /// source was emitted from, so the size is never transcribed by hand.
   std::vector<ComputeEntryPointInfo> computeEntryPoints;
+  /// Buffer requirements derived from shader IR. An engaged empty list means no entry point
+  /// uses a buffer; absence means requirements were not supplied. Native Metal requires these
+  /// facts because its buffer arguments do not retain a declared binding range.
+  std::optional<std::vector<ShaderBufferBindingInfo>> bufferBindings;
 };
 
 /// One vertex attribute within a \ref VertexBufferLayout.

--- a/donner/gpu/shader/BUILD.bazel
+++ b/donner/gpu/shader/BUILD.bazel
@@ -153,6 +153,7 @@ donner_cc_test(
         "tests/IrSerialization_tests.cc",
         "tests/MathPrimitiveCoverageModule.h",
         "tests/MathPrimitives_tests.cc",
+        "tests/ModuleInterface_tests.cc",
         "tests/MslEmitter_tests.cc",
         "tests/ReductionCoverageModule.h",
         "tests/ShaderGoldenUtils.h",
@@ -187,6 +188,7 @@ donner_cc_test(
         "tests/testdata/subregion_clip.wgsl",
     ],
     deps = [
+        ":module_interface",
         ":msl_emitter",
         ":programs",
         ":shader",

--- a/donner/gpu/shader/IrLayout.cc
+++ b/donner/gpu/shader/IrLayout.cc
@@ -2,22 +2,30 @@
 
 #include <algorithm>
 #include <format>
+#include <limits>
 
 namespace donner::gpu::shader {
 
 namespace {
 
+constexpr uint64_t kMaxLayoutBytes = std::numeric_limits<uint32_t>::max();
+
 /// Rounds \p value up to the next multiple of \p alignment.
-uint32_t RoundUp(uint32_t alignment, uint32_t value) {
+uint64_t RoundUp(uint32_t alignment, uint64_t value) {
   return ((value + alignment - 1) / alignment) * alignment;
 }
 
 /// Alignment of \p type as a member or array element in \p addressSpace: in uniform space,
 /// structs and arrays round their alignment up to 16 (WGSL uniform layout constraints).
+///
+/// std::max rather than RoundUp: every alignment here is a power of two and IrType::Struct
+/// rejects empty structs, so baseAlign is at least 4 and rounding 16 up to it is exactly the
+/// larger of the two. Saying max directly keeps this out of the overflow-checked arithmetic
+/// below, where RoundUp's operands now have to be proven not to wrap.
 uint32_t EffectiveAlign(const IrType& type, AddressSpace addressSpace, uint32_t baseAlign) {
   if (addressSpace == AddressSpace::Uniform &&
       (type.kind() == IrType::Kind::Struct || type.kind() == IrType::Kind::SizedArray)) {
-    return RoundUp(16, baseAlign);
+    return std::max(16u, baseAlign);
   }
   return baseAlign;
 }
@@ -68,11 +76,12 @@ ShaderResult<TypeLayout> ComputeTypeLayout(const IrType& type, AddressSpace addr
         return std::move(stride).error();
       }
       // WGSL: in the uniform address space, arrays align to roundUp(16, AlignOf(element)).
-      uint32_t align = elementLayout.result().alignBytes;
-      if (addressSpace == AddressSpace::Uniform) {
-        align = RoundUp(16, align);
+      const uint32_t align = EffectiveAlign(type, addressSpace, elementLayout.result().alignBytes);
+      const uint64_t size = uint64_t{type.arrayCount()} * stride.result();
+      if (size > kMaxLayoutBytes) {
+        return ShaderError{"array size exceeds the 32-bit byte layout limit", "layout"};
       }
-      return TypeLayout{align, type.arrayCount() * stride.result()};
+      return TypeLayout{align, static_cast<uint32_t>(size)};
     }
 
     case IrType::Kind::RuntimeArray:
@@ -118,16 +127,19 @@ ShaderResult<ArrayStrideInfo> ComputeArrayStrideInfo(const IrType& arrayType,
     return std::move(elementLayout).error();
   }
 
-  const uint32_t naturalStride =
+  const uint64_t naturalStride =
       RoundUp(elementLayout.result().alignBytes, elementLayout.result().sizeBytes);
-  uint32_t stride = naturalStride;
+  uint64_t stride = naturalStride;
   if (addressSpace == AddressSpace::Uniform) {
     // WGSL uniform address space requires array element strides to be multiples of 16. Rounding
     // (instead of rejecting) keeps natural-stride-16 arrays like slug_fill's clipPolygonPlanes
     // array<vec4f, 4> simple; emitters must wrap padded elements when paddedFromNatural is set.
     stride = RoundUp(16, stride);
   }
-  return ArrayStrideInfo{stride, stride != naturalStride};
+  if (stride > kMaxLayoutBytes) {
+    return ShaderError{"array stride exceeds the 32-bit byte layout limit", "arrayStride"};
+  }
+  return ArrayStrideInfo{static_cast<uint32_t>(stride), stride != naturalStride};
 }
 
 ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
@@ -138,7 +150,7 @@ ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
   }
 
   StructLayout layout;
-  uint32_t offset = 0;
+  uint64_t offset = 0;
   for (const IrType::Member& member : structType.structMembers()) {
     ShaderResult<TypeLayout> memberLayout = ComputeTypeLayout(member.type, addressSpace);
     if (memberLayout.hasError()) {
@@ -151,8 +163,12 @@ ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
     const uint32_t memberAlign =
         EffectiveAlign(member.type, addressSpace, memberLayout.result().alignBytes);
     offset = RoundUp(memberAlign, offset);
-    layout.members.push_back(
-        StructMemberLayout{offset, TypeLayout{memberAlign, memberLayout.result().sizeBytes}});
+    if (offset > kMaxLayoutBytes) {
+      return ShaderError{"struct member offset exceeds the 32-bit byte layout limit",
+                         "structLayout"};
+    }
+    layout.members.push_back(StructMemberLayout{
+        static_cast<uint32_t>(offset), TypeLayout{memberAlign, memberLayout.result().sizeBytes}});
     layout.alignBytes = std::max(layout.alignBytes, memberAlign);
 
     // WGSL uniform constraint: the member following a struct-typed member S must start at least
@@ -163,9 +179,17 @@ ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
     } else {
       offset += memberLayout.result().sizeBytes;
     }
+    if (offset > kMaxLayoutBytes) {
+      return ShaderError{"struct member extent exceeds the 32-bit byte layout limit",
+                         "structLayout"};
+    }
   }
 
-  layout.sizeBytes = RoundUp(layout.alignBytes, offset);
+  const uint64_t size = RoundUp(layout.alignBytes, offset);
+  if (size > kMaxLayoutBytes) {
+    return ShaderError{"struct size exceeds the 32-bit byte layout limit", "structLayout"};
+  }
+  layout.sizeBytes = static_cast<uint32_t>(size);
   return layout;
 }
 

--- a/donner/gpu/shader/IrLayout.h
+++ b/donner/gpu/shader/IrLayout.h
@@ -8,6 +8,7 @@
 /// struct size rounded up to the struct alignment. In the uniform address space, arrays round
 /// their element stride up to a multiple of 16, and members whose type is a struct or array
 /// round their alignment up to 16.
+/// Layouts that cannot represent a size, stride, or member offset in 32 bits fail before narrowing.
 ///
 /// The C++ mirror structs the GPU runtime uploads (e.g. the Geode encoder's Uniforms/Band/
 /// InstanceTransform) must byte-match these computed layouts; the shader tests anchor that.

--- a/donner/gpu/shader/ModuleInterface.cc
+++ b/donner/gpu/shader/ModuleInterface.cc
@@ -1,6 +1,97 @@
 #include "donner/gpu/shader/ModuleInterface.h"
 
+#include <algorithm>
+
+#include "donner/gpu/shader/IrLayout.h"
+
 namespace donner::gpu::shader {
+namespace {
+
+struct FunctionReferences {
+  std::vector<IrExpr::RefInfo> names;
+  std::vector<RcString> calls;
+};
+
+void CollectReferences(const IrStmt& statement, FunctionReferences& references) {
+  const IrStmt::Data& data = statement.data();
+  for (const IrExpr& expression : data.exprs) {
+    expression.collectRefs(references.names);
+    expression.collectUserCalls(references.calls);
+  }
+  for (const IrStmt& child : data.body) {
+    CollectReferences(child, references);
+  }
+  for (const IrStmt& child : data.elseBody) {
+    CollectReferences(child, references);
+  }
+  if (data.init) {
+    CollectReferences(*data.init, references);
+  }
+  if (data.continuing) {
+    CollectReferences(*data.continuing, references);
+  }
+}
+
+void CollectUsedBindings(const IrModule& module, size_t functionIndex, std::vector<bool>& visited,
+                         std::vector<bool>& used) {
+  if (visited[functionIndex]) {
+    return;
+  }
+  visited[functionIndex] = true;
+  FunctionReferences references;
+  for (const IrStmt& statement : module.functions()[functionIndex].body) {
+    CollectReferences(statement, references);
+  }
+  for (const IrExpr::RefInfo& reference : references.names) {
+    if (reference.kind != RefKind::Resource) {
+      continue;
+    }
+    for (size_t index = 0; index < module.bindings().size(); ++index) {
+      used[index] = used[index] || module.bindings()[index].name == reference.name;
+    }
+  }
+  for (const RcString& call : references.calls) {
+    const auto function = std::ranges::find(module.functions(), call, &IrFunction::name);
+    if (function != module.functions().end()) {
+      CollectUsedBindings(module, function - module.functions().begin(), visited, used);
+    }
+  }
+}
+
+ShaderStage RuntimeStage(StageKind stage) {
+  switch (stage) {
+    case StageKind::None: return ShaderStage::None;
+    case StageKind::Vertex: return ShaderStage::Vertex;
+    case StageKind::Fragment: return ShaderStage::Fragment;
+    case StageKind::Compute: return ShaderStage::Compute;
+  }
+  return ShaderStage::None;
+}
+
+ShaderResult<ShaderBufferBindingInfo> BufferInfo(const IrBinding& binding,
+                                                 const IrFunction& function) {
+  const bool uniform = binding.kind == BindingKind::UniformBuffer;
+  ShaderBufferBindingInfo info{
+      function.name, RuntimeStage(function.stage), binding.group, binding.binding,
+      uniform ? BindingType::UniformBuffer : BindingType::ReadOnlyStorageBuffer};
+  const AddressSpace addressSpace = uniform ? AddressSpace::Uniform : AddressSpace::Storage;
+  if (binding.type.kind() == IrType::Kind::RuntimeArray) {
+    auto stride = ComputeArrayStride(binding.type, addressSpace);
+    if (stride.hasError()) {
+      return std::move(stride).error();
+    }
+    info.minSizeBytes = info.runtimeArrayStrideBytes = stride.result();
+  } else {
+    auto layout = ComputeTypeLayout(binding.type, addressSpace);
+    if (layout.hasError()) {
+      return std::move(layout).error();
+    }
+    info.minSizeBytes = layout.result().sizeBytes;
+  }
+  return info;
+}
+
+}  // namespace
 
 std::vector<ComputeEntryPointInfo> ComputeEntryPointsOf(const IrModule& module) {
   std::vector<ComputeEntryPointInfo> entryPoints;
@@ -16,6 +107,32 @@ std::vector<ComputeEntryPointInfo> ComputeEntryPointsOf(const IrModule& module) 
                                      function.workgroupSize->z}});
   }
   return entryPoints;
+}
+
+ShaderResult<std::vector<ShaderBufferBindingInfo>> BufferBindingsOf(const IrModule& module) {
+  std::vector<ShaderBufferBindingInfo> result;
+  for (size_t index = 0; index < module.functions().size(); ++index) {
+    const IrFunction& function = module.functions()[index];
+    if (function.stage == StageKind::None) {
+      continue;
+    }
+    std::vector<bool> used(module.bindings().size());
+    std::vector<bool> visited(module.functions().size());
+    CollectUsedBindings(module, index, visited, used);
+    for (size_t bindingIndex = 0; bindingIndex < module.bindings().size(); ++bindingIndex) {
+      const IrBinding& binding = module.bindings()[bindingIndex];
+      if (!used[bindingIndex] || (binding.kind != BindingKind::UniformBuffer &&
+                                  binding.kind != BindingKind::ReadOnlyStorageBuffer)) {
+        continue;
+      }
+      auto info = BufferInfo(binding, function);
+      if (info.hasError()) {
+        return std::move(info).error();
+      }
+      result.push_back(std::move(info).result());
+    }
+  }
+  return result;
 }
 
 }  // namespace donner::gpu::shader

--- a/donner/gpu/shader/ModuleInterface.h
+++ b/donner/gpu/shader/ModuleInterface.h
@@ -22,4 +22,13 @@ namespace donner::gpu::shader {
  */
 std::vector<ComputeEntryPointInfo> ComputeEntryPointsOf(const IrModule& module);
 
+/**
+ * Computes buffer requirements for each entry point from its reachable resource references and
+ * the IR memory layout. Runtime arrays require at least one element and report their stride.
+ * Unused bindings are omitted. The result is generated alongside source, never at draw time.
+ *
+ * @param module Built IR module the shader source was emitted from.
+ */
+ShaderResult<std::vector<ShaderBufferBindingInfo>> BufferBindingsOf(const IrModule& module);
+
 }  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/IrLayout_tests.cc
+++ b/donner/gpu/shader/tests/IrLayout_tests.cc
@@ -296,5 +296,54 @@ TEST(IrLayoutAnchorTests, InstanceTransformIs32Bytes) {
   EXPECT_THAT(layout.members, ElementsAre(OffsetIs(0), OffsetIs(16)));
 }
 
+TEST(IrLayoutOverflowTests, ArrayMultiplicationCannotWrapToASmallBinding) {
+  const IrType overflowing =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 0x10000001u), IrType::F32());
+  for (AddressSpace space : {AddressSpace::Storage, AddressSpace::Uniform}) {
+    EXPECT_THAT(ComputeTypeLayout(overflowing, space), IsShaderError(testing::HasSubstr("32-bit")));
+  }
+  const IrType largest =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 0x0fffffffu), IrType::F32());
+  EXPECT_THAT(GetShaderResultOrFail(ComputeTypeLayout(largest, AddressSpace::Storage)),
+              testing::Eq(TypeLayout{16, 0xfffffff0u}));
+}
+
+TEST(IrLayoutOverflowTests, StructMemberAdditionCannotWrap) {
+  const IrType half =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 0x08000000u), IrType::F32());
+  const IrType combined = GetShaderResultOrFail(
+      IrType::Struct("Combined", {{"first", half}, {"second", half}}), IrType::F32());
+  EXPECT_THAT(ComputeStructLayout(combined, AddressSpace::Storage),
+              IsShaderError(testing::HasSubstr("32-bit")));
+}
+
+TEST(IrLayoutOverflowTests, MemberAlignmentAndFinalSizeRoundingCannotWrap) {
+  const IrType leading =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::F32(), 0x3fffffffu), IrType::F32());
+  const IrType memberRoundUp = GetShaderResultOrFail(
+      IrType::Struct("MemberRoundUp", {{"leading", leading}, {"aligned", IrType::Vec4f()}}),
+      IrType::F32());
+  EXPECT_THAT(ComputeStructLayout(memberRoundUp, AddressSpace::Storage),
+              IsShaderError(testing::HasSubstr("32-bit")));
+  const IrType trailing =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::F32(), 0x3ffffffbu), IrType::F32());
+  const IrType finalRoundUp = GetShaderResultOrFail(
+      IrType::Struct("FinalRoundUp", {{"aligned", IrType::Vec4f()}, {"trailing", trailing}}),
+      IrType::F32());
+  EXPECT_THAT(ComputeStructLayout(finalRoundUp, AddressSpace::Storage),
+              IsShaderError(testing::HasSubstr("32-bit")));
+}
+
+TEST(IrLayoutOverflowTests, UniformPaddingCannotWrapALargeNestedStruct) {
+  const IrType array =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 0x0fffffffu), IrType::F32());
+  const IrType nested =
+      GetShaderResultOrFail(IrType::Struct("Nested", {{"items", array}}), IrType::F32());
+  const IrType outer = GetShaderResultOrFail(
+      IrType::Struct("Outer", {{"nested", nested}, {"tail", IrType::Vec4f()}}), IrType::F32());
+  EXPECT_THAT(ComputeStructLayout(outer, AddressSpace::Uniform),
+              IsShaderError(testing::HasSubstr("32-bit")));
+}
+
 }  // namespace
 }  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/ModuleInterface_tests.cc
+++ b/donner/gpu/shader/tests/ModuleInterface_tests.cc
@@ -1,0 +1,141 @@
+/// @file
+/// Shader buffer requirements derived from reachable IR resource references and memory layouts.
+
+#include "donner/gpu/shader/ModuleInterface.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "donner/gpu/shader/IrLayout.h"
+#include "donner/gpu/shader/programs/ColorMatrix.h"
+#include "donner/gpu/shader/tests/ShaderTestUtils.h"
+
+namespace donner::gpu::shader {
+namespace {
+
+using testing::AllOf;
+using testing::ElementsAre;
+using testing::Field;
+using testing::IsEmpty;
+
+auto BufferIs(const RcString& entry, ShaderStage stage, uint32_t group, uint32_t binding,
+              BindingType type, uint64_t size, uint32_t stride = 0) {
+  return AllOf(
+      Field("entryPoint", &ShaderBufferBindingInfo::entryPoint, entry),
+      Field("stage", &ShaderBufferBindingInfo::stage, stage),
+      Field("group", &ShaderBufferBindingInfo::group, group),
+      Field("binding", &ShaderBufferBindingInfo::binding, binding),
+      Field("type", &ShaderBufferBindingInfo::type, type),
+      Field("minSizeBytes", &ShaderBufferBindingInfo::minSizeBytes, size),
+      Field("runtimeArrayStrideBytes", &ShaderBufferBindingInfo::runtimeArrayStrideBytes, stride));
+}
+
+TEST(ModuleInterfaceTests, ColorMatrixReportsFixedUniformAndRuntimeArrayRequirements) {
+  auto module = programs::BuildColorMatrixModule();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(
+      GetShaderResultOrFail(BufferBindingsOf(module.result())),
+      ElementsAre(BufferIs("cs_main", ShaderStage::Compute, 0, 2, BindingType::UniformBuffer, 80),
+                  BufferIs("cs_main", ShaderStage::Compute, 0, 3,
+                           BindingType::ReadOnlyStorageBuffer, 16, 16)));
+}
+
+TEST(ModuleInterfaceTests, HelperCallsAndNestedBranchesDetermineEachEntryPointsRequirements) {
+  ModuleBuilder builder;
+  const IrType params =
+      GetShaderResultOrFail(IrType::Struct("Params", {{"color", IrType::Vec4f()}}), IrType::F32());
+  ASSERT_THAT(builder.addUniformBuffer(2, 3, "params", params), IsShaderOk());
+  ASSERT_THAT(builder.addUniformBuffer(0, 0, "unused", params), IsShaderOk());
+  auto helper = builder.createFunction("readParams", {}, IrType::Vec4f());
+  ASSERT_THAT(helper, HasShaderResult());
+  auto member =
+      Member(GetShaderResultOrFail(helper.result().ref("params"), LiteralF32(0)), "color");
+  ASSERT_THAT(member, HasShaderResult());
+  ASSERT_THAT(helper.result().returnValue(member.result()), IsShaderOk());
+  ASSERT_THAT(helper.result().finish(), IsShaderOk());
+
+  auto compute = builder.createComputeEntryPoint("usesHelper", {}, {1, 1, 1});
+  ASSERT_THAT(compute, HasShaderResult());
+  ASSERT_THAT(compute.result().beginIf(LiteralBool(true)), IsShaderOk());
+  ASSERT_THAT(compute.result().elseBranch(), IsShaderOk());
+  auto call = compute.result().callFunction("readParams", {});
+  ASSERT_THAT(call, HasShaderResult());
+  ASSERT_THAT(compute.result().addLet("color", call.result()), HasShaderResult());
+  ASSERT_THAT(compute.result().endIf(), IsShaderOk());
+  ASSERT_THAT(compute.result().finish(), IsShaderOk());
+
+  auto empty = builder.createComputeEntryPoint("noBuffers", {}, {1, 1, 1});
+  ASSERT_THAT(empty, HasShaderResult());
+  ASSERT_THAT(empty.result().finish(), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(GetShaderResultOrFail(BufferBindingsOf(module.result())),
+              ElementsAre(BufferIs("usesHelper", ShaderStage::Compute, 2, 3,
+                                   BindingType::UniformBuffer, 16)));
+}
+
+TEST(ModuleInterfaceTests, RuntimeVec3UsesPaddedStrideAndLoopExpressionsAreVisited) {
+  ModuleBuilder builder;
+  auto array = IrType::RuntimeArray(IrType::Vec3f());
+  ASSERT_THAT(array, HasShaderResult());
+  ASSERT_THAT(builder.addReadOnlyStorageBuffer(0, 1, "values", array.result()), IsShaderOk());
+  auto entry = builder.createComputeEntryPoint("cs", {}, {1, 1, 1});
+  ASSERT_THAT(entry, HasShaderResult());
+  auto value =
+      Index(GetShaderResultOrFail(entry.result().ref("values"), LiteralF32(0)), LiteralU32(0));
+  ASSERT_THAT(value, HasShaderResult());
+  auto scalar = Swizzle(value.result(), "x");
+  ASSERT_THAT(scalar, HasShaderResult());
+  auto counter = entry.result().beginFor("counter", scalar.result());
+  ASSERT_THAT(counter, HasShaderResult());
+  ASSERT_THAT(entry.result().forCondition(LiteralBool(false)), IsShaderOk());
+  ASSERT_THAT(entry.result().forContinuing(counter.result(), scalar.result()), IsShaderOk());
+  ASSERT_THAT(entry.result().endFor(), IsShaderOk());
+  ASSERT_THAT(entry.result().finish(), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(GetShaderResultOrFail(BufferBindingsOf(module.result())),
+              ElementsAre(BufferIs("cs", ShaderStage::Compute, 0, 1,
+                                   BindingType::ReadOnlyStorageBuffer, 16, 16)));
+}
+
+TEST(ModuleInterfaceTests, NoBuffersProducesKnownEmptyMetadata) {
+  ModuleBuilder builder;
+  auto entry = builder.createComputeEntryPoint("cs", {}, {1, 1, 1});
+  ASSERT_THAT(entry, HasShaderResult());
+  ASSERT_THAT(entry.result().finish(), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(GetShaderResultOrFail(BufferBindingsOf(module.result())), IsEmpty());
+}
+
+TEST(ModuleInterfaceLayoutTests, MetadataRejectsOverflowingFixedSizesAndRuntimeStrides) {
+  const IrType array =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 0x10000001u), IrType::F32());
+  const IrType huge =
+      GetShaderResultOrFail(IrType::Struct("Huge", {{"items", array}}), IrType::F32());
+  const IrType runtimeArray = GetShaderResultOrFail(IrType::RuntimeArray(huge), IrType::F32());
+  EXPECT_THAT(ComputeArrayStride(runtimeArray, AddressSpace::Storage),
+              IsShaderError(testing::HasSubstr("32-bit")));
+  for (bool runtime : {false, true}) {
+    SCOPED_TRACE(runtime);
+    ModuleBuilder builder;
+    ASSERT_THAT(runtime ? builder.addReadOnlyStorageBuffer(0, 0, "data", runtimeArray)
+                        : builder.addUniformBuffer(0, 0, "data", huge),
+                IsShaderOk());
+    auto entry = builder.createComputeEntryPoint("cs", {}, {1, 1, 1});
+    ASSERT_THAT(entry, HasShaderResult());
+    IrExpr value = GetShaderResultOrFail(entry.result().ref("data"), LiteralF32(0));
+    if (runtime) {
+      value = GetShaderResultOrFail(Index(value, LiteralU32(0)), LiteralF32(0));
+    }
+    ASSERT_THAT(entry.result().addLet("read", value), HasShaderResult());
+    ASSERT_THAT(entry.result().finish(), IsShaderOk());
+    auto module = builder.build();
+    ASSERT_THAT(module, HasShaderResult());
+    EXPECT_THAT(BufferBindingsOf(module.result()), IsShaderError(testing::HasSubstr("32-bit")));
+  }
+}
+
+}  // namespace
+}  // namespace donner::gpu::shader


### PR DESCRIPTION
Shader modules need one authoritative description of the buffer ranges their entry points read. Derive immutable buffer-binding facts from the typed IR, including minimum byte sizes and runtime-array strides, so the runtime and the native backends do not transcribe shader layouts independently.

Reject host-shareable layout arithmetic that overflows before narrowing to the public byte-size fields. Coverage spans fixed layouts, runtime arrays, entry-point filtering, serialization stability, malformed locations, and values above 4 GiB.

This is the foundation of a four-part stack; the active draw and dispatch range validation that consumes these facts sits above it.

Three commits, because only part of this can be shown red first. The layout overflow cases fail against the current 32-bit arithmetic and are committed before the fix; the module-interface API and its tests land together, since those tests cannot compile without it.

Verification: a full run of the GPU, shader, and Metal test trees on an Apple Silicon Mac at the top of the stack gives 16 passing targets, 7 skipped for the absent Vulkan driver, and no failures. Formatting, BUILD formatting, and lint pass.
