### PR TITLE
Validate active GPU resource lifetimes and texture roles

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -106,6 +106,7 @@ jobs:
             -- \
             //donner/... \
             -//donner/editor/tests:gl_rnr_replay_tests \
+            -//donner/gpu:gpu_allocation_tests \
             -//donner/svg/renderer/geode/... \
             -//donner/svg/renderer/tests:renderer_geode_golden_tests \
             -//donner/svg/renderer/tests:renderer_geode_tests
@@ -171,7 +172,9 @@ jobs:
             --test_output=errors \
             --test_tag_filters=-fuzz_target \
             --build_tag_filters=-fuzz_target \
-            //donner/...
+            -- \
+            //donner/... \
+            -//donner/gpu:gpu_allocation_tests
 
       - name: Replay untrusted-input fuzzer corpora with UBSan
         run: |

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -117,4 +117,22 @@ donner_cc_test(
     ],
 )
 
+# Separate binary because AllocationTracker.h defines global replacement operator new/delete,
+# which take precedence over the sanitizers' interceptors. Linking it into gpu_tests would weaken
+# the ASan and UBSan lanes for every other test in that binary, so this target is excluded from
+# them instead (.github/workflows/sanitizers.yml).
+donner_cc_test(
+    name = "gpu_allocation_tests",
+    srcs = [
+        "tests/EncoderAllocation_tests.cc",
+        "//donner/svg/renderer/benchmarks:AllocationTracker.h",
+    ],
+    deps = [
+        ":gpu",
+        ":gpu_test_utils",
+        ":recording_device",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -1,5 +1,4 @@
-#include "donner/gpu/CommandEncoder.h"
-
+#include <algorithm>
 #include <cmath>
 #include <format>
 #include <sstream>
@@ -7,6 +6,7 @@
 #include <vector>
 
 #include "donner/gpu/CheckedArithmetic.h"
+#include "donner/gpu/CommandEncoder.h"
 
 namespace donner::gpu {
 
@@ -93,24 +93,72 @@ void CommandEncoder::resetPassBindings() {
   currentPipeline_.reset();
   boundVertexBuffers_.fill(std::nullopt);
   boundBindGroups_.fill(std::nullopt);
+  passAttachmentTextures_.clear();
 }
 
 Status CommandEncoder::validateBoundBindGroups(std::string_view operation) {
-  for (size_t index = 0; index < currentPipeline_->bindGroupLayoutIds.size(); ++index) {
-    if (!boundBindGroups_[index]) {
-      return fail(Err(GpuErrorType::InvalidState,
-                      std::format("{}: the pipeline layout requires a bind group at index {} "
-                                  "but none is bound",
-                                  operation, index)));
+  std::vector<Device::BoundTextureBinding> sampledTextures;
+  std::vector<Device::BoundTextureBinding> storageTextures;
+  for (uint32_t index = 0; index < currentPipeline_->bindGroupLayoutIds.size(); ++index) {
+    auto group = validateBoundBindGroup(index, operation);
+    if (group.hasError()) {
+      return fail(std::move(group).error());
     }
-    if (!(boundBindGroups_[index]->layoutIdentity == currentPipeline_->bindGroupLayoutIds[index])) {
-      return fail(Err(GpuErrorType::InvalidState,
-                      std::format("{}: the bind group at index {} was created against a "
-                                  "different layout than the pipeline expects",
-                                  operation, index)));
+    const ResourceIdentity layoutIdentity = boundBindGroups_[index]->layoutIdentity;
+    const auto* layout =
+        device_->bindGroupLayouts_.find(layoutIdentity.slotIndex, layoutIdentity.generation);
+    const auto sampled = device_->collectBoundTextures(
+        group.result()->descriptor, layout->descriptor.entries, BindingType::SampledTexture2dFloat);
+    const auto storage =
+        device_->collectBoundTextures(group.result()->descriptor, layout->descriptor.entries,
+                                      BindingType::WriteOnlyStorageTexture2d);
+    sampledTextures.insert(sampledTextures.end(), sampled.begin(), sampled.end());
+    storageTextures.insert(storageTextures.end(), storage.begin(), storage.end());
+  }
+  for (const auto& sampled : sampledTextures) {
+    for (const auto& storage : storageTextures) {
+      if (sampled.textureIdentity == storage.textureIdentity) {
+        return fail(Err(GpuErrorType::UsageMismatch,
+                        std::format("{}: active bind groups use one texture as both sampled and "
+                                    "storage (texture slot {}, generation {})",
+                                    operation, sampled.textureIdentity.slotIndex,
+                                    sampled.textureIdentity.generation)));
+      }
     }
   }
   return OkStatus();
+}
+
+Result<const Device::BindGroupRecord*> CommandEncoder::validateBoundBindGroup(
+    uint32_t index, std::string_view operation) {
+  if (!boundBindGroups_[index]) {
+    return Err(GpuErrorType::InvalidState,
+               std::format("{}: the pipeline layout requires a bind group at index {} but none "
+                           "is bound",
+                           operation, index));
+  }
+  const BoundBindGroup& bound = *boundBindGroups_[index];
+  if (bound.layoutIdentity != currentPipeline_->bindGroupLayoutIds[index]) {
+    return Err(GpuErrorType::InvalidState,
+               std::format("{}: the bind group at index {} was created against a different "
+                           "layout than the pipeline expects",
+                           operation, index));
+  }
+  const auto* group =
+      device_->bindGroups_.find(bound.identity.slotIndex, bound.identity.generation);
+  const auto* layout = device_->bindGroupLayouts_.find(bound.layoutIdentity.slotIndex,
+                                                       bound.layoutIdentity.generation);
+  if (group == nullptr || layout == nullptr) {
+    return Err(GpuErrorType::InvalidHandle,
+               std::format("{}: the bind group at index {} or its layout was destroyed", operation,
+                           index));
+  }
+  for (const BindGroupEntry& entry : group->descriptor.entries) {
+    if (Status status = revalidateBindGroupEntry(entry); status.hasError()) {
+      return std::move(status).error();
+    }
+  }
+  return group;
 }
 
 Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescriptor& descriptor) {
@@ -137,8 +185,8 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
   Extent2d passExtent;
   std::vector<TextureFormat> attachmentFormats;
   attachmentFormats.reserve(descriptor.colorAttachments.size());
-  std::vector<ResourceIdentity> seenViews;
-  seenViews.reserve(descriptor.colorAttachments.size());
+  std::vector<ResourceIdentity> seenTextures;
+  seenTextures.reserve(descriptor.colorAttachments.size());
   for (size_t i = 0; i < descriptor.colorAttachments.size(); ++i) {
     const RenderPassColorAttachment& attachment = descriptor.colorAttachments[i];
     auto viewRecord =
@@ -147,17 +195,18 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
       return fail(std::move(viewRecord).error()).error();
     }
 
-    const ResourceIdentity viewIdentity{attachment.view.slotIndex(), attachment.view.generation()};
-    for (const ResourceIdentity& seenView : seenViews) {
-      if (seenView == viewIdentity) {
+    const ResourceIdentity textureIdentity = viewRecord.result()->textureIdentity;
+    for (const ResourceIdentity& seenTexture : seenTextures) {
+      if (seenTexture == textureIdentity) {
         return fail(Err(GpuErrorType::InvalidDescriptor,
-                        std::format("beginRenderPass: attachment {} view \"{}\" appears in "
-                                    "multiple color attachments of the same pass",
-                                    i, viewRecord.result()->descriptor.label.str())))
+                        std::format(
+                            "beginRenderPass: attachment {} texture viewed by \"{}\" appears in "
+                            "multiple color attachments of the same pass",
+                            i, viewRecord.result()->descriptor.label.str())))
             .error();
       }
     }
-    seenViews.push_back(viewIdentity);
+    seenTextures.push_back(textureIdentity);
 
     if (!IsKnownEnumValue(attachment.loadOp)) {
       return fail(Err(GpuErrorType::InvalidDescriptor,
@@ -211,6 +260,7 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
   passExtent_ = passExtent;
   passAttachmentFormats_ = std::move(attachmentFormats);
   resetPassBindings();
+  passAttachmentTextures_ = std::move(seenTextures);
   commands_.push_back(BeginRenderPassCommand{descriptor});
   return &passEncoder_;
 }
@@ -292,7 +342,8 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
     }
   }
 
-  boundBindGroups_[index] = BoundBindGroup{bindGroup.slotIndex(), record.result()->layoutIdentity};
+  boundBindGroups_[index] = BoundBindGroup{{bindGroup.slotIndex(), bindGroup.generation()},
+                                           record.result()->layoutIdentity};
   commands_.push_back(
       SetBindGroupCommand{index, ResourceIdentity{bindGroup.slotIndex(), bindGroup.generation()}});
   return OkStatus();
@@ -315,6 +366,11 @@ Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry) {
     auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
     if (viewedTexture.hasError()) {
       return fail(std::move(viewedTexture).error());
+    }
+    if (std::ranges::find(passAttachmentTextures_, viewRecord.result()->textureIdentity) !=
+        passAttachmentTextures_.end()) {
+      return fail(Err(GpuErrorType::UsageMismatch,
+                      "setBindGroup: a texture binding aliases an active color attachment"));
     }
   } else if (const SamplerBinding* samplerBinding = std::get_if<SamplerBinding>(&entry.resource)) {
     auto samplerRecord =

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -1,3 +1,5 @@
+#include "donner/gpu/CommandEncoder.h"
+
 #include <algorithm>
 #include <cmath>
 #include <format>
@@ -6,7 +8,6 @@
 #include <vector>
 
 #include "donner/gpu/CheckedArithmetic.h"
-#include "donner/gpu/CommandEncoder.h"
 
 namespace donner::gpu {
 
@@ -97,39 +98,38 @@ void CommandEncoder::resetPassBindings() {
 }
 
 Status CommandEncoder::validateBoundBindGroups(std::string_view operation) {
-  std::vector<Device::BoundTextureBinding> sampledTextures;
-  std::vector<Device::BoundTextureBinding> storageTextures;
+  // Called once per draw and per dispatch, on the path the Geode renderer runs through, so the
+  // collectors are encoder-owned and reused rather than allocated here. They are cleared, not
+  // shrunk, and they accumulate across every bound group, so a pass allocates at most once for
+  // the largest total those groups reach.
+  sampledTextureScratch_.clear();
+  storageTextureScratch_.clear();
   for (uint32_t index = 0; index < currentPipeline_->bindGroupLayoutIds.size(); ++index) {
     auto group = validateBoundBindGroup(index, operation);
     if (group.hasError()) {
       return fail(std::move(group).error());
     }
-    const ResourceIdentity layoutIdentity = boundBindGroups_[index]->layoutIdentity;
-    const auto* layout =
-        device_->bindGroupLayouts_.find(layoutIdentity.slotIndex, layoutIdentity.generation);
-    const auto sampled = device_->collectBoundTextures(
-        group.result()->descriptor, layout->descriptor.entries, BindingType::SampledTexture2dFloat);
-    const auto storage =
-        device_->collectBoundTextures(group.result()->descriptor, layout->descriptor.entries,
-                                      BindingType::WriteOnlyStorageTexture2d);
-    sampledTextures.insert(sampledTextures.end(), sampled.begin(), sampled.end());
-    storageTextures.insert(storageTextures.end(), storage.begin(), storage.end());
+    device_->collectBoundTextures(group.result().group->descriptor,
+                                  group.result().layout->descriptor.entries, sampledTextureScratch_,
+                                  storageTextureScratch_);
   }
-  for (const auto& sampled : sampledTextures) {
-    for (const auto& storage : storageTextures) {
+  for (const auto& sampled : sampledTextureScratch_) {
+    for (const auto& storage : storageTextureScratch_) {
       if (sampled.textureIdentity == storage.textureIdentity) {
-        return fail(Err(GpuErrorType::UsageMismatch,
-                        std::format("{}: active bind groups use one texture as both sampled and "
-                                    "storage (texture slot {}, generation {})",
-                                    operation, sampled.textureIdentity.slotIndex,
-                                    sampled.textureIdentity.generation)));
+        return fail(Err(
+            GpuErrorType::UsageMismatch,
+            std::format("{}: active bind groups use one texture as both a sampled "
+                        "binding ({}) and a storage-write binding ({}) (texture slot "
+                        "{}, generation {})",
+                        operation, sampled.binding, storage.binding,
+                        sampled.textureIdentity.slotIndex, sampled.textureIdentity.generation)));
       }
     }
   }
   return OkStatus();
 }
 
-Result<const Device::BindGroupRecord*> CommandEncoder::validateBoundBindGroup(
+Result<CommandEncoder::ResolvedBindGroup> CommandEncoder::validateBoundBindGroup(
     uint32_t index, std::string_view operation) {
   if (!boundBindGroups_[index]) {
     return Err(GpuErrorType::InvalidState,
@@ -154,11 +154,11 @@ Result<const Device::BindGroupRecord*> CommandEncoder::validateBoundBindGroup(
                            index));
   }
   for (const BindGroupEntry& entry : group->descriptor.entries) {
-    if (Status status = revalidateBindGroupEntry(entry); status.hasError()) {
+    if (Status status = revalidateBindGroupEntry(entry, operation); status.hasError()) {
       return std::move(status).error();
     }
   }
-  return group;
+  return ResolvedBindGroup{group, layout};
 }
 
 Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescriptor& descriptor) {
@@ -336,7 +336,7 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
                                 record.result()->layoutIdentity.slotIndex)));
   }
   for (const BindGroupEntry& entry : record.result()->descriptor.entries) {
-    const Status entryStatus = revalidateBindGroupEntry(entry);
+    const Status entryStatus = revalidateBindGroupEntry(entry, "setBindGroup");
     if (entryStatus.hasError()) {
       return entryStatus;
     }
@@ -349,7 +349,8 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
   return OkStatus();
 }
 
-Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry) {
+Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry,
+                                                std::string_view operation) {
   if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
     auto bufferRecord =
         device_->resolve(device_->buffers_, bufferBinding->buffer, BufferTag::kName);
@@ -369,8 +370,9 @@ Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry) {
     }
     if (std::ranges::find(passAttachmentTextures_, viewRecord.result()->textureIdentity) !=
         passAttachmentTextures_.end()) {
-      return fail(Err(GpuErrorType::UsageMismatch,
-                      "setBindGroup: a texture binding aliases an active color attachment"));
+      return fail(
+          Err(GpuErrorType::UsageMismatch,
+              std::format("{}: a texture binding aliases an active color attachment", operation)));
     }
   } else if (const SamplerBinding* samplerBinding = std::get_if<SamplerBinding>(&entry.resource)) {
     auto samplerRecord =

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -154,7 +154,8 @@ Result<CommandEncoder::ResolvedBindGroup> CommandEncoder::validateBoundBindGroup
                            index));
   }
   for (const BindGroupEntry& entry : group->descriptor.entries) {
-    if (Status status = revalidateBindGroupEntry(entry, operation); status.hasError()) {
+    if (Status status = revalidateBindGroupEntry(entry, operation, AttachmentAliasPolicy::Reject);
+        status.hasError()) {
       return std::move(status).error();
     }
   }
@@ -336,7 +337,12 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
                                 record.result()->layoutIdentity.slotIndex)));
   }
   for (const BindGroupEntry& entry : record.result()->descriptor.entries) {
-    const Status entryStatus = revalidateBindGroupEntry(entry, "setBindGroup");
+    // Binding a group is not using it. A group bound at an index the eventual pipeline layout
+    // does not declare, or replaced before the draw, never reaches the backend, so rejecting an
+    // attachment alias here would fail sequences that are harmless. The draw and dispatch path
+    // applies the check to exactly the groups the active pipeline uses.
+    const Status entryStatus =
+        revalidateBindGroupEntry(entry, "setBindGroup", AttachmentAliasPolicy::Ignore);
     if (entryStatus.hasError()) {
       return entryStatus;
     }
@@ -350,7 +356,8 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
 }
 
 Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry,
-                                                std::string_view operation) {
+                                                std::string_view operation,
+                                                AttachmentAliasPolicy attachmentAlias) {
   if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
     auto bufferRecord =
         device_->resolve(device_->buffers_, bufferBinding->buffer, BufferTag::kName);
@@ -368,8 +375,9 @@ Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry,
     if (viewedTexture.hasError()) {
       return fail(std::move(viewedTexture).error());
     }
-    if (std::ranges::find(passAttachmentTextures_, viewRecord.result()->textureIdentity) !=
-        passAttachmentTextures_.end()) {
+    if (attachmentAlias == AttachmentAliasPolicy::Reject &&
+        std::ranges::find(passAttachmentTextures_, viewRecord.result()->textureIdentity) !=
+            passAttachmentTextures_.end()) {
       return fail(
           Err(GpuErrorType::UsageMismatch,
               std::format("{}: a texture binding aliases an active color attachment", operation)));

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -288,16 +288,30 @@ private:
   ///   operation only requires a usable encoder.
   std::optional<GpuError> checkRecordable(PassKind requiredPass);
 
-  /// Verifies that every bind group index the bound pipeline layout declares holds a group
-  /// created against the same layout. Shared by draw and dispatch.
+  /// Revalidates the bound groups at use time, shared by draw and dispatch. Verifies that every
+  /// bind group index the bound pipeline layout declares holds a live group created against that
+  /// layout, re-resolves every entry of those groups so a destroyed or recycled resource fails
+  /// here rather than during backend encoding, and rejects one texture reached as both a sampled
+  /// and a storage-write binding across the groups the active pipeline uses.
+  ///
+  /// This runs per draw rather than only at setBindGroup because a resource can be destroyed
+  /// between binding and use without changing any group's identity, which is the case the
+  /// generation check exists to catch. It therefore cannot be cached across draws.
   /// @param operation Operation name for diagnostics, e.g. `"draw"`.
   Status validateBoundBindGroups(std::string_view operation);
 
-  /// Resolves one required group and its dependencies for this draw or dispatch.
-  /// The returned record remains live during validation under the device's thread affinity.
+  /// One bound group and the layout it was created against, both resolved and revalidated.
+  struct ResolvedBindGroup {
+    const Device::BindGroupRecord* group = nullptr;         //!< Live bind group record.
+    const Device::BindGroupLayoutRecord* layout = nullptr;  //!< Layout it was created against.
+  };
+
+  /// Revalidates one required group for this draw or dispatch: the group and its layout are still
+  /// live, the layout is the one the pipeline expects, and every entry still resolves. Returns
+  /// both records so the caller does not look the layout up a second time. They remain live for
+  /// the rest of the validation under the device's thread affinity.
   /// @param index Required group index. @param operation Operation name for diagnostics.
-  Result<const Device::BindGroupRecord*> validateBoundBindGroup(uint32_t index,
-                                                                std::string_view operation);
+  Result<ResolvedBindGroup> validateBoundBindGroup(uint32_t index, std::string_view operation);
 
   /// Resets the per-pass binding state a begin or end transitions through.
   void resetPassBindings();
@@ -305,7 +319,8 @@ private:
   /// Re-resolves the resource one bind group entry references, failing closed when it was
   /// destroyed after the group was created.
   /// @param entry Entry to re-resolve.
-  Status revalidateBindGroupEntry(const BindGroupEntry& entry);
+  /// @param operation Operation name for diagnostics, e.g. `"draw"` or `"setBindGroup"`.
+  Status revalidateBindGroupEntry(const BindGroupEntry& entry, std::string_view operation);
 
   /// Validates that a texture-to-texture copy's operands are distinct, share a format, and carry
   /// the CopySrc / CopyDst usages.
@@ -369,6 +384,11 @@ private:
   std::optional<BoundPipeline> currentPipeline_;
   std::array<std::optional<BoundVertexBuffer>, kMaxVertexBuffers> boundVertexBuffers_;
   std::array<std::optional<BoundBindGroup>, kMaxBindGroups> boundBindGroups_;
+
+  /// Reused across draws so the per-draw texture-role check does not allocate. Cleared at the
+  /// start of every validation; capacity is retained for the rest of the encoder's life.
+  SmallVector<Device::BoundTextureBinding, kMaxBindings> sampledTextureScratch_;
+  SmallVector<Device::BoundTextureBinding, kMaxBindings> storageTextureScratch_;
 };
 
 }  // namespace donner::gpu

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -316,11 +316,20 @@ private:
   /// Resets the per-pass binding state a begin or end transitions through.
   void resetPassBindings();
 
+  /// Whether a re-resolution also rejects a texture that aliases an active color attachment.
+  /// Only an operation that uses the group applies the check; binding one does not.
+  enum class AttachmentAliasPolicy {
+    Ignore,  //!< Re-resolve only. Used when a group is bound.
+    Reject,  //!< Also reject an alias with an active color attachment. Used at draw and dispatch.
+  };
+
   /// Re-resolves the resource one bind group entry references, failing closed when it was
   /// destroyed after the group was created.
   /// @param entry Entry to re-resolve.
   /// @param operation Operation name for diagnostics, e.g. `"draw"` or `"setBindGroup"`.
-  Status revalidateBindGroupEntry(const BindGroupEntry& entry, std::string_view operation);
+  /// @param attachmentAlias Whether to also reject an active color-attachment alias.
+  Status revalidateBindGroupEntry(const BindGroupEntry& entry, std::string_view operation,
+                                  AttachmentAliasPolicy attachmentAlias);
 
   /// Validates that a texture-to-texture copy's operands are distinct, share a format, and carry
   /// the CopySrc / CopyDst usages.

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -275,7 +275,7 @@ private:
   };
   /// Draw-time validation state for one bound bind group index.
   struct BoundBindGroup {
-    uint32_t bindGroupSlot = 0;       //!< Bind group slot index.
+    ResourceIdentity identity;        //!< Bound group slot and generation.
     ResourceIdentity layoutIdentity;  //!< Layout the group was created against.
   };
 
@@ -292,6 +292,12 @@ private:
   /// created against the same layout. Shared by draw and dispatch.
   /// @param operation Operation name for diagnostics, e.g. `"draw"`.
   Status validateBoundBindGroups(std::string_view operation);
+
+  /// Resolves one required group and its dependencies for this draw or dispatch.
+  /// The returned record remains live during validation under the device's thread affinity.
+  /// @param index Required group index. @param operation Operation name for diagnostics.
+  Result<const Device::BindGroupRecord*> validateBoundBindGroup(uint32_t index,
+                                                                std::string_view operation);
 
   /// Resets the per-pass binding state a begin or end transitions through.
   void resetPassBindings();
@@ -359,6 +365,7 @@ private:
 
   Extent2d passExtent_;
   std::vector<TextureFormat> passAttachmentFormats_;
+  std::vector<ResourceIdentity> passAttachmentTextures_;
   std::optional<BoundPipeline> currentPipeline_;
   std::array<std::optional<BoundVertexBuffer>, kMaxVertexBuffers> boundVertexBuffers_;
   std::array<std::optional<BoundBindGroup>, kMaxBindGroups> boundBindGroups_;

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -795,6 +795,34 @@ Status Device::validateBindGroupEntryForLayout(const BindGroupLayoutEntry& layou
   return OkStatus();
 }
 
+void Device::collectBoundTextures(
+    const BindGroupDescriptor& descriptor, const std::vector<BindGroupLayoutEntry>& layoutEntries,
+    SmallVector<BoundTextureBinding, kMaxBindings>& sampledOut,
+    SmallVector<BoundTextureBinding, kMaxBindings>& storageOut) const {
+  for (const BindGroupLayoutEntry& layoutEntry : layoutEntries) {
+    const bool sampled = layoutEntry.type == BindingType::SampledTexture2dFloat;
+    const bool storage = layoutEntry.type == BindingType::WriteOnlyStorageTexture2d;
+    if (!sampled && !storage) {
+      continue;
+    }
+    const BindGroupEntry* entry = nullptr;
+    if (findBindGroupEntryForBinding(descriptor, layoutEntry, entry).hasError()) {
+      continue;  // Already reported by the per-binding pass.
+    }
+    const TextureViewBinding* viewBinding = std::get_if<TextureViewBinding>(&entry->resource);
+    if (viewBinding == nullptr) {
+      continue;  // Already reported by the per-binding pass.
+    }
+    const TextureViewRecord* view =
+        textureViews_.find(viewBinding->view.slotIndex(), viewBinding->view.generation());
+    if (view == nullptr) {
+      continue;
+    }
+    (sampled ? sampledOut : storageOut)
+        .push_back(BoundTextureBinding{layoutEntry.binding, view->textureIdentity});
+  }
+}
+
 std::vector<Device::BoundTextureBinding> Device::collectBoundTextures(
     const BindGroupDescriptor& descriptor, const std::vector<BindGroupLayoutEntry>& layoutEntries,
     BindingType type) const {

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -13,8 +13,10 @@
 #include <utility>
 #include <vector>
 
+#include "donner/base/SmallVector.h"
 #include "donner/gpu/Commands.h"
 #include "donner/gpu/Descriptors.h"
+#include "donner/gpu/GpuLimits.h"
 #include "donner/gpu/GpuResult.h"
 #include "donner/gpu/Handles.h"
 
@@ -991,6 +993,20 @@ private:
   std::vector<BoundTextureBinding> collectBoundTextures(
       const BindGroupDescriptor& descriptor, const std::vector<BindGroupLayoutEntry>& layoutEntries,
       BindingType type) const;
+
+  /// Collects sampled and storage-write texture bindings in one walk of \p layoutEntries,
+  /// appending to caller-owned storage. The draw and dispatch path calls this once per bound
+  /// group, so it allocates nothing while the outputs stay inside their inline capacity, which
+  /// bounds the total across every bound group rather than the largest single one. Two passes
+  /// over the layout and two returned vectors showed up as avoidable per-draw work.
+  /// @param descriptor Bind group descriptor being validated.
+  /// @param layoutEntries Layout the group was created against.
+  /// @param sampledOut Receives every sampled-texture binding that resolves to a live view.
+  /// @param storageOut Receives every storage-write binding that resolves to a live view.
+  void collectBoundTextures(const BindGroupDescriptor& descriptor,
+                            const std::vector<BindGroupLayoutEntry>& layoutEntries,
+                            SmallVector<BoundTextureBinding, kMaxBindings>& sampledOut,
+                            SmallVector<BoundTextureBinding, kMaxBindings>& storageOut) const;
 
   /// Rejects a bind group that names one texture through both a sampled and a storage-write
   /// binding: the two declare different layouts for one image, so neither backend transition can

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -414,6 +414,39 @@ TEST_F(CommandEncoderTests, DuplicateAttachmentViewFails) {
                                     HasSubstr("multiple color attachments")));
 }
 
+TEST_F(CommandEncoderTests, DistinctViewsOfOneAttachmentTextureFail) {
+  const TextureView secondView =
+      GetResultOrFail(device_.createTextureView(target_, TextureViewDescriptor{"secondView"}));
+  EXPECT_THAT(encoder_->beginRenderPass(RenderPassDescriptor{
+                  "aliasedPass",
+                  {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store},
+                   RenderPassColorAttachment{secondView, LoadOp::Load, StoreOp::Store}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("multiple color attachments")));
+}
+
+TEST_F(CommandEncoderTests, SamplingAnotherViewOfAnActiveAttachmentFails) {
+  const Texture texture = GetResultOrFail(device_.createTexture(
+      TextureDescriptor{"feedback", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                        TextureUsage::RenderAttachment | TextureUsage::Sampled}));
+  const TextureView attachmentView =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"attachment"}));
+  const TextureView sampledView =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"sampled"}));
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "feedbackLayout",
+          {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
+  const BindGroup group = GetResultOrFail(device_.createBindGroup(BindGroupDescriptor{
+      "feedbackGroup", layout, {BindGroupEntry{0, TextureViewBinding{sampledView}}}}));
+  RenderPassEncoder* pass = GetResultOrFail(encoder_->beginRenderPass(RenderPassDescriptor{
+      "feedbackPass", {RenderPassColorAttachment{attachmentView, LoadOp::Clear, StoreOp::Store}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(
+      pass->setBindGroup(0, group),
+      IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("active color attachment")));
+}
+
 TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMisalignedOffset) {
   EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
                                             TexelCopyBufferLayout{2, 256, 4}, Extent2d{4, 4}),

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -426,6 +426,8 @@ TEST_F(CommandEncoderTests, DistinctViewsOfOneAttachmentTextureFail) {
 }
 
 TEST_F(CommandEncoderTests, SamplingAnotherViewOfAnActiveAttachmentFails) {
+  // The alias is rejected when the draw uses the group, not when the group is bound: binding is
+  // not using, and the encoder must not be poisoned by a group the eventual pipeline never reads.
   const Texture texture = GetResultOrFail(device_.createTexture(
       TextureDescriptor{"feedback", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
                         TextureUsage::RenderAttachment | TextureUsage::Sampled}));
@@ -439,12 +441,50 @@ TEST_F(CommandEncoderTests, SamplingAnotherViewOfAnActiveAttachmentFails) {
           {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
   const BindGroup group = GetResultOrFail(device_.createBindGroup(BindGroupDescriptor{
       "feedbackGroup", layout, {BindGroupEntry{0, TextureViewBinding{sampledView}}}}));
+  const PipelineLayout feedbackPipelineLayout = GetResultOrFail(
+      device_.createPipelineLayout(PipelineLayoutDescriptor{"feedbackPipelineLayout", {layout}}));
+  RenderPipelineDescriptor pipelineDescriptor = solidPipelineDescriptor();
+  pipelineDescriptor.layout = feedbackPipelineLayout;
+  const RenderPipeline feedbackPipeline =
+      GetResultOrFail(device_.createRenderPipeline(pipelineDescriptor));
+
   RenderPassEncoder* pass = GetResultOrFail(encoder_->beginRenderPass(RenderPassDescriptor{
       "feedbackPass", {RenderPassColorAttachment{attachmentView, LoadOp::Clear, StoreOp::Store}}}));
   ASSERT_NE(pass, nullptr);
-  EXPECT_THAT(
-      pass->setBindGroup(0, group),
-      IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("active color attachment")));
+  EXPECT_THAT(pass->setPipeline(feedbackPipeline), IsOk());
+  EXPECT_THAT(pass->setBindGroup(0, group), IsOk());
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+  EXPECT_THAT(pass->draw(3), IsGpuErrorWithMessage(GpuErrorType::UsageMismatch,
+                                                   HasSubstr("active color attachment")));
+}
+
+TEST_F(CommandEncoderTests, AGroupOutsideThePipelineLayoutMayReferenceAnAttachment) {
+  // A group bound at an index the active pipeline layout does not declare is never read, so it
+  // cannot alias anything. Rejecting it would fail an ordinary pre-bind or replace sequence.
+  const Texture texture = GetResultOrFail(device_.createTexture(
+      TextureDescriptor{"feedback", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                        TextureUsage::RenderAttachment | TextureUsage::Sampled}));
+  const TextureView attachmentView =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"attachment"}));
+  const TextureView sampledView =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"sampled"}));
+  const BindGroupLayout unusedLayout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "unusedLayout",
+          {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
+  const BindGroup unusedGroup = GetResultOrFail(device_.createBindGroup(BindGroupDescriptor{
+      "unusedGroup", unusedLayout, {BindGroupEntry{0, TextureViewBinding{sampledView}}}}));
+
+  RenderPassEncoder* pass = GetResultOrFail(encoder_->beginRenderPass(RenderPassDescriptor{
+      "feedbackPass", {RenderPassColorAttachment{attachmentView, LoadOp::Clear, StoreOp::Store}}}));
+  ASSERT_NE(pass, nullptr);
+  // pipeline_ declares one bind group layout, so index 1 is outside what the draw reads.
+  EXPECT_THAT(pass->setPipeline(pipeline_), IsOk());
+  EXPECT_THAT(pass->setBindGroup(1, unusedGroup), IsOk());
+  EXPECT_THAT(pass->setBindGroup(0, bindGroup_), IsOk());
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+  EXPECT_THAT(pass->draw(3), IsOk());
+  EXPECT_THAT(pass->end(), IsOk());
 }
 
 TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMisalignedOffset) {

--- a/donner/gpu/tests/ComputePass_tests.cc
+++ b/donner/gpu/tests/ComputePass_tests.cc
@@ -388,6 +388,156 @@ TEST_F(ComputePassTests, BindGroupAcceptsDistinctSampledAndStorageTextures) {
               HasResult());
 }
 
+class ActiveTextureBindingsTests : public ComputePassTests {
+protected:
+  void SetUp() override {
+    ComputePassTests::SetUp();
+    texture_ = GetResultOrFail(device_.createTexture(
+        TextureDescriptor{"shared",
+                          {16, 16},
+                          TextureFormat::RGBA8Unorm,
+                          TextureUsage::Sampled | TextureUsage::StorageBinding}));
+    view_ = GetResultOrFail(device_.createTextureView(texture_, {"sharedView"}));
+    sampledLayout_ = GetResultOrFail(device_.createBindGroupLayout(
+        {"sampled", {{0, ShaderStage::Compute, BindingType::SampledTexture2dFloat}}}));
+    storageLayout_ = GetResultOrFail(device_.createBindGroupLayout(
+        {"storage", {{0, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
+    sampled_ = makeGroup(sampledLayout_, view_);
+    storage_ = makeGroup(storageLayout_, view_);
+  }
+
+  BindGroup makeGroup(const BindGroupLayout& layout, const TextureView& view) {
+    return GetResultOrFail(
+        device_.createBindGroup({"textureGroup", layout, {{0, TextureViewBinding{view}}}}));
+  }
+
+  ComputePipeline makePipeline(std::vector<BindGroupLayoutRef> groups) {
+    const PipelineLayout layout =
+        GetResultOrFail(device_.createPipelineLayout({"activeGroups", std::move(groups)}));
+    return GetResultOrFail(
+        device_.createComputePipeline({"activeGroups", layout, {shader_, "csMain"}, {8, 8, 1}}));
+  }
+
+  Texture texture_;
+  TextureView view_;
+  BindGroupLayout sampledLayout_;
+  BindGroupLayout storageLayout_;
+  BindGroup sampled_;
+  BindGroup storage_;
+};
+
+TEST_F(ActiveTextureBindingsTests, RejectsSampledStorageAliasesInEitherGroupOrder) {
+  for (const bool sampledFirst : {true, false}) {
+    SCOPED_TRACE(sampledFirst);
+    encoder_ = GetResultOrFail(device_.createCommandEncoder());
+    const ComputePipeline pipeline = makePipeline(
+        sampledFirst ? std::vector<BindGroupLayoutRef>{sampledLayout_, storageLayout_}
+                     : std::vector<BindGroupLayoutRef>{storageLayout_, sampledLayout_});
+    ComputePassEncoder* pass = beginComputePass();
+    ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+    ASSERT_THAT(pass->setBindGroup(0, sampledFirst ? sampled_ : storage_), IsOk());
+    ASSERT_THAT(pass->setBindGroup(1, sampledFirst ? storage_ : sampled_), IsOk());
+    EXPECT_THAT(
+        pass->dispatchWorkgroups(1),
+        IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("sampled and storage")));
+    EXPECT_THAT(encoder_->finish(), IsGpuError(GpuErrorType::UsageMismatch));
+  }
+}
+
+TEST_F(ActiveTextureBindingsTests, AllowsTheSameTextureInReadOnlyGroups) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_, sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, sampled_), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(ActiveTextureBindingsTests, IgnoresGroupsOutsideTheCurrentPipelineLayout) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, storage_), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(ActiveTextureBindingsTests, ReplacedGroupsDoNotLeaveTextureAliases) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_, storageLayout_});
+  const BindGroup replacement = makeGroup(storageLayout_, outputView_);
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, storage_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, replacement), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(ActiveTextureBindingsTests, PipelineChangesUseOnlyTheNewDeclaredGroups) {
+  const ComputePipeline both = makePipeline({sampledLayout_, storageLayout_});
+  const ComputePipeline sampledOnly = makePipeline({sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(both), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, storage_), IsOk());
+  ASSERT_THAT(pass->setPipeline(sampledOnly), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(ActiveTextureBindingsTests, ATextureCanChangeRolesBetweenDispatches) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_, storageLayout_});
+  const BindGroup unrelatedSample = makeGroup(sampledLayout_, inputView_);
+  const BindGroup unrelatedStorage = makeGroup(storageLayout_, outputView_);
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, unrelatedStorage), IsOk());
+  ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, unrelatedSample), IsOk());
+  ASSERT_THAT(pass->setBindGroup(1, storage_), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(ActiveTextureBindingsTests, DestroyedBoundGroupCannotResolveToItsReplacement) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  const uint32_t oldSlot = sampled_.slotIndex();
+  const uint32_t oldGeneration = sampled_.generation();
+  ASSERT_THAT(device_.destroyBindGroup(std::move(sampled_)), IsOk());
+  const BindGroup replacement = makeGroup(sampledLayout_, inputView_);
+  ASSERT_EQ(replacement.slotIndex(), oldSlot);
+  ASSERT_NE(replacement.generation(), oldGeneration);
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+TEST_F(ActiveTextureBindingsTests, DestroyedBoundTextureCannotResolveToItsReplacement) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  const uint32_t oldSlot = texture_.slotIndex();
+  ASSERT_THAT(device_.destroyTexture(std::move(texture_)), IsOk());
+  const Texture replacement = GetResultOrFail(device_.createTexture(
+      {"replacement", {16, 16}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+  ASSERT_EQ(replacement.slotIndex(), oldSlot);
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+TEST_F(ActiveTextureBindingsTests, DestroyedBoundLayoutCannotResolveToItsReplacement) {
+  const ComputePipeline pipeline = makePipeline({sampledLayout_});
+  ComputePassEncoder* pass = beginComputePass();
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+  const uint32_t oldSlot = sampledLayout_.slotIndex();
+  ASSERT_THAT(device_.destroyBindGroupLayout(std::move(sampledLayout_)), IsOk());
+  const BindGroupLayout replacement = GetResultOrFail(device_.createBindGroupLayout(
+      {"replacement", {{0, ShaderStage::Compute, BindingType::SampledTexture2dFloat}}}));
+  ASSERT_EQ(replacement.slotIndex(), oldSlot);
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
 TEST_F(ComputePassTests, StorageTextureBindingRejectsANonTextureResource) {
   std::vector<BindGroupEntry> entries = bindGroupEntries(outputView_);
   entries[1] = BindGroupEntry{1, BufferBinding{params_, 0, 64}};

--- a/donner/gpu/tests/ComputePass_tests.cc
+++ b/donner/gpu/tests/ComputePass_tests.cc
@@ -15,6 +15,7 @@
 #include "donner/gpu/shader/IrModule.h"
 #include "donner/gpu/tests/GpuTestUtils.h"
 
+using testing::AllOf;
 using testing::HasSubstr;
 
 namespace donner::gpu {
@@ -437,9 +438,11 @@ TEST_F(ActiveTextureBindingsTests, RejectsSampledStorageAliasesInEitherGroupOrde
     ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
     ASSERT_THAT(pass->setBindGroup(0, sampledFirst ? sampled_ : storage_), IsOk());
     ASSERT_THAT(pass->setBindGroup(1, sampledFirst ? storage_ : sampled_), IsOk());
-    EXPECT_THAT(
-        pass->dispatchWorkgroups(1),
-        IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("sampled and storage")));
+    EXPECT_THAT(pass->dispatchWorkgroups(1),
+                IsGpuErrorWithMessage(
+                    GpuErrorType::UsageMismatch,
+                    AllOf(HasSubstr("sampled binding (0)"), HasSubstr("storage-write binding (0)"),
+                          HasSubstr("texture slot"))));
     EXPECT_THAT(encoder_->finish(), IsGpuError(GpuErrorType::UsageMismatch));
   }
 }

--- a/donner/gpu/tests/EncoderAllocation_tests.cc
+++ b/donner/gpu/tests/EncoderAllocation_tests.cc
@@ -1,0 +1,104 @@
+/// @file
+/// Allocation budget for the encoder's per-draw revalidation.
+///
+/// This lives in its own binary on purpose. AllocationTracker.h defines global replacement
+/// `operator new` and `operator delete`, which take precedence over the sanitizers' own
+/// interceptors, so linking it into a general test binary would quietly weaken the ASan and UBSan
+/// lanes for everything else in that binary. Keeping it here bounds the damage to one target that
+/// those lanes skip, and keeps the header's non-inline operators to a single translation unit.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+#include "donner/svg/renderer/benchmarks/AllocationTracker.h"
+
+namespace donner::gpu {
+namespace {
+
+/// One sampled texture reached through one bind group: the smallest shape that exercises the
+/// per-draw group revalidation and the sampled/storage role check together.
+class EncoderAllocationTests : public testing::Test {
+protected:
+  void SetUp() override {
+    texture_ = GetResultOrFail(device_.createTexture(
+        TextureDescriptor{"shared", {16, 16}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+    view_ = GetResultOrFail(device_.createTextureView(texture_, {"sharedView"}));
+    sampledLayout_ = GetResultOrFail(device_.createBindGroupLayout(
+        {"sampled", {{0, ShaderStage::Compute, BindingType::SampledTexture2dFloat}}}));
+    sampled_ = GetResultOrFail(device_.createBindGroup(
+        {"textureGroup", sampledLayout_, {{0, TextureViewBinding{view_}}}}));
+    shader_ = GetResultOrFail(device_.createShaderModule(
+        ShaderModuleDescriptor{"noop",
+                               "@compute @workgroup_size(8, 8, 1) fn csMain() {}",
+                               ShaderSourceKind::Wgsl,
+                               {},
+                               {ComputeEntryPointInfo{"csMain", WorkgroupSize{8, 8, 1}}}}));
+  }
+
+  ComputePipeline makePipeline(std::vector<BindGroupLayoutRef> groups) {
+    const PipelineLayout layout =
+        GetResultOrFail(device_.createPipelineLayout({"activeGroups", std::move(groups)}));
+    return GetResultOrFail(
+        device_.createComputePipeline({"activeGroups", layout, {shader_, "csMain"}, {8, 8, 1}}));
+  }
+
+  RecordingDevice device_;
+  Texture texture_;
+  TextureView view_;
+  BindGroupLayout sampledLayout_;
+  BindGroup sampled_;
+  ShaderModule shader_;
+  std::unique_ptr<CommandEncoder> encoder_;
+};
+
+TEST_F(EncoderAllocationTests, RevalidationDoesNotAllocatePerDispatch) {
+  // The role and lifetime checks run on every dispatch, on the path the Geode renderer records
+  // through, so their cost must not grow with the dispatch count. Recording a command is itself an
+  // amortized vector growth, so measure a pipeline with no bind groups as the baseline and require
+  // that adding a validated group costs nothing beyond it. Both encoders enter the measurement
+  // window having recorded the same number of commands, so the growth ahead of them matches.
+  constexpr uint32_t kDispatches = 512;
+
+  const auto measure = [&](bool withBoundGroup) {
+    encoder_ = GetResultOrFail(device_.createCommandEncoder());
+    const ComputePipeline pipeline =
+        withBoundGroup ? makePipeline({sampledLayout_}) : makePipeline({});
+    ComputePassEncoder* pass =
+        GetResultOrFail(encoder_->beginComputePass(ComputePassDescriptor{"pass"}));
+    EXPECT_THAT(pass->setPipeline(pipeline), IsOk());
+    if (withBoundGroup) {
+      EXPECT_THAT(pass->setBindGroup(0, sampled_), IsOk());
+    } else {
+      // Stands in for the setBindGroup command, so both encoders reach the window with the same
+      // recorded-command count.
+      EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    }
+    EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+
+    benchmarks::allocations::Scope allocations;
+    for (uint32_t dispatch = 0; dispatch < kDispatches; ++dispatch) {
+      EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    }
+    return allocations.stop().allocationCalls;
+  };
+
+  // Not an equality assertion: the baseline window runs first, so a one-time lazy allocation in a
+  // shared path would land there and make the validated count legitimately smaller. Two
+  // allocations per dispatch, the regression this guards, is 1024 over this loop and cannot hide
+  // under it. One group with one sampled texture stays inside the collectors' inline capacity, so
+  // this does not cover a spill.
+  const uint64_t baseline = measure(false);
+  const uint64_t validated = measure(true);
+  EXPECT_THAT(validated, testing::Le(baseline))
+      << validated << " allocations with a bound group versus " << baseline
+      << " recording the same " << kDispatches << " dispatches without one";
+}
+
+}  // namespace
+}  // namespace donner::gpu


### PR DESCRIPTION
Bind groups validated when they are set can be destroyed, recycled, or have a referenced resource retired before the eventual draw or dispatch. Preserve each bound group's slot and generation, then re-resolve its layout and resources at use time so stale identities fail before backend encoding.

Validate texture roles across every group the active pipeline uses. Reject a texture that is sampled and storage-written in one operation, distinct attachment views of the same texture, and sampling of an active render attachment. Groups outside the selected pipeline do not affect the check, and textures may change roles between operations.

This runs per draw rather than once at bind time on purpose. A resource can be destroyed between setBindGroup and the draw without changing any group's identity, which is exactly the case the generation check exists to catch, so the result cannot be cached across draws. What it can avoid is allocating: the layout of each bound group is walked once, into two collectors the encoder owns and clears rather than reallocates. A new test pins that. Recording 512 dispatches with a validated bind group previously cost 2056 allocations against a 1032 baseline for the same dispatches without one, two per dispatch; it now matches the baseline exactly.

This PR depends on the typed shader-interface facts below it in the stack but does not otherwise consume those facts.

Verification: a full run of the GPU, shader, and Metal test trees on an Apple Silicon Mac at the top of the stack gives 16 passing targets, 7 skipped for the absent Vulkan driver, and no failures. Formatting, BUILD formatting, and lint pass.
