### PR TITLE
Validate active shader buffer ranges before encoding

### DIFF
--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -360,10 +360,20 @@ py_test(
         # layer that finishes that move: wasm 13,315,197 raw / 5,237,419 gzip,
         # js 175,205 raw / 49,318 gzip, and package 13,531,958 raw. Budgets
         # retain about 1 percent headroom over that measurement.
+        #
+        # GPU binding-validation retune: shader buffer facts, use-time bind
+        # group revalidation, and active buffer range checks run on the path
+        # the renderer records through, so they are shipped code. Measured at
+        # this layer: wasm 13,452,374 raw / 5,279,367 gzip, js 175,446 raw /
+        # 49,395 gzip, and package 13,669,376 raw. The wasm gzip gate had
+        # fallen to 0.20 percent headroom, so it is retuned alongside the two
+        # raw gates it would otherwise have flipped red before; the js gates
+        # are untouched because this layer adds no JavaScript. Budgets retain
+        # about 1 percent headroom over that measurement.
         "--max-wasm-raw-bytes",
-        "13449000",
+        "13586000",
         "--max-wasm-gzip-bytes",
-        "5290000",
+        "5332000",
         "--max-wasm-function-body-bytes",
         "46000",
         "--max-wasm-data-segments",
@@ -373,7 +383,7 @@ py_test(
         "--max-js-gzip-bytes",
         "49710",
         "--max-total-raw-bytes",
-        "13668000",
+        "13806000",
         "--expected-js-property",
         "__donnerLastScrollEvent",
         # SHIP BLOCKER, tracked with the deferred WebKit decision: the WebGPU diagnostic

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -98,6 +98,7 @@ donner_cc_library(
 donner_cc_test(
     name = "gpu_tests",
     srcs = [
+        "tests/BufferBindingBounds_tests.cc",
         "tests/CommandEncoder_tests.cc",
         "tests/ComputePass_tests.cc",
         "tests/DeviceValidation_tests.cc",

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -126,6 +126,31 @@ Status CommandEncoder::validateBoundBindGroups(std::string_view operation) {
       }
     }
   }
+  return validateBoundBufferRanges(operation);
+}
+
+Status CommandEncoder::validateBoundBufferRanges(std::string_view operation) {
+  for (const auto& requirement : currentPipeline_->bufferRequirements) {
+    const ResourceIdentity identity = boundBindGroups_[requirement.group]->identity;
+    const auto* group = device_->bindGroups_.find(identity.slotIndex, identity.generation);
+    if (group == nullptr) {
+      return fail(Err(GpuErrorType::InvalidHandle,
+                      "Buffer range validation references a destroyed bind group"));
+    }
+    const auto entry =
+        std::ranges::find(group->descriptor.entries, requirement.binding, &BindGroupEntry::binding);
+    const BufferBinding* buffer = entry != group->descriptor.entries.end()
+                                      ? std::get_if<BufferBinding>(&entry->resource)
+                                      : nullptr;
+    if (buffer == nullptr || buffer->sizeBytes < requirement.minSizeBytes) {
+      return fail(Err(
+          GpuErrorType::InvalidDescriptor,
+          std::format(
+              "{}: group {} binding {} requires at least {} buffer bytes; declared range has {}",
+              operation, requirement.group, requirement.binding, requirement.minSizeBytes,
+              buffer ? buffer->sizeBytes : 0)));
+    }
+  }
   return OkStatus();
 }
 
@@ -301,6 +326,8 @@ Status CommandEncoder::passSetPipeline(const RenderPipeline& pipeline) {
 
   currentPipeline_ = BoundPipeline{record.result()->descriptor.vertex.buffers,
                                    record.result()->bindGroupLayoutIds};
+  currentPipeline_->bufferRequirements.assign(record.result()->bufferRequirements.begin(),
+                                              record.result()->bufferRequirements.end());
   commands_.push_back(
       SetPipelineCommand{ResourceIdentity{pipeline.slotIndex(), pipeline.generation()}});
   return OkStatus();
@@ -707,6 +734,8 @@ Status CommandEncoder::computePassSetPipeline(const ComputePipeline& pipeline) {
   }
 
   currentPipeline_ = BoundPipeline{{}, record.result()->bindGroupLayoutIds};
+  currentPipeline_->bufferRequirements.assign(record.result()->bufferRequirements.begin(),
+                                              record.result()->bufferRequirements.end());
   commands_.push_back(
       SetComputePipelineCommand{ResourceIdentity{pipeline.slotIndex(), pipeline.generation()}});
   return OkStatus();

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -131,6 +131,9 @@ Status CommandEncoder::validateBoundBindGroups(std::string_view operation) {
 
 Status CommandEncoder::validateBoundBufferRanges(std::string_view operation) {
   for (const auto& requirement : currentPipeline_->bufferRequirements) {
+    // Engaged: createRenderPipeline and createComputePipeline bound requirement.group against
+    // the pipeline layout's group count, and validateBoundBindGroups has already returned an
+    // error for any group in that range that is unbound, so this optional cannot be empty here.
     const ResourceIdentity identity = boundBindGroups_[requirement.group]->identity;
     const auto* group = device_->bindGroups_.find(identity.slotIndex, identity.generation);
     if (group == nullptr) {

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/base/SmallVector.h"
 #include "donner/gpu/Commands.h"
 #include "donner/gpu/Device.h"
 #include "donner/gpu/GpuLimits.h"
@@ -267,6 +268,9 @@ private:
   struct BoundPipeline {
     std::vector<VertexBufferLayout> vertexBuffers;     //!< Declared vertex layouts.
     std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Required group layouts.
+    /// Inline range requirements retained when a pipeline is selected.
+    SmallVector<Device::PipelineBufferRequirement, kMaxBindGroups * kMaxBindings>
+        bufferRequirements;
   };
   /// Draw-time validation state for one bound vertex buffer slot.
   struct BoundVertexBuffer {
@@ -294,6 +298,9 @@ private:
   /// here rather than during backend encoding, and rejects one texture reached as both a sampled
   /// and a storage-write binding across the groups the active pipeline uses.
   ///
+  /// Then validates that every buffer range the active pipeline declared a minimum size for is
+  /// at least that large at the moment it is used.
+  ///
   /// This runs per draw rather than only at setBindGroup because a resource can be destroyed
   /// between binding and use without changing any group's identity, which is the case the
   /// generation check exists to catch. It therefore cannot be cached across draws.
@@ -312,6 +319,10 @@ private:
   /// the rest of the validation under the device's thread affinity.
   /// @param index Required group index. @param operation Operation name for diagnostics.
   Result<ResolvedBindGroup> validateBoundBindGroup(uint32_t index, std::string_view operation);
+
+  /// Checks active declared buffer ranges after group and resource lifetime validation.
+  /// @param operation Draw or dispatch name for the diagnostic.
+  Status validateBoundBufferRanges(std::string_view operation);
 
   /// Resets the per-pass binding state a begin or end transitions through.
   void resetPassBindings();

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -268,9 +268,11 @@ private:
   struct BoundPipeline {
     std::vector<VertexBufferLayout> vertexBuffers;     //!< Declared vertex layouts.
     std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Required group layouts.
-    /// Inline range requirements retained when a pipeline is selected.
-    SmallVector<Device::PipelineBufferRequirement, kMaxBindGroups * kMaxBindings>
-        bufferRequirements;
+    /// Inline range requirements retained when a pipeline is selected. Sized for one group's
+    /// worth of bindings, which covers every pipeline this runtime accepts today; a pipeline
+    /// that declared bindings across more groups spills to the heap once at setPipeline rather
+    /// than carrying kMaxBindGroups * kMaxBindings inline in every encoder.
+    SmallVector<Device::PipelineBufferRequirement, kMaxBindings> bufferRequirements;
   };
   /// Draw-time validation state for one bound vertex buffer slot.
   struct BoundVertexBuffer {

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1,5 +1,3 @@
-#include "donner/gpu/Device.h"
-
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -12,6 +10,7 @@
 
 #include "donner/gpu/CheckedArithmetic.h"
 #include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/Device.h"
 #include "donner/gpu/GpuLimits.h"
 
 namespace donner::gpu {
@@ -234,6 +233,53 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
           }
         }
       }
+    }
+  }
+  return OkStatus();
+}
+
+Status ValidateShaderBufferLocation(const ShaderBufferBindingInfo& info) {
+  if (info.entryPoint.empty() || info.group >= kMaxBindGroups || info.binding >= kMaxBindings) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "Shader buffer metadata has an invalid entry point or binding location");
+  }
+  switch (info.stage) {
+    case ShaderStage::Vertex:
+    case ShaderStage::Fragment:
+    case ShaderStage::Compute: return OkStatus();
+    default:
+      return Err(GpuErrorType::InvalidDescriptor,
+                 "Shader buffer metadata requires one shader stage");
+  }
+}
+
+Status ValidateShaderBufferRange(const ShaderBufferBindingInfo& info) {
+  if (info.type != BindingType::UniformBuffer && info.type != BindingType::ReadOnlyStorageBuffer) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "Shader buffer metadata has a non-buffer binding type");
+  }
+  if (info.minSizeBytes == 0 || info.minSizeBytes > kMaxBufferByteSize) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "Shader buffer metadata has an invalid minimum size");
+  }
+  if (info.runtimeArrayStrideBytes != 0 && (info.type != BindingType::ReadOnlyStorageBuffer ||
+                                            info.minSizeBytes != info.runtimeArrayStrideBytes)) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "Shader runtime-array metadata requires one storage element as its minimum");
+  }
+  return OkStatus();
+}
+
+Status ValidateShaderBufferMetadata(const ShaderModuleDescriptor& descriptor) {
+  if (!descriptor.bufferBindings) {
+    return OkStatus();
+  }
+  for (const ShaderBufferBindingInfo& info : *descriptor.bufferBindings) {
+    if (Status status = ValidateShaderBufferLocation(info); status.hasError()) {
+      return status;
+    }
+    if (Status status = ValidateShaderBufferRange(info); status.hasError()) {
+      return status;
     }
   }
   return OkStatus();
@@ -972,6 +1018,10 @@ Result<ShaderModule> Device::createShaderModule(const ShaderModuleDescriptor& de
     }
   }
 
+  if (Status status = ValidateShaderBufferMetadata(descriptor); status.hasError()) {
+    return std::move(status).error();
+  }
+
   ShaderModule handle =
       allocateHandle<ShaderModuleTag>(shaderModules_, ShaderModuleRecord{descriptor});
   if (Status status = onCreateShaderModule(handle.slotIndex(), descriptor); status.hasError()) {
@@ -979,6 +1029,56 @@ Result<ShaderModule> Device::createShaderModule(const ShaderModuleDescriptor& de
     return std::move(status).error();
   }
   return handle;
+}
+
+Status Device::validatePipelineBufferBinding(const PipelineLayoutRecord& layout,
+                                             const ShaderBufferBindingInfo& info) const {
+  if (info.group >= layout.bindGroupLayoutIds.size()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "Shader buffer metadata requires a missing pipeline bind group");
+  }
+  const ResourceIdentity identity = layout.bindGroupLayoutIds[info.group];
+  const auto* group = bindGroupLayouts_.find(identity.slotIndex, identity.generation);
+  if (group == nullptr) {
+    return Err(GpuErrorType::InvalidHandle,
+               "Shader buffer metadata references a destroyed bind group layout");
+  }
+  const auto entry =
+      std::ranges::find(group->descriptor.entries, info.binding, &BindGroupLayoutEntry::binding);
+  if (entry == group->descriptor.entries.end() || entry->type != info.type ||
+      !HasAllFlags(entry->visibility, info.stage)) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("Shader buffer group {} binding {} does not match the pipeline layout's "
+                           "type and stage visibility",
+                           info.group, info.binding));
+  }
+  return OkStatus();
+}
+
+Status Device::appendPipelineBufferRequirements(
+    const PipelineLayoutRecord& layout, const ShaderModuleDescriptor& module,
+    std::string_view entryPoint, ShaderStage stage,
+    std::vector<PipelineBufferRequirement>& requirements) const {
+  if (!module.bufferBindings) {
+    return OkStatus();
+  }
+  for (const ShaderBufferBindingInfo& info : *module.bufferBindings) {
+    if (info.entryPoint != entryPoint || info.stage != stage) {
+      continue;
+    }
+    if (Status status = validatePipelineBufferBinding(layout, info); status.hasError()) {
+      return status;
+    }
+    const auto previous = std::ranges::find_if(requirements, [&](const auto& requirement) {
+      return requirement.group == info.group && requirement.binding == info.binding;
+    });
+    if (previous == requirements.end()) {
+      requirements.push_back({info.group, info.binding, info.minSizeBytes});
+    } else {
+      previous->minSizeBytes = std::max(previous->minSizeBytes, info.minSizeBytes);
+    }
+  }
+  return OkStatus();
 }
 
 Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescriptor& descriptor) {
@@ -1056,6 +1156,18 @@ Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescript
   }
 
   RenderPipelineRecord record{descriptor, layoutRecord.result()->bindGroupLayoutIds};
+  if (Status status = appendPipelineBufferRequirements(
+          *layoutRecord.result(), vertexModule.result()->descriptor, descriptor.vertex.entryPoint,
+          ShaderStage::Vertex, record.bufferRequirements);
+      status.hasError()) {
+    return std::move(status).error();
+  }
+  if (Status status = appendPipelineBufferRequirements(
+          *layoutRecord.result(), fragmentModule.result()->descriptor,
+          descriptor.fragment.entryPoint, ShaderStage::Fragment, record.bufferRequirements);
+      status.hasError()) {
+    return std::move(status).error();
+  }
   RenderPipeline handle = allocateHandle<RenderPipelineTag>(renderPipelines_, std::move(record));
   if (Status status = onCreateRenderPipeline(handle.slotIndex(), descriptor); status.hasError()) {
     renderPipelines_.release(handle.slotIndex());
@@ -1087,6 +1199,12 @@ Result<ComputePipeline> Device::createComputePipeline(const ComputePipelineDescr
   }
 
   ComputePipelineRecord record{descriptor, layoutRecord.result()->bindGroupLayoutIds};
+  if (Status status = appendPipelineBufferRequirements(
+          *layoutRecord.result(), computeModule.result()->descriptor, descriptor.compute.entryPoint,
+          ShaderStage::Compute, record.bufferRequirements);
+      status.hasError()) {
+    return std::move(status).error();
+  }
   ComputePipeline handle = allocateHandle<ComputePipelineTag>(computePipelines_, std::move(record));
   if (Status status = onCreateComputePipeline(handle.slotIndex(), descriptor); status.hasError()) {
     computePipelines_.release(handle.slotIndex());

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1,3 +1,5 @@
+#include "donner/gpu/Device.h"
+
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -10,7 +12,6 @@
 
 #include "donner/gpu/CheckedArithmetic.h"
 #include "donner/gpu/CommandEncoder.h"
-#include "donner/gpu/Device.h"
 #include "donner/gpu/GpuLimits.h"
 
 namespace donner::gpu {
@@ -165,6 +166,56 @@ Status ValidateBindGroupLayoutDescriptor(const BindGroupLayoutDescriptor& descri
   return OkStatus();
 }
 
+/// Validates one color target's blend state.
+/// @param blend Blend state to check.
+Status ValidateBlendState(const BlendState& blend) {
+  for (const BlendComponent& component : {blend.color, blend.alpha}) {
+    if (Status status = CheckEnum(component.srcFactor, "BlendComponent.srcFactor");
+        status.hasError()) {
+      return std::move(status).error();
+    }
+    if (Status status = CheckEnum(component.dstFactor, "BlendComponent.dstFactor");
+        status.hasError()) {
+      return std::move(status).error();
+    }
+    if (Status status = CheckEnum(component.operation, "BlendComponent.operation");
+        status.hasError()) {
+      return std::move(status).error();
+    }
+  }
+  return OkStatus();
+}
+
+/// Validates the color targets of a \ref RenderPipelineDescriptor's fragment state.
+/// @param targets Color targets to check.
+Status ValidateColorTargets(const std::vector<ColorTargetState>& targets) {
+  if (targets.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.fragment.targets is empty");
+  }
+  if (targets.size() > kMaxColorAttachments) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("RenderPipelineDescriptor has {} color targets, exceeding "
+                           "kMaxColorAttachments {}",
+                           targets.size(), kMaxColorAttachments));
+  }
+  for (const ColorTargetState& target : targets) {
+    if (Status status = CheckEnum(target.format, "ColorTargetState.format"); status.hasError()) {
+      return std::move(status).error();
+    }
+    if (Status status = CheckBitmask(target.writeMask, "ColorTargetState.writeMask");
+        status.hasError()) {
+      return std::move(status).error();
+    }
+    if (target.blend) {
+      if (Status status = ValidateBlendState(*target.blend); status.hasError()) {
+        return std::move(status).error();
+      }
+    }
+  }
+  return OkStatus();
+}
+
 /// Validates the vertex buffer layouts of a \ref RenderPipelineDescriptor.
 Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffers) {
   if (buffers.size() > kMaxVertexBuffers) {
@@ -234,6 +285,41 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
         }
       }
     }
+  }
+  return OkStatus();
+}
+
+/// Validates the parts of a \ref RenderPipelineDescriptor that depend only on the descriptor
+/// itself, not on any resolved layout or module record.
+/// @param descriptor Descriptor to check.
+Status ValidateRenderPipelineDescriptor(const RenderPipelineDescriptor& descriptor) {
+  if (descriptor.vertex.entryPoint.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.vertex.entryPoint is empty");
+  }
+  if (descriptor.fragment.entryPoint.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.fragment.entryPoint is empty");
+  }
+  if (Status status = ValidateVertexBufferLayouts(descriptor.vertex.buffers); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (Status status = ValidateColorTargets(descriptor.fragment.targets); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (Status status = CheckEnum(descriptor.topology, "RenderPipelineDescriptor.topology");
+      status.hasError()) {
+    return std::move(status).error();
+  }
+  if (Status status = CheckEnum(descriptor.cullMode, "RenderPipelineDescriptor.cullMode");
+      status.hasError()) {
+    return std::move(status).error();
+  }
+  if (descriptor.multisampleCount != 1) {
+    return Err(GpuErrorType::Unsupported,
+               std::format("RenderPipelineDescriptor.multisampleCount {} is not supported; only "
+                           "1 sample per pixel is available",
+                           descriptor.multisampleCount));
   }
   return OkStatus();
 }
@@ -1094,65 +1180,8 @@ Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescript
   if (fragmentModule.hasError()) {
     return std::move(fragmentModule).error();
   }
-  if (descriptor.vertex.entryPoint.empty()) {
-    return Err(GpuErrorType::InvalidDescriptor,
-               "RenderPipelineDescriptor.vertex.entryPoint is empty");
-  }
-  if (descriptor.fragment.entryPoint.empty()) {
-    return Err(GpuErrorType::InvalidDescriptor,
-               "RenderPipelineDescriptor.fragment.entryPoint is empty");
-  }
-  if (Status status = ValidateVertexBufferLayouts(descriptor.vertex.buffers); status.hasError()) {
+  if (Status status = ValidateRenderPipelineDescriptor(descriptor); status.hasError()) {
     return std::move(status).error();
-  }
-  if (descriptor.fragment.targets.empty()) {
-    return Err(GpuErrorType::InvalidDescriptor,
-               "RenderPipelineDescriptor.fragment.targets is empty");
-  }
-  if (descriptor.fragment.targets.size() > kMaxColorAttachments) {
-    return Err(GpuErrorType::LimitExceeded,
-               std::format("RenderPipelineDescriptor has {} color targets, exceeding "
-                           "kMaxColorAttachments {}",
-                           descriptor.fragment.targets.size(), kMaxColorAttachments));
-  }
-  for (const ColorTargetState& target : descriptor.fragment.targets) {
-    if (Status status = CheckEnum(target.format, "ColorTargetState.format"); status.hasError()) {
-      return std::move(status).error();
-    }
-    if (Status status = CheckBitmask(target.writeMask, "ColorTargetState.writeMask");
-        status.hasError()) {
-      return std::move(status).error();
-    }
-    if (target.blend) {
-      for (const BlendComponent& component : {target.blend->color, target.blend->alpha}) {
-        if (Status status = CheckEnum(component.srcFactor, "BlendComponent.srcFactor");
-            status.hasError()) {
-          return std::move(status).error();
-        }
-        if (Status status = CheckEnum(component.dstFactor, "BlendComponent.dstFactor");
-            status.hasError()) {
-          return std::move(status).error();
-        }
-        if (Status status = CheckEnum(component.operation, "BlendComponent.operation");
-            status.hasError()) {
-          return std::move(status).error();
-        }
-      }
-    }
-  }
-  if (Status status = CheckEnum(descriptor.topology, "RenderPipelineDescriptor.topology");
-      status.hasError()) {
-    return std::move(status).error();
-  }
-  if (Status status = CheckEnum(descriptor.cullMode, "RenderPipelineDescriptor.cullMode");
-      status.hasError()) {
-    return std::move(status).error();
-  }
-  if (descriptor.multisampleCount != 1) {
-    return Err(GpuErrorType::Unsupported,
-               std::format("RenderPipelineDescriptor.multisampleCount {} is not supported; only "
-                           "1 sample per pixel is available",
-                           descriptor.multisampleCount));
   }
 
   RenderPipelineRecord record{descriptor, layoutRecord.result()->bindGroupLayoutIds};

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -773,15 +773,24 @@ private:
   struct ShaderModuleRecord {
     ShaderModuleDescriptor descriptor;  //!< Creation descriptor.
   };
+  /// Buffer range required by the selected stages, independent of shader-module lifetime.
+  struct PipelineBufferRequirement {
+    uint32_t group = 0;         //!< Required bind group.
+    uint32_t binding = 0;       //!< Buffer binding within the group.
+    uint64_t minSizeBytes = 0;  //!< Largest requirement across the selected stages.
+  };
+
   /// Validated per-pipeline state used for draw-time compatibility checks.
   struct RenderPipelineRecord {
     RenderPipelineDescriptor descriptor;               //!< Creation descriptor.
     std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Pipeline layout's group identities.
+    std::vector<PipelineBufferRequirement> bufferRequirements;  //!< Validated buffer ranges.
   };
   /// Validated per-pipeline state used for dispatch-time compatibility checks.
   struct ComputePipelineRecord {
     ComputePipelineDescriptor descriptor;              //!< Creation descriptor.
     std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Pipeline layout's group identities.
+    std::vector<PipelineBufferRequirement> bufferRequirements;  //!< Validated buffer ranges.
   };
   /// A finished, not-yet-submitted command buffer.
   struct CommandBufferRecord {
@@ -940,6 +949,20 @@ private:
   /// @param uses Accumulator of resources referenced by the submission.
   Status checkSubmissionBindGroup(const ResourceIdentity& groupIdentity,
                                   std::vector<SubmissionUse>& uses) const;
+
+  /// Validates one generated shader requirement against the pipeline's declared group layout.
+  /// @param layout Pipeline layout being used. @param info Generated shader binding facts.
+  Status validatePipelineBufferBinding(const PipelineLayoutRecord& layout,
+                                       const ShaderBufferBindingInfo& info) const;
+
+  /// Merges one selected entry point's buffer requirements into the pipeline's retained facts.
+  /// @param layout Pipeline layout. @param module Shader descriptor carrying generated facts.
+  /// @param entryPoint Selected entry point. @param stage Selected shader stage.
+  /// @param requirements Destination list, merging shared bindings by their largest minimum.
+  Status appendPipelineBufferRequirements(
+      const PipelineLayoutRecord& layout, const ShaderModuleDescriptor& module,
+      std::string_view entryPoint, ShaderStage stage,
+      std::vector<PipelineBufferRequirement>& requirements) const;
 
   /// Finds the bind group entry matching \p layoutEntry's binding number, failing closed on a
   /// duplicate or missing entry.

--- a/donner/gpu/RecordingDevice.cc
+++ b/donner/gpu/RecordingDevice.cc
@@ -59,6 +59,26 @@ std::string RefId(std::string_view resourceName, uint32_t slotIndex) {
   return std::format("{}#{}", resourceName, slotIndex);
 }
 
+/// Includes supplied shader facts while retaining the distinction between absent and empty.
+void AppendShaderBufferBindings(
+    std::ostringstream& os, const std::optional<std::vector<ShaderBufferBindingInfo>>& bindings) {
+  if (!bindings) {
+    return;
+  }
+  os << " bufferBindings=[";
+  for (size_t index = 0; index < bindings->size(); ++index) {
+    if (index > 0) {
+      os << " ";
+    }
+    const ShaderBufferBindingInfo& info = (*bindings)[index];
+    os << "{entryPoint=" << QuoteLabel(info.entryPoint) << " stage=" << info.stage
+       << " group=" << info.group << " binding=" << info.binding << " type=" << info.type
+       << " minSizeBytes=" << info.minSizeBytes
+       << " runtimeArrayStrideBytes=" << info.runtimeArrayStrideBytes << "}";
+  }
+  os << "]";
+}
+
 /// Serializes the vertex buffer layout list of a pipeline descriptor.
 void AppendVertexBufferLayouts(std::ostringstream& os,
                                const std::vector<VertexBufferLayout>& buffers) {
@@ -313,6 +333,7 @@ Status RecordingDevice::onCreateShaderModule(uint32_t slotIndex,
     }
     os << "]";
   }
+  AppendShaderBufferBindings(os, descriptor.bufferBindings);
   lines_.push_back(os.str());
   return OkStatus();
 }

--- a/donner/gpu/tests/BufferBindingBounds_tests.cc
+++ b/donner/gpu/tests/BufferBindingBounds_tests.cc
@@ -1,0 +1,216 @@
+/// @file
+/// Declared buffer ranges must cover the active shader's generated minimum requirements.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+namespace donner::gpu {
+namespace {
+
+using testing::HasSubstr;
+
+class BufferBindingBoundsTests : public testing::Test {
+protected:
+  void SetUp() override {
+    buffer_ = GetResultOrFail(device_.createBuffer({"largeBuffer", 512, BufferUsage::Uniform}));
+    groupLayout_ = GetResultOrFail(device_.createBindGroupLayout(
+        {"group", {{0, ShaderStage::Compute, BindingType::UniformBuffer}}}));
+    layout_ = GetResultOrFail(device_.createPipelineLayout({"layout", {groupLayout_}}));
+  }
+
+  ComputePipeline createPipeline(uint64_t minSize) {
+    ShaderModuleDescriptor descriptor{"shader",
+                                      "@compute @workgroup_size(1) fn cs() {}",
+                                      ShaderSourceKind::Wgsl,
+                                      {},
+                                      {{"cs", {1, 1, 1}}}};
+    descriptor.bufferBindings = std::vector<ShaderBufferBindingInfo>{
+        {"cs", ShaderStage::Compute, 0, 0, BindingType::UniformBuffer, minSize}};
+    modules_.push_back(GetResultOrFail(device_.createShaderModule(descriptor)));
+    return GetResultOrFail(
+        device_.createComputePipeline({"pipeline", layout_, {modules_.back(), "cs"}, {1, 1, 1}}));
+  }
+
+  BindGroup createGroup(uint64_t size, uint64_t offset = 0) {
+    return GetResultOrFail(device_.createBindGroup(
+        {"group", groupLayout_, {{0, BufferBinding{buffer_, offset, size}}}}));
+  }
+
+  RecordingDevice device_;
+  Buffer buffer_;
+  BindGroupLayout groupLayout_;
+  PipelineLayout layout_;
+  std::vector<ShaderModule> modules_;
+};
+
+TEST_F(BufferBindingBoundsTests, OneByteAndOneByteShortRangesFailBeforeDispatch) {
+  const ComputePipeline pipeline = createPipeline(80);
+  for (uint64_t size : {uint64_t{1}, uint64_t{79}}) {
+    SCOPED_TRACE(size);
+    const BindGroup group = createGroup(size);
+    auto encoder = GetResultOrFail(device_.createCommandEncoder());
+    ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+    ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+    ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+    EXPECT_THAT(pass->dispatchWorkgroups(1),
+                IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("80")));
+  }
+}
+
+TEST_F(BufferBindingBoundsTests, ExactMinimumRangeIsAccepted) {
+  const ComputePipeline pipeline = createPipeline(80);
+  const BindGroup group = createGroup(80);
+  auto encoder = GetResultOrFail(device_.createCommandEncoder());
+  ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1), IsOk());
+}
+
+TEST_F(BufferBindingBoundsTests, LargeAllocationDoesNotEnlargeAnOffsetDeclaredRange) {
+  const ComputePipeline pipeline = createPipeline(80);
+  const BindGroup group = createGroup(79, 256);
+  auto encoder = GetResultOrFail(device_.createCommandEncoder());
+  ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+  ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("80")));
+}
+
+TEST_F(BufferBindingBoundsTests, PipelineSwitchRechecksAlreadyBoundBufferRanges) {
+  const ComputePipeline small = createPipeline(16);
+  const ComputePipeline large = createPipeline(80);
+  const BindGroup group = createGroup(16);
+  auto encoder = GetResultOrFail(device_.createCommandEncoder());
+  ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+  ASSERT_THAT(pass->setPipeline(small), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+  ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
+  ASSERT_THAT(pass->setPipeline(large), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("80")));
+}
+
+TEST_F(BufferBindingBoundsTests, PipelineRetainsRequirementsAfterShaderModuleDestruction) {
+  const ComputePipeline pipeline = createPipeline(80);
+  ASSERT_THAT(device_.destroyShaderModule(std::move(modules_.back())), IsOk());
+  const BindGroup group = createGroup(16);
+  auto encoder = GetResultOrFail(device_.createCommandEncoder());
+  ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+  ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+  EXPECT_THAT(pass->dispatchWorkgroups(1),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("80")));
+}
+
+TEST(ShaderBufferMetadataTests, MalformedFactsFailAtModuleCreation) {
+  RecordingDevice device;
+  const ShaderBufferBindingInfo valid{
+      "cs", ShaderStage::Compute, 0, 0, BindingType::ReadOnlyStorageBuffer, 16, 16};
+  std::vector<ShaderBufferBindingInfo> invalid(8, valid);
+  invalid[0].entryPoint = "";
+  invalid[1].stage = ShaderStage::Vertex | ShaderStage::Compute;
+  invalid[2].group = kMaxBindGroups;
+  invalid[3].binding = kMaxBindings;
+  invalid[4].type = BindingType::FilteringSampler;
+  invalid[5].minSizeBytes = 0;
+  invalid[6].minSizeBytes = kMaxBufferByteSize + 1;
+  invalid[7].runtimeArrayStrideBytes = 32;
+  for (size_t index = 0; index < invalid.size(); ++index) {
+    SCOPED_TRACE(index);
+    ShaderModuleDescriptor descriptor{"invalid", "shader", ShaderSourceKind::Wgsl};
+    descriptor.bufferBindings = std::vector<ShaderBufferBindingInfo>{invalid[index]};
+    EXPECT_THAT(device.createShaderModule(descriptor), IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+}
+
+TEST(ShaderBufferMetadataTests, PipelineRejectsMissingBindingTypeAndVisibilityMismatches) {
+  RecordingDevice device;
+  ShaderModuleDescriptor descriptor{
+      "shader", "shader", ShaderSourceKind::Wgsl, {}, {{"cs", {1, 1, 1}}}};
+  descriptor.bufferBindings = std::vector<ShaderBufferBindingInfo>{
+      {"cs", ShaderStage::Compute, 0, 1, BindingType::UniformBuffer, 80}};
+  const ShaderModule module = GetResultOrFail(device.createShaderModule(descriptor));
+  const std::array<BindGroupLayoutEntry, 3> entries = {
+      BindGroupLayoutEntry{0, ShaderStage::Compute, BindingType::UniformBuffer},
+      BindGroupLayoutEntry{1, ShaderStage::Compute, BindingType::ReadOnlyStorageBuffer},
+      BindGroupLayoutEntry{1, ShaderStage::Vertex, BindingType::UniformBuffer}};
+  for (const auto& entry : entries) {
+    SCOPED_TRACE(entry.binding);
+    const BindGroupLayout group = GetResultOrFail(device.createBindGroupLayout({"group", {entry}}));
+    const PipelineLayout layout = GetResultOrFail(device.createPipelineLayout({"layout", {group}}));
+    EXPECT_THAT(device.createComputePipeline({"pipeline", layout, {module, "cs"}, {1, 1, 1}}),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+}
+
+TEST(ShaderBufferMetadataTests, RenderStagesUseTheLargestRequirementForTheirSharedBinding) {
+  RecordingDevice device;
+  ShaderModuleDescriptor descriptor{"shader", "shader", ShaderSourceKind::Wgsl};
+  descriptor.bufferBindings = std::vector<ShaderBufferBindingInfo>{
+      {"vs", ShaderStage::Vertex, 0, 0, BindingType::UniformBuffer, 16},
+      {"fs", ShaderStage::Fragment, 0, 0, BindingType::UniformBuffer, 80}};
+  const ShaderModule module = GetResultOrFail(device.createShaderModule(descriptor));
+  const BindGroupLayout groupLayout = GetResultOrFail(device.createBindGroupLayout(
+      {"group", {{0, ShaderStage::Vertex | ShaderStage::Fragment, BindingType::UniformBuffer}}}));
+  const PipelineLayout layout =
+      GetResultOrFail(device.createPipelineLayout({"layout", {groupLayout}}));
+  const RenderPipeline pipeline = GetResultOrFail(device.createRenderPipeline(
+      {"pipeline", layout, {module, "vs", {}}, {module, "fs", {{TextureFormat::RGBA8Unorm}}}}));
+  const Buffer buffer = GetResultOrFail(device.createBuffer({"buffer", 80, BufferUsage::Uniform}));
+  const Texture target = GetResultOrFail(device.createTexture(
+      {"target", {1, 1}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView view = GetResultOrFail(device.createTextureView(target, {}));
+  for (uint64_t size : {uint64_t{79}, uint64_t{80}}) {
+    SCOPED_TRACE(size);
+    const BindGroup group = GetResultOrFail(
+        device.createBindGroup({"group", groupLayout, {{0, BufferBinding{buffer, 0, size}}}}));
+    auto encoder = GetResultOrFail(device.createCommandEncoder());
+    RenderPassEncoder* pass = GetResultOrFail(
+        encoder->beginRenderPass({"render", {{view, LoadOp::Clear, StoreOp::Store, {}}}}));
+    ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
+    ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+    if (size == 80) {
+      EXPECT_THAT(pass->draw(3), IsOk());
+    } else {
+      EXPECT_THAT(pass->draw(3), IsGpuError(GpuErrorType::InvalidDescriptor));
+    }
+  }
+}
+
+std::string RecordShaderFacts(std::optional<std::vector<ShaderBufferBindingInfo>> facts) {
+  RecordingDevice device;
+  ShaderModuleDescriptor descriptor{"shader", "shader", ShaderSourceKind::Wgsl};
+  descriptor.bufferBindings = std::move(facts);
+  const ShaderModule module = GetResultOrFail(device.createShaderModule(descriptor));
+  return device.serialize();
+}
+
+TEST(ShaderBufferRecordingTests, OmittedAndKnownEmptyMetadataAreDifferent) {
+  EXPECT_NE(RecordShaderFacts(std::nullopt),
+            RecordShaderFacts(std::vector<ShaderBufferBindingInfo>{}));
+}
+
+TEST(ShaderBufferRecordingTests, SuppliedFactsAreCompleteAndDeterministic) {
+  std::vector<ShaderBufferBindingInfo> facts{
+      {"cs", ShaderStage::Compute, 2, 3, BindingType::ReadOnlyStorageBuffer, 16, 16}};
+  const std::string recorded = RecordShaderFacts(facts);
+  EXPECT_EQ(recorded, RecordShaderFacts(facts));
+  EXPECT_THAT(recorded, HasSubstr("bufferBindings=[{entryPoint=\"cs\" stage=Compute group=2 "
+                                  "binding=3 type=ReadOnlyStorageBuffer minSizeBytes=16 "
+                                  "runtimeArrayStrideBytes=16}]"));
+  facts[0].minSizeBytes = 32;
+  facts[0].runtimeArrayStrideBytes = 32;
+  EXPECT_NE(recorded, RecordShaderFacts(facts));
+}
+
+}  // namespace
+}  // namespace donner::gpu


### PR DESCRIPTION
Shader buffer metadata must agree with the selected entry point, pipeline layout, binding type, stage visibility, and the range actually bound at draw or dispatch time. Validate those contracts once when modules and pipelines are created, retain the resulting minimum ranges, and fail before encoding when an active binding is too small.

Combine vertex and fragment requirements for the same binding by their maximum size. Preserve the distinction between omitted metadata and an explicitly empty fact set in the recording backend, and keep active validation generation-safe through the resource-lifetime layer below this PR.

The retained requirements are sized for one group's worth of bindings rather than every group's, which no accepted pipeline fills; a wider pipeline spills to the heap once when the pipeline is selected instead of carrying two kilobytes inline in every encoder.

Verification: a full run of the GPU, shader, and Metal test trees on an Apple Silicon Mac at the top of the stack gives 16 passing targets, 7 skipped for the absent Vulkan driver, and no failures. Formatting, BUILD formatting, and lint pass.

The editor Wasm size budgets are retuned here. This validation runs on the path the renderer records through, so it is shipped code, and it put the raw wasm gate 3,374 bytes and the package gate 1,376 bytes over. The compressed wasm gate is retuned in the same change because it had fallen to 0.20 percent headroom and would otherwise have been the next gate to flip red on an unrelated change. The two JavaScript gates are untouched, since this layer adds none.
