### PR TITLE
Bound generated Metal reads to declared buffer ranges

### DIFF
--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -30,11 +30,14 @@ namespace donner::gpu::metal {
  * texture and sampler bindings map directly, and stage-in vertex data occupies vertex buffer
  * index 30.
  *
- * Generated runtime-array reads use the exact declared binding sizes in a fixed length table
- * at buffer index 0. Each immutable bind group caches the table and copies it to storage-buffer
- * stages when the group changes; each new pass binds it again. Repeated draws and dispatches
- * reuse that binding. Raw MSL remains trusted
- * caller code, and omitted interface metadata retains the shared runtime's existing semantics.
+ * Generated runtime-array reads use the exact declared binding sizes in a fixed length table.
+ * Metal buffer index 0 is reserved for that table, so raw MSL this backend accepts must leave
+ * index 0 free. Each immutable bind group caches the table; when the bound group changes it is
+ * uploaded to every stage the active encoder has, deliberately without consulting the layout,
+ * because the generated code's need for the table follows from the shader IR rather than from a
+ * layout's binding types or visibility. Repeated draws and dispatches reuse that binding, and
+ * each new pass binds it again. Raw MSL otherwise remains trusted caller code, and omitted
+ * interface metadata retains the shared runtime's existing semantics.
  *
  * Queue writes update idle resources directly. Writes to resources an earlier submission still
  * uses are copied into bounded host storage and uploaded at the beginning of the next ordinary

--- a/donner/gpu/metal/MetalDevice.h
+++ b/donner/gpu/metal/MetalDevice.h
@@ -30,6 +30,12 @@ namespace donner::gpu::metal {
  * texture and sampler bindings map directly, and stage-in vertex data occupies vertex buffer
  * index 30.
  *
+ * Generated runtime-array reads use the exact declared binding sizes in a fixed length table
+ * at buffer index 0. Each immutable bind group caches the table and copies it to storage-buffer
+ * stages when the group changes; each new pass binds it again. Repeated draws and dispatches
+ * reuse that binding. Raw MSL remains trusted
+ * caller code, and omitted interface metadata retains the shared runtime's existing semantics.
+ *
  * Queue writes update idle resources directly. Writes to resources an earlier submission still
  * uses are copied into bounded host storage and uploaded at the beginning of the next ordinary
  * submission. Repeated writes of the same resource range are coalesced. A batch adds one staging

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -8,6 +8,7 @@
 #import <Metal/Metal.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -207,6 +208,8 @@ struct MetalDevice::Impl {
     /// are immutable value descriptors, so the copy stays correct even if the layout object is
     /// destroyed and its slot recycled; encode never looks the layout up by slot.
     BindGroupLayoutDescriptor layout;
+    std::array<uint32_t, shader::kMslBufferBindingCount> bufferLengths{};
+    ShaderStage storageBufferStages = ShaderStage::None;
   };
 
   /// A compiled render pipeline plus the encoder state every draw through it uses (cull mode
@@ -335,6 +338,8 @@ struct MetalDevice::Impl {
     PrimitiveTopology currentTopology = PrimitiveTopology::TriangleList;
     /// Threadgroup shape of the bound compute pipeline, applied at dispatch.
     WorkgroupSize currentWorkgroupSize;
+    // Bind-group records stay stable throughout synchronous submission encoding.
+    const BindGroupRecord* lengthTableGroup = nullptr;
     std::vector<id<MTLBuffer>> hostReadBuffers;  //!< GPU-written buffers needing CPU visibility.
   };
 
@@ -347,6 +352,9 @@ struct MetalDevice::Impl {
   /// @param state Encoding state.
   /// @param setPipeline Recorded command.
   Status encodeSetPipeline(EncodingState& state, const SetPipelineCommand& setPipeline);
+
+  /// Copies the group's exact buffer ranges into the reserved argument slot of storage stages.
+  void encodeBufferLengths(EncodingState& state, const BindGroupRecord& group);
 
   /// Binds one buffer entry to the stages its layout entry declares.
   /// @param state Encoding state.
@@ -705,6 +713,18 @@ Status MetalDevice::onCreateSampler(uint32_t slotIndex, const SamplerDescriptor&
 
 Status MetalDevice::onCreateBindGroupLayout(uint32_t slotIndex,
                                             const BindGroupLayoutDescriptor& descriptor) {
+  for (const BindGroupLayoutEntry& entry : descriptor.entries) {
+    const bool invalidBuffer = (entry.type == BindingType::UniformBuffer ||
+                                entry.type == BindingType::ReadOnlyStorageBuffer) &&
+                               entry.binding >= shader::kMslBufferBindingCount;
+    const bool invalidSampler = entry.type == BindingType::FilteringSampler &&
+                                entry.binding >= shader::kMslSamplerBindingCount;
+    if (invalidBuffer || invalidSampler) {
+      return GpuError{GpuErrorType::Unsupported,
+                      std::format("Metal {} binding {} exceeds the native argument table",
+                                  invalidBuffer ? "buffer" : "sampler", entry.binding)};
+    }
+  }
   SetSlot(impl_->bindGroupLayouts, slotIndex, std::optional<BindGroupLayoutDescriptor>(descriptor));
   return OkStatus();
 }
@@ -719,8 +739,18 @@ Status MetalDevice::onCreateBindGroup(uint32_t slotIndex, const BindGroupDescrip
                     std::format("bind group layout slot {} has no Metal-side descriptor",
                                 descriptor.layout.slotIndex())};
   }
-  SetSlot(impl_->bindGroups, slotIndex,
-          std::optional<Impl::BindGroupRecord>(Impl::BindGroupRecord{descriptor, *layout}));
+  Impl::BindGroupRecord record{descriptor, *layout};
+  for (const BindGroupEntry& entry : descriptor.entries) {
+    if (const auto* buffer = std::get_if<BufferBinding>(&entry.resource)) {
+      record.bufferLengths[entry.binding] = static_cast<uint32_t>(buffer->sizeBytes);
+    }
+  }
+  for (const BindGroupLayoutEntry& entry : layout->entries) {
+    if (entry.type == BindingType::ReadOnlyStorageBuffer) {
+      record.storageBufferStages |= entry.visibility;
+    }
+  }
+  SetSlot(impl_->bindGroups, slotIndex, std::optional<Impl::BindGroupRecord>(std::move(record)));
   return OkStatus();
 }
 
@@ -1048,6 +1078,7 @@ Status MetalDevice::Impl::beginEncodedRenderPass(EncodingState& state,
                           attachment.clearColor[2], attachment.clearColor[3]);
   }
 
+  state.lengthTableGroup = nullptr;
   state.renderEncoder = [state.commandBuffer renderCommandEncoderWithDescriptor:passDescriptor];
   if (state.renderEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal render command encoder creation failed"};
@@ -1177,6 +1208,30 @@ Status MetalDevice::Impl::encodeBindGroupEntry(EncodingState& state,
   return OkStatus();
 }
 
+void MetalDevice::Impl::encodeBufferLengths(EncodingState& state, const BindGroupRecord& group) {
+  if (state.lengthTableGroup == &group) {
+    return;
+  }
+  state.lengthTableGroup = &group;
+  const uint32_t* lengths = group.bufferLengths.data();
+  constexpr size_t kLengthBytes = sizeof(group.bufferLengths);
+  if (state.renderEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Vertex)) {
+    [state.renderEncoder setVertexBytes:lengths
+                                 length:kLengthBytes
+                                atIndex:shader::kMslBufferLengthsIndex];
+  }
+  if (state.renderEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Fragment)) {
+    [state.renderEncoder setFragmentBytes:lengths
+                                   length:kLengthBytes
+                                  atIndex:shader::kMslBufferLengthsIndex];
+  }
+  if (state.computeEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Compute)) {
+    [state.computeEncoder setBytes:lengths
+                            length:kLengthBytes
+                           atIndex:shader::kMslBufferLengthsIndex];
+  }
+}
+
 Status MetalDevice::Impl::encodeSetBindGroup(EncodingState& state,
                                              const SetBindGroupCommand& setBindGroup) {
   if (setBindGroup.index != 0) {
@@ -1196,6 +1251,7 @@ Status MetalDevice::Impl::encodeSetBindGroup(EncodingState& state,
       return bindStatus;
     }
   }
+  encodeBufferLengths(state, *bindGroup);
   return OkStatus();
 }
 
@@ -1344,6 +1400,7 @@ std::optional<Status> MetalDevice::Impl::encodeRenderCommand(EncodingState& stat
 }
 
 Status MetalDevice::Impl::beginEncodedComputePass(EncodingState& state) {
+  state.lengthTableGroup = nullptr;
   state.computeEncoder = [state.commandBuffer computeCommandEncoder];
   if (state.computeEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal compute command encoder creation failed"};

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cstring>
 #include <format>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -209,7 +210,6 @@ struct MetalDevice::Impl {
     /// destroyed and its slot recycled; encode never looks the layout up by slot.
     BindGroupLayoutDescriptor layout;
     std::array<uint32_t, shader::kMslBufferBindingCount> bufferLengths{};
-    ShaderStage storageBufferStages = ShaderStage::None;
   };
 
   /// A compiled render pipeline plus the encoder state every draw through it uses (cull mode
@@ -339,7 +339,10 @@ struct MetalDevice::Impl {
     /// Threadgroup shape of the bound compute pipeline, applied at dispatch.
     WorkgroupSize currentWorkgroupSize;
     // Bind-group records stay stable throughout synchronous submission encoding.
-    const BindGroupRecord* lengthTableGroup = nullptr;
+    /// Identity of the bind group whose length table is already bound on this encoder, keyed
+    /// by (slot, generation) rather than by record address so a recycled slot cannot read as a
+    /// hit. Reset whenever an encoder begins.
+    std::optional<ResourceIdentity> lengthTableGroup;
     std::vector<id<MTLBuffer>> hostReadBuffers;  //!< GPU-written buffers needing CPU visibility.
   };
 
@@ -353,8 +356,13 @@ struct MetalDevice::Impl {
   /// @param setPipeline Recorded command.
   Status encodeSetPipeline(EncodingState& state, const SetPipelineCommand& setPipeline);
 
-  /// Copies the group's exact buffer ranges into the reserved argument slot of storage stages.
-  void encodeBufferLengths(EncodingState& state, const BindGroupRecord& group);
+  /// Uploads \p group's declared buffer lengths into the reserved argument slot of every stage
+  /// the active encoder has, skipping the upload when that group's table is already bound.
+  /// @param state Encoder state for the pass being recorded.
+  /// @param group Bind group whose declared lengths are uploaded.
+  /// @param groupId Identity of \p group, used to skip a redundant upload.
+  void encodeBufferLengths(EncodingState& state, const BindGroupRecord& group,
+                           const ResourceIdentity& groupId);
 
   /// Binds one buffer entry to the stages its layout entry declares.
   /// @param state Encoding state.
@@ -742,12 +750,15 @@ Status MetalDevice::onCreateBindGroup(uint32_t slotIndex, const BindGroupDescrip
   Impl::BindGroupRecord record{descriptor, *layout};
   for (const BindGroupEntry& entry : descriptor.entries) {
     if (const auto* buffer = std::get_if<BufferBinding>(&entry.resource)) {
+      // createBindGroup enforces a bijection with the layout, and onCreateBindGroupLayout
+      // rejects buffer bindings at or above kMslBufferBindingCount, so this index is in range.
+      // kMaxBindings is larger than that, so state the invariant where the write happens.
+      UTILS_RELEASE_ASSERT_MSG(entry.binding < shader::kMslBufferBindingCount,
+                               "buffer binding is inside the Metal argument table");
+      static_assert(kMaxBufferByteSize <= std::numeric_limits<uint32_t>::max(),
+                    "buffer lengths are uploaded as uint32; raising the buffer size cap must not "
+                    "silently truncate a declared range");
       record.bufferLengths[entry.binding] = static_cast<uint32_t>(buffer->sizeBytes);
-    }
-  }
-  for (const BindGroupLayoutEntry& entry : layout->entries) {
-    if (entry.type == BindingType::ReadOnlyStorageBuffer) {
-      record.storageBufferStages |= entry.visibility;
     }
   }
   SetSlot(impl_->bindGroups, slotIndex, std::optional<Impl::BindGroupRecord>(std::move(record)));
@@ -1078,7 +1089,7 @@ Status MetalDevice::Impl::beginEncodedRenderPass(EncodingState& state,
                           attachment.clearColor[2], attachment.clearColor[3]);
   }
 
-  state.lengthTableGroup = nullptr;
+  state.lengthTableGroup.reset();
   state.renderEncoder = [state.commandBuffer renderCommandEncoderWithDescriptor:passDescriptor];
   if (state.renderEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal render command encoder creation failed"};
@@ -1123,6 +1134,14 @@ Status MetalDevice::Impl::encodeBufferBinding(EncodingState& state, const BindGr
         GpuErrorType::InvalidState,
         std::format("setBindGroup: binding {} does not resolve to a Metal buffer", entry.binding)};
   }
+  // The buffer itself stays gated on the layout's declared visibility, unlike the length table
+  // above. That is a deliberate asymmetry with a known gap: the table is safe to over-bind, while
+  // binding a buffer to a stage its layout does not declare would silently accept a layout that
+  // disagrees with the shader. The gap is that a module with interface metadata omitted, which
+  // this backend still accepts, is not cross-checked against the layout, so a stage the IR reads
+  // but the layout does not declare leaves the generated code with a bounded index into a nil
+  // pointer. Closing it belongs with metadata admission, not here; supplying the facts makes
+  // pipeline creation reject the disagreement outright.
   if (state.renderEncoder != nil && HasAllFlags(visibility, ShaderStage::Vertex)) {
     [state.renderEncoder setVertexBuffer:buffer
                                   offset:bufferBinding.offsetBytes
@@ -1208,24 +1227,31 @@ Status MetalDevice::Impl::encodeBindGroupEntry(EncodingState& state,
   return OkStatus();
 }
 
-void MetalDevice::Impl::encodeBufferLengths(EncodingState& state, const BindGroupRecord& group) {
-  if (state.lengthTableGroup == &group) {
+void MetalDevice::Impl::encodeBufferLengths(EncodingState& state, const BindGroupRecord& group,
+                                            const ResourceIdentity& groupId) {
+  if (state.lengthTableGroup == groupId) {
     return;
   }
-  state.lengthTableGroup = &group;
+  state.lengthTableGroup = groupId;
   const uint32_t* lengths = group.bufferLengths.data();
   constexpr size_t kLengthBytes = sizeof(group.bufferLengths);
-  if (state.renderEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Vertex)) {
+  // Bound to every stage the active encoder has, deliberately without consulting the layout.
+  // MslEmitter declares and dereferences donner_msl_lengths in every entry point of a module
+  // that holds any runtime-array binding, which is a fact about the IR; the bind-group layout's
+  // binding types and visibility are a different fact and can be narrower. Gating the upload on
+  // the layout leaves a shader dereferencing a nil constant uint* whenever the two disagree -
+  // for instance a buffer declared ReadOnlyStorageBuffer in the IR but UniformBuffer in the
+  // layout - which is exactly the unbounded read this table exists to prevent. Binding an
+  // argument index a pipeline does not read costs one setBytes of a fixed 116-byte table.
+  if (state.renderEncoder != nil) {
     [state.renderEncoder setVertexBytes:lengths
                                  length:kLengthBytes
                                 atIndex:shader::kMslBufferLengthsIndex];
-  }
-  if (state.renderEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Fragment)) {
     [state.renderEncoder setFragmentBytes:lengths
                                    length:kLengthBytes
                                   atIndex:shader::kMslBufferLengthsIndex];
   }
-  if (state.computeEncoder != nil && HasAllFlags(group.storageBufferStages, ShaderStage::Compute)) {
+  if (state.computeEncoder != nil) {
     [state.computeEncoder setBytes:lengths
                             length:kLengthBytes
                            atIndex:shader::kMslBufferLengthsIndex];
@@ -1251,7 +1277,7 @@ Status MetalDevice::Impl::encodeSetBindGroup(EncodingState& state,
       return bindStatus;
     }
   }
-  encodeBufferLengths(state, *bindGroup);
+  encodeBufferLengths(state, *bindGroup, setBindGroup.bindGroupId);
   return OkStatus();
 }
 
@@ -1400,7 +1426,7 @@ std::optional<Status> MetalDevice::Impl::encodeRenderCommand(EncodingState& stat
 }
 
 Status MetalDevice::Impl::beginEncodedComputePass(EncodingState& state) {
-  state.lengthTableGroup = nullptr;
+  state.lengthTableGroup.reset();
   state.computeEncoder = [state.commandBuffer computeCommandEncoder];
   if (state.computeEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal compute command encoder creation failed"};

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -153,4 +153,30 @@ donner_cc_test(
     ],
 )
 
+donner_cc_test(
+    name = "metal_buffer_bounds_tests",
+    srcs = [
+        "MetalBufferBounds_tests.cc",
+        "//donner/svg/renderer/benchmarks:AllocationTracker.h",
+    ],
+    env = {
+        "MTL_DEBUG_LAYER": "1",
+        "MTL_SHADER_VALIDATION": "1",
+    },
+    env_inherit = ["GITHUB_ACTIONS"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_device_gate",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/gpu",
+        "//donner/gpu:gpu_test_utils",
+        "//donner/gpu/metal:metal_device",
+        "//donner/gpu/shader",
+        "//donner/gpu/shader:module_interface",
+        "//donner/gpu/shader:msl_emitter",
+        "//donner/gpu/shader:programs",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_package()

--- a/donner/gpu/metal/tests/MetalBufferBounds_tests.cc
+++ b/donner/gpu/metal/tests/MetalBufferBounds_tests.cc
@@ -67,6 +67,10 @@ struct ReadOptions {
   uint32_t dispatchCount = 1;
   bool bindEachDispatch = false;
   bool secondPass = false;
+  /// Declare the runtime-array binding as a uniform buffer in the bind group layout, while the
+  /// shader IR still reads it as a runtime array. The RHI permits this: the buffer carries both
+  /// usages and the layout's binding type is a separate fact from the IR's.
+  bool declareRuntimeArrayAsUniform = false;
 };
 
 class MetalBufferBoundsTests : public testing::Test {
@@ -93,20 +97,40 @@ protected:
           {1, ShaderStage::Compute, BindingType::UniformBuffer},
           {2, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
     layout_ = GetResultOrFail(device_->createPipelineLayout({"readBuffer", {groupLayout_}}));
+    // The same generated MSL with its interface metadata omitted, which the backend documents as
+    // retaining the shared runtime's existing semantics. Without facts, nothing cross-checks the
+    // layout's binding types against the IR, so the layout may name the runtime array a uniform
+    // buffer while the generated code still indexes it through donner_msl_lengths.
+    noFactsModule_ =
+        GetResultOrFail(device_->createShaderModule({"readBufferNoFacts",
+                                                     RcString(msl.result()),
+                                                     ShaderSourceKind::Msl,
+                                                     {},
+                                                     shader::ComputeEntryPointsOf(ir.result()),
+                                                     std::nullopt}));
+    uniformDeclaredGroupLayout_ = GetResultOrFail(device_->createBindGroupLayout(
+        {"readBufferAsUniform",
+         {{0, ShaderStage::Compute, BindingType::UniformBuffer},
+          {1, ShaderStage::Compute, BindingType::UniformBuffer},
+          {2, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
+    uniformDeclaredLayout_ = GetResultOrFail(
+        device_->createPipelineLayout({"readBufferAsUniform", {uniformDeclaredGroupLayout_}}));
     pipeline_ = GetResultOrFail(
         device_->createComputePipeline({"readBuffer", layout_, {module_, "cs"}, {1, 1, 1}}));
     alternatePipeline_ = GetResultOrFail(
         device_->createComputePipeline({"alternate", layout_, {module_, "cs"}, {1, 1, 1}}));
+    uniformDeclaredPipeline_ = GetResultOrFail(device_->createComputePipeline(
+        {"readBufferAsUniform", uniformDeclaredLayout_, {noFactsModule_, "cs"}, {1, 1, 1}}));
   }
 
   void bindForRead(ComputePassEncoder* pass, const BindGroup& group, const BindGroup& fullGroup,
-                   BindingOrder order) {
+                   BindingOrder order, const ComputePipeline& pipeline) {
     if (order == BindingOrder::BeforePipeline) {
       ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
-      ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+      ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
       return;
     }
-    ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+    ASSERT_THAT(pass->setPipeline(pipeline), IsOk());
     if (order == BindingOrder::Replacement) {
       ASSERT_THAT(pass->setBindGroup(0, fullGroup), IsOk());
       ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
@@ -122,8 +146,13 @@ protected:
     const std::array<float, 8> values{1, 0, 0, 1, 0, 1, 0, 1};
     std::vector<uint8_t> data(offset + sizeof(values));
     std::memcpy(data.data() + offset, values.data(), sizeof(values));
+    const ComputePipeline& selectedPipeline =
+        options.declareRuntimeArrayAsUniform ? uniformDeclaredPipeline_ : pipeline_;
+    const BindGroupLayout& selectedGroupLayout =
+        options.declareRuntimeArrayAsUniform ? uniformDeclaredGroupLayout_ : groupLayout_;
     const Buffer input = GetResultOrFail(device_->createBuffer(
-        {"values", data.size(), BufferUsage::Storage | BufferUsage::CopyDst}));
+        {"values", data.size(),
+         BufferUsage::Storage | BufferUsage::Uniform | BufferUsage::CopyDst}));
     ASSERT_THAT(device_->writeBuffer(input, 0, data), IsOk());
     const Buffer params = GetResultOrFail(device_->createBuffer(
         {"params", sizeof(index), BufferUsage::Uniform | BufferUsage::CopyDst}));
@@ -140,7 +169,7 @@ protected:
     const Buffer readback = GetResultOrFail(
         device_->createBuffer({"readback", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
     BindGroupDescriptor groupDescriptor{"readBuffer",
-                                        groupLayout_,
+                                        selectedGroupLayout,
                                         {{0, BufferBinding{input, offset, declaredBytes}},
                                          {1, BufferBinding{params, 0, sizeof(index)}},
                                          {2, TextureViewBinding{view}}}};
@@ -149,7 +178,7 @@ protected:
     const BindGroup fullGroup = GetResultOrFail(device_->createBindGroup(groupDescriptor));
     auto encoder = GetResultOrFail(device_->createCommandEncoder());
     ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
-    bindForRead(pass, group, fullGroup, options.bindingOrder);
+    bindForRead(pass, group, fullGroup, options.bindingOrder, selectedPipeline);
     for (uint32_t dispatch = 0; dispatch < options.dispatchCount; ++dispatch) {
       if (options.bindEachDispatch && dispatch != 0) {
         ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
@@ -159,7 +188,7 @@ protected:
     ASSERT_THAT(pass->end(), IsOk());
     if (options.secondPass) {
       pass = GetResultOrFail(encoder->beginComputePass({}));
-      ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+      ASSERT_THAT(pass->setPipeline(selectedPipeline), IsOk());
       ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
       ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
       ASSERT_THAT(pass->end(), IsOk());
@@ -200,10 +229,14 @@ protected:
 
   std::unique_ptr<MetalDevice> device_;
   ShaderModule module_;
+  ShaderModule noFactsModule_;
   BindGroupLayout groupLayout_;
   PipelineLayout layout_;
   ComputePipeline pipeline_;
   ComputePipeline alternatePipeline_;
+  BindGroupLayout uniformDeclaredGroupLayout_;
+  PipelineLayout uniformDeclaredLayout_;
+  ComputePipeline uniformDeclaredPipeline_;
 };
 
 TEST_F(MetalBufferBoundsTests, RejectsBindingsBeyondTheNativeArgumentTables) {
@@ -257,6 +290,17 @@ TEST_F(MetalBufferBoundsTests, RejectsGroupsOutsideTheNativeMapping) {
   ASSERT_THAT(pass->end(), IsOk());
   EXPECT_THAT(device_->submit(GetResultOrFail(encoder->finish())),
               IsGpuError(GpuErrorType::Unsupported));
+}
+
+TEST_F(MetalBufferBoundsTests, LayoutBindingTypeDoesNotDecideWhetherLengthsAreBound) {
+  // The emitter puts donner_msl_lengths in every entry point of a module that holds any
+  // runtime-array binding, so the generated code dereferences it however the layout names the
+  // binding. With interface metadata supplied, pipeline creation rejects a layout that disagrees
+  // with the shader; with metadata omitted, which this backend still accepts, nothing does.
+  // Uploading the table only for layout entries typed ReadOnlyStorageBuffer left that pipeline
+  // reading a nil constant uint*, so the declared ranges below were never applied.
+  expectRead(0, 0, 16, {255, 0, 0, 255}, {.declareRuntimeArrayAsUniform = true});
+  expectRead(1, 0, 16, {0, 0, 0, 0}, {.declareRuntimeArrayAsUniform = true});
 }
 
 TEST_F(MetalBufferBoundsTests, ANewPassBindsTheSameGroupsLengthsAgain) {

--- a/donner/gpu/metal/tests/MetalBufferBounds_tests.cc
+++ b/donner/gpu/metal/tests/MetalBufferBounds_tests.cc
@@ -1,0 +1,276 @@
+/// @file
+/// Declared buffer ranges remain separate from the containing allocation.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <format>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
+#include "donner/gpu/shader/ModuleInterface.h"
+#include "donner/gpu/shader/MslEmitter.h"
+#include "donner/gpu/shader/programs/ErrorLatch.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+#include "donner/svg/renderer/benchmarks/AllocationTracker.h"
+
+namespace donner::gpu::metal {
+namespace {
+
+shader::ShaderResult<shader::IrModule> BuildBufferReadModule() {
+  using namespace shader;
+  programs::ErrorLatch e;
+  ModuleBuilder builder;
+  const IrType params = e(IrType::Struct("Params", {{"index", IrType::I32()}}));
+  e.ok(builder.addReadOnlyStorageBuffer(0, 0, "values", e(IrType::RuntimeArray(IrType::Vec4f()))));
+  e.ok(builder.addUniformBuffer(0, 1, "params", params));
+  e.ok(builder.addWriteOnlyStorageTexture2d(0, 2, "outputTexture",
+                                            StorageTextureFormat::Rgba8Unorm));
+  auto helperResult =
+      builder.createFunction("readValue", {{"index", IrType::I32()}}, IrType::Vec4f());
+  if (helperResult.hasError()) {
+    return std::move(helperResult).error();
+  }
+  FunctionBuilder helper = std::move(helperResult).result();
+  e.ok(helper.returnValue(e(Index(e(helper.ref("values")), e(helper.ref("index"))))));
+  e.ok(helper.finish());
+  auto entryResult = builder.createComputeEntryPoint("cs", {}, {1, 1, 1});
+  if (entryResult.hasError()) {
+    return std::move(entryResult).error();
+  }
+  FunctionBuilder entry = std::move(entryResult).result();
+  const IrExpr value =
+      e(entry.callFunction("readValue", {e(Member(e(entry.ref("params")), "index"))}));
+  e.ok(entry.textureStore(e(entry.ref("outputTexture")),
+                          e(ConstructVector(IrType::Vec2i(), {LiteralI32(0)})), value));
+  e.ok(entry.finish());
+  if (e.error) {
+    return *e.error;
+  }
+  return builder.build();
+}
+
+enum class BindingOrder { Normal, BeforePipeline, PipelineSwitch, Replacement };
+
+struct ReadOptions {
+  BindingOrder bindingOrder = BindingOrder::Normal;
+  uint32_t dispatchCount = 1;
+  bool bindEachDispatch = false;
+  bool secondPass = false;
+};
+
+class MetalBufferBoundsTests : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = MetalDevice::Create();
+    DONNER_REQUIRE_METAL_DEVICE(device_, "Metal declared buffer bounds");
+    auto ir = BuildBufferReadModule();
+    ASSERT_FALSE(ir.hasError()) << ir.error();
+    auto msl = shader::EmitMsl(ir.result());
+    ASSERT_FALSE(msl.hasError()) << msl.error();
+    auto facts = shader::BufferBindingsOf(ir.result());
+    ASSERT_FALSE(facts.hasError()) << facts.error();
+    module_ =
+        GetResultOrFail(device_->createShaderModule({"readBuffer",
+                                                     RcString(msl.result()),
+                                                     ShaderSourceKind::Msl,
+                                                     {},
+                                                     shader::ComputeEntryPointsOf(ir.result()),
+                                                     std::move(facts).result()}));
+    groupLayout_ = GetResultOrFail(device_->createBindGroupLayout(
+        {"readBuffer",
+         {{0, ShaderStage::Compute, BindingType::ReadOnlyStorageBuffer},
+          {1, ShaderStage::Compute, BindingType::UniformBuffer},
+          {2, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d}}}));
+    layout_ = GetResultOrFail(device_->createPipelineLayout({"readBuffer", {groupLayout_}}));
+    pipeline_ = GetResultOrFail(
+        device_->createComputePipeline({"readBuffer", layout_, {module_, "cs"}, {1, 1, 1}}));
+    alternatePipeline_ = GetResultOrFail(
+        device_->createComputePipeline({"alternate", layout_, {module_, "cs"}, {1, 1, 1}}));
+  }
+
+  void bindForRead(ComputePassEncoder* pass, const BindGroup& group, const BindGroup& fullGroup,
+                   BindingOrder order) {
+    if (order == BindingOrder::BeforePipeline) {
+      ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+      ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+      return;
+    }
+    ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+    if (order == BindingOrder::Replacement) {
+      ASSERT_THAT(pass->setBindGroup(0, fullGroup), IsOk());
+      ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    }
+    ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+    if (order == BindingOrder::PipelineSwitch) {
+      ASSERT_THAT(pass->setPipeline(alternatePipeline_), IsOk());
+    }
+  }
+
+  void expectRead(int32_t index, uint64_t offset, uint64_t declaredBytes,
+                  const std::array<uint8_t, 4>& expected, ReadOptions options = {}) {
+    const std::array<float, 8> values{1, 0, 0, 1, 0, 1, 0, 1};
+    std::vector<uint8_t> data(offset + sizeof(values));
+    std::memcpy(data.data() + offset, values.data(), sizeof(values));
+    const Buffer input = GetResultOrFail(device_->createBuffer(
+        {"values", data.size(), BufferUsage::Storage | BufferUsage::CopyDst}));
+    ASSERT_THAT(device_->writeBuffer(input, 0, data), IsOk());
+    const Buffer params = GetResultOrFail(device_->createBuffer(
+        {"params", sizeof(index), BufferUsage::Uniform | BufferUsage::CopyDst}));
+    ASSERT_THAT(device_->writeBuffer(params, 0,
+                                     std::span<const uint8_t>(
+                                         reinterpret_cast<const uint8_t*>(&index), sizeof(index))),
+                IsOk());
+    const Texture output = GetResultOrFail(
+        device_->createTexture({"output",
+                                {1, 1},
+                                TextureFormat::RGBA8Unorm,
+                                TextureUsage::StorageBinding | TextureUsage::CopySrc}));
+    const TextureView view = GetResultOrFail(device_->createTextureView(output, {}));
+    const Buffer readback = GetResultOrFail(
+        device_->createBuffer({"readback", 256, BufferUsage::CopyDst | BufferUsage::MapRead}));
+    BindGroupDescriptor groupDescriptor{"readBuffer",
+                                        groupLayout_,
+                                        {{0, BufferBinding{input, offset, declaredBytes}},
+                                         {1, BufferBinding{params, 0, sizeof(index)}},
+                                         {2, TextureViewBinding{view}}}};
+    const BindGroup group = GetResultOrFail(device_->createBindGroup(groupDescriptor));
+    std::get<BufferBinding>(groupDescriptor.entries[0].resource).sizeBytes = sizeof(values);
+    const BindGroup fullGroup = GetResultOrFail(device_->createBindGroup(groupDescriptor));
+    auto encoder = GetResultOrFail(device_->createCommandEncoder());
+    ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+    bindForRead(pass, group, fullGroup, options.bindingOrder);
+    for (uint32_t dispatch = 0; dispatch < options.dispatchCount; ++dispatch) {
+      if (options.bindEachDispatch && dispatch != 0) {
+        ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+      }
+      ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
+    }
+    ASSERT_THAT(pass->end(), IsOk());
+    if (options.secondPass) {
+      pass = GetResultOrFail(encoder->beginComputePass({}));
+      ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+      ASSERT_THAT(pass->setBindGroup(0, group), IsOk());
+      ASSERT_THAT(pass->dispatchWorkgroups(1), IsOk());
+      ASSERT_THAT(pass->end(), IsOk());
+    }
+    ASSERT_THAT(
+        encoder->copyTextureToBuffer(TexelCopyTextureInfo{output}, readback, {0, 256, 1}, {1, 1}),
+        IsOk());
+    CommandBuffer commands = GetResultOrFail(encoder->finish());
+    benchmarks::allocations::Scope allocations;
+    const auto start = std::chrono::steady_clock::now();
+    const uint64_t serial = GetResultOrFail(device_->submit(std::move(commands)));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    const auto snapshot = allocations.stop();
+    if (options.dispatchCount > 1) {
+      std::fprintf(
+          stderr,
+          "native_dispatch rebind=%d count=%u ns=%.3f allocations=%" PRIu64 " bytes=%" PRIu64 "\n",
+          options.bindEachDispatch, options.dispatchCount,
+          std::chrono::duration<double, std::nano>(elapsed).count() / options.dispatchCount,
+          snapshot.allocationCalls, snapshot.allocationBytes);
+    }
+    ASSERT_THAT(device_->waitForSerial(serial, 5.0), testing::IsTrue())
+        << device_->lastErrorForTest();
+    auto result = device_->readBackBuffer(readback);
+    ASSERT_THAT(result, HasResult());
+    ASSERT_GE(result.result().size(), 4u);
+    result.result().resize(4);
+    const svg::RendererBitmap actual{
+        .dimensions = {1, 1}, .pixels = std::move(result).result(), .rowBytes = 4};
+    const svg::RendererBitmap reference{
+        .dimensions = {1, 1},
+        .pixels = std::vector<uint8_t>(expected.begin(), expected.end()),
+        .rowBytes = 4};
+    editor::tests::CompareBitmapToBitmap(actual, reference,
+                                         std::format("buffer_range_{}_{}", offset, index),
+                                         editor::tests::PixelmatchIdentityParams());
+  }
+
+  std::unique_ptr<MetalDevice> device_;
+  ShaderModule module_;
+  BindGroupLayout groupLayout_;
+  PipelineLayout layout_;
+  ComputePipeline pipeline_;
+  ComputePipeline alternatePipeline_;
+};
+
+TEST_F(MetalBufferBoundsTests, RejectsBindingsBeyondTheNativeArgumentTables) {
+  EXPECT_THAT(device_->createBindGroupLayout(
+                  {"buffer limit", {{29, ShaderStage::Compute, BindingType::UniformBuffer}}}),
+              IsGpuError(GpuErrorType::Unsupported));
+  EXPECT_THAT(device_->createBindGroupLayout(
+                  {"sampler limit", {{16, ShaderStage::Fragment, BindingType::FilteringSampler}}}),
+              IsGpuError(GpuErrorType::Unsupported));
+}
+
+TEST_F(MetalBufferBoundsTests, ADeclaredRangeDoesNotExposeTheRestOfTheAllocation) {
+  expectRead(0, 0, 16, {255, 0, 0, 255});
+  expectRead(1, 0, 16, {0, 0, 0, 0});
+}
+
+TEST_F(MetalBufferBoundsTests, AnOffsetRangeDoesNotExposeItsFollowingElement) {
+  expectRead(0, 256, 16, {255, 0, 0, 255});
+  expectRead(1, 256, 16, {0, 0, 0, 0});
+}
+
+TEST_F(MetalBufferBoundsTests, RangesExposeOnlyTheirWholeElements) {
+  expectRead(1, 0, 31, {0, 0, 0, 0});
+  expectRead(1, 0, 32, {0, 255, 0, 255});
+  expectRead(1, 256, 32, {0, 255, 0, 255});
+}
+
+TEST_F(MetalBufferBoundsTests, ReplacingAGroupReplacesItsDeclaredLengths) {
+  expectRead(1, 256, 16, {0, 0, 0, 0}, {.bindingOrder = BindingOrder::Replacement});
+}
+
+TEST_F(MetalBufferBoundsTests, PipelineSwitchPreservesTheBoundLengths) {
+  expectRead(0, 256, 16, {255, 0, 0, 255}, {.bindingOrder = BindingOrder::PipelineSwitch});
+  expectRead(1, 256, 16, {0, 0, 0, 0}, {.bindingOrder = BindingOrder::PipelineSwitch});
+}
+
+TEST_F(MetalBufferBoundsTests, GroupCanBeBoundBeforeThePipeline) {
+  expectRead(0, 0, 16, {255, 0, 0, 255}, {.bindingOrder = BindingOrder::BeforePipeline});
+  expectRead(1, 0, 16, {0, 0, 0, 0}, {.bindingOrder = BindingOrder::BeforePipeline});
+}
+
+TEST_F(MetalBufferBoundsTests, RejectsGroupsOutsideTheNativeMapping) {
+  const Buffer buffer = GetResultOrFail(device_->createBuffer({"value", 16, BufferUsage::Uniform}));
+  const BindGroupLayout layout = GetResultOrFail(device_->createBindGroupLayout(
+      {"value", {{0, ShaderStage::Compute, BindingType::UniformBuffer}}}));
+  const BindGroup group = GetResultOrFail(
+      device_->createBindGroup({"value", layout, {{0, BufferBinding{buffer, 0, 16}}}}));
+  auto encoder = GetResultOrFail(device_->createCommandEncoder());
+  ComputePassEncoder* pass = GetResultOrFail(encoder->beginComputePass({}));
+  ASSERT_THAT(pass->setBindGroup(1, group), IsOk());
+  ASSERT_THAT(pass->end(), IsOk());
+  EXPECT_THAT(device_->submit(GetResultOrFail(encoder->finish())),
+              IsGpuError(GpuErrorType::Unsupported));
+}
+
+TEST_F(MetalBufferBoundsTests, ANewPassBindsTheSameGroupsLengthsAgain) {
+  expectRead(0, 256, 16, {255, 0, 0, 255}, {.secondPass = true});
+  expectRead(1, 256, 16, {0, 0, 0, 0}, {.secondPass = true});
+}
+
+TEST_F(MetalBufferBoundsTests, RepeatedBindingsReportNativeSubmissionCost) {
+  for (bool bindEach : {false, true}) {
+    for (uint32_t sample = 0; sample < 7; ++sample) {
+      expectRead(0, 0, 16, {255, 0, 0, 255}, {.dispatchCount = 512, .bindEachDispatch = bindEach});
+    }
+  }
+}
+
+}  // namespace
+}  // namespace donner::gpu::metal

--- a/donner/gpu/shader/MslBindingMap.h
+++ b/donner/gpu/shader/MslBindingMap.h
@@ -11,7 +11,10 @@
 
 namespace donner::gpu::shader {
 
-/// Fixed table of declared buffer lengths, copied when a storage-buffer group is bound.
+/// Reserved Metal buffer index for the fixed table of declared buffer lengths. Populated from
+/// every buffer binding in a group, uniform bindings included, and uploaded to each stage of the
+/// active encoder whenever the bound group changes. Raw MSL this backend accepts must leave this
+/// index free.
 inline constexpr uint32_t kMslBufferLengthsIndex = 0;
 /// Number of buffer bindings before the dedicated vertex slot.
 inline constexpr uint32_t kMslBufferBindingCount = 29;

--- a/donner/gpu/shader/MslBindingMap.h
+++ b/donner/gpu/shader/MslBindingMap.h
@@ -3,30 +3,30 @@
 /// The deterministic Metal argument-table mapping shared by the MSL emitter and the Metal
 /// backend.
 ///
-/// Both sides of the Metal path must agree on how RHI (group, binding) pairs map onto Metal's
-/// per-stage argument tables. This header is the single source of truth (design 0053 "Original
-/// emitters": all emitters consume the same binding metadata):
-///
-/// - Uniform and storage buffer binding `b` -> `[[buffer(1 + b)]]`.
-/// - Texture binding `b` -> `[[texture(b)]]`.
-/// - Sampler binding `b` -> `[[sampler(b)]]`.
-/// - Stage-in vertex data occupies the dedicated vertex buffer index 30 (the last slot of
-///   Metal's 0..30 vertex buffer argument table). The `1 + b` mapping therefore supports RHI
-///   buffer bindings b in 0..28 only: b = 29 would land on the reserved index 30, and b >= 30
-///   would exceed Metal's table. The MSL emitter and the Metal backend both fail closed for
-///   b >= 29; the solid-fill family uses b in 0..11.
-///
-/// Only bind group 0 exists in the solid-fill pipeline family; multi-group support would extend
-/// this map with a per-group base offset when a pipeline family needs it.
+/// Bind group 0 uses one flat argument table per stage. Slot 0 carries exact declared buffer
+/// lengths, buffer binding `b` uses slot `1 + b`, and vertex data uses slot 30. Texture and
+/// sampler bindings use their binding numbers directly.
 
 #include <cstdint>
 
 namespace donner::gpu::shader {
 
+/// Fixed table of declared buffer lengths, copied when a storage-buffer group is bound.
+inline constexpr uint32_t kMslBufferLengthsIndex = 0;
+/// Number of buffer bindings before the dedicated vertex slot.
+inline constexpr uint32_t kMslBufferBindingCount = 29;
+/// Number of texture argument slots per stage.
+inline constexpr uint32_t kMslTextureBindingCount = 128;
+/// Number of sampler argument slots per stage.
+inline constexpr uint32_t kMslSamplerBindingCount = 16;
+/// Dedicated Metal vertex buffer index for stage-in vertex data.
+inline constexpr uint32_t kMslVertexBufferIndex = 30;
+
 /// Metal buffer argument-table index for an RHI buffer binding (uniform or storage).
+/// Invalid bindings return the reserved vertex index so callers reject them without overflow.
 /// @param binding RHI binding index within group 0.
 inline constexpr uint32_t MslBufferIndex(uint32_t binding) {
-  return 1 + binding;
+  return binding < kMslBufferBindingCount ? 1 + binding : kMslVertexBufferIndex;
 }
 
 /// Metal texture argument-table index for an RHI texture binding.
@@ -40,8 +40,5 @@ inline constexpr uint32_t MslTextureIndex(uint32_t binding) {
 inline constexpr uint32_t MslSamplerIndex(uint32_t binding) {
   return binding;
 }
-
-/// Dedicated Metal vertex buffer index for stage-in vertex data (see file comment).
-inline constexpr uint32_t kMslVertexBufferIndex = 30;
 
 }  // namespace donner::gpu::shader

--- a/donner/gpu/shader/MslEmitter.cc
+++ b/donner/gpu/shader/MslEmitter.cc
@@ -1,5 +1,6 @@
 #include "donner/gpu/shader/MslEmitter.h"
 
+#include <algorithm>
 #include <cmath>
 #include <format>
 #include <functional>
@@ -83,10 +84,10 @@ ShaderStatus CheckMslIdentifier(const RcString& name, std::string_view context) 
   }
   // C++ reserves identifiers containing a double underscore; reject the leading form the same
   // way the WGSL emitter does.
-  if (!lexicallyValid || text.starts_with("__")) {
+  if (!lexicallyValid || text.starts_with("__") || text.starts_with("donner_msl_")) {
     return ShaderError{
         std::format("{}: \"{}\" is not a valid identifier (MSL identifiers match "
-                    "[A-Za-z_][A-Za-z0-9_]* and may not start with a double underscore)",
+                    "[A-Za-z_][A-Za-z0-9_]* and may not start with __ or donner_msl_)",
                     context, name.str()),
         "msl"};
   }
@@ -258,7 +259,11 @@ std::optional<std::vector<uint32_t>> ComputeMslMemberOffsets(const IrType& struc
 /// Emitter state: output text plus the first latched error.
 class Emitter {
 public:
-  explicit Emitter(const IrModule& module) : module_(module) {}
+  explicit Emitter(const IrModule& module)
+      : module_(module),
+        usesRuntimeArrays_(std::ranges::any_of(module.bindings(), [](const IrBinding& binding) {
+          return binding.type.kind() == IrType::Kind::RuntimeArray;
+        })) {}
 
   /// Runs emission. @return The MSL text or the first error.
   ShaderResult<std::string> emit();
@@ -286,6 +291,10 @@ private:
 
   std::string literalToMsl(const IrExpr::Node& node);
   std::string exprToMsl(const IrExpr& expr);
+  /// Emits a runtime-array read against its declared byte range; evaluates the index once.
+  std::string indexToMsl(const IrExpr::Node& node);
+  /// Emits the small typed read helper shared by runtime-array bindings.
+  void emitRuntimeArrayReadHelper();
   void emitStatement(const IrStmt& statement, const IrFunction& function);
   /// Emits `for (init; cond; continuing) { body }`.
   /// @param data Statement payload. @param function Enclosing function.
@@ -297,6 +306,12 @@ private:
 
   void collectStructs(const IrType& type, std::vector<IrType>& out);
   void verifyBufferStructLayouts(const IrType& type, AddressSpace addressSpace);
+  /// Verifies a representable array element and its native stride.
+  void verifyArrayLayout(const IrType& type, AddressSpace addressSpace);
+  /// Checks one binding's target layout and argument-table index.
+  void verifyBinding(const IrBinding& binding);
+  /// Rejects locations the fixed native argument mapping cannot represent.
+  void verifyBindingIndex(const IrBinding& binding);
   void emitStructDeclarations();
   void emitConstants();
   void emitFunction(const IrFunction& function);
@@ -363,6 +378,7 @@ private:
   }
 
   const IrModule& module_;
+  const bool usesRuntimeArrays_;
   std::string out_;
   int indent_ = 0;
   std::vector<RcString> userStructNames_;
@@ -410,8 +426,7 @@ std::string Emitter::exprToMsl(const IrExpr& expr) {
       return std::format("{}.{}", exprToMsl(node.children[0]), node.name.str());
     case IrExpr::Kind::Swizzle:
       return std::format("{}.{}", exprToMsl(node.children[0]), node.swizzle);
-    case IrExpr::Kind::Index:
-      return std::format("{}[{}]", exprToMsl(node.children[0]), exprToMsl(node.children[1]));
+    case IrExpr::Kind::Index: return indexToMsl(node);
     case IrExpr::Kind::Construct:
     case IrExpr::Kind::Convert: {
       std::string result = TypeToMsl(node.type);
@@ -470,6 +485,38 @@ std::string Emitter::exprToMsl(const IrExpr& expr) {
     }
   }
   return "0.0f";
+}
+
+std::string Emitter::indexToMsl(const IrExpr::Node& node) {
+  const IrExpr& base = node.children[0];
+  const std::string index = exprToMsl(node.children[1]);
+  if (base.type().kind() != IrType::Kind::RuntimeArray) {
+    return std::format("{}[{}]", exprToMsl(base), index);
+  }
+  const auto binding = std::ranges::find(module_.bindings(), base.node().name, &IrBinding::name);
+  if (base.kind() != IrExpr::Kind::Ref || base.node().refKind != RefKind::Resource ||
+      binding == module_.bindings().end()) {
+    latch(ShaderError{"runtime array access must reference a storage binding", "msl"});
+    return "0";
+  }
+  const auto stride = ComputeArrayStride(base.type(), AddressSpace::Storage);
+  if (stride.hasError()) {
+    latch(ShaderError{stride.error().message, "msl"});
+    return "0";
+  }
+  return std::format("donner_msl_read({}, uint({}), donner_msl_lengths[{}] / {}u)", exprToMsl(base),
+                     index, binding->binding, stride.result());
+}
+
+void Emitter::emitRuntimeArrayReadHelper() {
+  if (!usesRuntimeArrays_) {
+    return;
+  }
+  line("template <typename T>");
+  line("T donner_msl_read(device const T* values, uint index, uint count) {");
+  line("  return index < count ? values[index] : T{};");
+  line("}");
+  blank();
 }
 
 void Emitter::emitStatement(const IrStmt& statement, const IrFunction& function) {
@@ -643,29 +690,34 @@ void Emitter::verifyBufferStructLayouts(const IrType& type, AddressSpace address
       return;
     }
     case IrType::Kind::SizedArray:
-    case IrType::Kind::RuntimeArray: {
-      // Array strides must also agree (the WGSL uniform 16-byte rounding has no MSL C-array
-      // equivalent without a wrapper).
-      ShaderResult<uint32_t> wgslStride = ComputeArrayStride(type, addressSpace);
-      const std::optional<MslLayout> element = ComputeMslLayout(type.elementType());
-      if (wgslStride.hasError() || !element) {
-        latch(ShaderError{"array element has no shared MSL/WGSL layout", "msl"});
-        return;
-      }
-      const uint32_t mslStride = RoundUp(element->alignBytes, element->sizeBytes);
-      if (mslStride != wgslStride.result()) {
-        latch(ShaderError{
-            std::format("array stride diverges between MSL ({}) and the WGSL layout ({}); a "
-                        "padded element wrapper would be required",
-                        mslStride, wgslStride.result()),
-            "msl"});
-        return;
-      }
-      verifyBufferStructLayouts(type.elementType(), addressSpace);
-      return;
-    }
+    case IrType::Kind::RuntimeArray: verifyArrayLayout(type, addressSpace); return;
     default: return;
   }
+}
+
+void Emitter::verifyArrayLayout(const IrType& type, AddressSpace addressSpace) {
+  if (type.elementType().kind() == IrType::Kind::SizedArray) {
+    latch(ShaderError{"nested array elements have no MSL declaration in this emitter", "msl"});
+    return;
+  }
+  // Array strides must also agree (the WGSL uniform 16-byte rounding has no MSL C-array
+  // equivalent without a wrapper).
+  ShaderResult<uint32_t> wgslStride = ComputeArrayStride(type, addressSpace);
+  const std::optional<MslLayout> element = ComputeMslLayout(type.elementType());
+  if (wgslStride.hasError() || !element) {
+    latch(ShaderError{"array element has no shared MSL/WGSL layout", "msl"});
+    return;
+  }
+  const uint32_t mslStride = RoundUp(element->alignBytes, element->sizeBytes);
+  if (mslStride != wgslStride.result()) {
+    latch(ShaderError{
+        std::format("array stride diverges between MSL ({}) and the WGSL layout ({}); a "
+                    "padded element wrapper would be required",
+                    mslStride, wgslStride.result()),
+        "msl"});
+    return;
+  }
+  verifyBufferStructLayouts(type.elementType(), addressSpace);
 }
 
 void Emitter::emitStructDeclarations() {
@@ -774,6 +826,9 @@ std::string Emitter::bindingForwardArgs() const {
     }
     result += binding.name.str();
   }
+  if (usesRuntimeArrays_) {
+    result += ", donner_msl_lengths";
+  }
   return result;
 }
 
@@ -871,6 +926,10 @@ std::vector<std::string> Emitter::entryPointParameters(const IrFunction& functio
   for (const IrBinding& binding : module_.bindings()) {
     parameters.push_back(bindingEntryParam(binding));
   }
+  if (usesRuntimeArrays_) {
+    parameters.push_back(
+        std::format("constant uint* donner_msl_lengths [[buffer({})]]", kMslBufferLengthsIndex));
+  }
   return parameters;
 }
 
@@ -878,6 +937,9 @@ std::vector<std::string> Emitter::plainFunctionParameters(const IrFunction& func
   std::vector<std::string> parameters;
   for (const IrBinding& binding : module_.bindings()) {
     parameters.push_back(bindingParam(binding));
+  }
+  if (usesRuntimeArrays_) {
+    parameters.push_back("constant uint* donner_msl_lengths");
   }
   for (const IrParam& param : function.params) {
     check(CheckMslIdentifier(param.name, "parameter"));
@@ -936,44 +998,62 @@ void Emitter::emitFunction(const IrFunction& function) {
   blank();
 }
 
+void Emitter::verifyBindingIndex(const IrBinding& binding) {
+  if (binding.group != 0) {
+    latch(ShaderError{std::format("binding {} is in group {}; the Metal binding map models only "
+                                  "bind group 0",
+                                  binding.binding, binding.group),
+                      "msl"});
+  }
+  const bool buffer = binding.kind == BindingKind::UniformBuffer ||
+                      binding.kind == BindingKind::ReadOnlyStorageBuffer;
+  const bool sampler = binding.kind == BindingKind::FilteringSampler;
+  const uint32_t limit = buffer    ? kMslBufferBindingCount
+                         : sampler ? kMslSamplerBindingCount
+                                   : kMslTextureBindingCount;
+  if (binding.binding < limit) {
+    return;
+  }
+  if (buffer) {
+    latch(ShaderError{
+        std::format("buffer binding {} collides with or exceeds the reserved stage-in vertex "
+                    "buffer index {}",
+                    binding.binding, kMslVertexBufferIndex),
+        "msl"});
+  } else {
+    latch(ShaderError{std::format("{} binding {} exceeds the Metal argument table",
+                                  sampler ? "sampler" : "texture", binding.binding),
+                      "msl"});
+  }
+}
+
+void Emitter::verifyBinding(const IrBinding& binding) {
+  check(CheckMslIdentifier(binding.name, "binding"));
+  verifyBindingIndex(binding);
+  switch (binding.kind) {
+    case BindingKind::UniformBuffer:
+      verifyBufferStructLayouts(binding.type, AddressSpace::Uniform);
+      break;
+    case BindingKind::ReadOnlyStorageBuffer:
+      verifyBufferStructLayouts(binding.type, AddressSpace::Storage);
+      break;
+    default: break;
+  }
+}
+
 ShaderResult<std::string> Emitter::emit() {
   out_ += "// Generated by donner::gpu::shader::MslEmitter. Do not edit.\n\n";
   out_ += "#include <metal_stdlib>\n\nusing namespace metal;\n\n";
 
-  // Verify every buffer-referenced struct's MSL natural layout matches the WGSL layout engine
-  // before emitting anything that depends on it.
   for (const IrBinding& binding : module_.bindings()) {
-    switch (binding.kind) {
-      case BindingKind::UniformBuffer:
-        verifyBufferStructLayouts(binding.type, AddressSpace::Uniform);
-        break;
-      case BindingKind::ReadOnlyStorageBuffer:
-        verifyBufferStructLayouts(binding.type, AddressSpace::Storage);
-        break;
-      default: break;
-    }
-    // The flat Metal argument-table map models only bind group 0 today (the solid-fill family
-    // is single-group); multi-group support arrives with later pipeline families.
-    if (binding.group != 0) {
-      latch(ShaderError{
-          std::format("binding {} is in group {}; the Metal binding map models only bind group "
-                      "0 today",
-                      binding.binding, binding.group),
-          "msl"});
-    }
-    if ((binding.kind == BindingKind::UniformBuffer ||
-         binding.kind == BindingKind::ReadOnlyStorageBuffer) &&
-        MslBufferIndex(binding.binding) >= kMslVertexBufferIndex) {
-      latch(ShaderError{
-          std::format("buffer binding {} maps to Metal buffer index {}, which collides with or "
-                      "exceeds the reserved stage-in vertex buffer index {}",
-                      binding.binding, MslBufferIndex(binding.binding), kMslVertexBufferIndex),
-          "msl"});
-    }
-    check(CheckMslIdentifier(binding.name, "binding"));
+    verifyBinding(binding);
+  }
+  if (error_) {
+    return *error_;
   }
 
   emitStructDeclarations();
+  emitRuntimeArrayReadHelper();
   emitConstants();
   for (const IrFunction& function : module_.functions()) {
     emitFunction(function);

--- a/donner/gpu/shader/MslEmitter.h
+++ b/donner/gpu/shader/MslEmitter.h
@@ -10,7 +10,7 @@
 namespace donner::gpu::shader {
 
 /**
- * Emits deterministic MSL text for \p module (design 0053 "Original emitters").
+ * Emits deterministic MSL text for \p module.
  *
  * Follows the same determinism discipline as \ref EmitWgsl: declaration-order emission with
  * dependency-ordered struct definitions, two-space indentation, LF-only lines with no trailing
@@ -19,7 +19,8 @@ namespace donner::gpu::shader {
  *
  * Mapping highlights:
  * - Types: f32 -> float, vecN<T> -> floatN/intN/uintN/boolN, mat4x4f -> float4x4, sized arrays
- *   -> C arrays, structs -> C++ structs. The MSL natural layout of every buffer-referenced
+ *   -> C arrays, structs -> C++ structs. Direct array-valued array elements are rejected.
+ *   The MSL natural layout of every buffer-referenced
  *   struct is verified member-by-member against the WGSL layout engine
  *   (\ref ComputeStructLayout); any divergence (for example MSL's 16-byte float3, or a uniform
  *   array whose WGSL stride was padded to 16) fails closed instead of emitting a silently
@@ -30,6 +31,10 @@ namespace donner::gpu::shader {
  *   parameters in module declaration order, and user-call sites forward them. Storage buffers
  *   are `device const` pointers (read-only expressed via const; `device` rather than `constant`
  *   address space so buffer sizes are unconstrained), uniform buffers are `constant T&`.
+ * - Runtime-array reads evaluate the index once and return zero outside the declared binding's
+ *   whole elements. A fixed byte-length table at buffer index 0 is forwarded through helpers;
+ *   the native backend supplies the exact ranges. Other indexing is unchanged. Identifiers
+ *   beginning with `donner_msl_` are reserved for generated helpers and parameters.
  * - Entry points: the vertex stage takes a generated `<name>_Input` struct via `[[stage_in]]`
  *   (fields carry `[[attribute(location)]]`) plus `[[instance_id]]`; the fragment stage takes a
  *   generated input struct whose members carry `[[position]]` / `[[user(locnN)]]`. Outputs are

--- a/donner/gpu/shader/tests/MslEmitter_tests.cc
+++ b/donner/gpu/shader/tests/MslEmitter_tests.cc
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstdlib>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
 
@@ -209,6 +210,87 @@ TEST(MslEmitterTests, RejectsBufferBindingsCollidingWithVertexBufferIndex) {
   EXPECT_THAT(EmitMsl(module.result()),
               IsShaderError(HasSubstr("collides with or exceeds the reserved stage-in vertex "
                                       "buffer index")));
+}
+
+TEST(MslEmitterTests, RejectsBufferBindingBeforeItsIndexCanWrap) {
+  ModuleBuilder builder;
+  const IrType params =
+      GetShaderResultOrFail(IrType::Struct("Params", {{"x", IrType::F32()}}), IrType::F32());
+  ASSERT_THAT(builder.addUniformBuffer(0, std::numeric_limits<uint32_t>::max(), "params", params),
+              IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("buffer binding")));
+}
+
+TEST(MslEmitterTests, RejectsSamplerBeyondTheNativeArgumentTable) {
+  ModuleBuilder builder;
+  ASSERT_THAT(builder.addSampler(0, 16, "filterSampler"), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("sampler binding")));
+}
+
+TEST(MslEmitterTests, RejectsTextureBeyondTheNativeArgumentTable) {
+  ModuleBuilder builder;
+  ASSERT_THAT(builder.addTexture2d(0, 128, "sourceTexture"), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("texture binding")));
+}
+
+TEST(MslEmitterTests, AcceptsTheLastSupportedArgumentIndices) {
+  ModuleBuilder builder;
+  const IrType params =
+      GetShaderResultOrFail(IrType::Struct("Params", {{"x", IrType::F32()}}), IrType::F32());
+  ASSERT_THAT(builder.addUniformBuffer(0, 28, "params", params), IsShaderOk());
+  ASSERT_THAT(builder.addSampler(0, 15, "filterSampler"), IsShaderOk());
+  ASSERT_THAT(builder.addTexture2d(0, 127, "sourceTexture"), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), HasShaderResult());
+}
+
+TEST(MslEmitterTests, ReservesGeneratedRuntimeArrayIdentifiers) {
+  ModuleBuilder builder;
+  ASSERT_THAT(builder.addConstant("donner_msl_read", LiteralU32(1)), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("not a valid identifier")));
+}
+
+TEST(MslEmitterTests, RejectsDirectArrayValuedRuntimeElements) {
+  ModuleBuilder builder;
+  const IrType pair = GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 2), IrType::F32());
+  const IrType values = GetShaderResultOrFail(IrType::RuntimeArray(pair), IrType::F32());
+  ASSERT_THAT(builder.addReadOnlyStorageBuffer(0, 0, "values", values), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("nested array")));
+}
+
+TEST(MslEmitterTests, RejectsNestedSizedArrayDeclarations) {
+  ModuleBuilder builder;
+  const IrType pair = GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 2), IrType::F32());
+  const IrType grid = GetShaderResultOrFail(IrType::SizedArray(pair, 2), IrType::F32());
+  const IrType values =
+      GetShaderResultOrFail(IrType::Struct("Values", {{"grid", grid}}), IrType::F32());
+  ASSERT_THAT(builder.addReadOnlyStorageBuffer(0, 0, "values", values), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), IsShaderError(HasSubstr("nested array")));
+}
+
+TEST(MslEmitterTests, RuntimeStructElementsMayContainArrayMembers) {
+  ModuleBuilder builder;
+  const IrType pair = GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 2), IrType::F32());
+  const IrType element =
+      GetShaderResultOrFail(IrType::Struct("Value", {{"pair", pair}}), IrType::F32());
+  const IrType values = GetShaderResultOrFail(IrType::RuntimeArray(element), IrType::F32());
+  ASSERT_THAT(builder.addReadOnlyStorageBuffer(0, 0, "values", values), IsShaderOk());
+  auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(EmitMsl(module.result()), HasShaderResult());
 }
 
 TEST(MslEmitterTests, RejectsBindingsOutsideGroupZero) {

--- a/donner/gpu/shader/tests/testdata/color_matrix.msl
+++ b/donner/gpu/shader/tests/testdata/color_matrix.msl
@@ -12,7 +12,12 @@ struct ColorMatrixParams {
   float4 row4;
 };
 
-kernel void cs_main(uint3 gid [[thread_position_in_grid]], texture2d<float> inputTexture [[texture(0)]], texture2d<float, access::write> outputTexture [[texture(1)]], constant ColorMatrixParams& params [[buffer(3)]], device const float4* bias [[buffer(4)]]) {
+template <typename T>
+T donner_msl_read(device const T* values, uint index, uint count) {
+  return index < count ? values[index] : T{};
+}
+
+kernel void cs_main(uint3 gid [[thread_position_in_grid]], texture2d<float> inputTexture [[texture(0)]], texture2d<float, access::write> outputTexture [[texture(1)]], constant ColorMatrixParams& params [[buffer(3)]], device const float4* bias [[buffer(4)]], constant uint* donner_msl_lengths [[buffer(0)]]) {
   const uint2 extent = uint2(outputTexture.get_width(), outputTexture.get_height());
   if (((gid.x >= extent.x) || (gid.y >= extent.y))) {
     return;
@@ -20,7 +25,7 @@ kernel void cs_main(uint3 gid [[thread_position_in_grid]], texture2d<float> inpu
   const int2 coords = int2(gid.xy);
   const float4 source = inputTexture.read(uint2(coords), uint(0));
   const uint biasIndex = ((gid.x > gid.y) ? 1u : 0u);
-  const float4 biasValue = bias[biasIndex];
+  const float4 biasValue = donner_msl_read(bias, uint(biasIndex), donner_msl_lengths[3] / 16u);
   const float4 weighted = ((((params.row0 * source.x) + (params.row1 * source.y)) + (params.row2 * source.z)) + (params.row3 * source.w));
   const float4 shifted = (weighted + params.row4);
   const float4 result = saturate((shifted + biasValue));

--- a/donner/gpu/shader/tests/testdata/math_primitives.msl
+++ b/donner/gpu/shader/tests/testdata/math_primitives.msl
@@ -4,13 +4,18 @@
 
 using namespace metal;
 
-float round_half_away_from_zero(texture2d<float, access::write> outputTexture, device const float* values, float x) {
+template <typename T>
+T donner_msl_read(device const T* values, uint index, uint count) {
+  return index < count ? values[index] : T{};
+}
+
+float round_half_away_from_zero(texture2d<float, access::write> outputTexture, device const float* values, constant uint* donner_msl_lengths, float x) {
   return (sign(x) * floor((abs(x) + 0.5f)));
 }
 
-kernel void cs_main(uint3 gid [[thread_position_in_grid]], texture2d<float, access::write> outputTexture [[texture(0)]], device const float* values [[buffer(2)]]) {
-  const float x = values[gid.x];
-  const float rounded = round_half_away_from_zero(outputTexture, values, x);
+kernel void cs_main(uint3 gid [[thread_position_in_grid]], texture2d<float, access::write> outputTexture [[texture(0)]], device const float* values [[buffer(2)]], constant uint* donner_msl_lengths [[buffer(0)]]) {
+  const float x = donner_msl_read(values, uint(gid.x), donner_msl_lengths[1] / 4u);
+  const float rounded = round_half_away_from_zero(outputTexture, values, donner_msl_lengths, x);
   const float2 axes = float2((x * 0.25f), (x * -0.25f));
   const float2 axisSigns = sign(axes);
   const float2 axisFloors = floor(axes);

--- a/donner/gpu/shader/tests/testdata/solid_fill.msl
+++ b/donner/gpu/shader/tests/testdata/solid_fill.msl
@@ -57,34 +57,39 @@ struct RayCoverage {
   float wgt;
 };
 
+template <typename T>
+T donner_msl_read(device const T* values, uint index, uint count) {
+  return index < count ? values[index] : T{};
+}
+
 constant uint kNoBand = 4294967295u;
 
-float clip_mask_coverage(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2 pixel_center) {
+float clip_mask_coverage(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2 pixel_center) {
   const int2 dims = int2(uint2(clipMaskTexture.get_width(), clipMaskTexture.get_height()));
   const int2 texel = clamp(int2(round((pixel_center - float2(0.5f)))), int2(0), (dims - int2(1)));
   const float4 sample = clipMaskTexture.read(uint2(texel), uint(0));
   return clamp(((((sample.x + sample.y) + sample.z) + sample.w) * 0.25f), 0.0f, 1.0f);
 }
 
-Quadratic load_h_curve(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint index) {
+Quadratic load_h_curve(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint index) {
   const uint base = (index * 6u);
   Quadratic q;
-  q.p0 = float2(curveData[(base + 0u)], curveData[(base + 1u)]);
-  q.p1 = float2(curveData[(base + 2u)], curveData[(base + 3u)]);
-  q.p2 = float2(curveData[(base + 4u)], curveData[(base + 5u)]);
+  q.p0 = float2(donner_msl_read(curveData, uint((base + 0u)), donner_msl_lengths[2] / 4u), donner_msl_read(curveData, uint((base + 1u)), donner_msl_lengths[2] / 4u));
+  q.p1 = float2(donner_msl_read(curveData, uint((base + 2u)), donner_msl_lengths[2] / 4u), donner_msl_read(curveData, uint((base + 3u)), donner_msl_lengths[2] / 4u));
+  q.p2 = float2(donner_msl_read(curveData, uint((base + 4u)), donner_msl_lengths[2] / 4u), donner_msl_read(curveData, uint((base + 5u)), donner_msl_lengths[2] / 4u));
   return q;
 }
 
-Quadratic load_v_curve(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint index) {
+Quadratic load_v_curve(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint index) {
   const uint base = (index * 6u);
   Quadratic q;
-  q.p0 = float2(vCurveData[(base + 0u)], vCurveData[(base + 1u)]);
-  q.p1 = float2(vCurveData[(base + 2u)], vCurveData[(base + 3u)]);
-  q.p2 = float2(vCurveData[(base + 4u)], vCurveData[(base + 5u)]);
+  q.p0 = float2(donner_msl_read(vCurveData, uint((base + 0u)), donner_msl_lengths[9] / 4u), donner_msl_read(vCurveData, uint((base + 1u)), donner_msl_lengths[9] / 4u));
+  q.p1 = float2(donner_msl_read(vCurveData, uint((base + 2u)), donner_msl_lengths[9] / 4u), donner_msl_read(vCurveData, uint((base + 3u)), donner_msl_lengths[9] / 4u));
+  q.p2 = float2(donner_msl_read(vCurveData, uint((base + 4u)), donner_msl_lengths[9] / 4u), donner_msl_read(vCurveData, uint((base + 5u)), donner_msl_lengths[9] / 4u));
   return q;
 }
 
-float2 solve_quadratic(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float a, float b, float c) {
+float2 solve_quadratic(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float a, float b, float c) {
   float2 roots = float2(-1.0f, -1.0f);
   if ((abs(a) < 1e-04f)) {
     if ((abs(b) > 1e-06f)) {
@@ -112,29 +117,29 @@ float2 solve_quadratic(constant Uniforms& uniforms, device const Band* bands, de
   return roots;
 }
 
-bool owns_axis_sample(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float start, float end, float sample) {
+bool owns_axis_sample(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float start, float end, float sample) {
   const float lo = min(start, end);
   const float hi = max(start, end);
   return ((sample >= lo) && (sample < hi));
 }
 
-RayCoverage accumulateHoriz(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint slot, float2 sample, float ppemX) {
+RayCoverage accumulateHoriz(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint slot, float2 sample, float ppemX) {
   RayCoverage result;
   result.cov = 0.0f;
   result.wgt = 0.0f;
   if ((slot == kNoBand)) {
     return result;
   }
-  const Band band = bands[slot];
+  const Band band = donner_msl_read(bands, uint(slot), donner_msl_lengths[1] / 32u);
   for (uint i = 0u; (i < band.curveCount); i = (i + 1u)) {
-    const Quadratic curve = load_h_curve(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, (band.curveStart + i));
-    if ((!owns_axis_sample(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, curve.p0.y, curve.p2.y, sample.y))) {
+    const Quadratic curve = load_h_curve(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, (band.curveStart + i));
+    if ((!owns_axis_sample(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, curve.p0.y, curve.p2.y, sample.y))) {
       continue;
     }
     const float a = ((curve.p0.y - (2.0f * curve.p1.y)) + curve.p2.y);
     const float b = (2.0f * (curve.p1.y - curve.p0.y));
     const float c = (curve.p0.y - sample.y);
-    const float2 roots = solve_quadratic(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, a, b, c);
+    const float2 roots = solve_quadratic(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, a, b, c);
     for (int k = 0; (k < 2); k = (k + 1)) {
       const float t = ((k == 0) ? roots.x : roots.y);
       if ((t < 0.0f)) {
@@ -152,23 +157,23 @@ RayCoverage accumulateHoriz(constant Uniforms& uniforms, device const Band* band
   return result;
 }
 
-RayCoverage accumulateVert(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint slot, float2 sample, float ppemY) {
+RayCoverage accumulateVert(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint slot, float2 sample, float ppemY) {
   RayCoverage result;
   result.cov = 0.0f;
   result.wgt = 0.0f;
   if ((slot == kNoBand)) {
     return result;
   }
-  const Band band = vBands[slot];
+  const Band band = donner_msl_read(vBands, uint(slot), donner_msl_lengths[8] / 32u);
   for (uint i = 0u; (i < band.curveCount); i = (i + 1u)) {
-    const Quadratic curve = load_v_curve(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, (band.curveStart + i));
-    if ((!owns_axis_sample(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, curve.p0.x, curve.p2.x, sample.x))) {
+    const Quadratic curve = load_v_curve(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, (band.curveStart + i));
+    if ((!owns_axis_sample(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, curve.p0.x, curve.p2.x, sample.x))) {
       continue;
     }
     const float a = ((curve.p0.x - (2.0f * curve.p1.x)) + curve.p2.x);
     const float b = (2.0f * (curve.p1.x - curve.p0.x));
     const float c = (curve.p0.x - sample.x);
-    const float2 roots = solve_quadratic(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, a, b, c);
+    const float2 roots = solve_quadratic(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, a, b, c);
     for (int k = 0; (k < 2); k = (k + 1)) {
       const float t = ((k == 0) ? roots.x : roots.y);
       if ((t < 0.0f)) {
@@ -186,13 +191,13 @@ RayCoverage accumulateVert(constant Uniforms& uniforms, device const Band* bands
   return result;
 }
 
-float calc_coverage(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, RayCoverage h, RayCoverage v) {
+float calc_coverage(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, RayCoverage h, RayCoverage v) {
   const float blended = (abs(((h.cov * h.wgt) + (v.cov * v.wgt))) / max((h.wgt + v.wgt), (1.0f / 65536.0f)));
   const float floor_cov = min(abs(h.cov), abs(v.cov));
   return max(blended, floor_cov);
 }
 
-bool sample_in_clip_polygon(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2 pixel_pos) {
+bool sample_in_clip_polygon(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2 pixel_pos) {
   if ((uniforms.hasClipPolygon == 0u)) {
     return true;
   }
@@ -205,33 +210,33 @@ bool sample_in_clip_polygon(constant Uniforms& uniforms, device const Band* band
   return true;
 }
 
-float2 load_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint index) {
+float2 load_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint index) {
   const float4 pair = uniforms.boundingVertices[(index / 2u)];
   return (((index % 2u) != 0u) ? pair.zw : pair.xy);
 }
 
-uint fan_polygon_index(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, uint vertex_index) {
+uint fan_polygon_index(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, uint vertex_index) {
   const uint triangle = (vertex_index / 3u);
   const uint corner = (vertex_index % 3u);
   return ((corner == 0u) ? 0u : (triangle + corner));
 }
 
-float axes_determinant(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes) {
+float axes_determinant(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes) {
   return ((axes[0u].x * axes[1u].y) - (axes[0u].y * axes[1u].x));
 }
 
-bool axes_are_well_conditioned(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes) {
+bool axes_are_well_conditioned(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes) {
   const float axis_scale = (length(axes[0u]) * length(axes[1u]));
-  const float determinant = axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes);
+  const float determinant = axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes);
   return (((axis_scale > 0.0f) && (axis_scale < 1e+30f)) && (abs(determinant) > (axis_scale * 1e-06f)));
 }
 
-float2 path_from_pixel_delta(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes, float2 pixel_delta) {
-  const float determinant = axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes);
+float2 path_from_pixel_delta(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes, float2 pixel_delta) {
+  const float determinant = axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes);
   return (float2(((axes[1u].y * pixel_delta.x) - (axes[1u].x * pixel_delta.y)), (((-axes[0u].y) * pixel_delta.x) + (axes[0u].x * pixel_delta.y))) / determinant);
 }
 
-float2x2 pixel_axes(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float4x4 effective_mvp) {
+float2x2 pixel_axes(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float4x4 effective_mvp) {
   const float2 pixel_scale = float2((uniforms.viewport.x * 0.5f), ((-uniforms.viewport.y) * 0.5f));
   const float2 origin_pixel = ((effective_mvp * float4(0.0f, 0.0f, 0.0f, 1.0f)).xy * pixel_scale);
   const float2 x_axis_pixel = (((effective_mvp * float4(1.0f, 0.0f, 0.0f, 1.0f)).xy * pixel_scale) - origin_pixel);
@@ -239,13 +244,13 @@ float2x2 pixel_axes(constant Uniforms& uniforms, device const Band* bands, devic
   return float2x2(x_axis_pixel, y_axis_pixel);
 }
 
-float conservative_path_aabb_expansion(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes) {
+float conservative_path_aabb_expansion(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes) {
   const float max_component = max(max(abs(axes[0u].x), abs(axes[0u].y)), max(abs(axes[1u].x), abs(axes[1u].y)));
   if ((!((max_component > 0.0f) && (max_component < 1e+30f)))) {
     return 0.0f;
   }
   const float2x2 scaled_axes = float2x2((axes[0u] / max_component), (axes[1u] / max_component));
-  const float scaled_determinant = abs(axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, scaled_axes));
+  const float scaled_determinant = abs(axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, scaled_axes));
   if ((!(scaled_determinant > 0.0f))) {
     return 0.0f;
   }
@@ -254,15 +259,15 @@ float conservative_path_aabb_expansion(constant Uniforms& uniforms, device const
   return (((expansion > 0.0f) && (expansion < 1e+30f)) ? expansion : 0.0f);
 }
 
-bool needs_device_aabb_fallback(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes) {
-  if ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes))) {
+bool needs_device_aabb_fallback(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes) {
+  if ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes))) {
     return false;
   }
-  const float orientation = ((axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes) > 0.0f) ? 1.0f : -1.0f);
+  const float orientation = ((axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes) > 0.0f) ? 1.0f : -1.0f);
   for (uint i = 0u; (i < uniforms.boundingVertexCount); i = (i + 1u)) {
-    const float2 previous = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, (((i + uniforms.boundingVertexCount) - 1u) % uniforms.boundingVertexCount));
-    const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, i);
-    const float2 next = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, ((i + 1u) % uniforms.boundingVertexCount));
+    const float2 previous = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, (((i + uniforms.boundingVertexCount) - 1u) % uniforms.boundingVertexCount));
+    const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, i);
+    const float2 next = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, ((i + 1u) % uniforms.boundingVertexCount));
     const float2 incoming = (axes * (position - previous));
     const float2 outgoing = (axes * (next - position));
     const float incoming_length = length(incoming);
@@ -286,27 +291,27 @@ bool needs_device_aabb_fallback(constant Uniforms& uniforms, device const Band* 
   return false;
 }
 
-float2 load_device_aabb_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float4x4 effective_mvp, float2x2 axes, uint polygon_index) {
+float2 load_device_aabb_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float4x4 effective_mvp, float2x2 axes, uint polygon_index) {
   const float2 pixel_scale = float2((uniforms.viewport.x * 0.5f), ((-uniforms.viewport.y) * 0.5f));
   const float2 origin_pixel = ((effective_mvp * float4(0.0f, 0.0f, 0.0f, 1.0f)).xy * pixel_scale);
   float2 pixel_min = float2(1e+30f, 1e+30f);
   float2 pixel_max = float2(-1e+30f, -1e+30f);
   for (uint i = 0u; (i < uniforms.boundingVertexCount); i = (i + 1u)) {
-    const float2 pixel = (origin_pixel + (axes * load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, i)));
+    const float2 pixel = (origin_pixel + (axes * load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, i)));
     pixel_min = min(pixel_min, pixel);
     pixel_max = max(pixel_max, pixel);
   }
   const bool left = ((polygon_index == 0u) || (polygon_index == 3u));
   const bool top = (polygon_index < 2u);
   const float2 pixel_corner = float2((left ? (pixel_min.x - 0.5f) : (pixel_max.x + 0.5f)), (top ? (pixel_min.y - 0.5f) : (pixel_max.y + 0.5f)));
-  return path_from_pixel_delta(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes, (pixel_corner - origin_pixel));
+  return path_from_pixel_delta(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes, (pixel_corner - origin_pixel));
 }
 
-float2 load_path_aabb_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float expansion, uint polygon_index) {
+float2 load_path_aabb_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float expansion, uint polygon_index) {
   float2 path_min = float2(1e+30f, 1e+30f);
   float2 path_max = float2(-1e+30f, -1e+30f);
   for (uint i = 0u; (i < uniforms.boundingVertexCount); i = (i + 1u)) {
-    const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, i);
+    const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, i);
     path_min = min(path_min, position);
     path_max = max(path_max, position);
   }
@@ -315,45 +320,45 @@ float2 load_path_aabb_vertex(constant Uniforms& uniforms, device const Band* ban
   return float2((left ? (path_min.x - expansion) : (path_max.x + expansion)), (lower ? (path_min.y - expansion) : (path_max.y + expansion)));
 }
 
-float2 dilated_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float2x2 axes, uint polygon_index) {
+float2 dilated_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float2x2 axes, uint polygon_index) {
   const uint count = uniforms.boundingVertexCount;
   const uint previous_index = (((polygon_index + count) - 1u) % count);
   const uint next_index = ((polygon_index + 1u) % count);
-  const float2 previous = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, previous_index);
-  const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, polygon_index);
-  const float2 next = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, next_index);
-  if ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes))) {
+  const float2 previous = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, previous_index);
+  const float2 position = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, polygon_index);
+  const float2 next = load_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, next_index);
+  if ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes))) {
     return position;
   }
   const float2 previous_edge = normalize((axes * (position - previous)));
   const float2 next_edge = normalize((axes * (next - position)));
-  const float orientation = ((axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes) > 0.0f) ? 1.0f : -1.0f);
+  const float orientation = ((axes_determinant(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes) > 0.0f) ? 1.0f : -1.0f);
   const float2 previous_normal = (orientation * float2(previous_edge.y, (-previous_edge.x)));
   const float2 next_normal = (orientation * float2(next_edge.y, (-next_edge.x)));
   const float miter_denominator = (1.0f + dot(previous_normal, next_normal));
   const float2 pixel_delta = ((0.5f * (previous_normal + next_normal)) / miter_denominator);
-  return (position + path_from_pixel_delta(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes, pixel_delta));
+  return (position + path_from_pixel_delta(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes, pixel_delta));
 }
 
-float2 effective_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, float4x4 effective_mvp, uint vertex_index) {
-  const float2x2 axes = pixel_axes(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, effective_mvp);
-  const float path_aabb_expansion = conservative_path_aabb_expansion(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes);
-  const bool use_path_aabb = ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes)) && (path_aabb_expansion > 0.0f));
-  const bool use_device_aabb = needs_device_aabb_fallback(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes);
+float2 effective_bounding_vertex(constant Uniforms& uniforms, device const Band* bands, device const float* curveData, texture2d<float> patternTexture, sampler patternSampler, texture2d<float> clipMaskTexture, sampler clipMaskSampler, device const InstanceTransform* instanceTransforms, device const Band* vBands, device const float* vCurveData, device const uint* hBandGrid, device const uint* vBandGrid, constant uint* donner_msl_lengths, float4x4 effective_mvp, uint vertex_index) {
+  const float2x2 axes = pixel_axes(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, effective_mvp);
+  const float path_aabb_expansion = conservative_path_aabb_expansion(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes);
+  const bool use_path_aabb = ((!axes_are_well_conditioned(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes)) && (path_aabb_expansion > 0.0f));
+  const bool use_device_aabb = needs_device_aabb_fallback(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes);
   const bool use_aabb = (use_path_aabb || use_device_aabb);
   const uint effective_count = (use_aabb ? 4u : uniforms.boundingVertexCount);
   const uint triangle = (vertex_index / 3u);
   uint polygon_index = 0u;
   if ((triangle < (effective_count - 2u))) {
-    polygon_index = fan_polygon_index(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, vertex_index);
+    polygon_index = fan_polygon_index(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, vertex_index);
   }
   if (use_path_aabb) {
-    return load_path_aabb_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, path_aabb_expansion, polygon_index);
+    return load_path_aabb_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, path_aabb_expansion, polygon_index);
   }
   if (use_device_aabb) {
-    return load_device_aabb_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, effective_mvp, axes, polygon_index);
+    return load_device_aabb_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, effective_mvp, axes, polygon_index);
   }
-  return dilated_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, axes, polygon_index);
+  return dilated_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, axes, polygon_index);
 }
 
 
@@ -362,11 +367,11 @@ struct vs_main_Output {
   float2 sample_pos [[user(locn0)]];
 };
 
-vertex vs_main_Output vs_main(uint vertex_index [[vertex_id]], uint instance_index [[instance_id]], constant Uniforms& uniforms [[buffer(1)]], device const Band* bands [[buffer(2)]], device const float* curveData [[buffer(3)]], texture2d<float> patternTexture [[texture(3)]], sampler patternSampler [[sampler(4)]], texture2d<float> clipMaskTexture [[texture(5)]], sampler clipMaskSampler [[sampler(6)]], device const InstanceTransform* instanceTransforms [[buffer(8)]], device const Band* vBands [[buffer(9)]], device const float* vCurveData [[buffer(10)]], device const uint* hBandGrid [[buffer(11)]], device const uint* vBandGrid [[buffer(12)]]) {
-  const InstanceTransform xf = instanceTransforms[instance_index];
+vertex vs_main_Output vs_main(uint vertex_index [[vertex_id]], uint instance_index [[instance_id]], constant Uniforms& uniforms [[buffer(1)]], device const Band* bands [[buffer(2)]], device const float* curveData [[buffer(3)]], texture2d<float> patternTexture [[texture(3)]], sampler patternSampler [[sampler(4)]], texture2d<float> clipMaskTexture [[texture(5)]], sampler clipMaskSampler [[sampler(6)]], device const InstanceTransform* instanceTransforms [[buffer(8)]], device const Band* vBands [[buffer(9)]], device const float* vCurveData [[buffer(10)]], device const uint* hBandGrid [[buffer(11)]], device const uint* vBandGrid [[buffer(12)]], constant uint* donner_msl_lengths [[buffer(0)]]) {
+  const InstanceTransform xf = donner_msl_read(instanceTransforms, uint(instance_index), donner_msl_lengths[7] / 32u);
   const float4x4 instance_mat = float4x4(float4(xf.row0.x, xf.row1.x, 0.0f, 0.0f), float4(xf.row0.y, xf.row1.y, 0.0f, 0.0f), float4(0.0f, 0.0f, 1.0f, 0.0f), float4(xf.row0.z, xf.row1.z, 0.0f, 1.0f));
   const float4x4 effective_mvp = (uniforms.mvp * instance_mat);
-  const float2 dilated = effective_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, effective_mvp, vertex_index);
+  const float2 dilated = effective_bounding_vertex(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, effective_mvp, vertex_index);
   return vs_main_Output{(effective_mvp * float4(dilated, 0.0f, 1.0f)), dilated};
 }
 
@@ -379,7 +384,7 @@ struct fs_main_Output {
   float4 color [[color(0)]];
 };
 
-fragment fs_main_Output fs_main(fs_main_Input in [[stage_in]], constant Uniforms& uniforms [[buffer(1)]], device const Band* bands [[buffer(2)]], device const float* curveData [[buffer(3)]], texture2d<float> patternTexture [[texture(3)]], sampler patternSampler [[sampler(4)]], texture2d<float> clipMaskTexture [[texture(5)]], sampler clipMaskSampler [[sampler(6)]], device const InstanceTransform* instanceTransforms [[buffer(8)]], device const Band* vBands [[buffer(9)]], device const float* vCurveData [[buffer(10)]], device const uint* hBandGrid [[buffer(11)]], device const uint* vBandGrid [[buffer(12)]]) {
+fragment fs_main_Output fs_main(fs_main_Input in [[stage_in]], constant Uniforms& uniforms [[buffer(1)]], device const Band* bands [[buffer(2)]], device const float* curveData [[buffer(3)]], texture2d<float> patternTexture [[texture(3)]], sampler patternSampler [[sampler(4)]], texture2d<float> clipMaskTexture [[texture(5)]], sampler clipMaskSampler [[sampler(6)]], device const InstanceTransform* instanceTransforms [[buffer(8)]], device const Band* vBands [[buffer(9)]], device const float* vCurveData [[buffer(10)]], device const uint* hBandGrid [[buffer(11)]], device const uint* vBandGrid [[buffer(12)]], constant uint* donner_msl_lengths [[buffer(0)]]) {
   const float4 clip_pos = in.clip_pos;
   const float2 sample_pos = in.sample_pos;
   const float2 pixel_center = clip_pos.xy;
@@ -389,29 +394,29 @@ fragment fs_main_Output fs_main(fs_main_Input in [[stage_in]], constant Uniforms
   hCov.wgt = 0.0f;
   if ((uniforms.hBandCount > 0u)) {
     const int hi = clamp(int(((sample_pos.y - uniforms.yBase) / uniforms.hStride)), 0, (int(uniforms.hBandCount) - 1));
-    const uint slot = hBandGrid[hi];
-    hCov = accumulateHoriz(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, slot, sample_pos, ppem.x);
+    const uint slot = donner_msl_read(hBandGrid, uint(hi), donner_msl_lengths[10] / 4u);
+    hCov = accumulateHoriz(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, slot, sample_pos, ppem.x);
   }
   RayCoverage vCov;
   vCov.cov = 0.0f;
   vCov.wgt = 0.0f;
   if ((uniforms.vBandCount > 0u)) {
     const int vj = clamp(int(((sample_pos.x - uniforms.xBase) / uniforms.vStride)), 0, (int(uniforms.vBandCount) - 1));
-    const uint slot = vBandGrid[vj];
-    vCov = accumulateVert(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, slot, sample_pos, ppem.y);
+    const uint slot = donner_msl_read(vBandGrid, uint(vj), donner_msl_lengths[11] / 4u);
+    vCov = accumulateVert(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, slot, sample_pos, ppem.y);
   }
-  float coverage = calc_coverage(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, hCov, vCov);
+  float coverage = calc_coverage(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, hCov, vCov);
   if ((uniforms.fillRule == 0u)) {
     coverage = saturate(coverage);
   } else {
     coverage = (1.0f - abs((1.0f - (fract((coverage * 0.5f)) * 2.0f))));
   }
-  if ((!sample_in_clip_polygon(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, pixel_center))) {
+  if ((!sample_in_clip_polygon(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, pixel_center))) {
     coverage = 0.0f;
   }
   float clipCoverage = 1.0f;
   if ((uniforms.hasClipMask != 0u)) {
-    clipCoverage = clip_mask_coverage(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, pixel_center);
+    clipCoverage = clip_mask_coverage(uniforms, bands, curveData, patternTexture, patternSampler, clipMaskTexture, clipMaskSampler, instanceTransforms, vBands, vCurveData, hBandGrid, vBandGrid, donner_msl_lengths, pixel_center);
   }
   coverage = (coverage * clipCoverage);
   if ((coverage <= 0.0f)) {


### PR DESCRIPTION
Generated Metal shaders previously indexed runtime storage arrays against the containing allocation rather than the binding's declared byte range. Pass exact binding lengths through a reserved native argument slot and lower generated runtime-array reads through one checked helper that evaluates each index once and returns a zero value outside the declared range.

Reject buffer, sampler, and texture indices beyond Metal's native argument tables before encoding. Reject generated nested-array forms the current MSL type writer cannot represent, reserve helper identifiers, preserve raw-MSL and absent-metadata behavior, and avoid repeated length-table uploads when the same group is rebound within a pass.

The length table is bound from the shader's needs, not the layout's types. The emitter declares and dereferences the table in every entry point of a module holding any runtime-array binding, which follows from the IR; a bind group layout's binding types and stage visibility are a separate fact and can be narrower. Uploading only for layout entries typed as read-only storage buffers left the generated code dereferencing a nil pointer wherever the two disagreed, which is the unbounded read this change exists to prevent. It now goes to every stage the active encoder has, and the per-encoder cache is keyed on the group's slot and generation rather than a record address. A layout that disagrees is rejected at pipeline creation once interface metadata is supplied, so the regression covers the case that is still reachable: a module with metadata omitted, which this backend documents as supported.

The backend remains explicitly group-0-only; fixed-size array and vector indexing and raw MSL are outside this generated-runtime-array fix. This is the top layer and depends on the three below it.

Verification: a full run of the GPU, shader, and Metal test trees on an Apple Silicon Mac at this revision gives 16 passing targets, 7 skipped for the absent Vulkan driver, and no failures, with the Metal suites under Metal API and shader validation and ordinary MSL goldens updated. Formatting, BUILD formatting, and lint pass.
