### PR TITLE
Keep GPU runtime sources out of shader generator builds

### DIFF
--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -11,10 +11,20 @@ load("//build_defs:package.bzl", "donner_package")
 # Geode path until each family is migrated.
 
 donner_cc_library(
+    name = "descriptors",
+    srcs = ["Descriptors.cc"],
+    hdrs = [
+        "Descriptors.h",
+        "Handles.h",
+    ],
+    visibility = donner_internal_visibility(),
+    deps = ["//donner/base"],
+)
+
+donner_cc_library(
     name = "gpu",
     srcs = [
         "CommandEncoder.cc",
-        "Descriptors.cc",
         "Device.cc",
         "GpuError.cc",
     ],
@@ -22,15 +32,14 @@ donner_cc_library(
         "CheckedArithmetic.h",
         "CommandEncoder.h",
         "Commands.h",
-        "Descriptors.h",
         "Device.h",
         "GpuError.h",
         "GpuLimits.h",
         "GpuResult.h",
-        "Handles.h",
     ],
     visibility = donner_internal_visibility(),
     deps = [
+        ":descriptors",
         "//donner/base",
     ],
 )

--- a/donner/gpu/shader/BUILD.bazel
+++ b/donner/gpu/shader/BUILD.bazel
@@ -84,7 +84,7 @@ donner_cc_library(
     visibility = donner_internal_visibility(),
     deps = [
         ":shader",
-        "//donner/gpu",
+        "//donner/gpu:descriptors",
     ],
 )
 


### PR DESCRIPTION
Keep the shader generator from compiling the GPU command encoder, device implementation, and runtime errors when it only needs descriptor types. Move descriptors and handles into a small library and retain that library transitively for existing GPU consumers.

The generator's compile action count drops from 26 to 23. GPU validation and allocation tests remain in place.

Validation: `bazel test //...` passed with 487 test targets successful and 31 configuration-incompatible targets skipped, including successful browser smoke and presentation checks. CMake generation/validation passed. The paired action graph confirms all three runtime translation units are absent from the generator.
