### PR TITLE
Preserve completion gaps between shared renderer frames

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1537,6 +1537,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (frameGpuEncoder == nullptr) {
       return true;
     }
+    // A sibling renderer may have replaced the shared adapter's host encoder.
+    device->adapterDevice().setHostCommandEncoder(frameCommandEncoder.get());
     gpu::Result<gpu::CommandBuffer> commandBuffer = frameGpuEncoder->finish();
     if (!commandBuffer.hasError()) {
       gpu::Result<uint64_t> submitted =

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1559,8 +1559,20 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   void closeFrameGpuEncoderAfterSubmit() {
     frameGpuEncoders.clear();
     frameGpuEncoder = nullptr;
-    device->adapterDevice().notifyHostSubmitted();
-    device->adapterDevice().clearHostCommandEncoder();
+    device->adapterDevice().notifyHostSubmitted(frameCommandEncoder.get());
+    if (device->adapterDevice().hostCommandEncoderIs(frameCommandEncoder.get())) {
+      device->adapterDevice().clearHostCommandEncoder();
+    }
+  }
+
+  /// Abandon this frame without completing any other renderer's recorded work.
+  void discardFrameGpuEncoder() {
+    if (device && frameCommandEncoder) {
+      device->adapterDevice().notifyHostDiscarded(frameCommandEncoder.get());
+    }
+    frameGpuEncoders.clear();
+    frameGpuEncoder = nullptr;
+    frameCommandEncoder.reset();
   }
 
   std::unique_ptr<geode::GeoEncoder> encoder;
@@ -4432,6 +4444,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     paint = PaintParams();
     encoder.reset();
     frameFinishedEncoders.clear();
+    discardFrameGpuEncoder();
     geometryDebugEdges.clear();
     rejectedFilterDepth = 0;
     if (frameResourceScopeDepth == 0) {
@@ -4568,8 +4581,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
 
   ~Impl() {
     encoder.reset();
-    frameCommandEncoder.reset();
     frameFinishedEncoders.clear();
+    discardFrameGpuEncoder();
 
     if (device && device->device()) {
       // Bounded drain before releasing frame resources; skips (and stays

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -403,13 +403,7 @@ struct FilterResourceArena {
       if (cmd) {
         device_.queue().submit(1, &cmd.get());
         device_.countSubmit();
-        if (replayingIntoThisEncoder) {
-          // The runtime holds completion of anything it replayed into this encoder until the
-          // submit of the buffer finished from it is reported, and this is that submit. Reporting
-          // it anywhere later would either retire the replayed work before it reached the queue or
-          // strand it as never complete.
-          device_.adapterDevice().notifyHostSubmitted();
-        }
+        device_.adapterDevice().notifyHostSubmitted(encoderSlot_->get());
       } else {
         // Nothing recorded into this encoder can reach the queue now, so the frame's output is
         // undefined and the pending serials must not be reported as submitted. Declaring the loss

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -1504,59 +1504,76 @@ bool GeodeWgpuAdapterDevice::hasHostCommandEncoder() const {
   return static_cast<bool>(hostCommandEncoder_);
 }
 
-void GeodeWgpuAdapterDevice::notifyHostSubmitted() {
-  if (hostPendingSerial_ == 0) {
-    return;
+void GeodeWgpuAdapterDevice::CompletionState::record(WGPUCommandEncoder host, uint64_t serial) {
+  std::scoped_lock lock(mutex);
+  if (host != nullptr) {
+    for (Pending& range : pending) {
+      if (range.host == host) {
+        range.lastSerial = serial;
+        return;
+      }
+    }
   }
-  // Anything a standalone submit queued while this frame was pending is older than the frame's
-  // own submit on the same queue, so it has certainly finished by the time this one does. Its
-  // completion was capped below the frame's unqueued serials and reported less than its own
-  // serial - possibly nothing at all - so the flush is what finally covers it.
-  const uint64_t serial = std::max(hostPendingSerial_, standaloneWhilePendingSerial_);
-  hostPendingSerial_ = 0;
-  hostFirstPendingSerial_ = 0;
-  standaloneWhilePendingSerial_ = 0;
-  advanceCompletedSerialWhenQueueDrains(serial);
+  pending.push_back(Pending{host, serial, serial});
 }
 
-void GeodeWgpuAdapterDevice::advanceCompletedSerialWhenQueueDrains(uint64_t serial) {
-  // Completion must stay below the first serial still waiting on the host's submit: those are
-  // recorded but not queued, and `completedSerial` is read by the deferred-destroy sweep and
-  // every wait, so reporting past them retires resources the open frame still uses. Capping at
-  // report time is free: the callback it would otherwise run in may land after the frame's flush.
-  const uint64_t cappedSerial =
-      hostFirstPendingSerial_ == 0 ? serial : std::min(serial, hostFirstPendingSerial_ - 1);
-  if (cappedSerial == 0) {
+uint64_t GeodeWgpuAdapterDevice::CompletionState::closeHost(WGPUCommandEncoder host) {
+  std::scoped_lock lock(mutex);
+  if (host != nullptr) {
+    for (Pending& range : pending) {
+      if (range.host == host) {
+        range.host = nullptr;
+        return range.firstSerial;
+      }
+    }
+  }
+  return 0;
+}
+
+void GeodeWgpuAdapterDevice::CompletionState::complete(uint64_t ticket) {
+  std::scoped_lock lock(mutex);
+  const auto range = std::find_if(pending.begin(), pending.end(), [ticket](const Pending& entry) {
+    return entry.firstSerial == ticket && entry.host == nullptr;
+  });
+  if (range == pending.end()) {
     return;
   }
+  completedHighWater = std::max(completedHighWater, range->lastSerial);
+  *range = pending.back();
+  pending.pop_back();
+  uint64_t prefix = completedHighWater;
+  for (const Pending& unfinished : pending) {
+    prefix = std::min(prefix, unfinished.firstSerial - 1);
+  }
+  completedSerial.store(prefix, std::memory_order_release);
+}
 
-  // Callback-mode handling (wgpu-native vs emdawnwebgpu) is centralized in
-  // notifyWhenSubmittedWorkDone; waitForSerial's poll loop drives delivery.
+void GeodeWgpuAdapterDevice::notifyHostSubmitted(wgpu::CommandEncoder encoder) {
+  const uint64_t ticket = completionState_->closeHost(static_cast<WGPUCommandEncoder>(encoder));
+  if (ticket != 0) {
+    completeWhenQueueDrains(ticket);
+  }
+}
+
+void GeodeWgpuAdapterDevice::notifyHostDiscarded(wgpu::CommandEncoder encoder) {
+  // A discarded range still waits for older queue work before its resources may retire.
+  notifyHostSubmitted(encoder);
+  if (hostCommandEncoderIs(encoder)) {
+    clearHostCommandEncoder();
+  }
+}
+
+void GeodeWgpuAdapterDevice::completeWhenQueueDrains(uint64_t ticket) {
   struct WorkDoneState {
-    std::shared_ptr<CompletionState> completion;  //!< Shared completion counter.
-    uint64_t serial = 0;                          //!< Serial this callback completes.
+    std::shared_ptr<CompletionState> completion;  //!< State independent of adapter lifetime.
+    uint64_t ticket = 0;                          //!< Unique range completed by this callback.
 
-    /// Monotonic max: callbacks may complete out of order across submissions.
-    void onWorkDone() {
-      uint64_t previous = completion->completedSerial.load(std::memory_order_relaxed);
-      while (previous < serial &&
-             !completion->completedSerial.compare_exchange_weak(
-                 previous, serial, std::memory_order_release, std::memory_order_relaxed)) {}
-    }
+    void onWorkDone() { completion->complete(ticket); }
   };
   auto workDoneState = std::make_shared<WorkDoneState>();
   workDoneState->completion = completionState_;
-  workDoneState->serial = cappedSerial;
+  workDoneState->ticket = ticket;
   notifyWhenSubmittedWorkDone(geodeDevice_.queue(), workDoneState);
-}
-
-void GeodeWgpuAdapterDevice::recordPendingHostSerial(uint64_t submissionSerial) {
-  // The oldest of these is the cap every completion respects, so it is remembered separately
-  // from the newest, which is what the eventual flush reports.
-  if (hostFirstPendingSerial_ == 0) {
-    hostFirstPendingSerial_ = submissionSerial;
-  }
-  hostPendingSerial_ = std::max(hostPendingSerial_, submissionSerial);
 }
 
 bool GeodeWgpuAdapterDevice::replaysIntoHostEncoder() const {
@@ -1571,11 +1588,6 @@ gpu::Result<uint64_t> GeodeWgpuAdapterDevice::submitStandalone(gpu::CommandBuffe
   gpu::Result<uint64_t> serial = submit(std::move(commands));
   bypassHostEncoderForSubmit_ = previous;
 
-  // Remember it so the host's eventual flush reports it. Its own completion cannot: it is capped
-  // below the frame's unqueued serials, which are lower than this one.
-  if (serial.hasResult() && hostPendingSerial_ != 0) {
-    standaloneWhilePendingSerial_ = std::max(standaloneWhilePendingSerial_, serial.result());
-  }
   return serial;
 }
 
@@ -1630,7 +1642,7 @@ gpu::Status GeodeWgpuAdapterDevice::onSubmit(uint64_t submissionSerial,
     // The host owns finish + submit for its encoder. Hold the serial back until it reports that
     // submit: reporting completion before the work is even submitted would be a lie the deferred
     // destruction and wait paths both act on.
-    recordPendingHostSerial(submissionSerial);
+    completionState_->record(static_cast<WGPUCommandEncoder>(state.encoder), submissionSerial);
     return OkStatus();
   }
 
@@ -1638,10 +1650,11 @@ gpu::Status GeodeWgpuAdapterDevice::onSubmit(uint64_t submissionSerial,
   if (!commandBuffer) {
     return GpuError{GpuErrorType::InvalidState, "wgpu command buffer finish failed"};
   }
+  completionState_->record(nullptr, submissionSerial);
   geodeDevice_.queue().submit(1, &commandBuffer.get());
   geodeDevice_.countSubmit();
 
-  advanceCompletedSerialWhenQueueDrains(submissionSerial);
+  completeWhenQueueDrains(submissionSerial);
   return OkStatus();
 }
 

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -10,11 +10,13 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <string_view>
 #include <vector>
 #include <webgpu/webgpu.hpp>
 
+#include "donner/base/SmallVector.h"
 #include "donner/gpu/Device.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
@@ -37,7 +39,7 @@ class GeodeDevice;
  * pipelines).
  *
  * Thread affinity matches \c donner::gpu::Device: single-threaded use. Completion callbacks
- * touch only the atomic completed-serial counter.
+ * touch only shared completion state, guarded independently of the adapter lifetime.
  */
 class GeodeWgpuAdapterDevice final : public gpu::Device {
 public:
@@ -190,12 +192,21 @@ public:
   bool hostCommandEncoderIs(const wgpu::CommandEncoder& encoder) const;
 
   /**
-   * Reports that the host submitted a command buffer carrying every stream replayed since the
-   * previous report, so their completion can now be observed. Advances \ref completedSerial to
-   * the highest replayed serial once the queue drains, exactly as an adapter-owned submit does.
-   * A no-op when nothing has been replayed since the last report.
+   * Reports the queue submission of every stream replayed into \p encoder. Its serials remain
+   * incomplete until that submission's callback runs, and completion cannot pass another host's
+   * unfinished serials. A no-op when this encoder has no replayed streams awaiting submission.
+   *
+   * @param encoder Host encoder whose finished command buffer was submitted.
    */
-  void notifyHostSubmitted();
+  void notifyHostSubmitted(wgpu::CommandEncoder encoder);
+
+  /**
+   * Discards every unsubmitted stream replayed into \p encoder. Retires those serials only once
+   * earlier queued work has drained. The caller must not subsequently submit the discarded work.
+   *
+   * @param encoder Host encoder being abandoned before submission.
+   */
+  void notifyHostDiscarded(wgpu::CommandEncoder encoder);
 
   /**
    * Submits \p commands straight to the queue, even while a host command encoder is installed.
@@ -290,9 +301,31 @@ private:
     wgpu::Texture texture;                         //!< Borrowed alias; null when the slot is dead.
   };
 
-  /// State shared with queue work-done callbacks.
+  friend struct GeodeWgpuAdapterDeviceTestAccess;
+
+  /// State retained by callbacks after their adapter may have been destroyed.
   struct CompletionState {
-    std::atomic<uint64_t> completedSerial{0};  //!< Highest completed submission serial.
+    /// One host's interleaved logical serials, or one standalone submission.
+    struct Pending {
+      WGPUCommandEncoder host = nullptr;  //!< Non-null only until the host submits or discards.
+      uint64_t firstSerial = 0;           //!< Unique ticket retained by its completion callback.
+      uint64_t lastSerial = 0;            //!< Highest serial in this submission.
+    };
+
+    /// Records a logical submission; a null host denotes a standalone queue submission.
+    /// @param host Host identity, or null for standalone work. @param serial Logical serial.
+    void record(WGPUCommandEncoder host, uint64_t serial);
+    /// Freezes a host range for its callback, returning its ticket or zero if no work is pending.
+    /// @param host Host whose work was queued or discarded.
+    uint64_t closeHost(WGPUCommandEncoder host);
+    /// Completes exactly one queued range and publishes the contiguous completed prefix.
+    /// @param ticket Unique first serial of the completed range.
+    void complete(uint64_t ticket);
+
+    std::atomic<uint64_t> completedSerial{0};  //!< Highest serial with no unfinished predecessor.
+    std::mutex mutex;                 //!< Protects ranges and their completed high-water mark.
+    SmallVector<Pending, 4> pending;  //!< Includes queued ranges until their callbacks run.
+    uint64_t completedHighWater = 0;  //!< Highest serial seen by a completed callback.
   };
 
   /// Mutable state threaded through the encoding of one command stream.
@@ -383,9 +416,9 @@ private:
   /// @param resourceName Resource type name. @param slotIndex Slot to clear.
   bool clearPipelineSlot(std::string_view resourceName, uint32_t slotIndex);
 
-  /// Attaches the queue work-done callback that advances \ref completedSerial to \p serial.
-  /// @param serial Submission serial the callback completes.
-  void advanceCompletedSerialWhenQueueDrains(uint64_t serial);
+  /// Attaches a queue callback retaining only shared completion state and a unique ticket.
+  /// @param ticket First serial of the queued or discarded range.
+  void completeWhenQueueDrains(uint64_t ticket);
 
   GeodeDevice& geodeDevice_;
 
@@ -398,20 +431,6 @@ private:
   /// Whether the next submit replays into the host encoder rather than reaching the queue: a
   /// host encoder is installed and this submit is not a standalone one.
   bool replaysIntoHostEncoder() const;
-
-  /// Records \p submissionSerial as replayed into the host encoder but not yet queued.
-  /// @param submissionSerial Serial of the stream just replayed.
-  void recordPendingHostSerial(uint64_t submissionSerial);
-  /// Highest serial replayed into \ref hostCommandEncoder_ since the last
-  /// \ref notifyHostSubmitted; 0 when nothing is awaiting the host's submit.
-  uint64_t hostPendingSerial_ = 0;
-  /// Oldest serial replayed into \ref hostCommandEncoder_ since the last \ref
-  /// notifyHostSubmitted, or 0 when nothing is awaiting that submit. A completion may not report
-  /// past this, because everything from here up has been recorded but not queued.
-  uint64_t hostFirstPendingSerial_ = 0;
-  /// Highest serial a standalone submit queued while a host frame was pending, or 0. Those
-  /// completions report capped, so the frame's flush is what finally covers them.
-  uint64_t standaloneWhilePendingSerial_ = 0;
 
   /// State of one pending or completed host mapping.
   ///

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -191,6 +191,25 @@ ComputeScene MakeComputeScene(GeodeWgpuAdapterDevice& adapter, const char* label
   return scene;
 }
 
+/// Replays a real clear into a selected host; its resources retire through the returned serial.
+uint64_t ReplayHostClear(GeodeWgpuAdapterDevice& adapter, wgpu::CommandEncoder host) {
+  adapter.setHostCommandEncoder(host);
+  const gpu::Texture target = gpu::GetResultOrFail(adapter.createTexture(
+      gpu::TextureDescriptor{"hostClear", gpu::Extent2d{4, 4}, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::RenderAttachment}));
+  const gpu::TextureView view = gpu::GetResultOrFail(
+      adapter.createTextureView(target, gpu::TextureViewDescriptor{"hostClearView"}));
+  std::unique_ptr<gpu::CommandEncoder> encoder =
+      gpu::GetResultOrFail(adapter.createCommandEncoder());
+  gpu::RenderPassEncoder* pass =
+      gpu::GetResultOrFail(encoder->beginRenderPass(gpu::RenderPassDescriptor{
+          "hostClear",
+          {gpu::RenderPassColorAttachment{
+              view, gpu::LoadOp::Clear, gpu::StoreOp::Store, {0, 0, 1, 1}}}}));
+  EXPECT_THAT(pass->end(), gpu::IsOk());
+  return gpu::GetResultOrFail(adapter.submit(gpu::GetResultOrFail(encoder->finish())));
+}
+
 class GeodeWgpuAdapterDeviceTests : public testing::Test {
 protected:
   void SetUp() override {
@@ -974,6 +993,49 @@ TEST_F(GeodeWgpuAdapterDeviceTests, AStandaloneSubmitDoesNotCompleteTheOpenFrame
       << "after the frame's submit everything must complete; completedSerial="
       << adapter_->completedSerial();
   EXPECT_THAT(adapter_->completedSerial(), Ge(standaloneSerial));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, SubmittingOneHostCannotCompleteAnotherUnsubmittedHost) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> parent(geodeDevice_->device().createCommandEncoder());
+  ScopedWgpuHandle<wgpu::CommandEncoder> sibling(geodeDevice_->device().createCommandEncoder());
+  const uint64_t parentSerial = ReplayHostClear(*adapter_, parent.get());
+  const uint64_t siblingSerial = ReplayHostClear(*adapter_, sibling.get());
+  ScopedWgpuHandle<wgpu::CommandBuffer> siblingCommands(sibling.get().finish());
+  geodeDevice_->queue().submit(1, &siblingCommands.get());
+  adapter_->notifyHostSubmitted();
+  ASSERT_THAT(geodeDevice_->waitForQueueIdle(std::chrono::seconds(2)),
+              testing::Eq(GpuWaitResult::Complete));
+  EXPECT_THAT(adapter_->completedSerial(), Lt(parentSerial));
+
+  adapter_->setHostCommandEncoder(parent.get());
+  ScopedWgpuHandle<wgpu::CommandBuffer> parentCommands(parent.get().finish());
+  geodeDevice_->queue().submit(1, &parentCommands.get());
+  adapter_->notifyHostSubmitted();
+  adapter_->clearHostCommandEncoder();
+  EXPECT_THAT(adapter_->waitForSerial(siblingSerial, 2.0), testing::IsTrue());
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, InterleavedHostSerialsCompleteOnlyThroughTheFirstGap) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> parent(geodeDevice_->device().createCommandEncoder());
+  ScopedWgpuHandle<wgpu::CommandEncoder> sibling(geodeDevice_->device().createCommandEncoder());
+  const uint64_t parentFirst = ReplayHostClear(*adapter_, parent.get());
+  const uint64_t siblingSerial = ReplayHostClear(*adapter_, sibling.get());
+  const uint64_t parentLast = ReplayHostClear(*adapter_, parent.get());
+  ASSERT_THAT(siblingSerial, testing::Eq(parentFirst + 1));
+  ASSERT_THAT(parentLast, testing::Eq(siblingSerial + 1));
+  ScopedWgpuHandle<wgpu::CommandBuffer> parentCommands(parent.get().finish());
+  geodeDevice_->queue().submit(1, &parentCommands.get());
+  adapter_->notifyHostSubmitted();
+  ASSERT_THAT(geodeDevice_->waitForQueueIdle(std::chrono::seconds(2)),
+              testing::Eq(GpuWaitResult::Complete));
+  EXPECT_THAT(adapter_->completedSerial(), testing::Eq(parentFirst));
+
+  adapter_->setHostCommandEncoder(sibling.get());
+  ScopedWgpuHandle<wgpu::CommandBuffer> siblingCommands(sibling.get().finish());
+  geodeDevice_->queue().submit(1, &siblingCommands.get());
+  adapter_->notifyHostSubmitted();
+  adapter_->clearHostCommandEncoder();
+  EXPECT_THAT(adapter_->waitForSerial(parentLast, 2.0), testing::IsTrue());
 }
 
 /// The adapter presents to a Metal layer; the other platform surfaces are still created by the

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -30,6 +30,12 @@ using testing::Lt;
 using testing::Not;
 
 namespace donner::geode {
+
+/// Exposes only the real completion state for deterministic callback-order tests.
+struct GeodeWgpuAdapterDeviceTestAccess {
+  using CompletionState = GeodeWgpuAdapterDevice::CompletionState;
+};
+
 namespace {
 
 /// Minimal compute WGSL writing a constant color into a write-only storage texture, matching the
@@ -192,6 +198,8 @@ ComputeScene MakeComputeScene(GeodeWgpuAdapterDevice& adapter, const char* label
 }
 
 /// Replays a real clear into a selected host; its resources retire through the returned serial.
+/// @param adapter Device recording the clear.
+/// @param host Encoder receiving the clear.
 uint64_t ReplayHostClear(GeodeWgpuAdapterDevice& adapter, wgpu::CommandEncoder host) {
   adapter.setHostCommandEncoder(host);
   const gpu::Texture target = gpu::GetResultOrFail(adapter.createTexture(
@@ -435,7 +443,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, HostEncoderReplayInterleavesInOneBufferAndDe
     ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
     geodeDevice_->queue().submit(1, &hostCommands.get());
   }
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(hostEncoder.get());
   adapter_->clearHostCommandEncoder();
 
   ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
@@ -556,7 +564,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, SubRectangleCopyHonorsBothOriginsWhenReplaye
     ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
     geodeDevice_->queue().submit(1, &hostCommands.get());
   }
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(hostEncoder.get());
   adapter_->clearHostCommandEncoder();
 
   ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
@@ -687,7 +695,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, HostEncoderReplaysAComputePassAheadOfHostRec
     ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
     geodeDevice_->queue().submit(1, &hostCommands.get());
   }
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(hostEncoder.get());
   adapter_->clearHostCommandEncoder();
 
   ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
@@ -986,7 +994,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, AStandaloneSubmitDoesNotCompleteTheOpenFrame
     ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
     geodeDevice_->queue().submit(1, &hostCommands.get());
   }
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(hostEncoder.get());
   adapter_->clearHostCommandEncoder();
 
   ASSERT_TRUE(adapter_->waitForSerial(standaloneSerial, /*timeoutSeconds=*/30.0))
@@ -1002,7 +1010,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, SubmittingOneHostCannotCompleteAnotherUnsubm
   const uint64_t siblingSerial = ReplayHostClear(*adapter_, sibling.get());
   ScopedWgpuHandle<wgpu::CommandBuffer> siblingCommands(sibling.get().finish());
   geodeDevice_->queue().submit(1, &siblingCommands.get());
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(sibling.get());
   ASSERT_THAT(geodeDevice_->waitForQueueIdle(std::chrono::seconds(2)),
               testing::Eq(GpuWaitResult::Complete));
   EXPECT_THAT(adapter_->completedSerial(), Lt(parentSerial));
@@ -1010,7 +1018,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, SubmittingOneHostCannotCompleteAnotherUnsubm
   adapter_->setHostCommandEncoder(parent.get());
   ScopedWgpuHandle<wgpu::CommandBuffer> parentCommands(parent.get().finish());
   geodeDevice_->queue().submit(1, &parentCommands.get());
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(parent.get());
   adapter_->clearHostCommandEncoder();
   EXPECT_THAT(adapter_->waitForSerial(siblingSerial, 2.0), testing::IsTrue());
 }
@@ -1025,7 +1033,7 @@ TEST_F(GeodeWgpuAdapterDeviceTests, InterleavedHostSerialsCompleteOnlyThroughThe
   ASSERT_THAT(parentLast, testing::Eq(siblingSerial + 1));
   ScopedWgpuHandle<wgpu::CommandBuffer> parentCommands(parent.get().finish());
   geodeDevice_->queue().submit(1, &parentCommands.get());
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(parent.get());
   ASSERT_THAT(geodeDevice_->waitForQueueIdle(std::chrono::seconds(2)),
               testing::Eq(GpuWaitResult::Complete));
   EXPECT_THAT(adapter_->completedSerial(), testing::Eq(parentFirst));
@@ -1033,9 +1041,77 @@ TEST_F(GeodeWgpuAdapterDeviceTests, InterleavedHostSerialsCompleteOnlyThroughThe
   adapter_->setHostCommandEncoder(sibling.get());
   ScopedWgpuHandle<wgpu::CommandBuffer> siblingCommands(sibling.get().finish());
   geodeDevice_->queue().submit(1, &siblingCommands.get());
-  adapter_->notifyHostSubmitted();
+  adapter_->notifyHostSubmitted(sibling.get());
   adapter_->clearHostCommandEncoder();
   EXPECT_THAT(adapter_->waitForSerial(parentLast, 2.0), testing::IsTrue());
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, ACallbackCannotPassAnEarlierSerialAlreadyQueuedByAnotherHost) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> parent(geodeDevice_->device().createCommandEncoder());
+  ScopedWgpuHandle<wgpu::CommandEncoder> sibling(geodeDevice_->device().createCommandEncoder());
+  GeodeWgpuAdapterDeviceTestAccess::CompletionState completion;
+  completion.record(parent.get(), 1);
+  completion.record(sibling.get(), 2);
+  completion.record(parent.get(), 3);
+  const uint64_t parentTicket = completion.closeHost(parent.get());
+  const uint64_t siblingTicket = completion.closeHost(sibling.get());
+  ASSERT_THAT(parentTicket, testing::Eq(1u));
+  ASSERT_THAT(siblingTicket, testing::Eq(2u));
+
+  completion.complete(parentTicket);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(1u));
+  completion.complete(siblingTicket);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(3u));
+  EXPECT_THAT(completion.pending.size(), testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, ReusedHostIdentityDoesNotRetargetAnOlderCallbackTicket) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> host(geodeDevice_->device().createCommandEncoder());
+  GeodeWgpuAdapterDeviceTestAccess::CompletionState completion;
+  completion.record(host.get(), 1);
+  const uint64_t oldTicket = completion.closeHost(host.get());
+  completion.record(host.get(), 2);
+  const uint64_t newTicket = completion.closeHost(host.get());
+  ASSERT_THAT(oldTicket, testing::Ne(newTicket));
+  completion.complete(oldTicket);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(1u));
+  completion.complete(oldTicket);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(1u));
+  completion.complete(newTicket);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(2u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, CompletedHighWaterWaitsForQueuedStandaloneCallbacks) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> host(geodeDevice_->device().createCommandEncoder());
+  GeodeWgpuAdapterDeviceTestAccess::CompletionState completion;
+  completion.record(host.get(), 1);
+  completion.record(nullptr, 2);
+  completion.record(nullptr, 3);
+  completion.complete(3);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(0u));
+  completion.complete(completion.closeHost(host.get()));
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(1u));
+  completion.complete(2);
+  EXPECT_THAT(completion.completedSerial.load(), testing::Eq(3u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, DiscardingOneHostCannotCompleteAnotherPendingHost) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> parent(geodeDevice_->device().createCommandEncoder());
+  ScopedWgpuHandle<wgpu::CommandEncoder> sibling(geodeDevice_->device().createCommandEncoder());
+  const uint64_t parentSerial = ReplayHostClear(*adapter_, parent.get());
+  const uint64_t siblingSerial = ReplayHostClear(*adapter_, sibling.get());
+  adapter_->notifyHostDiscarded(parent.get());
+  parent.reset();
+  ASSERT_THAT(geodeDevice_->waitForQueueIdle(std::chrono::seconds(2)),
+              testing::Eq(GpuWaitResult::Complete));
+  EXPECT_THAT(adapter_->completedSerial(), testing::Eq(parentSerial));
+  EXPECT_THAT(adapter_->hostCommandEncoderIs(sibling.get()), testing::IsTrue());
+
+  ScopedWgpuHandle<wgpu::CommandBuffer> siblingCommands(sibling.get().finish());
+  geodeDevice_->queue().submit(1, &siblingCommands.get());
+  adapter_->notifyHostSubmitted(sibling.get());
+  adapter_->clearHostCommandEncoder();
+  EXPECT_THAT(adapter_->waitForSerial(siblingSerial, 2.0), testing::IsTrue());
 }
 
 /// The adapter presents to a Metal layer; the other platform surfaces are still created by the

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -33,6 +33,7 @@
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
+#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
 #include "tiny_skia/Pixmap.h"
@@ -313,6 +314,64 @@ protected:
 };
 
 // ----------------------------------------------------------------------------
+
+TEST_F(RendererGeodeTest, OverlappingFramesKeepReplayWithTheirOwner) {
+  const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode parent(device);
+  RendererGeode sibling(device);
+  beginFrame(parent);
+  parent.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  parent.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+  beginFrame(sibling);
+  sibling.setPaint(solidFill(css::RGBA(0, 0, 255, 255)));
+  sibling.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+  parent.endFrame();
+  const RendererBitmap parentPixels = parent.takeSnapshot();
+  ASSERT_THAT(parentPixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
+  EXPECT_THAT(pixelAt(parentPixels, 32, 32), Rgba(255, 0, 0, 255));
+  sibling.endFrame();
+  const RendererBitmap siblingPixels = sibling.takeSnapshot();
+  ASSERT_THAT(siblingPixels.dimensions, testing::Eq(parentPixels.dimensions));
+  EXPECT_THAT(pixelAt(siblingPixels, 32, 32), Rgba(0, 0, 255, 255));
+}
+
+TEST_F(RendererGeodeTest, AbandoningOneFramePreservesItsUnsubmittedSibling) {
+  for (const bool destroy : {false, true}) {
+    SCOPED_TRACE(destroy);
+    const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+    ASSERT_THAT(device, testing::NotNull());
+    auto parent = std::make_unique<RendererGeode>(device);
+    RendererGeode sibling(device);
+    const auto drawFlood = [](RendererGeode& renderer, css::RGBA color) {
+      components::FilterGraph graph;
+      graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+      components::FilterNode node;
+      node.primitive = components::filter_primitive::Flood{.floodColor = css::Color(color)};
+      graph.nodes.push_back(node);
+      renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+      renderer.popFilterLayer();
+    };
+    beginFrame(*parent);
+    drawFlood(*parent, css::RGBA(255, 0, 0, 255));
+    const uint64_t parentSerial = device->adapterDevice().lastSubmittedSerial();
+    beginFrame(sibling);
+    drawFlood(sibling, css::RGBA(0, 0, 255, 255));
+    const uint64_t siblingSerial = device->adapterDevice().lastSubmittedSerial();
+    ASSERT_THAT(siblingSerial, testing::Gt(parentSerial));
+    if (destroy) {
+      parent.reset();
+    } else {
+      beginFrame(*parent);
+    }
+    ASSERT_THAT(device->adapterDevice().waitForSerial(parentSerial, 2.0), testing::IsTrue());
+    EXPECT_THAT(device->adapterDevice().completedSerial(), testing::Lt(siblingSerial));
+    sibling.endFrame();
+    const RendererBitmap pixels = sibling.takeSnapshot();
+    ASSERT_THAT(pixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
+    EXPECT_THAT(pixelAt(pixels, 32, 32), Rgba(0, 0, 255, 255));
+  }
+}
 
 /// Smoke test: empty frame should snap to a fully transparent bitmap.
 TEST_F(RendererGeodeTest, EmptyFrameIsTransparent) {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -913,6 +913,9 @@
         "wgpuTextureOf",
         "wgpuTextureViewOf"
       ],
+      "wgpuCTypes": [
+        "WGPUCommandEncoder"
+      ],
       "wgpuCppTokens": [
         "BindGroup",
         "BindGroupLayout",


### PR DESCRIPTION
Keep GPU completion behind every unfinished host encoder when renderers share a device. Previously, submitting a sibling could report serial 2 complete while serial 1 was still unsubmitted, or report serial 3 across an unfinished gap at 2.

Track each host's pending serial range with a unique callback ticket, retain queued ranges until their own callbacks complete, and publish only the contiguous completed prefix. Frame replay now selects its owning encoder before submission; submit, reset, and destruction report the exact host they finish or discard.

Regression coverage exercises interleaved hosts, reordered and duplicate callbacks, reused encoder identities, standalone submissions, and renderer overlap/reset/destruction. The new renderer tests first reproduced transparent output, then passed with distinct expected colors after owner selection was corrected.

Validation: complete Bazel suite (488 targets passed; 31 configuration-incompatible targets skipped), CMake generator, lint, formatting, and GPU inventory. Shared filter-parameter reuse and float-filter memory policy are separate work.
