### PR TITLE
Preserve filter parameters across shared renderer frames

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -4452,13 +4452,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (frameResourceScopeDepth == 0) {
       resetOwnedFrameBudgets();
     }
-    if (device) {
+    closeFrameGeneration();
+    // A sibling renderer may still have unsubmitted reads of the shared filter scratch.
+    if (device && device->oldestOpenFrameGeneration() == std::numeric_limits<uint64_t>::max()) {
       device->filterEngine().beginFrame();
     }
     if (texturePool) {
       texturePool->beginFrame();
     }
-    closeFrameGeneration();
     if (device) {
       currentFrameIndex = device->beginFrameGeneration();
       frameGenerationOpen = true;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -4586,6 +4586,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     encoder.reset();
     frameFinishedEncoders.clear();
     discardFrameGpuEncoder();
+    closeFrameGeneration();
 
     if (device && device->device()) {
       // Bounded drain before releasing frame resources; skips (and stays
@@ -4850,9 +4851,6 @@ RendererGeode::~RendererGeode() {
   // `initPipelines`, and the first one destroyed leaves `counters_` dangling for the others.
   if (impl_ && impl_->device && impl_->device->counters() == &impl_->counters) {
     impl_->device->setCounters(nullptr);
-  }
-  if (impl_) {
-    impl_->closeFrameGeneration();
   }
 }
 RendererGeode::RendererGeode(RendererGeode&&) noexcept = default;

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -316,28 +316,36 @@ protected:
 // ----------------------------------------------------------------------------
 
 TEST_F(RendererGeodeTest, SettledFilterFramesReuseParameterScratch) {
-  const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
-  ASSERT_THAT(device, testing::NotNull());
-  RendererGeode renderer(device);
-  components::FilterGraph graph;
-  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
-  for (size_t index = 0; index < components::kMaximumFilterGraphNodes; ++index) {
-    components::FilterNode node;
-    node.primitive =
-        components::filter_primitive::Flood{.floodColor = css::Color(css::RGBA(255, 0, 0, 255))};
-    graph.nodes.push_back(node);
-  }
-  for (int frame = 0; frame < 16; ++frame) {
-    SCOPED_TRACE(frame);
-    beginFrame(renderer);
-    renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
-    renderer.popFilterLayer();
-    renderer.endFrame();
-    const RendererBitmap pixels = renderer.takeSnapshot();
-    ASSERT_THAT(pixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
-    EXPECT_THAT(pixelAt(pixels, 32, 32), Rgba(255, 0, 0, 255));
-    if (frame >= 2) {
-      EXPECT_EQ(renderer.lastFrameTimings().counters.bufferCreates, 0u);
+  for (const bool replaceOpenFrame : {false, true}) {
+    SCOPED_TRACE(replaceOpenFrame);
+    const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+    ASSERT_THAT(device, testing::NotNull());
+    RendererGeode renderer(device);
+    if (replaceOpenFrame) {
+      beginFrame(renderer);
+      renderer = RendererGeode(device);
+      EXPECT_EQ(device->oldestOpenFrameGeneration(), std::numeric_limits<uint64_t>::max());
+    }
+    components::FilterGraph graph;
+    graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+    for (size_t index = 0; index < components::kMaximumFilterGraphNodes; ++index) {
+      components::FilterNode node;
+      node.primitive =
+          components::filter_primitive::Flood{.floodColor = css::Color(css::RGBA(255, 0, 0, 255))};
+      graph.nodes.push_back(node);
+    }
+    for (int frame = 0; frame < 16; ++frame) {
+      SCOPED_TRACE(frame);
+      beginFrame(renderer);
+      renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+      renderer.popFilterLayer();
+      renderer.endFrame();
+      const RendererBitmap pixels = renderer.takeSnapshot();
+      ASSERT_THAT(pixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
+      EXPECT_THAT(pixelAt(pixels, 32, 32), Rgba(255, 0, 0, 255));
+      if (frame >= 2) {
+        EXPECT_EQ(renderer.lastFrameTimings().counters.bufferCreates, 0u);
+      }
     }
   }
 }

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -315,6 +315,45 @@ protected:
 
 // ----------------------------------------------------------------------------
 
+TEST_F(RendererGeodeTest, OverlappingFiltersPreserveEachFramesParameters) {
+  for (const bool parentFirst : {false, true}) {
+    SCOPED_TRACE(parentFirst);
+    const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+    ASSERT_THAT(device, testing::NotNull());
+    RendererGeode parent(device);
+    RendererGeode sibling(device);
+    const auto drawFlood = [](RendererGeode& renderer, css::RGBA color) {
+      components::FilterGraph graph;
+      graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+      components::FilterNode node;
+      node.primitive = components::filter_primitive::Flood{.floodColor = css::Color(color)};
+      graph.nodes.push_back(node);
+      renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+      renderer.popFilterLayer();
+    };
+    beginFrame(parent);
+    drawFlood(parent, css::RGBA(255, 0, 0, 255));
+    beginFrame(sibling);
+    drawFlood(sibling, css::RGBA(0, 0, 255, 255));
+    if (parentFirst) {
+      parent.endFrame();
+      sibling.endFrame();
+    } else {
+      sibling.endFrame();
+      parent.endFrame();
+    }
+    const RendererBitmap parentPixels = parent.takeSnapshot();
+    const RendererBitmap siblingPixels = sibling.takeSnapshot();
+    ASSERT_THAT(parentPixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
+    ASSERT_THAT(siblingPixels.dimensions, testing::Eq(parentPixels.dimensions));
+    for (const int coordinate : {1, 32, 62}) {
+      SCOPED_TRACE(coordinate);
+      EXPECT_THAT(pixelAt(parentPixels, coordinate, coordinate), Rgba(255, 0, 0, 255));
+      EXPECT_THAT(pixelAt(siblingPixels, coordinate, coordinate), Rgba(0, 0, 255, 255));
+    }
+  }
+}
+
 TEST_F(RendererGeodeTest, OverlappingFramesKeepReplayWithTheirOwner) {
   const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
   ASSERT_THAT(device, testing::NotNull());

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -315,6 +315,33 @@ protected:
 
 // ----------------------------------------------------------------------------
 
+TEST_F(RendererGeodeTest, SettledFilterFramesReuseParameterScratch) {
+  const std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode renderer(device);
+  components::FilterGraph graph;
+  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+  for (size_t index = 0; index < components::kMaximumFilterGraphNodes; ++index) {
+    components::FilterNode node;
+    node.primitive =
+        components::filter_primitive::Flood{.floodColor = css::Color(css::RGBA(255, 0, 0, 255))};
+    graph.nodes.push_back(node);
+  }
+  for (int frame = 0; frame < 16; ++frame) {
+    SCOPED_TRACE(frame);
+    beginFrame(renderer);
+    renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+    renderer.popFilterLayer();
+    renderer.endFrame();
+    const RendererBitmap pixels = renderer.takeSnapshot();
+    ASSERT_THAT(pixels.dimensions, testing::Eq(Vector2i(kViewportSize, kViewportSize)));
+    EXPECT_THAT(pixelAt(pixels, 32, 32), Rgba(255, 0, 0, 255));
+    if (frame >= 2) {
+      EXPECT_EQ(renderer.lastFrameTimings().counters.bufferCreates, 0u);
+    }
+  }
+}
+
 TEST_F(RendererGeodeTest, OverlappingFiltersPreserveEachFramesParameters) {
   for (const bool parentFirst : {false, true}) {
     SCOPED_TRACE(parentFirst);


### PR DESCRIPTION
Preserve shared filter parameters while another renderer still has an open frame. Starting a blue filtered frame previously overwrote the parameters of an unsubmitted red frame, causing both frames to render blue regardless of submission order.

Close the current generation before checking for other open frames, and reset shared scratch only when no frame remains open. Generation cleanup now belongs to implementation teardown, so move-assigning over an open renderer cannot leave a phantom generation that prevents later scratch reuse.

Regression tests first reproduced both color corruption and renewed buffer growth after move-assignment. They cover both submission orders and verify zero new buffers after warm-up across settled filter frames, including replacement of an open renderer.

Indefinitely overlapping frames still require further working-set improvements; this change does not raise memory limits.

Validation: full Bazel suite (488 targets passed; 31 configuration-incompatible targets skipped), CMake generator, lint, formatting, GPU inventory, and independent code/security review.
