### PR TITLE
Reserve transformed local filter execution plans accurately

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1151,6 +1151,8 @@ struct GeodeFilterAdmission {
   bool transformedCaptureReserved = false;
   bool localRasterRequired = false;
   components::FilterExecutionBudget::Reservation reservation;
+  geode::FilterTilePlan fullPlan;
+  std::optional<geode::FilterTilePlan> localPlan;
 };
 
 struct GeodeFilterBuffer {
@@ -1243,22 +1245,40 @@ std::optional<GeodeLocalRasterGeometry> ComputeGeodeLocalRasterGeometry(
   return GeodeLocalRasterGeometry{scaleX, scaleY, blurPadding, paddedRegion, *width, *height};
 }
 
-std::optional<std::uint64_t> ComputeGeodeLocalFilterPixels(
+std::optional<geode::FilterTilePlan> ComputeGeodeLocalFilterPlan(
     const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion,
-    const Transform2d& deviceFromFilter, const GeodeFilterBuffer& buffer, bool fullExecutionFits) {
-  const std::optional<GeodeLocalRasterGeometry> geometry = ComputeGeodeLocalRasterGeometry(
-      filterGraph, filterRegion, deviceFromFilter, buffer, fullExecutionFits);
-  if (!geometry.has_value()) {
+    const Transform2d& deviceFromFilter, const GeodeFilterBuffer& buffer, bool fullExecutionFits,
+    const geode::GeodeFilterEngine& engine) {
+  const auto geometry = ComputeGeodeLocalRasterGeometry(filterGraph, filterRegion, deviceFromFilter,
+                                                        buffer, fullExecutionFits);
+  if (!geometry) {
     return std::nullopt;
   }
-  const std::uint64_t pixels =
-      static_cast<std::uint64_t>(geometry->width) * static_cast<std::uint64_t>(geometry->height);
-  if (!components::FilterGraphFitsExecutionBudget(filterGraph, pixels,
-                                                  components::FilterMemoryModel::GpuAllNodes)) {
+  const auto plan = engine.executionPlan(filterGraph, geometry->width, geometry->height,
+                                         Transform2d::Scale(geometry->scaleX, geometry->scaleY));
+  uint64_t work = 0;
+  uint64_t bytes = 0;
+  if (!components::FilterGraphExecutionCost(filterGraph, plan.workPixels(),
+                                            components::FilterMemoryModel::GpuAllNodes, work, bytes,
+                                            plan.pixels(), plan.tiles)) {
     return std::nullopt;
   }
-  return pixels;
+  return plan;
 }
+
+struct GeodeFilterWorkBounds {
+  uint64_t workPixels = 0;
+  uint64_t memoryPixels = 0;
+  uint64_t executions = 0;
+  uint64_t additionalTextureBytes = 0;
+
+  void include(const geode::FilterTilePlan& plan) {
+    workPixels = std::max(workPixels, plan.workPixels());
+    memoryPixels = std::max(memoryPixels, plan.pixels());
+    executions = std::max(executions, plan.tiles);
+    additionalTextureBytes = std::max(additionalTextureBytes, plan.additionalTextureBytes());
+  }
+};
 
 std::optional<GeodeFilterAdmission> AdmitGeodeFilter(const components::FilterGraph& filterGraph,
                                                      const std::optional<Box2d>& filterRegion,
@@ -1282,31 +1302,32 @@ std::optional<GeodeFilterAdmission> AdmitGeodeFilter(const components::FilterGra
   const bool fullExecutionFits = components::FilterGraphExecutionCost(
       filterGraph, plan.workPixels(), components::FilterMemoryModel::GpuAllNodes, plannedWork,
       plannedBytes, plan.pixels(), plan.tiles);
-  const std::optional<std::uint64_t> localPixels = ComputeGeodeLocalFilterPixels(
-      filterGraph, filterRegion, deviceFromFilter, *buffer, fullExecutionFits);
-  const std::uint64_t executionPixels = localPixels.has_value() && fullExecutionFits
-                                            ? std::max(bufferPixels, *localPixels)
-                                            : localPixels.value_or(bufferPixels);
-  const bool tiled = plan.tiles > 1 && !localPixels;
-  const std::uint64_t viewportCopyBytes =
+  const auto localPlan = ComputeGeodeLocalFilterPlan(filterGraph, filterRegion, deviceFromFilter,
+                                                     *buffer, fullExecutionFits, engine);
+  GeodeFilterWorkBounds bounds;
+  if (fullExecutionFits || !localPlan) {
+    bounds.include(plan);
+  }
+  if (localPlan) {
+    bounds.include(*localPlan);
+  }
+  const uint64_t localPixels = localPlan ? uint64_t{localPlan->width} * localPlan->height : 0;
+  const bool tiled = bounds.executions > 1;
+  const uint64_t viewportCopyBytes =
       buffer->offsetX || buffer->offsetY
           ? uint64_t{static_cast<uint32_t>(viewportWidth)} * viewportHeight * 4
           : 0;
-  const std::uint64_t captureBytes = bufferPixels * 4u + localPixels.value_or(0) * 4u +
-                                     (tiled ? plan.additionalTextureBytes() : 0) +
-                                     viewportCopyBytes;
-  const uint64_t workPixels = tiled ? plan.workPixels() : executionPixels;
-  const uint64_t memoryPixels = tiled ? plan.pixels() : executionPixels;
-  const uint64_t executions = tiled ? plan.tiles : 1;
+  const uint64_t captureBytes =
+      bufferPixels * 4 + localPixels * 4 + bounds.additionalTextureBytes + viewportCopyBytes;
   std::size_t surfaces = 0;
   uint64_t graphBytes = 0;
   uint64_t graphWork = 0;
-  if (components::FilterGraphExecutionCost(filterGraph, workPixels,
+  if (components::FilterGraphExecutionCost(filterGraph, bounds.workPixels,
                                            components::FilterMemoryModel::GpuAllNodes, graphWork,
-                                           graphBytes, memoryPixels, executions)) {
+                                           graphBytes, bounds.memoryPixels, bounds.executions)) {
     components::GpuFilterWorkingSet layout;
     (void)components::ComputeGpuFilterWorkingSet(filterGraph, layout);
-    surfaces = layout.floatTextures + 2 + (localPixels ? 1 : 0) + (tiled ? 2 : 0) +
+    surfaces = layout.floatTextures + 2 + (localPlan ? 1 : 0) + (tiled ? 2 : 0) +
                (viewportCopyBytes ? 1 : 0);
     surfaces +=
         std::count_if(filterGraph.nodes.begin(), filterGraph.nodes.end(), [](const auto& node) {
@@ -1320,14 +1341,15 @@ std::optional<GeodeFilterAdmission> AdmitGeodeFilter(const components::FilterGra
     }
   }
   auto reservation = budget.reserve(
-      filterGraph, workPixels, components::FilterMemoryModel::GpuAllNodes, captureBytes,
-      engine.retainedBufferBytes(), memoryPixels, executions, surfaces);
+      filterGraph, bounds.workPixels, components::FilterMemoryModel::GpuAllNodes, captureBytes,
+      engine.retainedBufferBytes(), bounds.memoryPixels, bounds.executions, surfaces);
   if (!reservation.has_value()) {
     return std::nullopt;
   }
   return GeodeFilterAdmission{buffer->region,     buffer->width,   buffer->height,
-                              buffer->offsetX,    buffer->offsetY, localPixels.has_value(),
-                              !fullExecutionFits, *reservation};
+                              buffer->offsetX,    buffer->offsetY, localPlan.has_value(),
+                              !fullExecutionFits, *reservation,    plan,
+                              localPlan};
 }
 
 }  // namespace
@@ -2055,6 +2077,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     /// Descriptors captured at push for texture-pool release.
     gpu::TextureDescriptor layerDesc = {};
     components::FilterGraph filterGraph;
+    geode::FilterTilePlan fullFilterPlan;
+    std::optional<geode::FilterTilePlan> localFilterPlan;
     components::FilterExecutionBudget::Reservation filterReservation;
     Box2d filterRegion;
     Transform2d deviceFromFilter;  // Full CTM at push time.
@@ -2137,6 +2161,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frame.savedTarget = target;
     frame.layerDesc = textureDesc;
     frame.filterGraph = filterGraph;
+    frame.fullFilterPlan = admission.fullPlan;
+    frame.localFilterPlan = admission.localPlan;
     frame.filterReservation = admission.reservation;
     frame.filterRegion = admission.region;
     frame.deviceFromFilter = deviceFromFilter;
@@ -2171,7 +2197,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   }
 
   bool tryCompositeTransformedFilter(FilterStackFrame& frame) {
-    if (!frame.transformedCaptureReserved || !filterEngine || frame.filterGraph.empty()) {
+    if (!frame.transformedCaptureReserved || !frame.localFilterPlan || !filterEngine ||
+        frame.filterGraph.empty()) {
       return false;
     }
     const GeodeFilterBuffer buffer{frame.filterRegion, static_cast<int>(frame.layerDesc.size.width),
@@ -2218,11 +2245,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
                                   Vector2d(geometry->blurPadding + frame.filterRegion.width(),
                                            geometry->blurPadding + frame.filterRegion.height()));
     if (!flushFrameGpuEncoder()) {
+      releaseTextureAtFrameEnd(std::move(localTexture), localDesc);
       return false;
     }
-    wgpu::Texture localFiltered =
-        filterEngine->execute(frame.filterGraph, localBackendTexture, localFilterRegion,
-                              localDeviceFromFilter, *this, frameCommandEncoder);
+    wgpu::Texture localFiltered = filterEngine->execute(
+        frame.filterGraph, localBackendTexture, localFilterRegion, localDeviceFromFilter, *this,
+        frameCommandEncoder, nullptr, frame.localFilterPlan);
 
     const Transform2d deviceFromLocal =
         Transform2d::Scale(1.0 / geometry->scaleX, 1.0 / geometry->scaleY) *
@@ -5610,9 +5638,9 @@ void RendererGeode::popFilterLayer() {
                  components::kMaximumFilterSurfacePixels) {
     UTILS_RELEASE_ASSERT_MSG(impl_->flushFrameGpuEncoder(),
                              "Failed to replay recorded draws before the filter passes");
-    filteredTexture =
-        impl_->filterEngine->execute(frame.filterGraph, layerBackendTexture, frame.filterRegion,
-                                     bufferDeviceFromFilter, *impl_, impl_->frameCommandEncoder);
+    filteredTexture = impl_->filterEngine->execute(
+        frame.filterGraph, layerBackendTexture, frame.filterRegion, bufferDeviceFromFilter, *impl_,
+        impl_->frameCommandEncoder, nullptr, frame.fullFilterPlan);
   }
 
   // Restore outer target and create a fresh encoder that preserves its

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -2411,6 +2411,7 @@ struct FilterGraphExecution {
   std::unordered_map<std::string, size_t> lastNamedUse;
   bool axisAligned;
   uint64_t executedTiles = 0;
+  uint64_t admittedWorkUnits = 0;
 };
 
 /// The primitive visitor owns node-local conversion and clip decisions.
@@ -2715,6 +2716,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
   lastExecutionMemory_ = execution.arena.memory();
   lastExecutionMemory_.persistentBuffers = retainedBufferBytes();
   lastExecutionMemory_.tileExecutions = execution.executedTiles;
+  lastExecutionMemory_.workUnits = execution.admittedWorkUnits;
   return output;
 }
 
@@ -2786,12 +2788,14 @@ wgpu::Texture FilterGraphExecution::run() {
   }
   FilterExecutionBudget localBudget;
   FilterExecutionBudget& budget = executionBudget ? *executionBudget : localBudget;
+  const uint64_t workBefore = budget.workUnits();
   auto reservation = budget.reserve(graph, plan.workPixels(), FilterMemoryModel::GpuAllNodes,
                                     plan.additionalTextureBytes(), engine.retainedBufferBytes(),
                                     plan.pixels(), plan.tiles);
   if (!reservation) {
     return sourceGraphic;
   }
+  admittedWorkUnits = budget.workUnits() - workBefore;
   const wgpu::Texture result = plan.tiles > 1 ? runTiled(plan) : runNodes();
   budget.release(*reservation);
   return result;

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -2375,11 +2375,13 @@ struct FilterGraphExecution {
                        const Transform2d& deviceFromFilter,
                        FilterTextureAllocator& textureAllocator,
                        ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
-                       svg::components::FilterExecutionBudget* executionBudget)
+                       svg::components::FilterExecutionBudget* executionBudget,
+                       std::optional<FilterTilePlan> admittedPlan)
       : engine(engine),
         graph(graph),
         sourceGraphic(sourceGraphic),
         executionBudget(executionBudget),
+        admittedPlan(admittedPlan),
         arena(engine.device_, textureAllocator, *engine.resourceCache_, commandEncoder,
               engine.framePassesInCommandBuffer_),
         coordinates(graph, sourceGraphic, filterRegion, deviceFromFilter),
@@ -2403,6 +2405,7 @@ struct FilterGraphExecution {
   wgpu::Texture sourceGraphic;
   Vector2d tileOrigin = Vector2d::Zero();
   svg::components::FilterExecutionBudget* executionBudget;
+  std::optional<FilterTilePlan> admittedPlan;
   FilterResourceArena arena;
   FilterExecutionCoordinates coordinates;
   wgpu::Texture currentBuffer;
@@ -2676,6 +2679,43 @@ FilterTilePlan ChooseFilterTiles(const svg::components::FilterGraph& graph, Filt
   return best;
 }
 
+bool ValidFilterPlanAxis(uint32_t size, uint32_t tile, uint32_t core) {
+  return size > 0 && tile > 0 && core > 0 && tile <= size && core <= tile;
+}
+
+bool WellFormedFilterPlan(const FilterTilePlan& plan, uint32_t width, uint32_t height) {
+  if (plan.width != width || plan.height != height ||
+      !ValidFilterPlanAxis(width, plan.tileWidth, plan.coreWidth) ||
+      !ValidFilterPlanAxis(height, plan.tileHeight, plan.coreHeight) ||
+      uint64_t{width} * height > svg::components::kMaximumFilterSurfacePixels) {
+    return false;
+  }
+  const uint64_t columns = (uint64_t{width} + plan.coreWidth - 1) / plan.coreWidth;
+  const uint64_t rows = (uint64_t{height} + plan.coreHeight - 1) / plan.coreHeight;
+  return plan.tiles == columns * rows;
+}
+
+bool FilterPlanAxisSupportsHalo(uint32_t size, uint32_t tile, uint32_t core, double halo) {
+  return tile == size || uint64_t{core} + 2 * static_cast<uint64_t>(std::ceil(halo)) <= tile;
+}
+
+bool AdmittedFilterPlanFitsSource(const svg::components::FilterGraph& graph,
+                                  const FilterTilePlan& plan, uint32_t width, uint32_t height,
+                                  const Transform2d& transform) {
+  if (!WellFormedFilterPlan(plan, width, height)) {
+    return false;
+  }
+  if (plan.tiles == 1) {
+    return true;
+  }
+  if (!CanTileFilter(graph, width, height, transform)) {
+    return false;
+  }
+  const auto halo = ComputeFilterSamplingHalo(graph, transform);
+  return halo && FilterPlanAxisSupportsHalo(width, plan.tileWidth, plan.coreWidth, halo->x) &&
+         FilterPlanAxisSupportsHalo(height, plan.tileHeight, plan.coreHeight, halo->y);
+}
+
 }  // namespace
 
 FilterTilePlan GeodeFilterEngine::executionPlan(const svg::components::FilterGraph& graph,
@@ -2709,9 +2749,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                                          const Transform2d& deviceFromFilter,
                                          FilterTextureAllocator& textureAllocator,
                                          ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
-                                         svg::components::FilterExecutionBudget* executionBudget) {
+                                         svg::components::FilterExecutionBudget* executionBudget,
+                                         std::optional<FilterTilePlan> admittedPlan) {
   FilterGraphExecution execution(*this, graph, sourceGraphic, filterRegion, deviceFromFilter,
-                                 textureAllocator, commandEncoder, executionBudget);
+                                 textureAllocator, commandEncoder, executionBudget, admittedPlan);
   const wgpu::Texture output = execution.run();
   lastExecutionMemory_ = execution.arena.memory();
   lastExecutionMemory_.persistentBuffers = retainedBufferBytes();
@@ -2781,9 +2822,19 @@ void FilterGraphExecution::record(const svg::components::FilterNode& node, const
 
 wgpu::Texture FilterGraphExecution::run() {
   using namespace svg::components;
-  FilterTilePlan plan = engine.executionPlan(
-      graph, sourceGraphic.getWidth(), sourceGraphic.getHeight(), coordinates.deviceFromFilter);
+  FilterTilePlan plan =
+      admittedPlan ? *admittedPlan
+                   : engine.executionPlan(graph, sourceGraphic.getWidth(),
+                                          sourceGraphic.getHeight(), coordinates.deviceFromFilter);
+  if (admittedPlan &&
+      !AdmittedFilterPlanFitsSource(graph, plan, sourceGraphic.getWidth(),
+                                    sourceGraphic.getHeight(), coordinates.deviceFromFilter)) {
+    return {};
+  }
   if (plan.tiles > 1 && !(sourceGraphic.getUsage() & wgpu::TextureUsage::CopySrc)) {
+    if (admittedPlan) {
+      return {};
+    }
     plan = {plan.width, plan.height, plan.width, plan.height, plan.width, plan.height, 1};
   }
   FilterExecutionBudget localBudget;
@@ -2793,7 +2844,7 @@ wgpu::Texture FilterGraphExecution::run() {
                                     plan.additionalTextureBytes(), engine.retainedBufferBytes(),
                                     plan.pixels(), plan.tiles);
   if (!reservation) {
-    return sourceGraphic;
+    return admittedPlan ? wgpu::Texture{} : sourceGraphic;
   }
   admittedWorkUnits = budget.workUnits() - workBefore;
   const wgpu::Texture result = plan.tiles > 1 ? runTiled(plan) : runNodes();

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -13,6 +13,7 @@
 /// `feDropShadow`, `feImage`, `feTile`. The primitive visitor is exhaustive.
 
 #include <memory>
+#include <optional>
 #include <webgpu/webgpu.hpp>
 
 #include "donner/base/Box.h"
@@ -186,6 +187,9 @@ public:
    *   keep the two-submissions-per-frame shape.
    * @param executionBudget Optional shared per-frame budget. Direct callers may omit it to apply
    *   only the graph-local limit.
+   * @param admittedPlan Optional immutable plan already reserved by the caller. Execution keeps
+   *   this layout even if shared scratch state or planning preferences change. Invalid plans or
+   *   failed execution-time budgets return an empty texture instead of bypassing the filter.
    * @return The filtered output texture (RGBA8Unorm, TextureBinding | CopySrc).
    */
   wgpu::Texture execute(const svg::components::FilterGraph& graph,
@@ -193,7 +197,8 @@ public:
                         const Transform2d& deviceFromFilter,
                         FilterTextureAllocator& textureAllocator,
                         ScopedWgpuHandle<wgpu::CommandEncoder>& commandEncoder,
-                        svg::components::FilterExecutionBudget* executionBudget = nullptr);
+                        svg::components::FilterExecutionBudget* executionBudget = nullptr,
+                        std::optional<FilterTilePlan> admittedPlan = std::nullopt);
 
   /**
    * Begin a new frame for this engine: reset the frame-scoped chunk pass

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -113,6 +113,7 @@ struct FilterExecutionMemory {
   uint64_t standaloneBuffers = 0;  //!< Per-execution buffers retained until submission.
   uint64_t persistentBuffers = 0;  //!< Parameter arenas and immutable transfer tables.
 
+  uint64_t workUnits = 0;       //!< Work charged for the chosen execution plan.
   uint64_t tileExecutions = 0;  //!< Complete graph evaluations, including sampling halos.
 
   /// Total retained allocation bytes.

--- a/donner/svg/renderer/geode/tests/GeodeFilterEngine_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeFilterEngine_tests.cc
@@ -507,6 +507,59 @@ TEST_F(GeodeFilterEngineTest, LargeBlurHalosUseBoundedStripsAtHighDprZoom) {
             128u * 1024u * 1024u);
 }
 
+TEST_F(GeodeFilterEngineTest, InvalidAdmittedPlansFailBeforeAllocation) {
+  using namespace svg::components;
+  source_ = gpu::GetResultOrFail(device_->adapterDevice().createTexture(
+      gpu::TextureDescriptor{"admitted source",
+                             {4, 4},
+                             gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc}));
+  FilterGraph graph;
+  FilterNode blur;
+  blur.primitive = filter_primitive::GaussianBlur{.stdDeviationX = 1, .stdDeviationY = 1};
+  graph.nodes.push_back(blur);
+  const auto valid = engine_->executionPlan(graph, 4, 4, Transform2d());
+  for (int invalid = 0; invalid < 4; ++invalid) {
+    SCOPED_TRACE(invalid);
+    auto plan = valid;
+    if (invalid == 0) {
+      plan.coreWidth = 0;
+    }
+    if (invalid == 1) {
+      plan.width = 5;
+    }
+    if (invalid == 2) {
+      plan.tiles = 0;
+    }
+    if (invalid == 3) {
+      plan.tileWidth = plan.tileHeight = 2;
+      plan.coreWidth = plan.coreHeight = 1;
+      plan.tiles = 16;
+    }
+    RefusingTextureAllocator allocator(device_->adapterDevice(), "");
+    const auto output =
+        engine_->execute(graph, device_->adapterDevice().wgpuTextureOf(source_),
+                         Box2d({0, 0}, {4, 4}), Transform2d(), allocator, encoder_, nullptr, plan);
+    EXPECT_FALSE(output);
+    EXPECT_EQ(allocator.allocations, 0u);
+  }
+}
+
+TEST_F(GeodeFilterEngineTest, FailedAdmittedBudgetDoesNotBypassTheFilter) {
+  using namespace svg::components;
+  const auto graph = MakeGraph(true);
+  const auto plan = engine_->executionPlan(graph, 4, 4, Transform2d());
+  FilterExecutionBudget budget;
+  budget.reject();
+  RefusingTextureAllocator allocator(device_->adapterDevice(), "");
+  const auto output =
+      engine_->execute(graph, device_->adapterDevice().wgpuTextureOf(source_),
+                       Box2d({0, 0}, {4, 4}), Transform2d(), allocator, encoder_, &budget, plan);
+  EXPECT_FALSE(output);
+  EXPECT_EQ(allocator.allocations, 0u);
+  EXPECT_EQ(engine_->lastExecutionMemory().tileExecutions, 0u);
+}
+
 INSTANTIATE_TEST_SUITE_P(EveryActivePath, FilterAllocationRefusal,
                          testing::ValuesIn(AllocationRefusalCases()),
                          [](const testing::TestParamInfo<AllocationRefusalCase>& info) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -317,6 +317,43 @@ protected:
 
 // ----------------------------------------------------------------------------
 
+TEST_F(RendererGeodeTest, TransformedLocalFilterAdmissionCoversItsTileWork) {
+  using namespace components;
+  constexpr uint32_t kWidth = 1024;
+  constexpr uint32_t kHeight = 768;
+  std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+  ASSERT_TRUE(device);
+  RendererGeode renderer(device);
+  RenderViewport viewport;
+  viewport.size = Vector2d(kWidth, kHeight);
+  renderer.beginFrame(viewport);
+  FilterGraph graph;
+  FilterNode blur;
+  blur.primitive = filter_primitive::GaussianBlur{.stdDeviationX = 4, .stdDeviationY = 2};
+  graph.nodes.push_back(blur);
+  renderer.setTransform(Transform2d::SkewX(0.2));
+  renderer.pushFilterLayer(graph, Box2d({0, 0}, {960, 640}));
+  const auto admitted = renderer.resourceStats();
+  ASSERT_FALSE(admitted.filterBudgetRejected);
+  renderer.setTransform(Transform2d());
+  renderer.setPaint(solidFill(css::RGBA(255, 255, 255, 255)));
+  renderer.drawRect(Box2d({0, 0}, {kWidth, kHeight}), StrokeParams{});
+  renderer.popFilterLayer();
+  const auto observed = device->filterEngine().lastExecutionMemory();
+  ASSERT_GT(observed.tileExecutions, 1u);
+  uint64_t untiledWork = 0;
+  uint64_t untiledBytes = 0;
+  ASSERT_TRUE(FilterGraphExecutionCost(graph, uint64_t{kWidth} * kHeight,
+                                       FilterMemoryModel::GpuAllNodes, untiledWork, untiledBytes));
+  EXPECT_GT(observed.workUnits, untiledWork);
+  EXPECT_GE(admitted.filterWorkUnits, observed.workUnits);
+  EXPECT_GE(admitted.filterRetainedBytes, observed.total());
+  renderer.endFrame();
+  EXPECT_FALSE(renderer.resourceStats().filterBudgetRejected);
+  EXPECT_FALSE(renderer.resourceStats().surfaceBudgetRejected);
+  EXPECT_FALSE(renderer.takeSnapshot().empty());
+}
+
 TEST_F(RendererGeodeTest, RefusalAfterAdmissionPreservesTheParentPixels) {
   RendererGeode renderer = createRenderer();
   beginFrame(renderer);

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -321,37 +321,44 @@ TEST_F(RendererGeodeTest, TransformedLocalFilterAdmissionCoversItsTileWork) {
   using namespace components;
   constexpr uint32_t kWidth = 1024;
   constexpr uint32_t kHeight = 768;
-  std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
-  ASSERT_TRUE(device);
-  RendererGeode renderer(device);
-  RenderViewport viewport;
-  viewport.size = Vector2d(kWidth, kHeight);
-  renderer.beginFrame(viewport);
-  FilterGraph graph;
-  FilterNode blur;
-  blur.primitive = filter_primitive::GaussianBlur{.stdDeviationX = 4, .stdDeviationY = 2};
-  graph.nodes.push_back(blur);
-  renderer.setTransform(Transform2d::SkewX(0.2));
-  renderer.pushFilterLayer(graph, Box2d({0, 0}, {960, 640}));
-  const auto admitted = renderer.resourceStats();
-  ASSERT_FALSE(admitted.filterBudgetRejected);
-  renderer.setTransform(Transform2d());
-  renderer.setPaint(solidFill(css::RGBA(255, 255, 255, 255)));
-  renderer.drawRect(Box2d({0, 0}, {kWidth, kHeight}), StrokeParams{});
-  renderer.popFilterLayer();
-  const auto observed = device->filterEngine().lastExecutionMemory();
-  ASSERT_GT(observed.tileExecutions, 1u);
-  uint64_t untiledWork = 0;
-  uint64_t untiledBytes = 0;
-  ASSERT_TRUE(FilterGraphExecutionCost(graph, uint64_t{kWidth} * kHeight,
-                                       FilterMemoryModel::GpuAllNodes, untiledWork, untiledBytes));
-  EXPECT_GT(observed.workUnits, untiledWork);
-  EXPECT_GE(admitted.filterWorkUnits, observed.workUnits);
-  EXPECT_GE(admitted.filterRetainedBytes, observed.total());
-  renderer.endFrame();
-  EXPECT_FALSE(renderer.resourceStats().filterBudgetRejected);
-  EXPECT_FALSE(renderer.resourceStats().surfaceBudgetRejected);
-  EXPECT_FALSE(renderer.takeSnapshot().empty());
+  for (bool changePreference : {false, true}) {
+    SCOPED_TRACE(changePreference);
+    std::shared_ptr<geode::GeodeDevice> device = geode::GeodeDevice::CreateHeadless();
+    ASSERT_TRUE(device);
+    RendererGeode renderer(device);
+    RenderViewport viewport;
+    viewport.size = Vector2d(kWidth, kHeight);
+    renderer.beginFrame(viewport);
+    FilterGraph graph;
+    FilterNode blur;
+    blur.primitive = filter_primitive::GaussianBlur{.stdDeviationX = 4, .stdDeviationY = 2};
+    graph.nodes.push_back(blur);
+    renderer.setTransform(Transform2d::SkewX(0.2));
+    renderer.pushFilterLayer(graph, Box2d({0, 0}, {960, 640}));
+    const auto admitted = renderer.resourceStats();
+    ASSERT_FALSE(admitted.filterBudgetRejected);
+    if (changePreference) {
+      device->filterEngine().setMaximumTileExtentForTesting(16);
+    }
+    renderer.setTransform(Transform2d());
+    renderer.setPaint(solidFill(css::RGBA(255, 255, 255, 255)));
+    renderer.drawRect(Box2d({0, 0}, {kWidth, kHeight}), StrokeParams{});
+    renderer.popFilterLayer();
+    const auto observed = device->filterEngine().lastExecutionMemory();
+    ASSERT_GT(observed.tileExecutions, 1u);
+    uint64_t untiledWork = 0;
+    uint64_t untiledBytes = 0;
+    ASSERT_TRUE(FilterGraphExecutionCost(graph, uint64_t{kWidth} * kHeight,
+                                         FilterMemoryModel::GpuAllNodes, untiledWork,
+                                         untiledBytes));
+    EXPECT_GT(observed.workUnits, untiledWork);
+    EXPECT_GE(admitted.filterWorkUnits, observed.workUnits);
+    EXPECT_GE(admitted.filterRetainedBytes, observed.total());
+    renderer.endFrame();
+    EXPECT_FALSE(renderer.resourceStats().filterBudgetRejected);
+    EXPECT_FALSE(renderer.resourceStats().surfaceBudgetRejected);
+    EXPECT_FALSE(renderer.takeSnapshot().empty());
+  }
 }
 
 TEST_F(RendererGeodeTest, RefusalAfterAdmissionPreservesTheParentPixels) {


### PR DESCRIPTION
Reserve transformed local filters using the tile plan that execution will actually use. The previous preflight could charge 9,437,184 work units for a path that executed 18,874,368, undercounting repeated work and parameter storage.

The frame retains its admitted local and full plans, conservatively bounds a permitted fallback, and validates plan geometry before allocating. Execution cannot choose a different tile layout after admission or run an unreserved second path after starting local filtering. An admitted budget refusal returns no filtered output rather than passing the source through.

Validation includes the causal transformed-local regression, changed tile preferences after admission, malformed-plan refusal before allocation, and admitted-budget refusal. The default suite, separate Geode editor lane, native Vulkan renderer/shader tests, CMake generation, lint, and inventory checks pass. Memory caps and pixel tolerances are unchanged.

Follow-up to the transformed-local reservation review on #1124.
