### PR TITLE
Include GPU suites in full coverage and reject partial failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -82,7 +82,7 @@ jobs:
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
       BAZEL_DIFF_SHA256: "eadec6d0ca0991de78bd9e063bfed993a359ed3bc60e507818077c300b6f58e0"
-      FULL_COVERAGE_TARGETS: "//donner/base/... //donner/css/... //donner/svg/... //donner/editor/..."
+      FULL_COVERAGE_TARGETS: "//donner/..."
       SMOKE_COVERAGE_TARGETS: "//donner/base/..."
     outputs:
       fallback: ${{ steps.determine.outputs.fallback }}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -83,8 +83,11 @@ py_test(
     size = "small",
     srcs = ["coverage_script_tests.py"],
     data = [
+        "check_lcov_report.py",
         "coverage.sh",
         "coverage_bep_status.py",
+        "filter_coverage.py",
+        "lcov_metrics.py",
     ],
     deps = ["@rules_python//python/runfiles"],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -79,6 +79,17 @@ py_test(
 )
 
 py_test(
+    name = "coverage_script_tests",
+    size = "small",
+    srcs = ["coverage_script_tests.py"],
+    data = [
+        "coverage.sh",
+        "coverage_bep_status.py",
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
     name = "coverage_bep_status_tests",
     size = "small",
     srcs = [

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -368,6 +368,7 @@ fi
   # early exits cannot accidentally process stale data.
   rm -f "$COVERAGE_REPORT"
 
+  coverage_status=0
   if [ "$QUIET" = true ]; then
     # Keep progress ON even in --quiet mode. Console noise is already handled by
     # redirecting to $BAZEL_COVERAGE_LOG, and `--noshow_progress` left that log
@@ -380,14 +381,14 @@ fi
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
       "${DIAG_FLAGS[@]}" \
-      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
+      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || coverage_status=$?
   else
     "${BAZEL_CMD[@]}" coverage --config=latest_llvm \
       "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
       "${DIAG_FLAGS[@]}" \
-      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
+      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || coverage_status=$?
   fi
   phase_mark bazel_coverage_done
 
@@ -406,7 +407,10 @@ fi
       BEP_STATUS="$(python3 tools/coverage_bep_status.py "$COVERAGE_BEP" |
         python3 -c 'import json, sys; print(json.load(sys.stdin)["status"])')"
     fi
-    if [ "$BEP_STATUS" = "all_skipped" ]; then
+    # Bazel may return NO_TESTS_FOUND (4) for an entirely incompatible set.
+    # A skip event alongside a build failure must not turn that failure green.
+    if [[ "$BEP_STATUS" = "all_skipped" &&
+          ( "$coverage_status" -eq 0 || "$coverage_status" -eq 4 ) ]]; then
       echo "No coverage report: every selected target was skipped as incompatible with this platform."
       echo "Nothing to measure here; treating the lane as satisfied."
       # Record the outcome instead of pretending a report exists. This path
@@ -423,6 +427,15 @@ fi
     fi
     echo "ERROR: Coverage report was not generated"
     exit 1
+  fi
+
+  # --keep_going may produce a valid LCOV file even after a build/test failure.
+  # That file describes only the successful subset and must never replace the
+  # complete baseline. The all-incompatible/no-report exception above remains
+  # separate; every invocation that actually produced a report must succeed.
+  if [[ "$coverage_status" -ne 0 ]]; then
+    echo "ERROR: Bazel coverage failed with status $coverage_status; refusing to publish a partial report."
+    exit "$coverage_status"
   fi
 
   FILTER_ARGS=(--input "$COVERAGE_REPORT" --output "$COVERAGE_HTML_DIR/filtered_report.dat")

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
 function print_help() {
   cat <<EOF

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -78,6 +78,14 @@ class CoverageLaneRoutingTest(unittest.TestCase):
     def setUpClass(cls):
         cls.text = _workflow_text()
 
+    def test_full_baseline_covers_the_complete_product_tree(self):
+        # GPU implementation files enter reports as SVG/editor dependencies.
+        # Their owning tests must run too; an enumerated package list silently
+        # omitted the entire GPU suite when that subtree was introduced.
+        match = re.search(r'FULL_COVERAGE_TARGETS: "([^"]+)"', self.text)
+        self.assertIsNotNone(match)
+        self.assertEqual(["//donner/..."], match.group(1).split())
+
     def test_every_emitted_reason_is_classified(self):
         """No reason may exist that the routing table has never heard of.
 

--- a/tools/coverage_script_tests.py
+++ b/tools/coverage_script_tests.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -18,10 +19,15 @@ class CoverageScriptTest(unittest.TestCase):
         (root / "output").mkdir()
         (root / "tools").mkdir()
         resolver = runfiles.Create()
-        shutil.copyfile(
-            resolver.Rlocation("donner/tools/coverage_bep_status.py"),
-            root / "tools/coverage_bep_status.py",
-        )
+        for name in (
+            "coverage_bep_status.py",
+            "filter_coverage.py",
+            "check_lcov_report.py",
+            "lcov_metrics.py",
+        ):
+            shutil.copyfile(resolver.Rlocation("donner/tools/" + name), root / "tools" / name)
+        (root / "donner").mkdir()
+        (root / "donner/example.cc").write_text("int answer() { return 42; }\n", encoding="utf-8")
         events = [
             {
                 "id": {"targetCompleted": {"label": "//fixture:incompatible"}},
@@ -47,6 +53,7 @@ class CoverageScriptTest(unittest.TestCase):
             '  output_path) echo "$FIXTURE_ROOT/output";;\n'
             ' esac;;\n'
             ' coverage)\n'
+            '  printf "invoked\\n" > "$FIXTURE_ROOT/coverage-invoked"\n'
             '  for arg in "$@"; do\n'
             '   case "$arg" in --build_event_json_file=*)\n'
             '    cp "$FIXTURE_ROOT/fixture-bep.json" "${arg#*=}";;\n'
@@ -54,7 +61,7 @@ class CoverageScriptTest(unittest.TestCase):
             '  done\n'
             '  if [[ "$FIXTURE_REPORT" = 1 ]]; then\n'
             '   mkdir -p "$FIXTURE_ROOT/output/_coverage"\n'
-            '   printf "SF:donner/example.cc\\nDA:1,1\\nend_of_record\\n" '
+            '   printf "SF:donner/example.cc\\nDA:1,1\\nLF:1\\nLH:1\\nend_of_record\\n" '
             '> "$FIXTURE_ROOT/output/_coverage/_coverage_report.dat"\n'
             '  fi\n'
             '  exit "$FIXTURE_STATUS";;\n'
@@ -64,7 +71,13 @@ class CoverageScriptTest(unittest.TestCase):
         fake_bazel.chmod(0o755)
         for name, body in (
             ("java", "#!/bin/sh\nexit 0\n"),
-            ("clang", "#!/bin/sh\necho /bin/true\n"),
+            # Discovery checks executable paths without running either tool.
+            # Supply fixture-owned executables instead of assuming /bin/true
+            # exists on every worker (macOS provides /usr/bin/true).
+            ("clang", '#!/bin/sh\nprintf "%s/%s\\n" "${0%/*}" "${1#--print-prog-name=}"\n'),
+            ("llvm-cov", "#!/bin/sh\nexit 99\n"),
+            ("llvm-profdata", "#!/bin/sh\nexit 99\n"),
+            ("python3", '#!/bin/sh\nexec "$FIXTURE_PYTHON" "$@"\n'),
         ):
             path = binaries / name
             path.write_text(body, encoding="utf-8")
@@ -72,13 +85,14 @@ class CoverageScriptTest(unittest.TestCase):
         command = ["bash", resolver.Rlocation("donner/tools/coverage.sh"), "--no-html"]
         if quiet:
             command.append("--quiet")
-        return subprocess.run(
+        result = subprocess.run(
             command,
             cwd=root,
             env={
                 **os.environ,
                 "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
                 "FIXTURE_ROOT": str(root),
+                "FIXTURE_PYTHON": sys.executable,
                 "FIXTURE_STATUS": str(status),
                 "FIXTURE_REPORT": str(int(report)),
                 "DONNER_BAZEL": str(fake_bazel),
@@ -89,6 +103,27 @@ class CoverageScriptTest(unittest.TestCase):
             timeout=20,
             check=False,
         )
+        self.assertEqual(
+            "invoked\n",
+            (root / "coverage-invoked").read_text(encoding="utf-8")
+            if (root / "coverage-invoked").exists() else "",
+            result.stdout + result.stderr,
+        )
+        return result
+
+    def test_successful_report_reaches_real_filtering_and_validation(self):
+        for quiet in (False, True):
+            with self.subTest(quiet=quiet), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                result = self.run_fixture(root, quiet, status=0, report=True)
+                self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+                self.assertIn("Filtered LCOV coverage metrics:", result.stdout)
+                filtered = (root / "coverage-report/filtered_report.dat").read_text(encoding="utf-8")
+                self.assertIn("SF:donner/example.cc\n", filtered)
+                self.assertIn("DA:1,1\n", filtered)
+                self.assertIn("LF:1\n", filtered)
+                self.assertIn("LH:1\n", filtered)
+                self.assertFalse((root / "coverage-report/coverage_skipped").exists())
 
     def test_failed_run_cannot_publish_an_existing_combined_report(self):
         for quiet in (False, True):
@@ -116,7 +151,12 @@ class CoverageScriptTest(unittest.TestCase):
             with self.subTest(quiet=quiet), tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
                 result = self.run_fixture(root, quiet, status=1, report=False, failed_target=True)
-                self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+                self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+                self.assertIn("ERROR: Coverage report was not generated", result.stdout)
+                self.assertEqual(
+                    (root / "fixture-bep.json").read_text(encoding="utf-8"),
+                    (root / "coverage-report/bep.json").read_text(encoding="utf-8"),
+                )
                 self.assertFalse((root / "coverage-report/coverage_skipped").exists())
                 self.assertFalse((root / "coverage-report/filtered_report.dat").exists())
 

--- a/tools/coverage_script_tests.py
+++ b/tools/coverage_script_tests.py
@@ -1,0 +1,125 @@
+"""Coverage orchestration refuses partial reports and mixed build failures."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from python.runfiles import runfiles
+
+
+class CoverageScriptTest(unittest.TestCase):
+    def run_fixture(self, root, quiet, status, report, failed_target=False):
+        binaries = root / "bin"
+        binaries.mkdir()
+        (root / "output").mkdir()
+        (root / "tools").mkdir()
+        resolver = runfiles.Create()
+        shutil.copyfile(
+            resolver.Rlocation("donner/tools/coverage_bep_status.py"),
+            root / "tools/coverage_bep_status.py",
+        )
+        events = [
+            {
+                "id": {"targetCompleted": {"label": "//fixture:incompatible"}},
+                "aborted": {"reason": "SKIPPED"},
+            }
+        ]
+        if failed_target:
+            events.append(
+                {
+                    "id": {"targetCompleted": {"label": "//fixture:failed"}},
+                    "completed": {"success": False},
+                }
+            )
+        (root / "fixture-bep.json").write_text(
+            "\n".join(json.dumps(event) for event in events), encoding="utf-8"
+        )
+        fake_bazel = binaries / "bazel"
+        fake_bazel.write_text(
+            '#!/bin/bash\n'
+            'case "$1" in\n'
+            ' info) case "$2" in\n'
+            '  workspace) echo "$FIXTURE_ROOT";;\n'
+            '  output_path) echo "$FIXTURE_ROOT/output";;\n'
+            ' esac;;\n'
+            ' coverage)\n'
+            '  for arg in "$@"; do\n'
+            '   case "$arg" in --build_event_json_file=*)\n'
+            '    cp "$FIXTURE_ROOT/fixture-bep.json" "${arg#*=}";;\n'
+            '   esac\n'
+            '  done\n'
+            '  if [[ "$FIXTURE_REPORT" = 1 ]]; then\n'
+            '   mkdir -p "$FIXTURE_ROOT/output/_coverage"\n'
+            '   printf "SF:donner/example.cc\\nDA:1,1\\nend_of_record\\n" '
+            '> "$FIXTURE_ROOT/output/_coverage/_coverage_report.dat"\n'
+            '  fi\n'
+            '  exit "$FIXTURE_STATUS";;\n'
+            'esac\n',
+            encoding="utf-8",
+        )
+        fake_bazel.chmod(0o755)
+        for name, body in (
+            ("java", "#!/bin/sh\nexit 0\n"),
+            ("clang", "#!/bin/sh\necho /bin/true\n"),
+        ):
+            path = binaries / name
+            path.write_text(body, encoding="utf-8")
+            path.chmod(0o755)
+        command = ["bash", resolver.Rlocation("donner/tools/coverage.sh"), "--no-html"]
+        if quiet:
+            command.append("--quiet")
+        return subprocess.run(
+            command,
+            cwd=root,
+            env={
+                **os.environ,
+                "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
+                "FIXTURE_ROOT": str(root),
+                "FIXTURE_STATUS": str(status),
+                "FIXTURE_REPORT": str(int(report)),
+                "DONNER_BAZEL": str(fake_bazel),
+                "DONNER_CI_DIAGNOSTICS_DIR": "",
+            },
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+
+    def test_failed_run_cannot_publish_an_existing_combined_report(self):
+        for quiet in (False, True):
+            with self.subTest(quiet=quiet), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                result = self.run_fixture(root, quiet, status=3, report=True)
+                self.assertEqual(3, result.returncode, result.stdout + result.stderr)
+                self.assertIn("refusing to publish a partial report", result.stdout)
+                self.assertTrue((root / "output/_coverage/_coverage_report.dat").is_file())
+                self.assertFalse((root / "coverage-report/filtered_report.dat").exists())
+
+    def test_all_incompatible_targets_accept_success_and_no_tests_found(self):
+        for quiet in (False, True):
+            for status in (0, 4):
+                with self.subTest(quiet=quiet, status=status):
+                    with tempfile.TemporaryDirectory() as directory:
+                        root = Path(directory)
+                        result = self.run_fixture(root, quiet, status, report=False)
+                        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+                        self.assertTrue((root / "coverage-report/coverage_skipped").is_file())
+                        self.assertFalse((root / "coverage-report/filtered_report.dat").exists())
+
+    def test_skipped_target_does_not_hide_a_failed_build(self):
+        for quiet in (False, True):
+            with self.subTest(quiet=quiet), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                result = self.run_fixture(root, quiet, status=1, report=False, failed_target=True)
+                self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+                self.assertFalse((root / "coverage-report/coverage_skipped").exists())
+                self.assertFalse((root / "coverage-report/filtered_report.dat").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Include all Donner suites in full coverage runs, including the previously omitted GPU owning tests. Reject partial LCOV reports after a failed Bazel run, and preserve failure propagation when the script is invoked through Bash.

Regression fixtures cover failed partial reports, mixed skipped/failed targets, benign incompatible-only runs, and successful filtering. This corrects measurement scope and report safety; it does not claim the project has reached its coverage target.

Validation: full suite (491 passed, 33 skipped), CMake generation, lint, and independent code/security review. The completed full CI coverage report is now processed by Codecov: project coverage is 83.78% (89,608/106,950 fully covered lines), up from 79.46%; the GPU subtree is 80.83% (10,855/13,430). The project target above 85% remains open.
