### PR TITLE
Exercise GPU device, encoder, and shader IR validation contracts

### DIFF
--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -1008,5 +1008,380 @@ TEST(ComputeEntryPointTests, TextureStoreRejectsIllTypedOperands) {
   }
 }
 
+TEST(ModuleBuilderLifecycle, AnOpenFunctionExcludesEveryOtherEntryAndModuleBuild) {
+  ModuleBuilder builder;
+  {
+    auto result = builder.createFunction("open", {}, std::nullopt);
+    ASSERT_THAT(result, HasShaderResult());
+    FunctionBuilder function = std::move(result).result();
+    EXPECT_THAT(builder.createFunction("next", {}, std::nullopt),
+                IsShaderError(HasSubstr("finish the previous function")));
+    EXPECT_THAT(builder.createVertexEntryPoint("vertex", {}, {}),
+                IsShaderError(HasSubstr("finish the previous function")));
+    EXPECT_THAT(builder.createFragmentEntryPoint("fragment", {}, {}),
+                IsShaderError(HasSubstr("finish the previous function")));
+    EXPECT_THAT(builder.createComputeEntryPoint("compute", {}, {1, 1, 1}),
+                IsShaderError(HasSubstr("finish the previous function")));
+    EXPECT_THAT(builder.build(), IsShaderError(HasSubstr("finish the in-progress function")));
+  }
+  auto next = builder.createFunction("next", {}, std::nullopt);
+  ASSERT_THAT(next, HasShaderResult());
+  EXPECT_THAT(next.result().finish(), IsShaderOk());
+  const auto module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+  ASSERT_THAT(module.result().functions(), testing::SizeIs(1));
+  EXPECT_THAT(module.result().functions().front().name, testing::Eq(RcString("next")));
+}
+
+TEST_F(FunctionBuilderTests, FinishedFunctionsCannotBeMutatedOrRegisteredTwice) {
+  FunctionBuilder function = startFunction();
+  ASSERT_THAT(function.finish(), IsShaderOk());
+  EXPECT_THAT(function.addLet("later", F32Val()), IsShaderError(HasSubstr("already finished")));
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("already finished")));
+  const auto module = builder_.build();
+  ASSERT_THAT(module, HasShaderResult());
+  EXPECT_THAT(module.result().functions(), testing::SizeIs(1));
+}
+
+TEST_F(FunctionBuilderTests, FirstFailureSurvivesEverySubsequentMutation) {
+  FunctionBuilder function = startFunction();
+  const auto mutableValue =
+      GetShaderResultOrFail(function.addVar("v", IrType::F32(), F32Val()), F32Val());
+  ASSERT_THAT(function.addLet("v", F32Val()), IsShaderError(HasSubstr("already declared")));
+  const auto error = IsShaderError(HasSubstr("already declared"));
+  EXPECT_THAT(function.addLet("later", F32Val()), error);
+  EXPECT_THAT(function.addVar("later", IrType::F32(), F32Val()), error);
+  EXPECT_THAT(function.assign(mutableValue, F32Val()), error);
+  EXPECT_THAT(function.beginIf(LiteralBool(true)), error);
+  EXPECT_THAT(function.elseBranch(), error);
+  EXPECT_THAT(function.endIf(), error);
+  EXPECT_THAT(function.beginFor("i", LiteralU32(0)), error);
+  EXPECT_THAT(function.forCondition(LiteralBool(true)), error);
+  EXPECT_THAT(function.forContinuing(mutableValue, F32Val()), error);
+  EXPECT_THAT(function.endFor(), error);
+  EXPECT_THAT(function.breakStmt(), error);
+  EXPECT_THAT(function.continueStmt(), error);
+  EXPECT_THAT(function.returnValue(F32Val()), error);
+  EXPECT_THAT(function.returnVoid(), error);
+  EXPECT_THAT(function.returnOutputs({Vec4fVal()}), error);
+  EXPECT_THAT(function.discard(), error);
+  EXPECT_THAT(function.textureStore(F32Val(), Vec2uVal(), Vec4fVal()), error);
+  EXPECT_THAT(function.finish(), error);
+}
+
+TEST(ModuleBuilderValidation, FunctionsAndConstantsShareTheModuleNamespace) {
+  ModuleBuilder builder;
+  ASSERT_THAT(builder.addConstant("constant", F32Val()), IsShaderOk());
+  EXPECT_THAT(builder.addConstant("constant", F32Val()),
+              IsShaderError(HasSubstr("already exists")));
+  EXPECT_THAT(builder.createFunction("constant", {}, std::nullopt),
+              IsShaderError(HasSubstr("already exists")));
+  EXPECT_THAT(builder.createVertexEntryPoint("constant", {}, {}),
+              IsShaderError(HasSubstr("already exists")));
+  EXPECT_THAT(builder.createFragmentEntryPoint("constant", {}, {}),
+              IsShaderError(HasSubstr("already exists")));
+  EXPECT_THAT(builder.createComputeEntryPoint("constant", {}, {1, 1, 1}),
+              IsShaderError(HasSubstr("already exists")));
+  auto function = builder.createFunction("function", {}, std::nullopt);
+  ASSERT_THAT(function, HasShaderResult());
+  ASSERT_THAT(function.result().finish(), IsShaderOk());
+  EXPECT_THAT(builder.addConstant("function", F32Val()),
+              IsShaderError(HasSubstr("already exists")));
+}
+
+TEST(ModuleBuilderValidation, DuplicateParametersDoNotAcquireTheFunctionSlot) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.createFunction("duplicate", {{"x", IrType::F32()}, {"x", IrType::U32()}},
+                                     std::nullopt),
+              IsShaderError(HasSubstr("duplicate parameter name x")));
+  auto valid = builder.createFunction("valid", {{"x", IrType::F32()}}, std::nullopt);
+  ASSERT_THAT(valid, HasShaderResult());
+  EXPECT_THAT(valid.result().finish(), IsShaderOk());
+}
+
+TEST_F(FunctionBuilderTests, ResourceTypesCannotBecomeLocalVariables) {
+  auto function = startFunction();
+  EXPECT_THAT(function.addVar("texture", IrType::Texture2dF32(), std::nullopt),
+              IsShaderError(HasSubstr("not plain data")));
+}
+
+TEST_F(FunctionBuilderTests, AssignmentReportsATypeMismatchOnAMutableTarget) {
+  auto function = startFunction();
+  const auto target =
+      GetShaderResultOrFail(function.addVar("value", IrType::F32(), F32Val()), F32Val());
+  EXPECT_THAT(function.assign(target, LiteralU32(2)),
+              IsShaderError(HasSubstr("assignment type mismatch")));
+}
+
+TEST_F(FunctionBuilderTests, AVariableInitializerCannotEscapeItsDefiningBranch) {
+  auto function = startFunction();
+  ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const auto temporary = GetShaderResultOrFail(function.addLet("temporary", F32Val()), F32Val());
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  EXPECT_THAT(function.addVar("escaped", IrType::F32(), temporary),
+              IsShaderError(HasSubstr("out of scope")));
+}
+
+TEST_F(FunctionBuilderTests, AVariableCannotRedeclareAnExistingParameter) {
+  auto function = startFunction();
+  EXPECT_THAT(function.addVar("t", IrType::F32(), F32Val()),
+              IsShaderError(HasSubstr("already declared")));
+}
+
+TEST_F(FunctionBuilderTests, AssignmentRejectsAnOutOfScopeRightHandSide) {
+  auto function = startFunction();
+  const auto target =
+      GetShaderResultOrFail(function.addVar("value", IrType::F32(), F32Val()), F32Val());
+  ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const auto temporary = GetShaderResultOrFail(function.addLet("temporary", F32Val()), F32Val());
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  EXPECT_THAT(function.assign(target, temporary), IsShaderError(HasSubstr("out of scope")));
+}
+
+TEST(FunctionBuilderScope, ExpressionsCannotImportAnotherModulesResources) {
+  ModuleBuilder donor;
+  ASSERT_THAT(donor.addTexture2d(0, 0, "foreign"), IsShaderOk());
+  auto donorResult = donor.createFunction("donor", {}, std::nullopt);
+  ASSERT_THAT(donorResult, HasShaderResult());
+  const auto foreign = GetShaderResultOrFail(donorResult.result().ref("foreign"), F32Val());
+  ModuleBuilder target;
+  auto result = target.createFunction("target", {}, std::nullopt);
+  ASSERT_THAT(result, HasShaderResult());
+  EXPECT_THAT(result.result().addLet("borrowed", foreign),
+              IsShaderError(HasSubstr("unknown module-scope name foreign")));
+}
+
+TEST(FunctionBuilderControlFlow, ClosingOrContinuingAClosedBlockFailsPrecisely) {
+  struct Case {
+    ShaderStatus (FunctionBuilder::*action)();
+    const char* message;
+  };
+  const Case cases[] = {{&FunctionBuilder::elseBranch, "elseBranch without an open if"},
+                        {&FunctionBuilder::endIf, "endIf without an open if"},
+                        {&FunctionBuilder::endFor, "endFor without an open for"},
+                        {&FunctionBuilder::continueStmt, "continue outside of a loop"}};
+  for (const auto& test : cases) {
+    SCOPED_TRACE(test.message);
+    ModuleBuilder builder;
+    auto result = builder.createFunction("control", {}, std::nullopt);
+    ASSERT_THAT(result, HasShaderResult());
+    EXPECT_THAT((result.result().*test.action)(), IsShaderError(HasSubstr(test.message)));
+  }
+}
+
+TEST_F(FunctionBuilderTests, ForConditionNeedsAnOpenLoop) {
+  auto function = startFunction();
+  EXPECT_THAT(function.forCondition(LiteralBool(true)),
+              IsShaderError(HasSubstr("without an open for")));
+}
+
+TEST_F(FunctionBuilderTests, ForConditionRequiresBoolOnTheFirstAttempt) {
+  auto function = startFunction();
+  ASSERT_THAT(function.beginFor("i", LiteralU32(0)), HasShaderResult());
+  EXPECT_THAT(function.forCondition(F32Val()),
+              IsShaderError(HasSubstr("for condition must be bool")));
+}
+
+TEST_F(FunctionBuilderTests, ForConditionCannotBeReplaced) {
+  auto function = startFunction();
+  ASSERT_THAT(function.beginFor("i", LiteralU32(0)), HasShaderResult());
+  ASSERT_THAT(function.forCondition(LiteralBool(true)), IsShaderOk());
+  EXPECT_THAT(function.forCondition(LiteralBool(false)),
+              IsShaderError(HasSubstr("for condition already set")));
+}
+
+TEST_F(FunctionBuilderTests, ContinuingNeedsAnOpenLoop) {
+  auto function = startFunction();
+  const auto variable =
+      GetShaderResultOrFail(function.addVar("v", IrType::F32(), F32Val()), F32Val());
+  EXPECT_THAT(function.forContinuing(variable, F32Val()),
+              IsShaderError(HasSubstr("without an open for")));
+}
+
+TEST_F(FunctionBuilderTests, ContinuingRejectsAnImmutableTarget) {
+  auto function = startFunction();
+  ASSERT_THAT(function.beginFor("i", LiteralU32(0)), HasShaderResult());
+  EXPECT_THAT(function.forContinuing(F32Val(), F32Val()),
+              IsShaderError(HasSubstr("mutable lvalue")));
+}
+
+TEST_F(FunctionBuilderTests, ContinuingRejectsAMismatchedUpdateType) {
+  auto function = startFunction();
+  const auto index = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), F32Val());
+  EXPECT_THAT(function.forContinuing(index, F32Val()),
+              IsShaderError(HasSubstr("type-correct assignment")));
+}
+
+TEST_F(FunctionBuilderTests, ContinuingCannotBeReplaced) {
+  auto function = startFunction();
+  const auto index = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), F32Val());
+  ASSERT_THAT(function.forContinuing(index, LiteralU32(1)), IsShaderOk());
+  EXPECT_THAT(function.forContinuing(index, LiteralU32(2)),
+              IsShaderError(HasSubstr("continuing already set")));
+}
+
+TEST_F(FunctionBuilderTests, DuplicateLoopVariableRejectsTheHeader) {
+  auto function = startFunction();
+  EXPECT_THAT(function.beginFor("t", F32Val()), IsShaderError(HasSubstr("already declared")));
+}
+
+TEST_F(FunctionBuilderTests, LoopInitializerCannotReferenceAClosedBranch) {
+  auto function = startFunction();
+  ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const auto temporary = GetShaderResultOrFail(function.addLet("temporary", F32Val()), F32Val());
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  EXPECT_THAT(function.beginFor("i", temporary), IsShaderError(HasSubstr("out of scope")));
+}
+
+TEST(FunctionBuilderReturns, StageOutputsReportTypeMismatchBeforeFinish) {
+  ModuleBuilder builder;
+  auto result = builder.createFragmentEntryPoint("fragment", {}, {{"color", IrType::Vec4f(), 0}});
+  ASSERT_THAT(result, HasShaderResult());
+  EXPECT_THAT(result.result().returnOutputs({Vec2fVal()}),
+              IsShaderError(HasSubstr("output 0 (color) type mismatch")));
+}
+
+TEST(FunctionBuilderReturns, StageEntryCannotReturnAPlainValue) {
+  ModuleBuilder builder;
+  auto result = builder.createFragmentEntryPoint("fragment", {}, {{"color", IrType::Vec4f(), 0}});
+  ASSERT_THAT(result, HasShaderResult());
+  EXPECT_THAT(result.result().returnValue(Vec4fVal()),
+              IsShaderError(HasSubstr("via returnOutputs")));
+}
+
+TEST_F(FunctionBuilderTests, AValueReturningFunctionCannotReturnVoid) {
+  auto function = startFunction(IrType::F32());
+  EXPECT_THAT(function.returnVoid(), IsShaderError(HasSubstr("returnVoid requires")));
+}
+
+TEST(FunctionBuilderCalls, VoidCalleesAreNotExpressions) {
+  ModuleBuilder builder;
+  auto callee = builder.createFunction("voidCallee", {}, std::nullopt);
+  ASSERT_THAT(callee, HasShaderResult());
+  ASSERT_THAT(callee.result().finish(), IsShaderOk());
+  auto caller = builder.createFunction("caller", {}, std::nullopt);
+  ASSERT_THAT(caller, HasShaderResult());
+  EXPECT_THAT(caller.result().callFunction("voidCallee", {}),
+              IsShaderError(HasSubstr("returns void")));
+}
+
+TEST(FunctionBuilderCalls, ArgumentTypesAreValidatedOnTheFirstCall) {
+  ModuleBuilder builder;
+  auto callee = builder.createFunction("identity", {{"value", IrType::F32()}}, IrType::F32());
+  ASSERT_THAT(callee, HasShaderResult());
+  const auto value = GetShaderResultOrFail(callee.result().ref("value"), F32Val());
+  ASSERT_THAT(callee.result().returnValue(value), IsShaderOk());
+  ASSERT_THAT(callee.result().finish(), IsShaderOk());
+  auto caller = builder.createFunction("caller", {}, std::nullopt);
+  ASSERT_THAT(caller, HasShaderResult());
+  EXPECT_THAT(caller.result().callFunction("identity", {LiteralU32(0)}),
+              IsShaderError(HasSubstr("argument 0 type mismatch")));
+}
+
+TEST(StageIoValidation, UnlocatedInputsAndInvalidOutputTypesAreRejected) {
+  ModuleBuilder builder;
+  const std::vector<IrOutputMember> position{
+      {"position", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}};
+  EXPECT_THAT(builder.createVertexEntryPoint("vertex", {{"unlocated", IrType::F32()}}, position),
+              IsShaderError(HasSubstr("needs a location or builtin")));
+  EXPECT_THAT(builder.createVertexEntryPoint("vertex", {{"boolean", IrType::Bool(), 0}}, position),
+              IsShaderError(HasSubstr("must be a numeric scalar or vector")));
+  EXPECT_THAT(
+      builder.createVertexEntryPoint(
+          "vertex", {}, {{"badPosition", IrType::Vec2f(), std::nullopt, BuiltinOutput::Position}}),
+      IsShaderError(HasSubstr("must be position: vec4<f32>")));
+  EXPECT_THAT(builder.createVertexEntryPoint("vertex", {}, {{"unlocated", IrType::Vec4f()}}),
+              IsShaderError(HasSubstr("needs a location or builtin")));
+  EXPECT_THAT(builder.createFragmentEntryPoint("fragment", {{"unlocated", IrType::F32()}},
+                                               {{"color", IrType::Vec4f(), 0}}),
+              IsShaderError(HasSubstr("must have a location or builtin")));
+  EXPECT_THAT(builder.createFragmentEntryPoint("fragment", {{"boolean", IrType::Bool(), 0}},
+                                               {{"color", IrType::Vec4f(), 0}}),
+              IsShaderError(HasSubstr("must be a numeric scalar or vector")));
+  EXPECT_THAT(builder.createFragmentEntryPoint("fragment", {}, {{"unlocated", IrType::Vec4f()}}),
+              IsShaderError(HasSubstr("must have a location")));
+  EXPECT_THAT(
+      builder.createComputeEntryPoint("compute", {{"boolean", IrType::Bool(), 0}}, {1, 1, 1}),
+      IsShaderError(HasSubstr("must be a numeric scalar or vector")));
+}
+
+TEST(ComputeStageRestrictions, DerivativesAreFoundInLoopHeadersAndNestedElseBlocks) {
+  for (int placement = 0; placement < 3; ++placement) {
+    SCOPED_TRACE(placement);
+    ModuleBuilder builder;
+    auto result = builder.createComputeEntryPoint("compute", {}, {1, 1, 1});
+    ASSERT_THAT(result, HasShaderResult());
+    auto& function = result.result();
+    const auto derivative =
+        GetShaderResultOrFail(CallBuiltin(BuiltinFn::Fwidth, {F32Val()}), F32Val());
+    if (placement == 0) {
+      ASSERT_THAT(function.beginFor("i", derivative), HasShaderResult());
+      ASSERT_THAT(function.breakStmt(), IsShaderOk());
+      ASSERT_THAT(function.endFor(), IsShaderOk());
+    } else if (placement == 1) {
+      const auto index = GetShaderResultOrFail(function.beginFor("i", F32Val()), F32Val());
+      ASSERT_THAT(function.forContinuing(index, derivative), IsShaderOk());
+      ASSERT_THAT(function.breakStmt(), IsShaderOk());
+      ASSERT_THAT(function.endFor(), IsShaderOk());
+    } else {
+      ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+      ASSERT_THAT(function.elseBranch(), IsShaderOk());
+      ASSERT_THAT(function.addLet("d", derivative), HasShaderResult());
+      ASSERT_THAT(function.endIf(), IsShaderOk());
+    }
+    EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("fragment-only")));
+  }
+}
+
+TEST(FunctionBuilderStorage, StorageWritesValidateEveryOperandsScope) {
+  for (int escapedOperand = 0; escapedOperand < 3; ++escapedOperand) {
+    SCOPED_TRACE(escapedOperand);
+    ModuleBuilder donor;
+    ASSERT_THAT(
+        donor.addWriteOnlyStorageTexture2d(0, 0, "foreign", StorageTextureFormat::Rgba32Float),
+        IsShaderOk());
+    auto donorFunction = donor.createFunction("donor", {}, std::nullopt);
+    ASSERT_THAT(donorFunction, HasShaderResult());
+    const auto foreignTexture =
+        GetShaderResultOrFail(donorFunction.result().ref("foreign"), F32Val());
+    ModuleBuilder builder;
+    ASSERT_THAT(
+        builder.addWriteOnlyStorageTexture2d(0, 0, "output", StorageTextureFormat::Rgba32Float),
+        IsShaderOk());
+    auto result = builder.createComputeEntryPoint("writer", {}, {1, 1, 1});
+    ASSERT_THAT(result, HasShaderResult());
+    auto& function = result.result();
+    const auto output = GetShaderResultOrFail(function.ref("output"), F32Val());
+    ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+    const auto escapedCoords =
+        GetShaderResultOrFail(function.addLet("coords", Vec2uVal()), F32Val());
+    const auto escapedValue = GetShaderResultOrFail(function.addLet("color", Vec4fVal()), F32Val());
+    ASSERT_THAT(function.endIf(), IsShaderOk());
+    EXPECT_THAT(function.textureStore(escapedOperand == 0 ? foreignTexture : output,
+                                      escapedOperand == 1 ? escapedCoords : Vec2uVal(),
+                                      escapedOperand == 2 ? escapedValue : Vec4fVal()),
+                IsShaderError(
+                    HasSubstr(escapedOperand == 0 ? "unknown module-scope name" : "out of scope")));
+  }
+}
+
+TEST(FunctionBuilderControlFlow, ContinuingRejectsEscapedTargetsAndValues) {
+  for (bool escapeTarget : {false, true}) {
+    SCOPED_TRACE(escapeTarget);
+    ModuleBuilder builder;
+    auto result = builder.createFunction("loop", {}, std::nullopt);
+    ASSERT_THAT(result, HasShaderResult());
+    auto& function = result.result();
+    ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+    const auto escaped =
+        GetShaderResultOrFail(function.addVar("escaped", IrType::U32(), LiteralU32(0)), F32Val());
+    ASSERT_THAT(function.endIf(), IsShaderOk());
+    const auto index = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), F32Val());
+    EXPECT_THAT(function.forContinuing(escapeTarget ? escaped : index,
+                                       escapeTarget ? LiteralU32(1) : escaped),
+                IsShaderError(HasSubstr("out of scope")));
+  }
+}
+
 }  // namespace
 }  // namespace donner::gpu::shader

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <utility>
 
+#include "donner/gpu/GpuLimits.h"
 #include "donner/gpu/RecordingDevice.h"
 #include "donner/gpu/tests/GpuTestUtils.h"
 
@@ -633,6 +634,99 @@ TEST_F(CopyTextureToTextureTests, RejectsSelfCopy) {
       encoder_->copyTextureToTexture(target_, target_, Extent2d{4, 4}),
       IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
                             HasSubstr("source and destination are the same texture \"target\"")));
+}
+
+TEST_F(CommandEncoderTests, InvalidAttachmentListsCannotProduceACommandBuffer) {
+  for (size_t count : {size_t{0}, size_t{kMaxColorAttachments + 1}}) {
+    SCOPED_TRACE(count);
+    auto encoder = GetResultOrFail(device_.createCommandEncoder());
+    auto descriptor = passDescriptor();
+    descriptor.colorAttachments.resize(count, descriptor.colorAttachments.front());
+    const auto error = encoder->beginRenderPass(descriptor);
+    ASSERT_TRUE(error.hasError());
+    EXPECT_EQ(error.error().type,
+              count == 0 ? GpuErrorType::InvalidDescriptor : GpuErrorType::LimitExceeded);
+    EXPECT_THAT(encoder->finish(),
+                IsGpuErrorWithMessage(error.error().type, Eq(error.error().message)));
+  }
+  EXPECT_EQ(device_.lastSubmittedSerial(), 0u);
+}
+
+TEST_F(CommandEncoderTests, MalformedAttachmentOperationsPoisonBeforeRecording) {
+  for (bool badLoad : {false, true}) {
+    auto encoder = GetResultOrFail(device_.createCommandEncoder());
+    auto descriptor = passDescriptor();
+    if (badLoad)
+      descriptor.colorAttachments[0].loadOp = static_cast<LoadOp>(255);
+    else
+      descriptor.colorAttachments[0].storeOp = static_cast<StoreOp>(255);
+    const auto result = encoder->beginRenderPass(descriptor);
+    ASSERT_THAT(result, IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                              HasSubstr(badLoad ? "loadOp" : "storeOp")));
+    EXPECT_THAT(encoder->beginRenderPass(passDescriptor()),
+                IsGpuErrorWithMessage(result.error().type, Eq(result.error().message)));
+    EXPECT_THAT(encoder->finish(), IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+}
+
+TEST_F(CommandEncoderTests, NonFiniteClearChannelsCannotReachTheBackend) {
+  for (double value :
+       {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity()}) {
+    for (size_t channel = 0; channel < 4; ++channel) {
+      SCOPED_TRACE(channel);
+      auto encoder = GetResultOrFail(device_.createCommandEncoder());
+      auto descriptor = passDescriptor();
+      descriptor.colorAttachments[0].clearColor[channel] = value;
+      EXPECT_THAT(encoder->beginRenderPass(descriptor),
+                  IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("not finite")));
+      EXPECT_THAT(encoder->finish(), IsGpuError(GpuErrorType::InvalidDescriptor));
+    }
+  }
+}
+
+TEST_F(CommandEncoderTests, MultipleAttachmentsMustHaveTheSameExtent) {
+  const Texture other = GetResultOrFail(device_.createTexture(
+      {"other", {4, 3}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView view = GetResultOrFail(device_.createTextureView(other, {}));
+  auto descriptor = passDescriptor();
+  descriptor.colorAttachments.push_back({view, LoadOp::Clear, StoreOp::Store, {}});
+  EXPECT_THAT(encoder_->beginRenderPass(descriptor),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("extent")));
+  EXPECT_THAT(encoder_->finish(), IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(CommandEncoderTests, VertexBindingPastEndPoisonsButExactEndCanBind) {
+  auto* pass = beginPass();
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_, 48), IsOk());
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_, 49),
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("offsetBytes 49")));
+  EXPECT_THAT(encoder_->finish(), IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(CommandEncoderTests, TextureReadbackNeedsDestinationUsage) {
+  const Buffer wrongUsage =
+      GetResultOrFail(device_.createBuffer({"not-copyable", 1024, BufferUsage::Uniform}));
+  EXPECT_THAT(encoder_->copyTextureToBuffer({target_}, wrongUsage, {0, 256, 4}, {4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("CopyDst")));
+  EXPECT_THAT(encoder_->finish(), IsGpuError(GpuErrorType::UsageMismatch));
+}
+
+TEST_F(CommandEncoderTests, ReadbackExtentAndOffsetCannotOverflowOrEscapeTheSource) {
+  for (const Extent2d extent : {Extent2d{0, 4}, Extent2d{4, 0}, Extent2d{5, 4}, Extent2d{4, 5}}) {
+    auto encoder = GetResultOrFail(device_.createCommandEncoder());
+    const auto result =
+        encoder->copyTextureToBuffer({target_}, readbackBuffer_, {0, 256, 5}, extent);
+    const auto expected = extent.width == 0 || extent.height == 0 ? GpuErrorType::InvalidDescriptor
+                                                                  : GpuErrorType::OutOfBounds;
+    ASSERT_THAT(result, IsGpuError(expected));
+    EXPECT_THAT(encoder->finish(), IsGpuErrorWithMessage(expected, Eq(result.error().message)));
+  }
+  const uint64_t alignedNearMaximum = std::numeric_limits<uint64_t>::max() - 3;
+  EXPECT_THAT(encoder_->copyTextureToBuffer({target_}, readbackBuffer_,
+                                            {alignedNearMaximum, 256, 4}, {4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("overflows")));
 }
 
 }  // namespace

--- a/donner/gpu/tests/DeviceValidation_tests.cc
+++ b/donner/gpu/tests/DeviceValidation_tests.cc
@@ -799,6 +799,12 @@ public:
   SurfaceStatus presentStatus = SurfaceStatus::Success;
   /// Number of times the runtime abandoned an acquired texture.
   int abandonCalls = 0;
+  /// Inject failures after entering the backend, without granting ownership of a frame.
+  bool failAcquire = false;
+  /// Present consumes backend ownership even when it reports an error.
+  bool failPresent = false;
+  /// Slots proposed by acquisition attempts, to verify failed attempts are recycled.
+  std::vector<uint32_t> acquireSlots;
 
 protected:
   // The operations this fake does not model are accepted and ignored: the tests below are about
@@ -844,7 +850,11 @@ protected:
 
   Status onConfigureSurface(uint32_t, const SurfaceConfiguration&) override { return OkStatus(); }
 
-  Result<SurfaceStatus> onAcquireCurrentTexture(uint32_t, uint32_t) override {
+  Result<SurfaceStatus> onAcquireCurrentTexture(uint32_t, uint32_t textureSlot) override {
+    acquireSlots.push_back(textureSlot);
+    if (failAcquire) {
+      return GpuError{GpuErrorType::InvalidState, "scripted acquire failure"};
+    }
     // The platform holds its own frame, and it holds exactly one: a backend tracks the frame it
     // handed out and refuses another until that one is presented or handed back. The wgpu
     // backend does this with its own per-surface flag, so a runtime that only cleaned up its own
@@ -861,6 +871,9 @@ protected:
 
   Result<SurfaceStatus> onPresentSurface(uint32_t) override {
     backendHasFrame = false;
+    if (failPresent) {
+      return GpuError{GpuErrorType::InvalidState, "scripted present failure"};
+    }
     return presentStatus;
   }
 
@@ -1297,6 +1310,105 @@ TEST_F(SurfaceTests, ABackendWithoutPresentationReportsItUnsupported) {
   descriptor.native.kind = NativeSurfaceKind::MetalLayer;
   descriptor.native.display = &layer_;
   EXPECT_THAT(plainDevice.createSurface(descriptor), IsGpuError(GpuErrorType::Unsupported));
+}
+
+TEST_F(RenderPipelineValidationTests, VertexLayoutsRequireStrideAndAttributesTogether) {
+  for (bool emptyAttributes : {false, true}) {
+    auto descriptor = validDescriptor();
+    if (emptyAttributes)
+      descriptor.vertex.buffers[0].attributes.clear();
+    else
+      descriptor.vertex.buffers[0].strideBytes = 0;
+    const auto before = device_.serialize();
+    EXPECT_THAT(
+        device_.createRenderPipeline(descriptor),
+        IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                              HasSubstr(emptyAttributes ? "no attributes" : "strideBytes 0")));
+    EXPECT_EQ(device_.serialize(), before)
+        << "Invalid layouts must never allocate a native pipeline";
+  }
+  auto generatedVertices = validDescriptor();
+  generatedVertices.vertex.buffers.clear();
+  EXPECT_THAT(device_.createRenderPipeline(generatedVertices), HasResult())
+      << "A shader-generated vertex stream needs no vertex buffer layout";
+}
+
+TEST_F(RenderPipelineValidationTests, ResourceCountsAcceptTheCapAndRejectCapPlusOne) {
+  auto descriptor = validDescriptor();
+  descriptor.fragment.targets.resize(kMaxColorAttachments, descriptor.fragment.targets.front());
+  ASSERT_THAT(device_.createRenderPipeline(descriptor), HasResult());
+  descriptor.fragment.targets.push_back(descriptor.fragment.targets.front());
+  EXPECT_THAT(device_.createRenderPipeline(descriptor), IsGpuError(GpuErrorType::LimitExceeded));
+
+  descriptor = validDescriptor();
+  descriptor.vertex.buffers.clear();
+  for (uint32_t i = 0; i < kMaxVertexBuffers; ++i) {
+    descriptor.vertex.buffers.push_back(
+        {4, VertexStepMode::Vertex, {{VertexFormat::Uint32, 0, i}}});
+  }
+  ASSERT_THAT(device_.createRenderPipeline(descriptor), HasResult());
+  descriptor.vertex.buffers.push_back(
+      {4, VertexStepMode::Instance, {{VertexFormat::Uint32, 0, kMaxVertexBuffers}}});
+  EXPECT_THAT(device_.createRenderPipeline(descriptor), IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(RenderPipelineValidationTests, FragmentEntryAndShaderLifetimeAreCheckedBeforeAllocation) {
+  auto descriptor = validDescriptor();
+  descriptor.fragment.entryPoint = "";
+  EXPECT_THAT(
+      device_.createRenderPipeline(descriptor),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("fragment.entryPoint")));
+  descriptor = validDescriptor();
+  ASSERT_THAT(device_.destroyShaderModule(std::move(shader_)), IsOk());
+  const auto before = device_.serialize();
+  EXPECT_THAT(device_.createRenderPipeline(descriptor), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_EQ(device_.serialize(), before);
+}
+
+TEST_F(SurfaceTests, FailedAcquireDoesNotLeakAFrameOrPreventRetry) {
+  const Surface surface = metalSurface();
+  ASSERT_THAT(device_.configureSurface(surface, configuration()), IsOk());
+  device_.failAcquire = true;
+  for (int attempt = 0; attempt < 3; ++attempt) {
+    EXPECT_THAT(
+        device_.acquireCurrentTexture(surface),
+        IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("scripted acquire failure")));
+    EXPECT_FALSE(device_.backendHasFrame);
+    EXPECT_THAT(device_.abandonCurrentTexture(surface), IsGpuError(GpuErrorType::InvalidState));
+  }
+  device_.failAcquire = false;
+  SurfaceTexture frame = GetResultOrFail(device_.acquireCurrentTexture(surface));
+  ASSERT_TRUE(frame.texture.isValid());
+  ASSERT_EQ(device_.acquireSlots.size(), 4u);
+  for (uint32_t slot : device_.acquireSlots) EXPECT_EQ(slot, frame.texture.slotIndex());
+  EXPECT_THAT(device_.abandonCurrentTexture(surface), IsOk());
+  EXPECT_FALSE(device_.backendHasFrame);
+}
+
+TEST_F(SurfaceTests, PresentFailureInvalidatesTheFrameAndAllowsTheNextAcquire) {
+  const Surface surface = metalSurface();
+  ASSERT_THAT(device_.configureSurface(surface, configuration()), IsOk());
+  SurfaceTexture frame = GetResultOrFail(device_.acquireCurrentTexture(surface));
+  device_.failPresent = true;
+  EXPECT_THAT(
+      device_.presentSurface(surface),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("scripted present failure")));
+  EXPECT_THAT(device_.createTextureView(frame.texture, {}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_FALSE(device_.backendHasFrame);
+  device_.failPresent = false;
+  EXPECT_THAT(device_.acquireCurrentTexture(surface), HasResult());
+}
+
+TEST_F(SurfaceTests, ExplicitSurfaceDestructionInvalidatesOutstandingTexture) {
+  Surface surface = metalSurface();
+  ASSERT_THAT(device_.configureSurface(surface, configuration()), IsOk());
+  SurfaceTexture frame = GetResultOrFail(device_.acquireCurrentTexture(surface));
+  EXPECT_THAT(device_.destroySurface(std::move(surface)), IsOk());
+  EXPECT_FALSE(surface.isValid());
+  EXPECT_THAT(device_.createTextureView(frame.texture, {}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.surfaceCapabilities(surface), IsGpuError(GpuErrorType::InvalidHandle));
 }
 
 }  // namespace


### PR DESCRIPTION
Exercise GPU device, command-encoder, and shader-IR contracts that were missing direct regression coverage. Add 43 tests for invalid descriptors and resource bindings, command ordering and bounds, and malformed shader types, functions, and control flow. The change is limited to three existing test files.

Validation: all three owning test targets passed, including the GPU inventory freshness check; formatting, lint, CMake generation, and independent code/security review passed. A full local test run was attempted but stopped on remote execution transport deadlines, so it did not pass. The full GitHub CI run subsequently passed.

Focused coverage identifies 357 existing lines in four implementation files becoming fully covered relative to the prior full report. The completed full Codecov report now measures 84.15% project coverage (90,002/106,950 fully covered lines), versus 83.81% on its base; GPU coverage is 83.76% (11,249/13,430). The project target above 85% remains open.
