### PR TITLE
Reject out-of-scope shader conditional expressions

### DIFF
--- a/donner/gpu/shader/IrModule.cc
+++ b/donner/gpu/shader/IrModule.cc
@@ -404,6 +404,10 @@ ShaderStatus FunctionBuilder::beginIf(const IrExpr& condition) {
                     function_.name));
   }
 
+  if (ShaderStatus status = verifyExprInScope(condition); status.hasError()) {
+    return status;
+  }
+
   BlockFrame frame;
   frame.kind = BlockFrame::Kind::IfThen;
   frame.condition = condition;
@@ -494,6 +498,9 @@ ShaderStatus FunctionBuilder::forCondition(const IrExpr& condition) {
   }
   if (blockStack_.back().forCondition) {
     return fail(Err("for condition already set", function_.name));
+  }
+  if (ShaderStatus status = verifyExprInScope(condition); status.hasError()) {
+    return status;
   }
   blockStack_.back().forCondition = condition;
   return OkShaderStatus();

--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -1383,5 +1383,42 @@ TEST(FunctionBuilderControlFlow, ContinuingRejectsEscapedTargetsAndValues) {
   }
 }
 
+TEST_F(FunctionBuilderTests, IfConditionCannotReferenceAClosedBranchLocal) {
+  FunctionBuilder function = startFunction();
+  ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const IrExpr expired =
+      GetShaderResultOrFail(function.addLet("expired", LiteralBool(true)), LiteralBool(false));
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  // Keep the typed expression after its declaration has left scope. It must not
+  // become an undeclared name in the next generated conditional.
+  EXPECT_THAT(function.beginIf(expired), IsShaderError(HasSubstr("out of scope")));
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("out of scope")));
+}
+
+TEST_F(FunctionBuilderTests, ForConditionCannotReferenceAClosedBranchLocal) {
+  FunctionBuilder function = startFunction();
+  ASSERT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const IrExpr expired =
+      GetShaderResultOrFail(function.addLet("expired", LiteralBool(true)), LiteralBool(false));
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  ASSERT_THAT(function.beginFor("i", LiteralU32(0)), HasShaderResult());
+  EXPECT_THAT(function.forCondition(expired), IsShaderError(HasSubstr("out of scope")));
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("out of scope")));
+}
+
+TEST_F(FunctionBuilderTests, ConditionalHeadersAcceptEnclosingScopeExpressions) {
+  FunctionBuilder function = startFunction();
+  const IrExpr condition =
+      GetShaderResultOrFail(function.addLet("condition", LiteralBool(true)), LiteralBool(false));
+  ASSERT_THAT(function.beginIf(condition), IsShaderOk());
+  ASSERT_THAT(function.endIf(), IsShaderOk());
+  ASSERT_THAT(function.beginFor("i", LiteralU32(0)), HasShaderResult());
+  ASSERT_THAT(function.forCondition(condition), IsShaderOk());
+  ASSERT_THAT(function.breakStmt(), IsShaderOk());
+  ASSERT_THAT(function.endFor(), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+  EXPECT_THAT(builder_.build(), HasShaderResult());
+}
+
 }  // namespace
 }  // namespace donner::gpu::shader


### PR DESCRIPTION
Reject conditional shader headers that reference a local value after its scope has closed. Both if and for conditions now use the existing expression-scope validation before being stored, preventing an undeclared local from reaching generated shader source. The original error remains latched; enclosing-scope values remain valid.

The regression commit reproduces both invalid conditions on the parent implementation and includes a passing enclosing-scope control. The fix passes the complete owning shader suite, inventory freshness, CMake generation, formatting, lint, and independent code/security review. The attempted full local suite stopped on remote execution transport deadlines; it did not pass. Full GitHub CI is required before merge.
