### PR TITLE
Refocus RHI design on remaining production cutover work

### DIFF
--- a/docs/design_docs/0053-native_gpu_hal.md
+++ b/docs/design_docs/0053-native_gpu_hal.md
@@ -1,688 +1,351 @@
 # Design: Donner Native GPU Runtime and Rust-Independent Build
 
-**Status:** Design\
+**Status:** Implementing. Production cutover remains open across shader selection, resource ownership,
+indexed UI rendering, native mapping and surfaces, and the browser bridge. The implementation plan
+below contains the work required to complete that cutover.\
 **Created:** 2026-07-05\
-**Updated:** 2026-09-03\
+**Updated:** 2026-09-10\
 **Author:** Claude Fable 5.1\
 **Drafted by:** GPT-5.6 Sol
 
 ## Summary
 
-Donner will replace its native `wgpu-native` dependency with an original C++20 GPU runtime built
-inside Donner. The runtime will expose a narrow Donner-owned rendering hardware interface, not the
-WebGPU C ABI. It will target Metal on Apple platforms, Vulkan on Linux, and the browser's WebGPU
-service through a small Donner-owned WebAssembly bridge.
+Donner's GPU runtime is the interface between Geode/editor rendering and Metal, Vulkan, or browser
+WebGPU. The remaining work is to make production callers use that interface end to end, supply the
+missing draw, mapping, upload, and presentation operations, and remove the transitional WebGPU
+implementation from the dependency closure.
 
-This is a clean-room, specification-led implementation. It must not copy, translate, vendor, link,
-or ship implementation code from `wgpu`, `wgpu-native`, Naga, Dawn, or Tint. Those projects may not
-become source, build, runtime, or test dependencies of the completed implementation. During the
-transition, the current renderer may be exercised as a black-box baseline, but it has a mandatory
-sunset and cannot remain in Donner's final dependency graph.
+`donner::gpu` provides the foundation for resource validation, command recording, submission,
+backend execution, and typed shader generation. Production `GeodeDevice`, filter resource plumbing,
+texture caches, and editor presentation still depend on concrete WebGPU objects. Native shader
+execution tests therefore establish individual capabilities; they do not establish a complete
+native editor or a Rust-independent build.
 
-The completion boundary is a closure property, not a file census. Shipped artifacts, every
-non-test dependency closure, and CI toolchains contain no Rust compiler invocation, Cargo
-execution, Rust-built library, or transitive Rust requirement. Inert upstream Rust source and Cargo
-metadata may remain only in an explicitly allowlisted resvg/tiny-skia third-party reference
-snapshot, which cannot be compiled, linked, executed, or treated as a Donner implementation
-dependency. The tiny-skia Rust FFI cross-validation fixture and its `rules_rust` graph are retained
-as a test-only oracle: they live inside the vendored tiny-skia workspace, which Donner's root module
-never evaluates, and only that workspace's own test targets reach them. The boundary is what the
-build does, not what a resolved module graph or generated lockfile mentions: an upstream module may
-declare `rules_rust` where Donner cannot remove the edge, and the invariant holds as long as nothing
-fetches or invokes a Rust toolchain. The inert reference allowlist stays limited to the resvg test
-corpus and the tiny-skia upstream snapshot.
-
-The result is not a general WebGPU implementation. It is the smallest coherent GPU runtime that
-supports Geode, editor presentation, deterministic replay, and Donner's embedding requirements at
-Donner's safety and code-quality bar.
-
-## Decision
-
-- Build an internal `donner::gpu` module with typed C++20 value descriptors, move-only resource
-  handles, explicit errors, deterministic command recording, and platform backends.
-- Do not preserve the WebGPU C ABI or expose `wgpu::`/`WGPU*` types in Donner APIs.
-- Replace WGSL translation with an original, typed Donner shader IR and deterministic WGSL, MSL,
-  and SPIR-V emitters. Do not add Naga, Tint, Dawn, or another third-party shader translator.
-- Build an original ImGui renderer on `donner::gpu`; do not keep the patched ImGui WebGPU backend as
-  a hidden dependency.
-- Keep the current implementation only as a bounded transition baseline. Remove it, its headers,
-  its prebuilts, its patches, and its build rules before completion.
-- Add a repository-wide no-Rust-dependency verifier that enforces the closure property: no Rust in
-  shipped artifacts or in any non-test dependency closure, a narrow inert-reference allowlist, and
-  test-only containment for the tiny-skia cross-validation oracle. Make it a release gate.
-
-## Why This Shape
-
-The current Geode surface is much smaller than WebGPU. The 2026-07-10 inventory found approximately
-40 distinct GPU operations across 35 Geode and editor files. Geode uses 23 WGSL shaders totaling
-3,687 lines and creates a fixed set of render and compute pipelines. It does not need a public
-browser-compatible device API, runtime shader reflection, render bundles, indirect draws, timestamp
-queries, or a general shader compiler.
-
-Implementing the WebGPU C ABI would force Donner to reproduce compatibility behavior it does not use
-and would preserve API and ownership assumptions inherited from the dependency being removed. A
-narrow Donner API lets the implementation express actual requirements: fixed pipeline layouts,
-premultiplied 2D rendering, explicit texture hand-offs, deterministic captures, bounded readback,
-and predictable embedding into native render loops.
-
-The prior draft proposed Naga at build time and an indefinitely buildable `wgpu-native` oracle.
-Both violate the final invariant. This revision replaces them with original shader emitters and a
-sunsetted, output-only transition baseline.
+The target is an original C++20 runtime serving Donner's own rendering requirements. It is not a
+WebGPU C ABI implementation or a general shader compiler.
 
 ## Goals
 
-- Ship native Geode through Donner-owned Metal and Vulkan implementations.
-- Preserve browser rendering through a Donner-owned bridge to `navigator.gpu`, without a native
-  Rust implementation or Dawn-generated C wrapper anywhere in Donner's non-test dependency closure.
-- Preserve Geode image quality, filter behavior, compositor behavior, editor responsiveness,
-  deterministic replay, and existing performance counters.
-- Make resource ownership, thread affinity, device loss, synchronization, and memory budgets
-  explicit and testable.
-- Improve embedding by accepting carefully scoped native platform objects instead of requiring a
-  WebGPU device.
-- Remove every Rust toolchain edge, Rust-built binary, and Cargo execution path from Donner's
-  shipped artifacts and from every non-test dependency closure.
-- Ensure the new implementation is original Donner code whose implementation license does not
-  derive from `wgpu`, Naga, Dawn, or Tint.
+- Run native Geode/editor rendering through Metal on macOS and Vulkan on Linux.
+- Preserve browser rendering through a Donner-owned bridge to the browser's WebGPU service.
+- Give renderer targets, snapshots, uploads, readback, and UI textures one runtime ownership model.
+- Preserve pixels, frame ordering, alpha interpretation, bounded resource use, and editor behavior.
+- Remove transitional adapters, raw WebGPU API dependencies, and Rust-built native GPU libraries
+  from production source, builds, and shipped artifacts.
+- Complete the remaining GPU audit acceptance on the exact integrated implementation.
 
 ## Non-Goals
 
-- Implementing WebGPU-the-standard or passing the WebGPU CTS.
-- Providing a drop-in replacement for `webgpu.h`, `wgpu.h`, `webgpu.hpp`, or `wgpu-native`.
-- Supporting arbitrary user-provided shaders or runtime shader parsing.
-- Adding GPU features that Geode and the editor do not use.
-- Rewriting Slug coverage, filter math, the compositor, or SVG traversal as part of the HAL swap.
-- Rewriting the C++ tiny-skia renderer, deleting inert upstream resvg/tiny-skia reference source, or
-  deleting the tiny-skia Rust FFI oracle. That oracle is a test-only cross-validation fixture inside
-  the vendored tiny-skia workspace, which Donner's build never enters, so the closure property holds
-  with it in place.
-- Rewriting Git history. The requirement applies to the checked-out release tree, generated source
-  archives, build dependency closure, and shipped artifacts.
-- Supporting Windows. Windows is out of scope for the project, so the Vulkan backend targets Linux
-  only and no Windows surface type, release floor, driver qualification, or CI lane is planned.
+- Implementing the WebGPU standard, its C ABI, or arbitrary runtime WGSL parsing.
+- Supporting user-supplied shaders or a public command-stream deserializer.
+- Replacing SVG traversal, Slug coverage, or the compositor with a second rendering engine.
+- Adding Windows or a native iOS host to this cutover; physical browser iOS qualification remains
+  part of the browser presentation matrix.
+- Expanding this plan into unrelated editor features or a project-wide release/audit backlog.
+- Deleting the isolated tiny-skia Rust cross-validation fixture or inert upstream reference source.
+  Their containment requirements are described below.
 
-## Clean-Room and Provenance Rules
+## Next Steps
 
-### Permitted implementation inputs
+1. Finish native vertex-layout support and define the indexed-draw contract needed by the UI renderer.
+2. Integrate the remaining typed filter/checkerboard programs and runtime snapshot identity changes,
+   then replace concrete adapter resource and encoder access in their production callers.
+3. Develop mapping, native surfaces, and the browser bridge against the existing runtime contracts
+   while resource and UI migration proceeds. Switch platform ownership after those paths qualify.
 
-- Donner's own renderer requirements, call sites, tests, captures, design docs, and shader
-  algorithms.
-- Normative public specifications: the
-  [WebGPU specification](https://gpuweb.github.io/gpuweb/),
-  [WGSL specification](https://www.w3.org/TR/WGSL/),
-  [Vulkan specification](https://registry.khronos.org/vulkan/), and
-  [SPIR-V specification](https://registry.khronos.org/SPIR-V/).
-- Official Apple Metal documentation and platform SDK interfaces.
-- Black-box outputs from the current Donner renderer: pixels, public error outcomes, counters,
-  command captures, and timing measurements produced from Donner-owned test inputs.
+## Implementation Plan
 
-### Prohibited implementation inputs
+Every item below is outstanding integration, implementation, or qualification work. A source patch or
+backend-only test does not close a production migration item. Keep regression commits and their
+corresponding fixes together in a focused reviewable change.
 
-- Copying or line-by-line translating source from `wgpu`, `wgpu-native`, Naga, Dawn, Tint, or their
-  internal tests.
-- Importing their internal object model, private algorithms, generated headers, state trackers,
-  shader IR, or backend workarounds.
-- Linking those implementations into the completed runtime, shader toolchain, tests, or CI.
-- Keeping an in-tree compatibility backend after the native cutover.
+### Native drawing
 
-### Provenance evidence
+- [ ] Integrate and qualify Metal's multiple vertex-buffer layouts, including collisions with
+      vertex-visible shader resources, all supported slots, instancing, and buffer/offset updates.
+- [ ] Add `setIndexBuffer` and `drawIndexed` to the shared command contract and platform backends.
+      Define index formats, index-buffer byte bounds, first-index/base-vertex semantics, and resource
+      retirement. Verify indexed geometry and invalid inputs on all three backends.
 
-Every implementation packet records:
+### Typed shaders and production selection
 
-- the Donner requirement or normative specification section it implements;
-- original design notes for nontrivial algorithms and state machines;
-- the tests that establish the behavior;
-- all third-party headers, tools, or SDKs used to build or validate it;
-- confirmation that no prohibited implementation source was used.
+- [ ] Complete blur, drop-shadow, component-transfer, displacement, blend, image, convolve-matrix,
+      diffuse/specular lighting, and turbulence migrations; use the production inventory to find
+      any additional live raw shader family.
+- [ ] Migrate checkerboard to a typed program and a runtime-device constructor, preserving device
+      pixel origin, DPR, clipping, and its compositing modes.
+- [ ] Make production pipeline creation select generated MSL, SPIR-V, or WGSL for the chosen backend.
+      Replace the WGSL-only assumption in `GeodeFilterEngine` and shared Geode pipeline construction.
+- [ ] Qualify the remaining emitter instruction contracts, real compiler outputs, native execution,
+      and renderer pixels. Remove each obsolete raw shader path with its final production caller.
 
-An independent provenance and license audit is a blocking release gate. This design does not claim
-that Donner as a whole has no third-party license obligations. It requires that the new GPU
-implementation does not inherit code or licensing obligations from the implementations it replaces.
+### Snapshot and target identity
 
-## Current-State Inventory
+- [ ] Keep the existing runtime texture identity through snapshot drawing and both readback routes.
+      Validate device identity, backing ownership, actual format, and content/allocation bounds
+      before consuming an owned texture. Refused adoption must leave the caller's handle intact.
+- [ ] Preserve detached snapshot ownership and frame-borrowed lifetimes, including move assignment,
+      producer destruction, overlapping frames, and explicit backing retirement.
+- [ ] Replace raw target binding in `RendererGeode` and `EditorShellPresentation` with validated
+      runtime textures or acquired surface textures, retaining embedder ownership where applicable.
 
-The implementation starts with a checked-in, reproducible inventory rather than the estimates in
-this document. The inventory must cover at least:
+### Resource plumbing and uploads
 
-- all `wgpu::`, `WGPU*`, `webgpu.hpp`, `wgpu.h`, and `wgpuDevicePoll` use sites;
-- all adapter, device, queue, surface, buffer, texture, sampler, bind-group, pipeline, pass,
-  copy, map, readback, submission, callback, and destruction operations;
-- all 23 WGSL shaders, their entry points, stage inputs and outputs, bindings, storage classes,
-  texture formats, workgroup sizes, and language features;
-- all C++ structs whose layout is shared with shaders;
-- editor surface creation, texture handoff, ImGui rendering, worker ownership, and WebAssembly
-  object-table constraints;
-- Bazel, CMake, WebAssembly, packaging, and CI dependency edges;
-- Rust material. 92 of the 93 tracked `.rs` files sit in the inert tiny-skia upstream snapshot
-  alongside four tracked Cargo manifests. The remaining `.rs` file and two more tracked Cargo files
-  are the cross-validation fixture under `third_party/tiny-skia-cpp/tests/rust_ffi/`, whose one Rust
-  source is compiled by `rust_static_library` and wrapped in a `cc_library` visible only to the
-  vendored workspace's own `//tests` subpackages. `rules_rust`, `crate_universe`, and the Rust
-  toolchain registration appear in exactly one tracked build file,
-  `third_party/tiny-skia-cpp/MODULE.bazel`. Donner's root `MODULE.bazel` pulls that subtree in
-  through a `local_repository` repo rule rather than as a Bazel module, and `.bazelignore` hides the
-  subtree, so that module is never evaluated. Separately, the repository tracks no root
-  `MODULE.bazel.lock`. Donner's own module graph reaches `rules_rust` anyway, independently, as a
-  transitive `bazel_dep` of `protobuf`, and the generated lockfile declares Rust toolchains. Nothing
-  fetches them, because no Donner target uses a Rust rule: a checkout with no `rustc` or `cargo` on
-  `PATH` builds and tests Donner cleanly. That gap is why the rule has to be stated over the
-  closure, and why deleting the oracle would not have made the module graph Rust-free. The Rust
-  that actually reaches shipped artifacts is the prebuilt `wgpu-native` library, and it leaves at
-  the Metal and Linux cutovers;
-- prebuilt `wgpu-native` archives and platform overlay rules in the non-BCR dependency extension;
-- generated and patched ImGui/WebGPU integration code.
+- [ ] Convert `GeodeFilterEngine::FilterResourceArena`, intermediate textures, shared pipeline
+      resources, and frame recording to runtime handles and encoders. Remove raw export/reimport
+      cycles and concrete host-encoder access as their callers migrate.
+- [ ] Add a checked destination origin to `Device::writeTexture` and implement the same subrectangle
+      semantics in each backend. Preserve extent, row-stride, data-size, and overflow validation.
+- [ ] Move `GlTextureCache` bitmap/thumbnail uploads, border replication, clear operations, and
+      allocation reuse onto runtime resources. Retire resources only after their consuming frames.
 
-The inventory becomes a machine-readable manifest. New GPU operations or shader features cannot be
-added without updating the manifest and the corresponding backend conformance tests.
+### Native mapping and completion
+
+- [ ] Implement native Metal and Vulkan hooks for `mapBufferAsync`, mapping readiness, `mappedBytes`,
+      and unmap/invalidation using the existing public runtime contract.
+- [ ] Route renderer readback and completion through those hooks, with the relevant submission
+      serial, bounded waits, cancellation, and device-loss outcomes.
+- [ ] Verify that cancelled mappings do not reenter the reusable readback pool while still active,
+      and that unmap, retirement, and loss invalidate access at the documented boundary.
+
+### UI rendering
+
+- [ ] Replace raw WebGPU texture-view IDs in `GlTextureCache` and `CompositorDebugPanel` with runtime
+      UI texture registrations carrying device identity, alpha mode, and frame lifetime.
+- [ ] Implement the ImGui renderer over typed shaders, indexed draws, bounded vertex/index uploads,
+      texture/sampler bindings, scissors, and renderer-state reset operations.
+- [ ] Migrate frame composition and remove `imgui_wgpu_backend` dependencies, registration calls,
+      and obsolete patches when their final consumers move.
+
+### Native surfaces
+
+- [ ] Implement Metal surface creation/configuration, drawable acquisition, presentation, and
+      abandonment through `Device` surface hooks.
+- [ ] Implement Vulkan platform surface and swapchain support, required queue/extension selection,
+      acquisition/presentation synchronization, and recreation through the same hooks.
+- [ ] Update `EditorWindow` to use acquired runtime textures directly. Exercise resize, minimized
+      windows, outdated/lost surfaces, timeout, device loss, and frame-handle invalidation.
+
+### Browser bridge
+
+- [ ] Replace the C WebGPU wrapper with the Donner-owned C++/JavaScript descriptor and command bridge
+      to `navigator.gpu`; keep generated WGSL as trusted build input.
+- [ ] Implement checked browser object IDs, worker ownership, asynchronous device requests, surface
+      configuration, completion, mapping, and device-loss propagation behind the runtime contract.
+- [ ] Run the complete browser editor path and remove emdawnwebgpu, `webgpu-cpp`, and remaining
+      generated C-ABI glue when no consumer needs them.
+
+### Device ownership and dependency closure
+
+- [ ] Make the selected `gpu::Device` the backend owner. Turn `GeodeDevice` into backend-neutral
+      renderer services for counters, caches, dummy resources, and deferred retirement; update
+      headless and embedded construction.
+- [ ] Select Metal, Vulkan, or the browser backend through one production path per platform after
+      resources, shaders, mapping, UI rendering, and surfaces qualify together.
+- [ ] Remove the transitional adapter, native `wgpu-native` archives/overlays, unused headers,
+      obsolete build rules, and orphaned code with their final callers.
+- [ ] Make every no-Rust-dependency verifier category blocking and verify clean Bazel/CMake source
+      archive builds without a Rust toolchain. Inspect link/dependency and packaged-artifact evidence.
+
+### Remaining GPU audit acceptance
+
+- [ ] Inspect the integrated source/dependency graph for concrete adapter access, raw handles outside
+      backend boundaries, duplicate ownership, unnecessary runtime emitter dependencies, and dead code.
+- [ ] Compare logical allocation accounting with actual CPU RAM/GPU residency for pending uploads,
+      scratch, parameter storage, cached textures, and deferred retirement under overlapping frames.
+- [ ] Verify representative DPR2 filter/thumbnail workloads under the existing 128 MiB Wasm and
+      256 MiB native working-set caps. Investigate regressions rather than raising the caps.
+- [ ] Run paired rendering/overlap, startup, clean/incremental build, and artifact-size measurements
+      on the same host and configuration; qualify the exact integrated candidate against the gates
+      below and resolve actionable review findings.
 
 ## Proposed Architecture
 
 ```mermaid
 flowchart TD
-    SVG[RendererDriver command stream] --> GEODE[RendererGeode and filter engine]
-    GEODE --> GPU[donner::gpu typed runtime]
-    EDITOR[Editor presentation and ImGui draw data] --> GPU
-
-    GPU --> METAL[Metal backend]
-    GPU --> VULKAN[Vulkan backend]
-    GPU --> WEB[WebAssembly browser bridge]
-    GPU --> RECORD[Recording and validation backend]
-
-    SIR[Donner shader IR] --> WGSL[Deterministic WGSL emitter]
-    SIR --> MSL[Deterministic MSL emitter]
-    SIR --> SPIRV[Deterministic SPIR-V emitter]
-    WGSL --> WEB
-    MSL --> METAL
-    SPIRV --> VULKAN
+    SVG[SVG rendering and filter graph] --> GEODE[RendererGeode and renderer services]
+    EDITOR[Editor presentation and ImGui draw data] --> UI[Runtime UI renderer and texture registry]
+    GEODE --> GPU[donner::gpu Device and command/resource contracts]
+    UI --> GPU
+    GPU --> METAL[Metal resources, completion and surfaces]
+    GPU --> VULKAN[Vulkan resources, completion and surfaces]
+    GPU --> WEB[Donner browser bridge to navigator.gpu]
+    IR[Typed Donner shader IR] --> BUILD[Build-time WGSL / MSL / SPIR-V generation]
+    BUILD --> ARTIFACTS[Backend shader artifacts and layouts]
+    ARTIFACTS --> GEODE
+    ARTIFACTS --> UI
+    TESTS[Recording and model tests] -.-> GPU
 ```
 
-### Module boundary
-
-The runtime lives under `donner/gpu/`, not under a third-party directory and not inside the SVG
-public API. `RendererInterface` remains the SVG-level backend contract. `RendererGeode` consumes
-`donner::gpu` internally.
-
-The initial API is private to Donner. Native embedding is exposed only after ownership, threading,
-device-loss, and compatibility contracts have survived the backend cutover.
-
-### Build and packaging
-
-Bazel remains the primary implementation and CI build. CMake gains equivalent native GPU targets
-as each backend reaches production; it may not silently remain TinySkia-only while release docs
-claim native Geode support. Generated CMake metadata stays derived from the same target inventory so
-backend sources, shader artifacts, platform libraries, and feature flags cannot drift between build
-systems.
-
-Platform SDK compilers and validators are discovered explicitly and recorded in provenance. Build
-rules do not download opaque compiler binaries. The Tiny profile excludes the GPU module cleanly,
-while Geode profiles link exactly one platform backend plus the recording/validation code selected
-for that configuration.
-
-The browser's own WebGPU implementation and native platform drivers are host services outside
-Donner's source and binary dependency closure. Donner owns and audits the bridge code that talks to
-those services.
-
-### Core types and ownership
-
-- `Device`, `Queue`, `Surface`, `Buffer`, `Texture`, `TextureView`, `Sampler`, `BindGroup`,
-  `PipelineLayout`, `RenderPipeline`, `ComputePipeline`, and `CommandBuffer` are move-only RAII
-  handles.
-- Descriptors are immutable value types with validated sizes, formats, usages, and labels.
-- APIs return explicit `Result<T, GpuError>` or status values. The module uses no exceptions.
-- Handles carry backend and generation identity in checked builds. Cross-device and use-after-free
-  use fail before reaching a driver.
-- Destruction is deferred by submission serial where required. No backend object is destroyed while
-  referenced by an in-flight command buffer.
-- Thread-affinity rules are explicit. The current async renderer's worker ownership remains the
-  default; cross-thread presentation transfers only documented snapshot or external-texture forms.
-- Host-provided native objects are a trusted embedding boundary with explicit borrowed lifetime.
-  Untrusted SVG data can never supply or reinterpret native handles.
-
-### Command model
-
-The command surface covers only operations present in the inventory:
-
-- resource creation and bounded writes;
-- render and compute pipeline creation from generated artifacts plus explicit layout metadata;
-- render and compute pass encoding;
-- vertex and storage buffers, sampled and storage textures, samplers, and bind groups;
-- direct and instanced draws, compute dispatch, and required copy/readback operations;
-- queue submission, completion serials, device polling, and surface presentation;
-- debug labels and capture markers.
-
-There is no public command-stream deserializer. The recording backend stores validated Donner value
-objects, never raw pointers or native handles, and feeds deterministic replay and debugger tooling.
-
-### Validation layer
-
-Validation is not debug-only for memory-safety invariants. Descriptor ranges, row pitches, texture
-extents, binding compatibility, copy bounds, dispatch limits, and resource-device identity are
-checked before backend calls. Expensive diagnostics and full state histories may be build-gated,
-but invalid input must fail closed in release builds.
-
-## Shader System
-
-### Donner shader IR
-
-Geode's shaders migrate from hand-authored WGSL strings into a typed, immutable IR under
-`donner/gpu/shader/`. The IR contains only features proven necessary by the inventory. It owns:
-
-- scalar, vector, matrix, array, and struct types;
-- explicit host-shareable layout and alignment;
-- functions, entry points, structured control flow, and supported built-ins;
-- sampled textures, storage textures, samplers, uniform buffers, and storage buffers;
-- render-stage inputs/outputs and compute workgroup sizes;
-- binding and pipeline-layout metadata.
-
-The IR builder rejects ill-typed programs and unsupported features. It is not a WGSL parser and does
-not accept runtime input.
-
-### Original emitters
-
-- The WGSL emitter serves the browser backend.
-- The MSL emitter serves Metal. Apple builds compile generated trusted MSL with the platform
-  toolchain into a checked artifact when supported by the packaging target.
-- The SPIR-V emitter writes the bounded Vulkan shader subset directly with deterministic IDs and
-  decorations.
-- All emitters consume the same binding and host-layout metadata. C++ host structs use generated
-  `sizeof`, `alignof`, and `offsetof` assertions so layout drift fails at compile time.
-
-No third-party shader compiler is linked or vendored. Platform compilers and validators may be run
-as out-of-process verification tools; they are recorded in build provenance and are not part of
-Donner's implementation source.
-
-### Shader verification
-
-Generated WGSL, MSL, and SPIR-V are build artifacts rather than committed golden fixtures. Do not
-add full emitted-shader snapshots, whether in files or inline test strings. Review readable IR and
-use focused binding, layout, and control-flow assertions instead.
-
-`//donner/gpu/shader:shader_tests` checks deterministic emission and structural/error contracts.
-`//donner/gpu/shader:msl_xcrun_validation_tests`,
-`//donner/gpu/shader:spirv_val_validation_tests`, and
-`//donner/gpu/shader:wgsl_emitter_geode_validation_tests` validate real compiler/runtime interfaces.
-Native Metal and Vulkan tests execute the programs, and renderer/editor image regressions retain
-pixel-level coverage. IR serialization tests remain independent of emitted shader snapshots.
-
-### Shader migration
-
-Migration is vertical, one pipeline family at a time. Each packet introduces the IR program, checks
-emitted artifacts, runs it through one native backend, compares pixels and counters to the frozen
-baseline, and deletes the corresponding legacy shader path. There is no final bulk rewrite in which
-all shaders change without per-family evidence.
-
-## Platform Backends
-
-### Metal
-
-Metal is first because it is the primary development platform and requires less explicit hazard
-management than Vulkan. The backend owns command queues, pipeline states, resource options, texture
-views, completion handlers, drawable presentation, and API validation integration. It starts with a
-single render triangle and proceeds through solid fills, gradients/images, clips/masks, filter
-compute chains, readback, and editor presentation.
-
-### Vulkan
-
-Vulkan supports Linux. It owns instance/device selection, queue families, descriptor pools, memory
-allocation, pipeline caches, surfaces/swapchains, submission fences, and device-loss recovery.
-
-The load-bearing subsystem is explicit synchronization. Every resource tracks its last writer,
-stage/access state, image layout, queue ownership, and submission serial. Encoders derive barriers
-from declared resource use. The first implementation is conservative and validation-clean; barrier
-elision is permitted only after counter and timing evidence identifies a bottleneck.
-
-The release matrix includes software Vulkan plus physical Intel, AMD, and NVIDIA coverage where
-available. One software adapter cannot substitute for the real-driver matrix.
-
-### WebAssembly browser bridge
-
-The browser backend maps the Donner descriptor and command subset to `navigator.gpu`. It uses a
-small, audited C++/JavaScript boundary owned by Donner, not the native WebGPU C ABI. It preserves
-worker ownership, asynchronous adapter/device requests, device-loss propagation, canvas
-configuration, and the editor's touch-oriented WebAssembly mode.
-
-The bridge must not expose general JavaScript evaluation or accept source from SVG documents.
-Generated WGSL is trusted build output. Browser-side IDs are range-checked generational handles,
-not raw object-table indices accepted from untrusted input.
-
-### Editor presentation
-
-The editor receives an original ImGui renderer implemented over `donner::gpu`. This removes
-`imgui_impl_wgpu`, its local patches, `EditorWgpuSurface`, and direct `WGPUTextureView` handoff.
-The presentation layer uses backend-neutral texture snapshots and explicit synchronization with the
-async render worker. Native zero-copy handoff is an optimization behind the same ownership contract,
-not a separate UI path.
-
-## Repository-Wide Rust Dependency Removal
-
-The dependency purge is complete only when all of these are true:
-
-- Rust source and Cargo metadata exist only under the reviewed, inert third-party reference
-  allowlist (`third_party/resvg-test-suite/**` and the tiny-skia upstream snapshot under
-  `third_party/tiny-skia-cpp/third_party/tiny-skia/**`) or under the test-only fixture prefix
-  `third_party/tiny-skia-cpp/tests/rust_ffi/`;
-- the fixture's targets and every package allowed to consume them keep visibility inside the
-  vendored tiny-skia workspace's own `//tests` tree, never `//visibility:public` and never a
-  cross-repository package; no `alias` or `.bzl` constant re-exports them under another name; and no
-  build file outside that test tree names the fixture package or the `rust_reference` and
-  `cross_validator` libraries built on it. No Donner target and no non-test target can therefore
-  reach a Rust artifact. Bazel enforces the same boundary independently: `@rules_rust` is not
-  visible from a repository Donner pulls in with a repo rule, so a Donner target that reaches the
-  fixture fails at load time;
-- no tracked build file outside the vendored tiny-skia workspace's own `MODULE.bazel` names
-  `rules_rust`, `crate_universe`, or a Rust toolchain: not Donner's root `MODULE.bazel`, not
-  `.bazelrc`, not a `.bzl` file, not a BUILD file, not a CMake input. The resolved module graph is
-  not held to that, because `protobuf` declares `rules_rust` and Donner cannot drop the edge; what
-  must hold is that no Rust toolchain is fetched or invoked, which follows from no Donner target
-  using a Rust rule;
-- no build rule downloads a Rust-built `wgpu-native` or equivalent archive;
-- `third_party/webgpu-cpp`, emdawnwebgpu stubs/glue, native archive overlays, and obsolete ImGui
-  WebGPU patches are removed once their last consumer is gone;
-- Bazel, CMake, WebAssembly, source-package, and release-artifact provenance list no Rust compiler,
-  Rust standard library, Cargo package, or Rust-built linked object;
-- the checked-in verifier `tools/gpu_inventory/check_no_rust_dependencies.py` enforces those path
-  and reference rules over the git-tracked tree in five categories: Rust source outside the inert
-  allowlist and the test-only prefix, Rust toolchain references outside the test-only prefix (Rust
-  rule-set names and bare `cargo`, `rustc`, and `rustup` commands in Bazel files, and the CMake
-  vocabulary in CMake files and the tracked sources under `tools/cmake/` that emit them), fixture
-  containment (visibility scope, re-export, and consumers confined to the vendored workspace's test
-  tree), compiled or linked references into the inert snapshot, and Rust-built archive downloads.
-  The Lint workflow runs it blocking for the first four; the archive category stays report-only
-  until the Metal and Linux cutovers delete the archives;
-- generated build state is covered where it exists rather than claimed to be covered everywhere.
-  Donner's production `CMakeLists.txt` files are emitted and git-ignored, so
-  `gen_cmakelists.py --check` scans its own output against the same CMake token list in the
-  cmake-validate job; that is the only gate that reads those files. A generated `MODULE.bazel.lock`
-  is out of scope, because it records the whole transitive Bzlmod graph, which is the graph rather
-  than the closure, and a fresh CI checkout has no lockfile to read anyway.
-
-Human-readable historical documentation may accurately say that a removed implementation was
-written in Rust. Approved upstream reference source may remain in its inert third-party boundary.
-The mechanical prohibition applies to Donner implementation source, executable dependencies,
-toolchains, generated build state, and artifacts, not to truthful history or the approved corpus.
-
-## Implementation Plan
-
-The work is organized as reviewable packets. Packet boundaries are behavior boundaries, not large
-directory drops.
-
-### Phase 0: Freeze requirements and provenance
-
-- [x] Generate the GPU-operation, shader-feature, editor-integration, and Rust-dependency manifests
-      (`tools/gpu_inventory/`, freshness-gated by
-      `//tools/gpu_inventory:manifest_freshness_tests` under plain `bazel test //...`).
-      The manifests record semantic inventory only; the per-file content hashes
-      the first implementation carried were removed, because they made every
-      unrelated edit to a GPU-using file a manifest change and a CI failure.
-- [ ] Freeze representative pixels, counters, captures, error outcomes, and performance baselines
-      from the current implementation using Donner-owned inputs.
-  - [x] Pixels, backend-independent structural counters, and error outcomes over a committed
-        Donner-owned corpus (`donner/gpu/baseline/`). Counters come from the CPU path encoder and
-        are checked on every lane by `//donner/gpu/baseline:baseline_counters_tests`; pixels come
-        from the current wgpu-backed production path and are checked by
-        `//donner/gpu/baseline:baseline_pixels_tests`. The degenerate and out-of-range scenes
-        freeze the encoder's `Empty` and `Rejected` admission outcomes, so a replacement is held to
-        the fail-closed behavior and not only to the successful paths.
-        Pixels are frozen per adapter: two Apple Silicon generations, at one revision through one
-        code path, produce different bytes on two of the six scenes, so an identity gate stated
-        across adapters would report a difference it cannot attribute. Adding an adapter is
-        mechanical (run the check there, commit the capture it leaves behind), and the two Apple
-        generations available today are both frozen. An adapter with no committed baseline skips
-        on a developer machine and fails on an automated lane, because a suite that skips every
-        case still reports its target as passing and the gate would retire itself silently.
-  - [ ] Command-stream captures. The recording backend already serializes a validated stream
-        deterministically with no GPU, but `GeoEncoder` and the Geode pipeline classes take the
-        wgpu transition adapter's concrete type rather than the runtime `Device` base, so the
-        production encoder cannot be pointed at the recording backend yet. Widening those
-        signatures belongs to the live-RHI extraction below; the capture freeze follows it rather
-        than duplicating the encoder to get an oracle.
-  - [ ] Performance baselines. Frame-time numbers taken on whatever machine happened to run the
-        capture are a property of that machine, and the counter corpus already gates the
-        CPU-invariant structural numbers. The wall-clock half needs a recorded run on the
-        scheduled performance lane, which is the only place a comparable number exists.
-- [ ] Approve the clean-room input rules and provenance template.
-      The template is written and committed as
-      [`gpu_provenance_template.md`](gpu_provenance_template.md); the input rules are the
-      clean-room section above. Both are waiting on approval, not on drafting.
-- [x] Add the no-Rust-dependency verifier and inert-reference allowlist
-      (`tools/gpu_inventory/check_no_rust_dependencies.py`, run by the Lint workflow; phase 6
-      below fixes which categories block).
-- [x] Define platform and driver release matrices plus binary-size budgets
-      ([0064: GPU release matrix](0064-gpu_release_matrix.md)). The matrix is derived from the
-      lanes and targets in the tree and labels every combination as executed, compiled but not
-      executed, developer-machine-only, or uncovered; the largest uncovered groups are physical
-      Vulkan drivers, Vulkan validation layers, and physical iOS. The budgets replace the
-      0.3-0.5 MB estimate with measured code-and-data sizes: 900,049 bytes for a Metal
-      configuration and 974,189 for a Vulkan one, roughly twice the estimate.
-
-### Phase 1: Live RHI extraction
-
-- [ ] Introduce `donner::gpu` descriptors, status types, ownership wrappers, and recording backend.
-- [ ] Move Geode call sites behind the RHI in small families while keeping one production renderer
-      path per build.
-- [ ] Add model tests for lifetime, submission serials, descriptor validation, and device loss.
-- [ ] Remove every migrated `wgpu` call and type in the same packet; temporary adapter code carries
-      an explicit removal gate.
-
-Geode's renderer runs one command encoder for a whole frame, and the filter engine records compute
-passes into that same encoder. A frame whose encoder became a `donner::gpu::CommandEncoder` would
-otherwise have to split into several command buffers - reinstating the per-boundary submits the
-single-encoder frame removed, and separating the layer-composite texture copy from the draws it
-must sit between.
-
-The Phase 1 transition adapter therefore gains a host-encoder replay mode: while a host encoder is
-installed, a submitted command stream is replayed into it instead of into an encoder the adapter
-owns, and the adapter performs no queue submit of its own. One command buffer still carries the
-whole frame in recording order, including the spans the host records directly around the replayed
-ones. Completion stays truthful because the adapter holds the replayed serial back until the host
-reports its queue submit, so no resource is treated as free before the work is even submitted. The
-mode is removed once the filter engine and the presentation paths record through the RHI, alongside
-the other Phase 1 escape hatches.
-
-Compute passes are modeled, so the filter engine has no remaining structural blocker. The RHI
-carries compute pipelines (whose descriptor declares the workgroup size, because Metal takes the
-threadgroup shape at dispatch rather than from the compiled pipeline state), begin/end compute
-pass, set pipeline, set bind group, and `dispatchWorkgroups`, plus write-only 2D storage textures
-with a declared texel format and the `StorageBinding` texture usage. Render and compute passes are
-mutually exclusive within one encoder but share a command buffer, so a frame can interleave them in
-recording order. Indirect dispatch, atomics, workgroup-shared memory, barriers, read-write storage
-textures, dynamic bind group offsets, and multiple bind groups are deliberately absent: the filter
-pipelines use none of them. The shader IR gained matching compute entry points with
-`global_invocation_id`, write-only storage texture bindings, and `textureStore`, emitted by all
-three backends and validated by the Metal compiler, `spirv-val`, and WebGPU pipeline creation.
-
-### Phase 2: Shader IR vertical slice
-
-- [ ] Inventory and specify the required shader language subset.
-- [ ] Implement typed IR validation, layout calculation, deterministic serialization, and source
-      locations for diagnostics.
-- [ ] Implement WGSL, MSL, and SPIR-V emitters for one solid-fill pipeline.
-- [ ] Extend the IR and emitters with compute entry points, storage textures, and `textureStore`,
-      proven by a compute vertical slice per backend.
-- [ ] Validate all three outputs with platform/browser validators and compare rendered pixels.
-- [ ] Expand pipeline family by pipeline family, deleting each migrated WGSL-only path.
-
-### Phase 3: Metal production path
-
-- [ ] Implement device/resource management, render/compute commands, copies, readback, completion,
-      and surface presentation.
-- [ ] Port all Geode pipelines and filter chains.
-- [ ] Replace editor WebGPU surface and ImGui integration on macOS.
-- [ ] Pass Metal API validation, deterministic replay, goldens, fuzzing, performance, memory,
-      device-loss, and physical-device tests.
-- [ ] Cut macOS production builds to Metal and remove the macOS `wgpu-native` archive immediately.
-
-### Phase 4: Vulkan production path
-
-- [ ] Implement device selection, resource allocation, descriptors, pipelines, synchronization,
-      submission, readback, and swapchains.
-- [ ] Prove the resource-state model with model tests and Vulkan validation layers.
-- [ ] Replace Linux editor presentation.
-- [ ] Pass software and physical-driver matrices, deterministic replay, goldens, fuzzing,
-      performance, memory, and device-loss tests.
-- [ ] Cut Linux production builds to Vulkan and remove the Linux `wgpu-native` archives.
-
-### Phase 5: Browser bridge
-
-- [ ] Replace the C WebGPU wrapper and generated bridge with the Donner descriptor/command bridge.
-- [ ] Port surface configuration, queue completion, device loss, generated WGSL, readback, and
-      browser editor presentation.
-- [ ] Pass Chromium and WebKit browser suites, touch UI tests, worker-ownership tests, and physical
-      iOS verification.
-- [ ] Remove emdawnwebgpu and the remaining `webgpu-cpp`/ImGui WebGPU sources and patches.
-
-### Phase 6: Rust-independent build cutover
-
-- [x] Enforce the closure property in the no-Rust-dependency verifier
-      (`tools/gpu_inventory/check_no_rust_dependencies.py`, wired into the Lint workflow). Rust
-      source scope, Rust build-token scope, test-only fixture containment, and compiled references
-      into the inert snapshot all block today.
-- [ ] Switch the Rust-built-archive category to blocking once phases 3 and 4 delete the
-      `wgpu-native` archives.
-- [ ] Verify clean Bazel and CMake builds from the release source archive on hosts without Rust or
-      Cargo installed.
-
-### Phase 7: Release qualification
-
-- [ ] Complete security, provenance, licensing, architecture, and Doxygen audits.
-- [ ] Publish backend architecture, ownership, synchronization, shader IR, embedding, diagnostics,
-      and failure-mode documentation.
-- [ ] Meet the numeric cutover gates below on the exact release candidate.
-- [ ] Promote only the reviewed immutable artifacts; rollback uses retained reviewed artifacts and
-      does not rebuild.
-
-## Suggested Change Sequence
-
-The expected sequence is 16 to 24 normal-sized pull requests:
-
-1. Baseline manifests and report-only no-Rust-dependency verifier.
-2. RHI value types, validation, and recording backend.
-3. Resource lifetime and submission model.
-4. Shader IR core and layout engine.
-5. WGSL emitter plus browser validation fixture.
-6. MSL emitter and solid-fill Metal vertical slice.
-7. SPIR-V emitter and solid-fill Vulkan vertical slice.
-8. Geode solid/gradient/image pipeline migration.
-9. Geode clip/mask/layer pipeline migration.
-10. Filter compute pipeline migrations in bounded families.
-11. Metal readback, presentation, and editor integration.
-12. Metal cutover and macOS dependency deletion.
-13. Vulkan synchronization/resource manager.
-14. Vulkan presentation and editor integration.
-15. Linux cutover and dependency deletion.
-16. Browser bridge and generated WGSL path.
-17. Donner ImGui renderer and WebGPU integration deletion.
-18. No-Rust-dependency verifier rework: closure-property categories and blocking Lint enforcement.
-19. Rust-built `wgpu-native` archive purge across Bzlmod, CMake, CI, and the source package.
-20. Security and provenance fixes from independent review.
-21. Documentation, release qualification, and final size/performance report.
-
-Packets may split when review surface becomes too large. They may not combine backend code,
-shader migration, build-graph deletion, and broad golden updates into one unreviewable change.
-
-## Cutover Gates
-
-Each platform becomes native only when all applicable gates pass:
-
-- zero unexpected pixel regressions across Donner goldens, resvg coverage, editor replay, and the
-  v1.0 conformance suite;
-- exact structural counter parity where backend-independent and reviewed per-backend expectations
-  where platform APIs necessarily differ;
-- no Metal API validation or Vulkan validation errors;
-- no crashes, hangs, leaks, use-after-free, or out-of-bounds access under sanitizer, structured GPU
-  fuzzing, device-loss injection, and repeated create/destroy stress;
-- frame time no worse than 5% at the median and 10% at p95 versus the frozen baseline on the
-  agreed corpus, unless the operator explicitly accepts a documented quality or size tradeoff;
-- no unbounded per-frame allocation or submission growth; existing Geode steady-state counters stay
-  within their budgets;
-- native GPU runtime and shader artifacts fit the measured binary-size budget established in
-  Phase 0. The prior 0.3-0.5 MB estimate is not accepted without measurement;
-- browser bridge passes headed Chromium, WebKit, and physical iOS presentation checks;
-- the no-Rust-dependency verifier passes with every category blocking, and the release candidate's
-  source archive, link maps, SBOM, and artifacts carry no Rust compiler, Cargo package, or
-  Rust-built object. The module graph's `rules_rust` edge is acceptable exactly because the
-  rustc-absent build test proves nothing fetches or invokes it;
-- independent security and provenance review has no unresolved critical or high findings.
-
-## Testing Strategy
-
-- Unit tests for every descriptor validator, state transition, layout rule, shader IR node, and
-  emitter instruction family.
-- Model-based tests compare resource-state transitions to a simple reference state machine.
-- A recording backend snapshots canonical commands for deterministic replay and editor debugging.
-- Shader tests validate emitted WGSL in browsers, MSL with Apple tools, and SPIR-V with Vulkan tools,
-  then execute cross-backend pixel and compute-buffer cases.
-- Renderer and editor goldens cover static output, repeated frames, transforms, clips, masks,
-  gradients, patterns, images, text, filters, layers, readback, and presentation.
-- Structured fuzzers generate only bounded, type-correct RHI sequences first, then inject one
-  invalid property at a time to verify fail-closed behavior. Real-driver fuzzing has time and memory
-  watchdogs.
-- Fault injection covers allocation failure, device loss, surface loss, submission failure,
-  callback reordering, worker shutdown, and stale external textures.
-- Physical-device tests cover Apple Silicon generations and the agreed Intel/AMD/NVIDIA matrix.
-- Dependency tests prove Donner's builds and tests neither discover nor invoke Rust when `rustc` and
-  `cargo` are absent from `PATH`. The vendored tiny-skia workspace's own cross-validation test is the
-  single target that legitimately needs a Rust toolchain, and it is not part of Donner's build or
-  test invocation, so its requirement never reaches a Donner lane.
+The runtime stays under `donner/gpu/`; `RendererInterface` remains the SVG-level renderer contract.
+Recording support is test-only. Production renderer and UI code consume the selected device rather
+than a concrete transition adapter. The initial GPU interface remains internal to Donner; exposing
+native device adoption to embedders is a separate API decision after lifetime and threading
+contracts qualify.
+
+### Resource and frame contracts
+
+Resource handles are move-only values associated with a device and slot generation. `Device` owns
+validation and backend dispatch; operations return `gpu::Result<T>` or status values. Backend
+resources referenced by submitted work require retirement through completion serials.
+
+The remaining migration must preserve three distinct texture roles:
+
+| Role | Required ownership and validity |
+| --- | --- |
+| Detached renderer snapshot | Own backing through sampling/readback and producer teardown; keep content extent distinct from allocation extent. |
+| Borrowed frame texture | Borrow without taking backing ownership; validity ends at the documented frame boundary. |
+| Acquired surface texture | Belong to one surface acquisition; present, abandon, reconfigure, or surface destruction invalidates the acquisition. |
+
+Host-provided native objects enter through a trusted embedding boundary with explicit ownership.
+An imported registration does not imply ownership of its backing. Device, generation, format, usage,
+and range checks remain necessary when replacing aliases with direct runtime handles. The test
+matrix below is the acceptance boundary for each migration; this table is not a claim that every
+remaining caller already enforces it.
+
+### Command ordering and concurrency
+
+A frame records render, compute, and copy work in the intended order through runtime encoders. The
+migration must not introduce per-pipeline queue submissions or lose ordering around layer copies.
+Completion of a recorded frame and completion of submitted GPU work are distinct events.
+
+Thread affinity remains explicit. The async renderer retains worker-owned device operations;
+cross-thread presentation passes only documented frame/snapshot forms. UI registrations and mapping
+requests retain their resources until their consuming work or cancellation completes.
+
+Native drawing and shader migration can proceed alongside resource migration and platform hooks.
+UI migration depends on indexed drawing and runtime textures/uploads. Device ownership switches only
+after shader selection, resources, mapping, UI, and platform presentation work together.
+
+### Shader and build boundary
+
+Typed shader programs are authored using Donner's IR and translated to deterministic backend
+artifacts at build time. Production binaries consume the artifact appropriate to the selected
+backend without linking shader emitters merely to regenerate constant shader text.
+
+WGSL/MSL/SPIR-V remain build outputs, not committed or large inline emitted-shader goldens. Use
+focused structure/layout/error assertions, deterministic generation, real compiler validation,
+native execution, and strict renderer pixel comparisons. IR serialization tests retain their
+separate role.
+
+Bazel is the primary build. CMake must describe the same native sources, shader artifacts, platform
+libraries, and feature flags. Tiny renderer profiles must remain independent of GPU backend linkage.
+The browser WebGPU implementation and native drivers are host services outside Donner's source and
+binary closure; the bridge and backend code calling them belong to Donner.
+
+## Clean-Room and Dependency Requirements
+
+Implementation inputs are Donner requirements, algorithms, tests and black-box renderer outputs;
+the public [WebGPU](https://gpuweb.github.io/gpuweb/), [WGSL](https://www.w3.org/TR/WGSL/),
+[Vulkan](https://registry.khronos.org/vulkan/), and [SPIR-V](https://registry.khronos.org/SPIR-V/)
+specifications; and official Metal documentation/SDK interfaces.
+
+Do not copy, translate, vendor, link, or retain implementation code or internal tests from `wgpu`,
+`wgpu-native`, Naga, Dawn, or Tint in the completed runtime, shader tooling, tests, or CI. Record the
+requirement/specification, algorithm choices, verification targets, and SDK/tool inputs for each
+implementation change. Keep transition reference pixels/counters as test data; remove the legacy
+implementation when it no longer has a migration caller.
+
+The no-Rust requirement applies to build and artifact closure. No shipped artifact or non-test
+closure may fetch/invoke Rust tooling or depend on a Rust-built GPU library. Inert reference material
+is confined to the reviewed resvg/tiny-skia prefixes. The tiny-skia Rust cross-validation fixture is
+confined to the vendored workspace's own tests, without consumers or re-exports outside that test workspace. No Donner target, including tests,
+may reach the fixture or its Rust-built objects.
+A transitive module declaration alone is not evidence that a Rust toolchain executes.
+
+`tools/gpu_inventory/check_no_rust_dependencies.py` and its tests enforce the tracked-tree rules;
+`tools/cmake/gen_cmakelists.py --check` also validates generated CMake output. Final closure acceptance
+additionally requires all verifier categories blocking, analyzed dependency/link evidence, and
+source-archive builds without `rustc` or `cargo`. Do not treat a lexical scan as complete proof of
+transitive build or artifact contents.
 
 ## Security and Reliability
 
-Untrusted SVG does not provide shaders or raw GPU commands, but it controls geometry volume, image
-sizes, filter graphs, render-target dimensions, and repetition. The GPU runtime therefore enforces:
+Untrusted SVG controls geometry, images, filter graphs, dimensions, and repetition. It does not
+provide native handles, arbitrary shader source, or serialized GPU commands. The remaining runtime
+operations must preserve release-build validation of sizes, arithmetic, usage, device identity,
+resource generation, and binding/copy ranges, plus bounded allocations and waits.
 
-- checked arithmetic for byte sizes, row pitches, offsets, workgroup counts, and allocation totals;
-- per-document and per-frame limits for buffers, textures, command count, dispatch size, readback,
-  and temporary memory;
-- initialized resources before observable reads;
-- deterministic rejection of invalid formats, usages, bindings, and cross-device handles;
-- bounded waits and watchdog-visible submission progress;
-- device-loss recovery that tears down backend state without invalidating DOM/editor ownership;
-- no pointer values, native handles, private paths, or process addresses in captures;
-- platform validation layers in qualification builds and negative tests for all failure paths.
+New mapping, indexed-draw, upload-origin, surface, and browser-ID paths require negative cases for
+invalid ranges, stale handles, cancellation, resource refusal, and loss. Use bounded structured
+command tests and backend fault injection; do not rely on driver errors or optional diagnostic
+assertions to enforce the contract. Capture output must not contain pointers, native handles, private paths, or
+process addresses. Backend failures must propagate without corrupting editor/DOM ownership.
 
-GPU and shader inputs produced by Donner remain inside the editor sandbox boundary defined for
-v1.0. Backend crashes, hangs, and driver resets are security findings, not ordinary rendering
-differences.
+The required owning tests and missing enforcement surfaces are listed below. Optional diagnostics
+and physical-hardware observations are evidence with their stated limits, not universal guarantees.
 
-## Documentation Deliverables
+## Testing and Validation
 
-- A five-minute architecture page explaining the SVG-to-Geode-to-GPU flow.
-- Doxygen module pages for `donner::gpu`, resource ownership, command encoding, synchronization,
-  shader IR, and each backend.
-- SVG diagrams for ownership, submission lifetime, Vulkan resource states, browser threading, and
-  device-loss recovery.
-- An embedding guide that distinguishes Donner-owned devices from trusted borrowed native devices.
-- A migration note for embedders that currently pass WebGPU handles.
-- A generated dependency and binary-size report demonstrating the Rust-independent final build.
+Extend existing targets where they own the changed behavior. Add focused native surface/browser
+bridge targets for new hooks; their existence and actual execution are outstanding work. The GPU
+operation and shader manifests must use the complete repository input set, with
+`//tools/gpu_inventory:manifest_freshness_tests` as the freshness gate.
 
-## Rollback
+| Contract / remaining work | Owning verification |
+| --- | --- |
+| Indexed draws, resource identity, command/lifetime validation | `//donner/gpu:gpu_tests`; extend native Metal/Vulkan execution tests and browser contract tests for indexed draws. |
+| Shader structure and emitter contracts | `//donner/gpu/shader:shader_tests`; `msl_xcrun_validation_tests`, `spirv_val_validation_tests`, and `wgsl_emitter_geode_validation_tests` in the same package. |
+| Native vertex layouts and pixels | `//donner/gpu/metal/tests:metal_solid_fill_tests`, `//donner/gpu/vulkan/tests:vulkan_solid_fill_tests`; add the matching browser execution cases. |
+| Snapshot/target lifetime, alpha, cropping, refusal | `//donner/svg/renderer/tests:renderer_geode_tests`; replace adapter-only coverage with native runtime execution as each caller migrates. |
+| Filter resource ordering, scratch and working sets | `//donner/svg/renderer/geode:geode_filter_engine_tests`, `//donner/svg/renderer/tests:renderer_geode_tests`, and native filter execution suites. |
+| Upload reuse, UI texture lifetime and thumbnails | `//donner/editor/tests:gl_texture_cache_tests`, `//donner/editor/tests:layer_thumbnail_golden_tests`; extend them for runtime-backed resources. |
+| Mapping, loss, cancellation and native surfaces | Shared `gpu_tests` plus new owning native-hook tests and actual editor surface execution; current default unsupported hooks do not qualify a backend. |
+| Editor ordering and presentation | The explicit Geode editor lane below, plus the browser rendering/interaction lanes for the selected bridge. |
+| Structural counters, memory, timing and size | `//donner/gpu/baseline:baseline_counters_tests`, `//donner/svg/renderer/geode:geode_perf_tests`, and the paired measurements required by the cutover gates. |
+| Dependency closure | `//tools/gpu_inventory:check_no_rust_dependencies_tests`, the blocking verifier invocation, generated CMake validation, and analyzed/source-archive/artifact evidence. |
 
-Development packets keep the last known-good renderer selectable only while the transition requires
-it. That compatibility path is not a release rollback mechanism and must be deleted by Phase 6.
+Run the full `bazel test //...` gate and, separately, these targets with `--config=geode`:
 
-Release rollback reactivates a retained, reviewed v0.8 or v1.0 candidate artifact and compatible
-configuration by digest. It never rebuilds an old revision and never reintroduces a removed Rust
-dependency into a new artifact.
+- `//donner/editor/tests:editor_window_tests_geode`
+- `//donner/editor/tests:layer_thumbnail_golden_tests`
+- `//donner/editor/tests:async_renderer_tests`
+- `//donner/editor/tests:rnr_replay_tests`
+- `//donner/editor/tests:gl_rnr_replay_tests`
 
-## Open Questions
+Use strict pixelmatch for image acceptance. Include existing resvg filter cases for the migrated
+families, chained filters, fractional alpha, nonzero subregions, clips/masks, and DPR2 workloads.
+Unsupported-device skips and compile-only jobs must remain distinguishable from actual execution.
+The physical adapter/browser matrix and size budgets are maintained in
+[0064: GPU release matrix](0064-gpu_release_matrix.md).
 
-- Final `donner::gpu` public embedding surface: keep private through v1.0, or expose only native
-  device adoption after platform cutover?
-- Vulkan memory allocator scope: implement only the allocation patterns in the manifest, or add
-  suballocation in the first production backend?
-- Whether iOS uses the Metal backend natively in v1.0 or remains browser-only until a native host
-  exists.
-- Which exact physical GPUs are release-blocking rather than best-effort.
-- Whether the allowlisted upstream reference snapshots stay in the default source package or move to
-  a separate conformance-data archive. Either shape must keep them inert and out of the build graph.
+## Cutover Acceptance
+
+The exact integrated candidate must satisfy all applicable platform gates:
+
+- Zero unexpected pixel regressions across renderer, resvg, editor replay, and conformance suites;
+  structural counters match exactly where backend-independent and meet explicitly reviewed
+  expectations where backend APIs differ; existing steady-state budgets also remain enforced.
+- No Metal API or Vulkan synchronization-validation errors in the exercised native workloads;
+  no failures in bounded invalid-input, device-loss, cancellation, or create/destroy stress cases.
+- No unbounded frame allocations, pending uploads, submissions, or retirement growth; representative
+  DPR2 workloads fit the existing working-set caps and physical residency is measured separately.
+- Same-host/configuration frame time is no worse than 5% at the median and 10% at p95 against the
+  agreed reference corpus unless a quality/size tradeoff is explicitly accepted. Add enforcing
+  performance targets where this comparison is not yet automated.
+- Native and Wasm artifacts meet the measured budgets in the GPU matrix and editor build rules;
+  comparable clean/incremental build and startup measurements accompany the cutover.
+- Browser presentation qualifies on Chromium, WebKit, and the agreed physical iOS matrix. Device or
+  browser-profile simulation alone does not establish physical-device coverage.
+- Production consumers and dependency/artifact evidence satisfy the runtime and no-Rust boundaries;
+  the concrete adapter and obsolete WebGPU/Rust implementation paths have no remaining consumers.
+- Independent security and implementation-provenance review of the RHI has no unresolved critical
+  or high findings.
+- Required tests and checks execute successfully on the candidate, and actionable RHI/GPU review
+  findings are resolved. Publish the ownership, embedding, backend and failure-mode documentation
+  that the integrated implementation supports.
+
+## Decisions Needed Before Platform Cutover
+
+- Which physical GPU/driver combinations are mandatory versus best-effort in the qualification matrix?
+- What trusted native embedding surface is exposed after cutover, if any, beyond internal callers?
+- Which actual Vulkan allocation patterns justify suballocation, based on the residency measurements?
 
 ## Related Designs
 
 - [0017: Geode renderer](0017-geode_renderer.md)
 - [0025: Composited rendering](0025-composited_rendering.md)
-- [0028: v1.0 release](0028-v1_0_release.md)
 - [0030: Geode performance](0030-geode_performance.md)
-- [0041: Geode analytical AA](0041-geode_analytical_aa.md)
 - [0042: Geode Slug conformance](0042-geode_slug_conformance.md)
 - [0043: Deterministic replay testing](0043-deterministic_replay_testing.md)
 - [0064: GPU release matrix and binary-size budgets](0064-gpu_release_matrix.md)


### PR DESCRIPTION
Reframe the native GPU design around the remaining production cutover work. Specify the dependencies and acceptance criteria for indexed drawing, backend shader selection, runtime texture ownership and uploads, native mapping and surfaces, ImGui rendering, the browser bridge, and device ownership.

Remove completed foundation checklists, dated inventories, and the obsolete implementation sequence. Preserve the clean-room and Rust-closure boundaries, existing performance and memory limits, and the GPU review gates. This changes documentation only.

Validation: independent documentation and security reviews, existing provenance-metadata validator, relative-link checks, privacy scan, and diff checks passed. No code or build changes.
