### PR TITLE
Fix native library lookup in Geode editor tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1003,14 +1003,14 @@ jobs:
       # gen_cmakelists_test invokes Homebrew LLVM from inside Bazel's test
       # sandbox; Homebrew's tool wrappers require HOME.
       BAZEL_MACOS_TEST_FLAGS: "--test_env=HOME"
-      # Exercise the Geode editor configuration explicitly. The window test uses its
-      # transitioned wrapper to locate declared shared libraries on clean workers.
+      # Exercise the Geode editor configuration through transitioned wrappers, which
+      # locate declared shared libraries consistently on clean workers.
       GEODE_EDITOR_TARGETS: >-
         //donner/editor/tests:editor_window_tests_geode
-        //donner/editor/tests:layer_thumbnail_golden_tests
-        //donner/editor/tests:async_renderer_tests
-        //donner/editor/tests:rnr_replay_tests
-        //donner/editor/tests:gl_rnr_replay_tests
+        //donner/editor/tests:layer_thumbnail_golden_tests_geode
+        //donner/editor/tests:async_renderer_tests_geode
+        //donner/editor/tests:rnr_replay_tests_geode
+        //donner/editor/tests:gl_rnr_replay_tests_geode
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -1121,10 +1121,10 @@ jobs:
       # targets need an explicit invocation.
       GEODE_EDITOR_TARGETS: >-
         //donner/editor/tests:editor_window_tests_geode
-        //donner/editor/tests:layer_thumbnail_golden_tests
-        //donner/editor/tests:async_renderer_tests
-        //donner/editor/tests:rnr_replay_tests
-        //donner/editor/tests:gl_rnr_replay_tests
+        //donner/editor/tests:layer_thumbnail_golden_tests_geode
+        //donner/editor/tests:async_renderer_tests_geode
+        //donner/editor/tests:rnr_replay_tests_geode
+        //donner/editor/tests:gl_rnr_replay_tests_geode
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ When creating a pull request:
      with `//donner/editor/tests:editor_window_tests_geode`, `//donner/editor/tests:layer_thumbnail_golden_tests_geode`,
      `//donner/editor/tests:async_renderer_tests_geode`, `//donner/editor/tests:rnr_replay_tests_geode`, and
      `//donner/editor/tests:gl_rnr_replay_tests_geode`. This matches the separate CI editor lane;
-     default `//...` reachability does not select these tests' Geode configuration.
+     run it explicitly in addition to the Geode variants covered by the default `//...` gate.
    - **`tools/lint.sh`** (~3 s) - the banned-patterns gate: `long long`, `std::aligned_storage`, user-defined literal operators, hidden Unicode whitespace/punctuation. This is one repo-wide scan, not a bazel test; it replaced 476 per-target `*_lint` py_tests that cost 31% of the suite's CPU to do the same work.
    - `python3 tools/cmake/gen_cmakelists.py --check` (CMake generator + output validator; runs outside bazel because it uses `bazel query`).
    - **`clang-format -i` on every modified C/C++ file** before committing — `git clang-format` covers staged changes. The project `.clang-format` is tuned so clang-format 18 and 19 produce identical output, so any locally-installed clang-format works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,9 @@ When creating a pull request:
      On Intel Arc Xe hosts the Geode lane needs `--test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp` to fall back to llvmpipe.
      Also run, separately:
    - **Geode editor integration:** for renderer changes, also run `bazel test --config=geode`
-     with `//donner/editor/tests:editor_window_tests_geode`, `//donner/editor/tests:layer_thumbnail_golden_tests`,
-     `//donner/editor/tests:async_renderer_tests`, `//donner/editor/tests:rnr_replay_tests`, and
-     `//donner/editor/tests:gl_rnr_replay_tests`. This matches the separate CI editor lane;
+     with `//donner/editor/tests:editor_window_tests_geode`, `//donner/editor/tests:layer_thumbnail_golden_tests_geode`,
+     `//donner/editor/tests:async_renderer_tests_geode`, `//donner/editor/tests:rnr_replay_tests_geode`, and
+     `//donner/editor/tests:gl_rnr_replay_tests_geode`. This matches the separate CI editor lane;
      default `//...` reachability does not select these tests' Geode configuration.
    - **`tools/lint.sh`** (~3 s) - the banned-patterns gate: `long long`, `std::aligned_storage`, user-defined literal operators, hidden Unicode whitespace/punctuation. This is one repo-wide scan, not a bazel test; it replaced 476 per-target `*_lint` py_tests that cost 31% of the suite's CPU to do the same work.
    - `python3 tools/cmake/gen_cmakelists.py --check` (CMake generator + output validator; runs outside bazel because it uses `bazel query`).

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -515,9 +515,11 @@ donner_cc_test(
     data = [
         "//:donner_splash.svg",
     ],
+    opens_gpu_device = True,
     # 75 independent gtest cases (wall-clock-sensitive cases live in the
     # separate async_renderer_wallclock_tests target); shard for parallelism.
     shard_count = 4,
+    variants = ["geode"],
     deps = [
         "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
@@ -998,6 +1000,7 @@ donner_cc_test(
         "//conditions:default": [],
     }),
     env = {"DONNER_TEST_TIMEOUT_SECONDS": "180"},
+    opens_gpu_device = True,
     # Six shards produced the shortest measured target critical path on the
     # software-Vulkan CI lane. Reducing this to two doubled target wall time;
     # per-case latency is controlled by compact deterministic fixtures.
@@ -1007,6 +1010,7 @@ donner_cc_test(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    variants = ["geode"],
     deps = [
         ":bitmap_golden_compare",
         "//donner/base:gtest_timeout_main",
@@ -1046,8 +1050,10 @@ donner_cc_test(
         ":rnr_replay_testdata",
         "//:donner_splash.svg",
     ],
+    opens_gpu_device = True,
     # One shard per scenario caps the target at its slowest single replay.
     shard_count = 4,
+    variants = ["geode"],
     deps = [
         ":bitmap_golden_compare",
         "//donner/base:base_test_utils",
@@ -1212,6 +1218,8 @@ donner_cc_test(
         ["testdata/layer_thumbnails/*.png"],
         allow_empty = True,
     ),
+    opens_gpu_device = True,
+    variants = ["geode"],
     deps = [
         ":bitmap_golden_compare",
         "//donner/base:base_test_utils",


### PR DESCRIPTION
Run the Geode editor suites through the existing runfiles-aware launchers so macOS test workers can locate native shared libraries before entering gtest. Add Geode variants for async rendering, thumbnails and both replay suites, and select those variants consistently in both macOS CI lanes.

Preserve sharding, timeout budgets, runtime environment, GPU scheduling and coverage forwarding. The explicit editor gate remains required alongside default variant coverage.

Validation: the full repository gate passed 496 targets with 33 standard configuration skips; all five Geode editor targets passed, followed by 20 passing async-renderer shard executions. Lint, CMake static checks and independent review passed. The previous raw async-renderer target failed before gtest while loading `libwgpu_native.dylib`.
