### PR TITLE
Support multiple Metal vertex buffers

### DIFF
--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -140,6 +140,21 @@ donner_cc_library(
     ],
 )
 
+donner_cc_library(
+    name = "vertex_input_slice",
+    testonly = 1,
+    hdrs = ["tests/VertexInputSlice.h"],
+    visibility = donner_internal_visibility(),
+    deps = [
+        ":gpu",
+        ":gpu_test_utils",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/gpu/shader",
+        "//donner/gpu/shader:programs",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
 donner_cc_test(
     name = "gpu_tests",
     srcs = [

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -219,6 +219,9 @@ struct MetalDevice::Impl {
     id<MTLRenderPipelineState> state = nil;                        //!< Compiled pipeline state.
     PrimitiveTopology topology = PrimitiveTopology::TriangleList;  //!< Pipeline topology.
     CullMode cullMode = CullMode::None;                            //!< Pipeline cull mode.
+    std::vector<uint32_t>
+        vertexBufferIndices;     //!< Metal argument index for each active vertex slot.
+    bool usesBindGroup = false;  //!< The pipeline declares resource group zero.
   };
 
   std::vector<id<MTLBuffer>> buffers;                         //!< Buffer slots.
@@ -337,6 +340,11 @@ struct MetalDevice::Impl {
     /// Topology of the bound pipeline; Metal takes it per draw call rather than from the
     /// pipeline state object.
     PrimitiveTopology currentTopology = PrimitiveTopology::TriangleList;
+    const RenderPipelineRecord* currentRenderPipeline = nullptr;
+    std::optional<ResourceIdentity> renderBindGroup;
+    bool renderInputsDirty =
+        true;  //!< Rebind after active layout or resource changes, not each draw.
+    std::array<std::optional<SetVertexBufferCommand>, kMaxVertexBuffers> vertexBindings;
     /// Threadgroup shape of the bound compute pipeline, applied at dispatch.
     WorkgroupSize currentWorkgroupSize;
     // Bind-group records stay stable throughout synchronous submission encoding.
@@ -346,6 +354,20 @@ struct MetalDevice::Impl {
     std::optional<ResourceIdentity> lengthTableGroup;
     std::vector<id<MTLBuffer>> hostReadBuffers;  //!< GPU-written buffers needing CPU visibility.
   };
+
+  /// Marks the fixed length table and vertex-visible resource arguments occupied by the layout.
+  /// @param descriptor Pipeline declaring the resource layout.
+  Result<std::array<bool, shader::kMslVertexBufferIndex + 1>> vertexArgumentOccupancy(
+      const RenderPipelineDescriptor& descriptor) const;
+
+  /// Finds free vertex-stage argument indices without reducing resource-binding capacity.
+  /// @param descriptor Pipeline whose active vertex buffers and resource layout are reserved.
+  Result<std::vector<uint32_t>> vertexBufferIndices(
+      const RenderPipelineDescriptor& descriptor) const;
+
+  /// Applies only resources read by the active pipeline, then its logical vertex bindings.
+  /// @param state Current render encoder and recorded bindings.
+  Status bindRenderInputs(EncodingState& state);
 
   /// Opens a render encoder for a recorded pass and configures its color attachments.
   /// @param state Encoding state.
@@ -801,6 +823,78 @@ Status MetalDevice::onCreateShaderModule(uint32_t slotIndex,
   return OkStatus();
 }
 
+Result<std::array<bool, shader::kMslVertexBufferIndex + 1>>
+MetalDevice::Impl::vertexArgumentOccupancy(const RenderPipelineDescriptor& descriptor) const {
+  const PipelineLayoutDescriptor* pipelineLayout =
+      FindRecord(pipelineLayouts, descriptor.layout.slotIndex());
+  if (pipelineLayout == nullptr) {
+    return GpuError{GpuErrorType::InvalidState, "render pipeline layout is unavailable"};
+  }
+  std::array<bool, shader::kMslVertexBufferIndex + 1> occupied{};
+  occupied[shader::kMslBufferLengthsIndex] = true;
+  for (const BindGroupLayoutRef& groupRef : pipelineLayout->bindGroupLayouts) {
+    const BindGroupLayoutDescriptor* group = FindRecord(bindGroupLayouts, groupRef.slotIndex());
+    if (group == nullptr) {
+      return GpuError{GpuErrorType::InvalidState, "render bind group layout is unavailable"};
+    }
+    for (const BindGroupLayoutEntry& entry : group->entries) {
+      if (HasAllFlags(entry.visibility, ShaderStage::Vertex) &&
+          (entry.type == BindingType::UniformBuffer ||
+           entry.type == BindingType::ReadOnlyStorageBuffer)) {
+        occupied[shader::MslBufferIndex(entry.binding)] = true;
+      }
+    }
+  }
+  return occupied;
+}
+
+Result<std::vector<uint32_t>> MetalDevice::Impl::vertexBufferIndices(
+    const RenderPipelineDescriptor& descriptor) const {
+  auto occupancy = vertexArgumentOccupancy(descriptor);
+  if (occupancy.hasError()) {
+    return std::move(occupancy).error();
+  }
+  const auto& occupied = occupancy.result();
+  std::vector<uint32_t> indices;
+  for (uint32_t index = shader::kMslVertexBufferIndex;
+       index > 0 && indices.size() < descriptor.vertex.buffers.size(); --index) {
+    if (!occupied[index]) {
+      indices.push_back(index);
+    }
+  }
+  if (indices.size() != descriptor.vertex.buffers.size()) {
+    return GpuError{
+        GpuErrorType::Unsupported,
+        "vertex buffers and vertex-visible resource buffers exceed Metal argument-table capacity"};
+  }
+  return indices;
+}
+
+/// Translates only the active vertex layouts using their collision-free argument indices.
+/// @param vertex Active vertex state. @param indices Metal argument index for each layout.
+MTLVertexDescriptor* CreateVertexDescriptor(const VertexState& vertex,
+                                            const std::vector<uint32_t>& indices) {
+  if (vertex.buffers.empty()) {
+    return nil;
+  }
+  MTLVertexDescriptor* descriptor = [MTLVertexDescriptor vertexDescriptor];
+  for (size_t slot = 0; slot < vertex.buffers.size(); ++slot) {
+    const VertexBufferLayout& layout = vertex.buffers[slot];
+    const uint32_t index = indices[slot];
+    for (const VertexAttribute& attribute : layout.attributes) {
+      MTLVertexAttributeDescriptor* attributeDescriptor =
+          descriptor.attributes[attribute.shaderLocation];
+      attributeDescriptor.format = ToMtlVertexFormat(attribute.format);
+      attributeDescriptor.offset = attribute.offsetBytes;
+      attributeDescriptor.bufferIndex = index;
+    }
+    MTLVertexBufferLayoutDescriptor* layoutDescriptor = descriptor.layouts[index];
+    layoutDescriptor.stride = layout.strideBytes;
+    layoutDescriptor.stepFunction = ToMtlStepFunction(layout.stepMode);
+  }
+  return descriptor;
+}
+
 Status MetalDevice::onCreateRenderPipeline(uint32_t slotIndex,
                                            const RenderPipelineDescriptor& descriptor) {
   id<MTLLibrary> vertexLibrary =
@@ -833,29 +927,12 @@ Status MetalDevice::onCreateRenderPipeline(uint32_t slotIndex,
   pipelineDescriptor.vertexFunction = vertexFunction;
   pipelineDescriptor.fragmentFunction = fragmentFunction;
 
-  if (!descriptor.vertex.buffers.empty()) {
-    if (descriptor.vertex.buffers.size() != 1) {
-      return GpuError{GpuErrorType::Unsupported,
-                      "the Metal backend supports a single vertex buffer layout (slot 0) in this "
-                      "slice"};
-    }
-
-    const VertexBufferLayout& layout = descriptor.vertex.buffers[0];
-    MTLVertexDescriptor* vertexDescriptor = [MTLVertexDescriptor vertexDescriptor];
-    for (const VertexAttribute& attribute : layout.attributes) {
-      MTLVertexAttributeDescriptor* attributeDescriptor =
-          vertexDescriptor.attributes[attribute.shaderLocation];
-      attributeDescriptor.format = ToMtlVertexFormat(attribute.format);
-      attributeDescriptor.offset = attribute.offsetBytes;
-      attributeDescriptor.bufferIndex = shader::kMslVertexBufferIndex;
-    }
-
-    MTLVertexBufferLayoutDescriptor* layoutDescriptor =
-        vertexDescriptor.layouts[shader::kMslVertexBufferIndex];
-    layoutDescriptor.stride = layout.strideBytes;
-    layoutDescriptor.stepFunction = ToMtlStepFunction(layout.stepMode);
-    pipelineDescriptor.vertexDescriptor = vertexDescriptor;
+  auto vertexIndicesResult = impl_->vertexBufferIndices(descriptor);
+  if (vertexIndicesResult.hasError()) {
+    return std::move(vertexIndicesResult).error();
   }
+  std::vector<uint32_t> vertexIndices = std::move(vertexIndicesResult).result();
+  pipelineDescriptor.vertexDescriptor = CreateVertexDescriptor(descriptor.vertex, vertexIndices);
 
   for (size_t i = 0; i < descriptor.fragment.targets.size(); ++i) {
     const ColorTargetState& target = descriptor.fragment.targets[i];
@@ -884,8 +961,10 @@ Status MetalDevice::onCreateRenderPipeline(uint32_t slotIndex,
   }
 
   SetSlot(impl_->renderPipelines, slotIndex,
-          std::optional<Impl::RenderPipelineRecord>(
-              Impl::RenderPipelineRecord{pipelineState, descriptor.topology, descriptor.cullMode}));
+          std::optional<Impl::RenderPipelineRecord>(Impl::RenderPipelineRecord{
+              pipelineState, descriptor.topology, descriptor.cullMode, std::move(vertexIndices),
+              !FindRecord(impl_->pipelineLayouts, descriptor.layout.slotIndex())
+                   ->bindGroupLayouts.empty()}));
   return OkStatus();
 }
 
@@ -1093,6 +1172,10 @@ Status MetalDevice::Impl::beginEncodedRenderPass(EncodingState& state,
   }
 
   state.lengthTableGroup.reset();
+  state.currentRenderPipeline = nullptr;
+  state.renderBindGroup.reset();
+  state.vertexBindings.fill(std::nullopt);
+  state.renderInputsDirty = true;
   state.renderEncoder = [state.commandBuffer renderCommandEncoderWithDescriptor:passDescriptor];
   if (state.renderEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "Metal render command encoder creation failed"};
@@ -1116,6 +1199,8 @@ Status MetalDevice::Impl::encodeSetPipeline(EncodingState& state,
   [state.renderEncoder
       setCullMode:(pipeline->cullMode == CullMode::Back ? MTLCullModeBack : MTLCullModeNone)];
   state.currentTopology = pipeline->topology;
+  state.renderInputsDirty |= state.currentRenderPipeline != pipeline;
+  state.currentRenderPipeline = pipeline;
   return OkStatus();
 }
 
@@ -1274,6 +1359,11 @@ Status MetalDevice::Impl::encodeSetBindGroup(EncodingState& state,
                                 setBindGroup.bindGroupId.slotIndex)};
   }
 
+  if (state.renderEncoder != nil) {
+    state.renderInputsDirty |= state.renderBindGroup != setBindGroup.bindGroupId;
+    state.renderBindGroup = setBindGroup.bindGroupId;
+    return OkStatus();
+  }
   for (const BindGroupEntry& entry : bindGroup->descriptor.entries) {
     Status bindStatus = encodeBindGroupEntry(state, bindGroup->layout, entry);
     if (bindStatus.hasError()) {
@@ -1286,19 +1376,57 @@ Status MetalDevice::Impl::encodeSetBindGroup(EncodingState& state,
 
 Status MetalDevice::Impl::encodeSetVertexBuffer(EncodingState& state,
                                                 const SetVertexBufferCommand& setVertexBuffer) {
-  if (setVertexBuffer.slot != 0) {
-    return GpuError{GpuErrorType::Unsupported,
-                    "the Metal backend supports vertex buffer slot 0 only in this slice"};
-  }
   id<MTLBuffer> buffer = GetSlot(buffers, setVertexBuffer.bufferId.slotIndex);
-  if (state.renderEncoder == nil || buffer == nil) {
+  if (state.renderEncoder == nil || buffer == nil ||
+      setVertexBuffer.slot >= state.vertexBindings.size()) {
     return GpuError{GpuErrorType::InvalidState,
                     std::format("setVertexBuffer: buffer slot {} is not encodable",
                                 setVertexBuffer.bufferId.slotIndex)};
   }
-  [state.renderEncoder setVertexBuffer:buffer
-                                offset:setVertexBuffer.offsetBytes
-                               atIndex:shader::kMslVertexBufferIndex];
+  const auto& prior = state.vertexBindings[setVertexBuffer.slot];
+  const bool changed = !prior || prior->bufferId != setVertexBuffer.bufferId ||
+                       prior->offsetBytes != setVertexBuffer.offsetBytes;
+  state.vertexBindings[setVertexBuffer.slot] = setVertexBuffer;
+  if (changed && state.currentRenderPipeline != nullptr &&
+      setVertexBuffer.slot < state.currentRenderPipeline->vertexBufferIndices.size()) {
+    state.renderInputsDirty = true;
+  }
+  return OkStatus();
+}
+
+Status MetalDevice::Impl::bindRenderInputs(EncodingState& state) {
+  if (!state.renderInputsDirty) {
+    return OkStatus();
+  }
+  const RenderPipelineRecord* pipeline = state.currentRenderPipeline;
+  if (pipeline == nullptr) {
+    return GpuError{GpuErrorType::InvalidState, "draw without an active render pipeline"};
+  }
+  if (pipeline->usesBindGroup) {
+    const BindGroupRecord* group =
+        state.renderBindGroup ? FindRecord(bindGroups, state.renderBindGroup->slotIndex) : nullptr;
+    if (group == nullptr) {
+      return GpuError{GpuErrorType::InvalidState, "draw without a bound resource group"};
+    }
+    for (const BindGroupEntry& entry : group->descriptor.entries) {
+      Status status = encodeBindGroupEntry(state, group->layout, entry);
+      if (status.hasError()) {
+        return status;
+      }
+    }
+    encodeBufferLengths(state, *group, *state.renderBindGroup);
+  }
+  for (size_t slot = 0; slot < pipeline->vertexBufferIndices.size(); ++slot) {
+    const auto& binding = state.vertexBindings[slot];
+    id<MTLBuffer> buffer = binding ? GetSlot(buffers, binding->bufferId.slotIndex) : nil;
+    if (buffer == nil) {
+      return GpuError{GpuErrorType::InvalidState, "draw without a bound vertex buffer"};
+    }
+    [state.renderEncoder setVertexBuffer:buffer
+                                  offset:binding->offsetBytes
+                                 atIndex:pipeline->vertexBufferIndices[slot]];
+  }
+  state.renderInputsDirty = false;
   return OkStatus();
 }
 
@@ -1326,6 +1454,9 @@ Status MetalDevice::Impl::encodeSetViewport(EncodingState& state,
 Status MetalDevice::Impl::encodeDraw(EncodingState& state, const DrawCommand& draw) {
   if (state.renderEncoder == nil) {
     return GpuError{GpuErrorType::InvalidState, "draw outside a render pass"};
+  }
+  if (Status status = bindRenderInputs(state); status.hasError()) {
+    return status;
   }
   [state.renderEncoder drawPrimitives:ToMtlPrimitiveType(state.currentTopology)
                           vertexStart:draw.firstVertex

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -38,7 +38,10 @@ donner_cc_test(
 # so validation issues abort loudly.
 donner_cc_test(
     name = "metal_solid_fill_tests",
-    srcs = ["MetalSolidFill_tests.cc"],
+    srcs = [
+        "MetalSolidFill_tests.cc",
+        "MetalVertexBindings_tests.cc",
+    ],
     data = ["//donner/gpu/baseline:baselines"],
     env = {
         "MTL_DEBUG_LAYER": "1",
@@ -59,6 +62,7 @@ donner_cc_test(
         "//donner/editor/tests:bitmap_golden_compare",
         "//donner/gpu",
         "//donner/gpu:baseline_scene",
+        "//donner/gpu:gpu_test_utils",
         "//donner/gpu:vertex_input_slice",
         "//donner/gpu/baseline:frozen_baseline_policy",
         "//donner/gpu/metal:metal_device",

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -59,6 +59,7 @@ donner_cc_test(
         "//donner/editor/tests:bitmap_golden_compare",
         "//donner/gpu",
         "//donner/gpu:baseline_scene",
+        "//donner/gpu:vertex_input_slice",
         "//donner/gpu/baseline:frozen_baseline_policy",
         "//donner/gpu/metal:metal_device",
         "//donner/gpu/shader",

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -37,6 +37,7 @@
 #include "donner/gpu/shader/programs/SolidFill.h"
 #include "donner/gpu/shader/tests/StageIoTestModules.h"
 #include "donner/gpu/tests/BaselineScene.h"
+#include "donner/gpu/tests/VertexInputSlice.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 
 using testing::HasSubstr;
@@ -453,6 +454,30 @@ TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
   // mismatched pixels, anti-aliased pixels included).
   editor::tests::CompareBitmapToGolden(bitmap, goldenPath, "metal_solid_fill",
                                        editor::tests::PixelmatchIdentityParams());
+}
+
+TEST_F(MetalSolidFillTest, VertexAndInstanceOffsetsSelectTheExpectedPixels) {
+  const auto module = gpu::tests::BuildVertexInputModule();
+  ASSERT_FALSE(module.hasError()) << module.error();
+  const auto emitted = shader::EmitMsl(module.result());
+  ASSERT_FALSE(emitted.hasError()) << emitted.error();
+  gpu::tests::CheckVertexInputScene(
+      *device_,
+      ShaderModuleDescriptor{"attributes", RcString(emitted.result()), ShaderSourceKind::Msl},
+      [this](const Buffer& buffer) { return device_->readBackBuffer(buffer); }, false);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+}
+
+TEST_F(MetalSolidFillTest, ViewportAndScissorPreserveTopLeftOrientation) {
+  const auto module = gpu::tests::BuildVertexInputModule();
+  ASSERT_FALSE(module.hasError()) << module.error();
+  const auto emitted = shader::EmitMsl(module.result());
+  ASSERT_FALSE(emitted.hasError()) << emitted.error();
+  gpu::tests::CheckVertexInputScene(
+      *device_,
+      ShaderModuleDescriptor{"attributes", RcString(emitted.result()), ShaderSourceKind::Msl},
+      [this](const Buffer& buffer) { return device_->readBackBuffer(buffer); }, true);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
 }
 
 }  // namespace

--- a/donner/gpu/metal/tests/MetalVertexBindings_tests.cc
+++ b/donner/gpu/metal/tests/MetalVertexBindings_tests.cc
@@ -11,6 +11,7 @@
 
 #include "donner/editor/tests/BitmapGoldenCompare.h"
 #include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/GpuLimits.h"
 #include "donner/gpu/metal/MetalDevice.h"
 #include "donner/gpu/metal/tests/MetalDeviceGate.h"
 #include "donner/gpu/shader/ModuleInterface.h"
@@ -334,6 +335,207 @@ TEST_P(MetalVertexBindingTransitions, PipelineSwitchesUnusedSlotsAndComputeKeepR
   compare(firstReadback, 16, 4, 0);
   compare(computeReadback, 2, 1, 1);
   compare(finalReadback, 16, 4, 2);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+}
+
+TEST_F(MetalVertexBindingsTest, ActiveVertexOffsetAndIdentityChangesAloneUpdateTheDraw) {
+  auto groupLayout = device_->createBindGroupLayout(
+      {"resources",
+       {{0, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d,
+         TextureFormat::RGBA8Unorm},
+        {27, ShaderStage::Vertex | ShaderStage::Compute, BindingType::ReadOnlyStorageBuffer},
+        {28, ShaderStage::Vertex, BindingType::UniformBuffer}}});
+  ASSERT_THAT(groupLayout, HasResult());
+  auto layout = device_->createPipelineLayout({"resources", {groupLayout.result()}});
+  ASSERT_THAT(layout, HasResult());
+  const auto shaderModule = compile(false, false);
+  ASSERT_THAT(shaderModule.isValid(), testing::IsTrue());
+  auto pipeline =
+      device_->createRenderPipeline(pipelineDescriptor(layout.result(), shaderModule, false));
+  ASSERT_THAT(pipeline, HasResult());
+  const auto quad = [](float left, float right) {
+    return std::array<float, 12>{left, -1, right, -1, right, 1, left, -1, right, 1, left, 1};
+  };
+  const std::array<std::array<float, 12>, 2> firstGeometry{quad(-1, -1.0f / 3),
+                                                           quad(-1.0f / 3, 1.0f / 3)};
+  const std::array<std::array<float, 12>, 2> secondGeometry{quad(-1, -1.0f / 3), quad(1.0f / 3, 1)};
+  const auto firstBuffer = upload(firstGeometry, BufferUsage::Vertex);
+  const auto secondBuffer = upload(secondGeometry, BufferUsage::Vertex);
+  const auto weights = upload(std::array<float, 2>{1, 0.5f}, BufferUsage::Storage);
+  const auto tint = upload(std::array<float, 4>{0.25f, 0, 0, 1}, BufferUsage::Uniform);
+  auto computeTexture = device_->createTexture(
+      {"unused compute", {1, 1}, TextureFormat::RGBA8Unorm, TextureUsage::StorageBinding});
+  ASSERT_THAT(computeTexture, HasResult());
+  auto computeView = device_->createTextureView(computeTexture.result(), {"unused compute"});
+  ASSERT_THAT(computeView, HasResult());
+  auto group = device_->createBindGroup({"resources",
+                                         groupLayout.result(),
+                                         {{0, TextureViewBinding{computeView.result()}},
+                                          {27, BufferBinding{weights, 0, sizeof(float)}},
+                                          {28, BufferBinding{tint, 0, 4 * sizeof(float)}}}});
+  ASSERT_THAT(group, HasResult());
+  auto target = device_->createTexture({"dirty tracking",
+                                        {12, 4},
+                                        TextureFormat::RGBA8Unorm,
+                                        TextureUsage::RenderAttachment | TextureUsage::CopySrc});
+  ASSERT_THAT(target, HasResult());
+  auto view = device_->createTextureView(target.result(), {"dirty tracking"});
+  ASSERT_THAT(view, HasResult());
+  const auto pixels = readback(4);
+  auto encoder = device_->createCommandEncoder();
+  ASSERT_THAT(encoder, HasResult());
+  auto pass = encoder.result()->beginRenderPass(
+      {"dirty tracking", {{view.result(), LoadOp::Clear, StoreOp::Store, {0, 0, 1, 1}}}});
+  ASSERT_THAT(pass, HasResult());
+  ASSERT_THAT(pass.result()->setPipeline(pipeline.result()), IsOk());
+  ASSERT_THAT(pass.result()->setBindGroup(0, group.result()), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, firstBuffer, 0), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, firstBuffer, sizeof(firstGeometry[0])), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, secondBuffer, sizeof(secondGeometry[0])), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->end(), IsOk());
+  ASSERT_THAT(
+      encoder.result()->copyTextureToBuffer({target.result()}, pixels, {0, 256, 4}, {12, 4}),
+      IsOk());
+  auto commands = encoder.result()->finish();
+  ASSERT_THAT(commands, HasResult());
+  auto serial = device_->submit(std::move(commands).result());
+  ASSERT_THAT(serial, HasResult());
+  ASSERT_THAT(device_->waitForSerial(serial.result(), 5.0), testing::IsTrue());
+  const auto data = device_->readBackBuffer(pixels);
+  ASSERT_THAT(data, HasResult());
+  svg::RendererBitmap actual;
+  actual.dimensions = {12, 4};
+  actual.rowBytes = 256;
+  actual.pixels = data.result();
+  svg::RendererBitmap expected;
+  expected.dimensions = actual.dimensions;
+  expected.rowBytes = actual.rowBytes;
+  expected.pixels.resize(expected.rowBytes * 4);
+  for (size_t y = 0; y < 4; ++y) {
+    for (size_t x = 0; x < 12; ++x) {
+      const std::array<uint8_t, 4> red{64, 0, 0, 255};
+      std::copy(red.begin(), red.end(), expected.pixels.begin() + y * expected.rowBytes + x * 4);
+    }
+  }
+  editor::tests::CompareBitmapToBitmap(actual, expected, "metal_active_vertex_dirty_tracking",
+                                       editor::tests::PixelmatchIdentityParams());
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+}
+
+shader::ShaderResult<shader::IrModule> MaximumVertexModule() {
+  using namespace shader;
+  programs::ErrorLatch e;
+  ModuleBuilder builder;
+  std::vector<IrParam> inputs;
+  for (uint32_t slot = 0; slot < kMaxVertexBuffers; ++slot) {
+    inputs.push_back({RcString("input" + std::to_string(slot)), IrType::Vec2f(), slot});
+  }
+  auto vertex = builder.createVertexEntryPoint(
+      "vs_maximum", inputs, {{"position", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}});
+  if (vertex.hasError()) {
+    return std::move(vertex).error();
+  }
+  auto v = std::move(vertex).result();
+  IrExpr position = e(v.ref("input0"));
+  for (uint32_t slot = 1; slot < kMaxVertexBuffers; ++slot) {
+    position = e(Add(position, e(v.ref(RcString("input" + std::to_string(slot))))));
+  }
+  e.ok(v.returnOutputs(
+      {e(ConstructVector(IrType::Vec4f(), {position, LiteralF32(0), LiteralF32(1)}))}));
+  e.ok(v.finish());
+  auto fragment =
+      builder.createFragmentEntryPoint("fs_maximum", {}, {{"color", IrType::Vec4f(), 0}});
+  if (fragment.hasError()) {
+    return std::move(fragment).error();
+  }
+  auto f = std::move(fragment).result();
+  e.ok(f.returnOutputs({e(ConstructVector(
+      IrType::Vec4f(), {LiteralF32(1), LiteralF32(0), LiteralF32(0), LiteralF32(1)}))}));
+  e.ok(f.finish());
+  if (e.error) {
+    return *e.error;
+  }
+  return builder.build();
+}
+
+TEST_F(MetalVertexBindingsTest, EverySupportedVertexSlotContributesToThePixels) {
+  const auto module = MaximumVertexModule();
+  ASSERT_FALSE(module.hasError()) << module.error();
+  const auto msl = shader::EmitMsl(module.result());
+  ASSERT_FALSE(msl.hasError()) << msl.error();
+  auto shaderModule =
+      device_->createShaderModule({"maximum", RcString(msl.result()), ShaderSourceKind::Msl});
+  ASSERT_THAT(shaderModule, HasResult());
+  auto layout = device_->createPipelineLayout({"maximum", {}});
+  ASSERT_THAT(layout, HasResult());
+  std::vector<VertexBufferLayout> buffers;
+  for (uint32_t slot = 0; slot < kMaxVertexBuffers; ++slot) {
+    buffers.push_back({8, VertexStepMode::Vertex, {{VertexFormat::Float32x2, 0, slot}}});
+  }
+  auto pipeline = device_->createRenderPipeline(
+      {"maximum",
+       layout.result(),
+       {shaderModule.result(), "vs_maximum", buffers},
+       {shaderModule.result(), "fs_maximum", {{TextureFormat::RGBA8Unorm}}}});
+  ASSERT_THAT(pipeline, HasResult());
+  const float shift = float(kMaxVertexBuffers - 1) * 0.25f;
+  const float left = -1 - shift, right = -shift;
+  const auto positions =
+      upload(std::array<float, 12>{left, -1, right, -1, right, 1, left, -1, right, 1, left, 1},
+             BufferUsage::Vertex);
+  const auto offsets =
+      upload(std::array<float, 12>{0.25f, 0, 0.25f, 0, 0.25f, 0, 0.25f, 0, 0.25f, 0, 0.25f, 0},
+             BufferUsage::Vertex);
+  auto target = device_->createTexture({"maximum",
+                                        {8, 4},
+                                        TextureFormat::RGBA8Unorm,
+                                        TextureUsage::RenderAttachment | TextureUsage::CopySrc});
+  ASSERT_THAT(target, HasResult());
+  auto view = device_->createTextureView(target.result(), {"maximum"});
+  ASSERT_THAT(view, HasResult());
+  const auto pixels = readback(4);
+  auto encoder = device_->createCommandEncoder();
+  ASSERT_THAT(encoder, HasResult());
+  auto pass = encoder.result()->beginRenderPass(
+      {"maximum", {{view.result(), LoadOp::Clear, StoreOp::Store, {0, 0, 1, 1}}}});
+  ASSERT_THAT(pass, HasResult());
+  ASSERT_THAT(pass.result()->setPipeline(pipeline.result()), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, positions), IsOk());
+  for (uint32_t slot = 1; slot < kMaxVertexBuffers; ++slot) {
+    ASSERT_THAT(pass.result()->setVertexBuffer(slot, offsets), IsOk());
+  }
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->end(), IsOk());
+  ASSERT_THAT(encoder.result()->copyTextureToBuffer({target.result()}, pixels, {0, 256, 4}, {8, 4}),
+              IsOk());
+  auto commands = encoder.result()->finish();
+  ASSERT_THAT(commands, HasResult());
+  auto serial = device_->submit(std::move(commands).result());
+  ASSERT_THAT(serial, HasResult());
+  ASSERT_THAT(device_->waitForSerial(serial.result(), 5.0), testing::IsTrue());
+  const auto data = device_->readBackBuffer(pixels);
+  ASSERT_THAT(data, HasResult());
+  svg::RendererBitmap actual;
+  actual.dimensions = {8, 4};
+  actual.rowBytes = 256;
+  actual.pixels = data.result();
+  svg::RendererBitmap expected;
+  expected.dimensions = actual.dimensions;
+  expected.rowBytes = actual.rowBytes;
+  expected.pixels.resize(expected.rowBytes * 4);
+  for (size_t y = 0; y < 4; ++y) {
+    for (size_t x = 0; x < 8; ++x) {
+      const std::array<uint8_t, 4> color =
+          x < 4 ? std::array<uint8_t, 4>{255, 0, 0, 255} : std::array<uint8_t, 4>{0, 0, 255, 255};
+      std::copy(color.begin(), color.end(),
+                expected.pixels.begin() + y * expected.rowBytes + x * 4);
+    }
+  }
+  editor::tests::CompareBitmapToBitmap(actual, expected, "metal_maximum_vertex_slots",
+                                       editor::tests::PixelmatchIdentityParams());
   EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
 }
 

--- a/donner/gpu/metal/tests/MetalVertexBindings_tests.cc
+++ b/donner/gpu/metal/tests/MetalVertexBindings_tests.cc
@@ -1,0 +1,342 @@
+/// @file
+/// Metal vertex/resource argument capacity and encoder-state transition acceptance.
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/metal/MetalDevice.h"
+#include "donner/gpu/metal/tests/MetalDeviceGate.h"
+#include "donner/gpu/shader/ModuleInterface.h"
+#include "donner/gpu/shader/MslEmitter.h"
+#include "donner/gpu/shader/programs/ErrorLatch.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+namespace donner::gpu::metal::tests {
+namespace {
+using gpu::HasResult;
+using gpu::IsOk;
+
+shader::ShaderResult<shader::IrModule> BindingModule(bool twoSlots, bool fragmentColor,
+                                                     bool allResourceSlots = false) {
+  using namespace shader;
+  programs::ErrorLatch e;
+  ModuleBuilder builder;
+  const auto array = e(IrType::RuntimeArray(IrType::F32()));
+  if (allResourceSlots) {
+    for (uint32_t b = 0; b < 29; ++b) {
+      e.ok(builder.addReadOnlyStorageBuffer(0, b, RcString("resource" + std::to_string(b)), array));
+    }
+  } else {
+    e.ok(builder.addReadOnlyStorageBuffer(0, 27, "weights", array));
+    e.ok(builder.addUniformBuffer(0, 28, "tint",
+                                  e(IrType::Struct("Tint", {{"color", IrType::Vec4f()}}))));
+    e.ok(builder.addWriteOnlyStorageTexture2d(0, 0, "computeOutput",
+                                              StorageTextureFormat::Rgba8Unorm));
+  }
+  std::vector<IrParam> inputs{{"position", IrType::Vec2f(), 0}};
+  if (twoSlots) {
+    inputs.push_back({"delta", IrType::Vec2f(), 1});
+  }
+  auto vertex = builder.createVertexEntryPoint(
+      "vs_bindings", inputs,
+      {{"position", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position},
+       {"color", IrType::Vec4f(), 0}});
+  if (vertex.hasError()) {
+    return std::move(vertex).error();
+  }
+  auto v = std::move(vertex).result();
+  const auto position =
+      twoSlots ? e(Add(e(v.ref("position")), e(v.ref("delta")))) : e(v.ref("position"));
+  IrExpr gain = LiteralF32(0);
+  if (allResourceSlots) {
+    for (uint32_t b = 0; b < 29; ++b) {
+      gain =
+          e(Add(gain, e(Index(e(v.ref(RcString("resource" + std::to_string(b)))), LiteralU32(0)))));
+    }
+  } else {
+    gain = e(Add(e(Index(e(v.ref("weights")), LiteralU32(0))),
+                 e(Index(e(v.ref("weights")), LiteralU32(1)))));
+  }
+  IrExpr color = e(ConstructVector(IrType::Vec4f(), {gain}));
+  if (!allResourceSlots && !fragmentColor) {
+    color = e(Mul(e(Member(e(v.ref("tint")), "color")), gain));
+  }
+  e.ok(v.returnOutputs(
+      {e(ConstructVector(IrType::Vec4f(), {position, LiteralF32(0), LiteralF32(1)})), color}));
+  e.ok(v.finish());
+  auto fragment = builder.createFragmentEntryPoint("fs_bindings", {{"color", IrType::Vec4f(), 0}},
+                                                   {{"color", IrType::Vec4f(), 0}});
+  if (fragment.hasError()) {
+    return std::move(fragment).error();
+  }
+  auto f = std::move(fragment).result();
+  const auto fragmentValue = fragmentColor && !allResourceSlots
+                                 ? e(Mul(e(f.ref("color")), e(Member(e(f.ref("tint")), "color"))))
+                                 : e(f.ref("color"));
+  e.ok(f.returnOutputs({fragmentValue}));
+  e.ok(f.finish());
+  if (!allResourceSlots) {
+    auto compute = builder.createComputeEntryPoint(
+        "cs_bindings",
+        {{"gid", IrType::Vec3(ScalarKind::U32), std::nullopt, BuiltinInput::GlobalInvocationId}},
+        {1, 1, 1});
+    if (compute.hasError()) {
+      return std::move(compute).error();
+    }
+    auto c = std::move(compute).result();
+    const auto result =
+        e(ConstructVector(IrType::Vec4f(), {e(Index(e(c.ref("weights")), LiteralU32(0))),
+                                            e(Index(e(c.ref("weights")), LiteralU32(1))),
+                                            LiteralF32(0), LiteralF32(1)}));
+    e.ok(c.textureStore(e(c.ref("computeOutput")), e(Swizzle(e(c.ref("gid")), "xy")), result));
+    e.ok(c.finish());
+  }
+  if (e.error) {
+    return *e.error;
+  }
+  return builder.build();
+}
+
+std::vector<VertexBufferLayout> VertexLayouts(bool twoSlots) {
+  std::vector<VertexBufferLayout> result{
+      {8, VertexStepMode::Vertex, {{VertexFormat::Float32x2, 0, 0}}}};
+  if (twoSlots) {
+    result.push_back({8, VertexStepMode::Vertex, {{VertexFormat::Float32x2, 0, 1}}});
+  }
+  return result;
+}
+
+class MetalVertexBindingsTest : public testing::Test {
+protected:
+  void SetUp() override {
+    device_ = MetalDevice::Create();
+    DONNER_REQUIRE_METAL_DEVICE(device_, "Metal vertex argument bindings");
+  }
+  ShaderModule compile(bool twoSlots, bool fragmentColor, bool all = false) {
+    const auto module = BindingModule(twoSlots, fragmentColor, all);
+    EXPECT_FALSE(module.hasError()) << module.error();
+    if (module.hasError()) {
+      return {};
+    }
+    const auto msl = shader::EmitMsl(module.result());
+    EXPECT_FALSE(msl.hasError()) << msl.error();
+    if (msl.hasError()) {
+      return {};
+    }
+    const auto bindings = shader::BufferBindingsOf(module.result());
+    EXPECT_FALSE(bindings.hasError()) << bindings.error();
+    if (bindings.hasError()) {
+      return {};
+    }
+    return gpu::GetResultOrFail(device_->createShaderModule(
+        ShaderModuleDescriptor{"bindings",
+                               RcString(msl.result()),
+                               ShaderSourceKind::Msl,
+                               {},
+                               shader::ComputeEntryPointsOf(module.result()),
+                               bindings.result()}));
+  }
+  RenderPipelineDescriptor pipelineDescriptor(const PipelineLayout& layout,
+                                              const ShaderModule& module, bool twoSlots) {
+    return {"bindings",
+            layout,
+            {module, "vs_bindings", VertexLayouts(twoSlots)},
+            {module, "fs_bindings", {{TextureFormat::RGBA8Unorm}}}};
+  }
+  template <typename T>
+  Buffer upload(const T& bytes, BufferUsage usage) {
+    auto result = device_->createBuffer({"upload", sizeof(bytes), usage | BufferUsage::CopyDst});
+    EXPECT_THAT(result, HasResult());
+    if (result.hasError()) {
+      return {};
+    }
+    Buffer buffer = std::move(result).result();
+    EXPECT_THAT(
+        device_->writeBuffer(buffer, 0, {reinterpret_cast<const uint8_t*>(&bytes), sizeof(bytes)}),
+        IsOk());
+    return buffer;
+  }
+  Buffer readback(uint32_t height) {
+    return gpu::GetResultOrFail(device_->createBuffer(
+        {"readback", uint64_t(256) * height, BufferUsage::CopyDst | BufferUsage::MapRead}));
+  }
+  void compare(const Buffer& buffer, uint32_t width, uint32_t height, int phase) {
+    const auto pixels = device_->readBackBuffer(buffer);
+    ASSERT_THAT(pixels, HasResult());
+    svg::RendererBitmap actual;
+    actual.dimensions = {int(width), int(height)};
+    actual.rowBytes = 256;
+    actual.pixels = pixels.result();
+    svg::RendererBitmap expected;
+    expected.dimensions = actual.dimensions;
+    expected.rowBytes = actual.rowBytes;
+    expected.pixels.resize(expected.rowBytes * height);
+    for (uint32_t y = 0; y < height; ++y) {
+      for (uint32_t x = 0; x < width; ++x) {
+        const std::array<uint8_t, 4> color = phase == 1   ? std::array<uint8_t, 4>{255, 0, 0, 255}
+                                             : phase == 2 ? std::array<uint8_t, 4>{0, 128, 0, 255}
+                                             : x < 4      ? std::array<uint8_t, 4>{64, 0, 0, 255}
+                                             : x < 12     ? std::array<uint8_t, 4>{0, 128, 0, 255}
+                                                          : std::array<uint8_t, 4>{0, 0, 255, 255};
+        std::copy(color.begin(), color.end(),
+                  expected.pixels.begin() + y * expected.rowBytes + x * 4);
+      }
+    }
+    editor::tests::CompareBitmapToBitmap(actual, expected,
+                                         "metal_vertex_binding_phase_" + std::to_string(phase),
+                                         editor::tests::PixelmatchIdentityParams());
+  }
+  std::unique_ptr<MetalDevice> device_;
+};
+
+TEST_F(MetalVertexBindingsTest, PreservesAllTwentyNineResourceBindingsWithOneVertexSlot) {
+  std::vector<BindGroupLayoutEntry> entries;
+  for (uint32_t binding = 0; binding < 29; ++binding) {
+    entries.push_back({binding, ShaderStage::Vertex, BindingType::ReadOnlyStorageBuffer});
+  }
+  auto group = device_->createBindGroupLayout({"capacity", entries});
+  ASSERT_THAT(group, HasResult());
+  auto layout = device_->createPipelineLayout({"capacity", {group.result()}});
+  ASSERT_THAT(layout, HasResult());
+  const auto single = compile(false, false, true);
+  ASSERT_THAT(single.isValid(), testing::IsTrue());
+  EXPECT_THAT(device_->createRenderPipeline(pipelineDescriptor(layout.result(), single, false)),
+              HasResult());
+  const auto two = compile(true, false, true);
+  ASSERT_THAT(two.isValid(), testing::IsTrue());
+  const auto refused =
+      device_->createRenderPipeline(pipelineDescriptor(layout.result(), two, true));
+  ASSERT_THAT(refused.hasError(), testing::IsTrue());
+  EXPECT_THAT(refused.error().type, testing::Eq(GpuErrorType::Unsupported));
+}
+
+class MetalVertexBindingTransitions : public MetalVertexBindingsTest,
+                                      public testing::WithParamInterface<bool> {};
+
+TEST_P(MetalVertexBindingTransitions, PipelineSwitchesUnusedSlotsAndComputeKeepResourcesIntact) {
+  const bool fragmentColor = GetParam();
+  auto groupLayout = device_->createBindGroupLayout(
+      {"resources",
+       {{0, ShaderStage::Compute, BindingType::WriteOnlyStorageTexture2d,
+         TextureFormat::RGBA8Unorm},
+        {27, ShaderStage::Vertex | ShaderStage::Compute, BindingType::ReadOnlyStorageBuffer},
+        {28, fragmentColor ? ShaderStage::Fragment : ShaderStage::Vertex,
+         BindingType::UniformBuffer}}});
+  ASSERT_THAT(groupLayout, HasResult());
+  auto layout = device_->createPipelineLayout({"resources", {groupLayout.result()}});
+  ASSERT_THAT(layout, HasResult());
+  const auto twoShader = compile(true, fragmentColor), oneShader = compile(false, fragmentColor);
+  ASSERT_THAT(twoShader.isValid(), testing::IsTrue());
+  ASSERT_THAT(oneShader.isValid(), testing::IsTrue());
+  auto two = device_->createRenderPipeline(pipelineDescriptor(layout.result(), twoShader, true));
+  auto one = device_->createRenderPipeline(pipelineDescriptor(layout.result(), oneShader, false));
+  ASSERT_THAT(two, HasResult());
+  ASSERT_THAT(one, HasResult());
+  auto compute = device_->createComputePipeline(
+      {"compute", layout.result(), {twoShader, "cs_bindings"}, {1, 1, 1}});
+  ASSERT_THAT(compute, HasResult());
+  const std::array<float, 12> positions{-1, -1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1};
+  const std::array<float, 12> zeros{};
+  std::array<float, 12> offscreen;
+  offscreen.fill(4);
+  const auto vertices = upload(positions, BufferUsage::Vertex),
+             offsets = upload(zeros, BufferUsage::Vertex),
+             unused = upload(offscreen, BufferUsage::Vertex);
+  const auto weights = upload(std::array<float, 2>{1, 0.5f}, BufferUsage::Storage);
+  const auto red = upload(std::array<float, 4>{0.25f, 0, 0, 1}, BufferUsage::Uniform),
+             green = upload(std::array<float, 4>{0, 0.5f, 0, 1}, BufferUsage::Uniform);
+  auto target = device_->createTexture({"target",
+                                        {16, 4},
+                                        TextureFormat::RGBA8Unorm,
+                                        TextureUsage::RenderAttachment | TextureUsage::CopySrc});
+  auto computeTarget =
+      device_->createTexture({"compute",
+                              {2, 1},
+                              TextureFormat::RGBA8Unorm,
+                              TextureUsage::StorageBinding | TextureUsage::CopySrc});
+  ASSERT_THAT(target, HasResult());
+  ASSERT_THAT(computeTarget, HasResult());
+  auto view = device_->createTextureView(target.result(), {"target"}),
+       computeView = device_->createTextureView(computeTarget.result(), {"compute"});
+  ASSERT_THAT(view, HasResult());
+  ASSERT_THAT(computeView, HasResult());
+  const auto group = [&](const Buffer& tint) {
+    return device_->createBindGroup({"resources",
+                                     groupLayout.result(),
+                                     {{0, TextureViewBinding{computeView.result()}},
+                                      {27, BufferBinding{weights, 0, sizeof(float)}},
+                                      {28, BufferBinding{tint, 0, 4 * sizeof(float)}}}});
+  };
+  auto redGroup = group(red), greenGroup = group(green);
+  ASSERT_THAT(redGroup, HasResult());
+  ASSERT_THAT(greenGroup, HasResult());
+  const auto firstReadback = readback(4), computeReadback = readback(1),
+             finalReadback = readback(4);
+  auto encoder = device_->createCommandEncoder();
+  ASSERT_THAT(encoder, HasResult());
+  auto pass = encoder.result()->beginRenderPass(
+      {"first", {{view.result(), LoadOp::Clear, StoreOp::Store, {0, 0, 1, 1}}}});
+  ASSERT_THAT(pass, HasResult());
+  ASSERT_THAT(pass.result()->setBindGroup(0, redGroup.result()), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, vertices), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(1, offsets), IsOk());
+  ASSERT_THAT(pass.result()->setPipeline(two.result()), IsOk());
+  ASSERT_THAT(pass.result()->setScissorRect(0, 0, 4, 4), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->setPipeline(one.result()), IsOk());
+  ASSERT_THAT(pass.result()->setBindGroup(0, greenGroup.result()), IsOk());
+  ASSERT_THAT(pass.result()->setScissorRect(4, 0, 4, 4), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(1, unused), IsOk());
+  ASSERT_THAT(pass.result()->setScissorRect(8, 0, 4, 4), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->setBindGroup(0, redGroup.result()), IsOk());
+  ASSERT_THAT(pass.result()->setPipeline(two.result()), IsOk());
+  ASSERT_THAT(pass.result()->setScissorRect(12, 0, 4, 4), IsOk());
+  ASSERT_THAT(pass.result()->draw(6), IsOk());
+  ASSERT_THAT(pass.result()->end(), IsOk());
+  ASSERT_THAT(
+      encoder.result()->copyTextureToBuffer({target.result()}, firstReadback, {0, 256, 4}, {16, 4}),
+      IsOk());
+  auto cp = encoder.result()->beginComputePass({"compute"});
+  ASSERT_THAT(cp, HasResult());
+  ASSERT_THAT(cp.result()->setPipeline(compute.result()), IsOk());
+  ASSERT_THAT(cp.result()->setBindGroup(0, greenGroup.result()), IsOk());
+  ASSERT_THAT(cp.result()->dispatchWorkgroups(2, 1, 1), IsOk());
+  ASSERT_THAT(cp.result()->end(), IsOk());
+  ASSERT_THAT(encoder.result()->copyTextureToBuffer({computeTarget.result()}, computeReadback,
+                                                    {0, 256, 1}, {2, 1}),
+              IsOk());
+  auto finalPass = encoder.result()->beginRenderPass(
+      {"final", {{view.result(), LoadOp::Clear, StoreOp::Store, {0, 0, 1, 1}}}});
+  ASSERT_THAT(finalPass, HasResult());
+  ASSERT_THAT(finalPass.result()->setBindGroup(0, greenGroup.result()), IsOk());
+  ASSERT_THAT(finalPass.result()->setPipeline(two.result()), IsOk());
+  ASSERT_THAT(finalPass.result()->setVertexBuffer(0, vertices), IsOk());
+  ASSERT_THAT(finalPass.result()->setVertexBuffer(1, offsets), IsOk());
+  ASSERT_THAT(finalPass.result()->draw(6), IsOk());
+  ASSERT_THAT(finalPass.result()->end(), IsOk());
+  ASSERT_THAT(
+      encoder.result()->copyTextureToBuffer({target.result()}, finalReadback, {0, 256, 4}, {16, 4}),
+      IsOk());
+  auto commands = encoder.result()->finish();
+  ASSERT_THAT(commands, HasResult());
+  auto serial = device_->submit(std::move(commands).result());
+  ASSERT_THAT(serial, HasResult());
+  ASSERT_THAT(device_->waitForSerial(serial.result(), 5.0), testing::IsTrue());
+  compare(firstReadback, 16, 4, 0);
+  compare(computeReadback, 2, 1, 1);
+  compare(finalReadback, 16, 4, 2);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+}
+
+INSTANTIATE_TEST_SUITE_P(VertexAndFragmentTint, MetalVertexBindingTransitions, testing::Bool());
+}  // namespace
+}  // namespace donner::gpu::metal::tests

--- a/donner/gpu/shader/MslBindingMap.h
+++ b/donner/gpu/shader/MslBindingMap.h
@@ -4,8 +4,9 @@
 /// backend.
 ///
 /// Bind group 0 uses one flat argument table per stage. Slot 0 carries exact declared buffer
-/// lengths, buffer binding `b` uses slot `1 + b`, and vertex data uses slot 30. Texture and
-/// sampler bindings use their binding numbers directly.
+/// lengths and buffer binding `b` uses slot `1 + b`. Vertex slot zero uses index 30; additional
+/// active vertex slots use unoccupied vertex-stage indices chosen from the pipeline layout.
+/// Texture and sampler bindings use their binding numbers directly.
 
 #include <cstdint>
 
@@ -22,7 +23,8 @@ inline constexpr uint32_t kMslBufferBindingCount = 29;
 inline constexpr uint32_t kMslTextureBindingCount = 128;
 /// Number of sampler argument slots per stage.
 inline constexpr uint32_t kMslSamplerBindingCount = 16;
-/// Dedicated Metal vertex buffer index for stage-in vertex data.
+/// Highest Metal buffer index, reserved for vertex slot zero. Additional vertex slots use
+/// lower indices not occupied by vertex-visible resource bindings in the active pipeline.
 inline constexpr uint32_t kMslVertexBufferIndex = 30;
 
 /// Metal buffer argument-table index for an RHI buffer binding (uniform or storage).

--- a/donner/gpu/tests/VertexInputSlice.h
+++ b/donner/gpu/tests/VertexInputSlice.h
@@ -182,7 +182,7 @@ void CheckVertexInputScene(DeviceType& device, const ShaderModuleDescriptor& sha
   actual.pixels = bytes.result();
   svg::RendererBitmap expected;
   expected.dimensions = actual.dimensions;
-  expected.rowBytes = 16 * 4;
+  expected.rowBytes = actual.rowBytes;
   expected.pixels.resize(expected.rowBytes * 12);
   for (uint32_t y = 0; y < 12; ++y) {
     for (uint32_t x = 0; x < 16; ++x) {

--- a/donner/gpu/tests/VertexInputSlice.h
+++ b/donner/gpu/tests/VertexInputSlice.h
@@ -1,0 +1,201 @@
+#pragma once
+/// @file
+/// Native vertex/instance fetch and viewport/scissor pixel acceptance.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <utility>
+
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/shader/IrModule.h"
+#include "donner/gpu/shader/programs/ErrorLatch.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+namespace donner::gpu::tests {
+
+/// Builds attribute-driven geometry with an independent instance-index check.
+inline shader::ShaderResult<shader::IrModule> BuildVertexInputModule() {
+  using namespace shader;
+  programs::ErrorLatch e;
+  ModuleBuilder builder;
+  auto vertex = builder.createVertexEntryPoint(
+      "vs_attributes",
+      {{"position", IrType::Vec2f(), 0},
+       {"color", IrType::Vec4f(), 1},
+       {"selector", IrType::U32(), 2},
+       {"instance", IrType::U32(), std::nullopt, BuiltinInput::InstanceIndex}},
+      {{"clipPosition", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position},
+       {"color", IrType::Vec4f(), 0}});
+  if (vertex.hasError()) {
+    return std::move(vertex).error();
+  }
+  auto fn = std::move(vertex).result();
+  const auto position = e(fn.ref("position")), selector = e(fn.ref("selector"));
+  const auto x = e(Add(e(Swizzle(position, "x")), e(Convert(IrType::F32(), selector))));
+  const auto clipPosition = e(ConstructVector(
+      IrType::Vec4f(), {x, e(Swizzle(position, "y")), LiteralF32(0.25f), LiteralF32(1)}));
+  const auto wrongInstance = e(ConstructVector(
+      IrType::Vec4f(), {LiteralF32(1), LiteralF32(0), LiteralF32(1), LiteralF32(1)}));
+  const auto color = e(CallBuiltin(
+      BuiltinFn::Select, {wrongInstance, e(fn.ref("color")),
+                          e(Eq(e(fn.ref("instance")), e(Add(selector, LiteralU32(1)))))}));
+  e.ok(fn.returnOutputs({clipPosition, color}));
+  e.ok(fn.finish());
+  auto fragment = builder.createFragmentEntryPoint("fs_attributes", {{"color", IrType::Vec4f(), 0}},
+                                                   {{"color", IrType::Vec4f(), 0}});
+  if (fragment.hasError()) {
+    return std::move(fragment).error();
+  }
+  auto fragmentFn = std::move(fragment).result();
+  e.ok(fragmentFn.returnOutputs({e(fragmentFn.ref("color"))}));
+  e.ok(fragmentFn.finish());
+  if (e.error) {
+    return *e.error;
+  }
+  return builder.build();
+}
+
+/// Padded position record; the attribute begins eight bytes into each element.
+struct VertexInputPosition {
+  std::array<float, 2> padding;
+  std::array<float, 2> position;
+};
+
+/// Padded instance record with both floating-point and integer attributes.
+struct VertexInputInstance {
+  float padding;
+  std::array<float, 4> color;
+  uint32_t selector;
+  std::array<float, 2> trailing;
+};
+
+static_assert(sizeof(VertexInputPosition) == 16);
+static_assert(sizeof(VertexInputInstance) == 32);
+
+/// Exact upload bytes of a fixed-size record container.
+/// @param value Owning source data, retained by the caller for the write.
+template <typename T>
+std::span<const uint8_t> VertexInputBytes(const T& value) {
+  return {reinterpret_cast<const uint8_t*>(&value), sizeof(value)};
+}
+
+/// Renders two top-half rectangles using offset vertex/instance buffers and first indices.
+/// @param device Native RHI device.
+/// @param shaderDescriptor Emitted module from BuildVertexInputModule.
+/// @param readbackBuffer Backend's host readback operation.
+/// @param restricted Use an asymmetric viewport and a smaller intersecting scissor.
+template <typename DeviceType, typename Readback>
+void CheckVertexInputScene(DeviceType& device, const ShaderModuleDescriptor& shaderDescriptor,
+                           Readback readbackBuffer, bool restricted) {
+  auto shaderModule = device.createShaderModule(shaderDescriptor);
+  ASSERT_THAT(shaderModule, HasResult());
+  auto layout = device.createPipelineLayout(PipelineLayoutDescriptor{"attributes", {}});
+  ASSERT_THAT(layout, HasResult());
+  auto pipeline = device.createRenderPipeline(RenderPipelineDescriptor{
+      "attributes", layout.result(),
+      VertexState{shaderModule.result(),
+                  "vs_attributes",
+                  {{sizeof(VertexInputPosition),
+                    VertexStepMode::Vertex,
+                    {{VertexFormat::Float32x2, offsetof(VertexInputPosition, position), 0}}},
+                   {sizeof(VertexInputInstance),
+                    VertexStepMode::Instance,
+                    {{VertexFormat::Float32x4, offsetof(VertexInputInstance, color), 1},
+                     {VertexFormat::Uint32, offsetof(VertexInputInstance, selector), 2}}}}},
+      FragmentState{shaderModule.result(), "fs_attributes", {{TextureFormat::RGBA8Unorm}}}});
+  ASSERT_THAT(pipeline, HasResult());
+
+  const std::array<VertexInputPosition, 8> vertices{{{{99, 99}, {99, 99}},
+                                                     {{88, 88}, {88, 88}},
+                                                     {{77, 77}, {-1, 0}},
+                                                     {{77, 77}, {0, 0}},
+                                                     {{77, 77}, {0, 1}},
+                                                     {{77, 77}, {-1, 0}},
+                                                     {{77, 77}, {0, 1}},
+                                                     {{77, 77}, {-1, 1}}}};
+  struct InstanceUpload {
+    std::array<float, 4> prefix;
+    std::array<VertexInputInstance, 3> records;
+  };
+  const InstanceUpload instances{{66, 66, 66, 66},
+                                 {{{55, {1, 0, 1, 1}, 9, {55, 55}},
+                                   {44, {1, 0, 0, 1}, 0, {44, 44}},
+                                   {33, {0, 1, 0, 1}, 1, {33, 33}}}}};
+  static_assert(offsetof(InstanceUpload, records) == 16);
+  auto vertexBuffer = device.createBuffer(
+      BufferDescriptor{"positions", sizeof(vertices), BufferUsage::Vertex | BufferUsage::CopyDst});
+  auto instanceBuffer = device.createBuffer(
+      BufferDescriptor{"instances", sizeof(instances), BufferUsage::Vertex | BufferUsage::CopyDst});
+  ASSERT_THAT(vertexBuffer, HasResult());
+  ASSERT_THAT(instanceBuffer, HasResult());
+  ASSERT_THAT(device.writeBuffer(vertexBuffer.result(), 0, VertexInputBytes(vertices)), IsOk());
+  ASSERT_THAT(device.writeBuffer(instanceBuffer.result(), 0, VertexInputBytes(instances)), IsOk());
+  auto target = device.createTexture(
+      TextureDescriptor{"target",
+                        {16, 12},
+                        TextureFormat::RGBA8Unorm,
+                        TextureUsage::RenderAttachment | TextureUsage::CopySrc});
+  ASSERT_THAT(target, HasResult());
+  auto view = device.createTextureView(target.result(), TextureViewDescriptor{"target"});
+  ASSERT_THAT(view, HasResult());
+  auto readback = device.createBuffer(
+      BufferDescriptor{"pixels", 256 * 12, BufferUsage::CopyDst | BufferUsage::MapRead});
+  ASSERT_THAT(readback, HasResult());
+  auto encoder = device.createCommandEncoder();
+  ASSERT_THAT(encoder, HasResult());
+  auto pass = encoder.result()->beginRenderPass(RenderPassDescriptor{
+      "attributes", {{view.result(), LoadOp::Clear, StoreOp::Store, {0, 0, 1, 1}}}});
+  ASSERT_THAT(pass, HasResult());
+  ASSERT_THAT(pass.result()->setPipeline(pipeline.result()), IsOk());
+  ASSERT_THAT(pass.result()->setVertexBuffer(0, vertexBuffer.result(), sizeof(VertexInputPosition)),
+              IsOk());
+  ASSERT_THAT(
+      pass.result()->setVertexBuffer(1, instanceBuffer.result(), offsetof(InstanceUpload, records)),
+      IsOk());
+  if (restricted) {
+    ASSERT_THAT(pass.result()->setViewport(2, 1, 12, 8, 0.2f, 0.8f), IsOk());
+    ASSERT_THAT(pass.result()->setScissorRect(5, 3, 8, 3), IsOk());
+  }
+  ASSERT_THAT(pass.result()->draw(6, 2, 1, 1), IsOk());
+  ASSERT_THAT(pass.result()->end(), IsOk());
+  ASSERT_THAT(encoder.result()->copyTextureToBuffer(TexelCopyTextureInfo{target.result()},
+                                                    readback.result(), {0, 256, 12}, {16, 12}),
+              IsOk());
+  auto commands = encoder.result()->finish();
+  ASSERT_THAT(commands, HasResult());
+  auto serial = device.submit(std::move(commands).result());
+  ASSERT_THAT(serial, HasResult());
+  ASSERT_THAT(device.waitForSerial(serial.result(), 5.0), testing::IsTrue());
+  const auto bytes = readbackBuffer(readback.result());
+  ASSERT_THAT(bytes, HasResult());
+  ASSERT_THAT(bytes.result(), testing::SizeIs(testing::Ge(256u * 12)));
+  svg::RendererBitmap actual;
+  actual.dimensions = {16, 12};
+  actual.rowBytes = 256;
+  actual.pixels = bytes.result();
+  svg::RendererBitmap expected;
+  expected.dimensions = actual.dimensions;
+  expected.rowBytes = 16 * 4;
+  expected.pixels.resize(expected.rowBytes * 12);
+  for (uint32_t y = 0; y < 12; ++y) {
+    for (uint32_t x = 0; x < 16; ++x) {
+      const bool inside = restricted ? (x >= 5 && x < 13 && y >= 3 && y < 5) : y < 6;
+      const std::array<uint8_t, 4> color = !inside ? std::array<uint8_t, 4>{0, 0, 255, 255}
+                                           : x < 8 ? std::array<uint8_t, 4>{255, 0, 0, 255}
+                                                   : std::array<uint8_t, 4>{0, 255, 0, 255};
+      std::copy(color.begin(), color.end(),
+                expected.pixels.begin() + y * expected.rowBytes + x * 4);
+    }
+  }
+  editor::tests::CompareBitmapToBitmap(
+      actual, expected, restricted ? "vertex_input_viewport_scissor" : "vertex_input_offsets",
+      editor::tests::PixelmatchIdentityParams());
+}
+}  // namespace donner::gpu::tests

--- a/donner/gpu/vulkan/tests/BUILD.bazel
+++ b/donner/gpu/vulkan/tests/BUILD.bazel
@@ -75,6 +75,7 @@ donner_cc_test(
         "//donner/editor/tests:bitmap_golden_compare",
         "//donner/gpu",
         "//donner/gpu:baseline_scene",
+        "//donner/gpu:vertex_input_slice",
         "//donner/gpu/shader",
         "//donner/gpu/shader:module_interface",
         "//donner/gpu/shader:programs",

--- a/donner/gpu/vulkan/tests/VulkanSolidFill_tests.cc
+++ b/donner/gpu/vulkan/tests/VulkanSolidFill_tests.cc
@@ -39,6 +39,7 @@
 #include "donner/gpu/shader/SpirvEmitter.h"
 #include "donner/gpu/shader/programs/SolidFill.h"
 #include "donner/gpu/tests/BaselineScene.h"
+#include "donner/gpu/tests/VertexInputSlice.h"
 #include "donner/gpu/vulkan/VulkanDevice.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/geode/GeoEncoder.h"
@@ -577,6 +578,28 @@ TEST_F(VulkanSolidFillTest, MatchesProductionWgpuRender) {
   expected.alphaType = svg::AlphaType::Premultiplied;
 
   ExpectRendersMatchWithinQuantization(actual, expected);
+}
+
+TEST_F(VulkanSolidFillTest, VertexAndInstanceOffsetsSelectTheExpectedPixels) {
+  const auto module = gpu::tests::BuildVertexInputModule();
+  ASSERT_FALSE(module.hasError()) << module.error();
+  const auto emitted = shader::EmitSpirv(module.result());
+  ASSERT_FALSE(emitted.hasError()) << emitted.error();
+  gpu::tests::CheckVertexInputScene(
+      *device_, ShaderModuleDescriptor{"attributes", {}, ShaderSourceKind::Spirv, emitted.result()},
+      [this](const Buffer& buffer) { return device_->readBackBuffer(buffer); }, false);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
+}
+
+TEST_F(VulkanSolidFillTest, ViewportAndScissorPreserveTopLeftOrientation) {
+  const auto module = gpu::tests::BuildVertexInputModule();
+  ASSERT_FALSE(module.hasError()) << module.error();
+  const auto emitted = shader::EmitSpirv(module.result());
+  ASSERT_FALSE(emitted.hasError()) << emitted.error();
+  gpu::tests::CheckVertexInputScene(
+      *device_, ShaderModuleDescriptor{"attributes", {}, ShaderSourceKind::Spirv, emitted.result()},
+      [this](const Buffer& buffer) { return device_->readBackBuffer(buffer); }, true);
+  EXPECT_THAT(device_->lastErrorForTest(), testing::IsEmpty());
 }
 
 }  // namespace


### PR DESCRIPTION
Allow Metal render pipelines to use all eight vertex input slots, including per-instance data, by allocating argument indices around each pipeline's vertex-visible resource bindings. Preserve all 29 shader-buffer bindings with one vertex input and reject combinations that exceed Metal's argument capacity.

Rebind inputs when the pipeline, resource group, active vertex buffer or binding offset changes. Native pixel regressions cover first vertex/instance indices, padded attributes, all vertex slots, viewport/scissor orientation and resource-layout transitions.

Validation: native Metal/Vulkan execution with strict pixelmatch, shader compiler and binding contracts, the full Bazel suite, all five Geode editor targets, lint, formatting, CMake static validation and independent source review.
