### PR TITLE
Preserve snapshot ownership and isolate capture state

### DIFF
--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -402,6 +402,7 @@ donner_cc_library(
         ":renderer_driver",
         ":renderer_interface",
         "//donner/base",
+        "//donner/gpu",
         "//donner/svg",
         "//donner/svg/components",
         "//donner/svg/renderer/geode:geo_encoder",

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -7285,10 +7285,8 @@ enum class ReadbackMapStatus {
   Success,
   /// A cancellation request fired; the buffer was unmapped and destroyed.
   Cancelled,
-  /// The readback deadline expired with no map completion; the buffer was
-  /// unmapped and destroyed and the device was declared lost. Distinct from
-  /// Cancelled so a caller can avoid starting a second full-deadline wait
-  /// against a device that just proved unresponsive.
+  /// The total capture deadline expired; any pending map was cancelled and its buffer retired.
+  /// Contention may consume that budget, so this alone does not declare device loss.
   TimedOut,
   /// The device was already declared lost before the map was requested; no
   /// GPU wait was performed.
@@ -7327,17 +7325,22 @@ struct ReadbackMapResult {
 /// @param buffer Buffer to map; destroyed and left invalid on cancellation or timeout.
 /// @param mapSize Bytes to map, from offset zero.
 /// @param shouldCancel Optional cancellation predicate, polled once per slice.
-ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& device,
-                                     gpu::Buffer& buffer, uint64_t mapSize,
-                                     const std::function<bool()>& shouldCancel) {
-  if (device->isDeviceLost()) {
+ReadbackMapResult MapAndWaitReadback(geode::GeodeDevice& device, gpu::Buffer& buffer,
+                                     uint64_t mapSize, const std::function<bool()>& shouldCancel,
+                                     std::chrono::steady_clock::time_point deadline,
+                                     const std::function<void()>& mapRequested) {
+  if (device.isDeviceLost()) {
     // A lost device will never deliver the map. Fail fast so a caller does
     // not spend another full readback deadline against a hung driver; the
     // caller drops the buffer without pooling it.
     return ReadbackMapResult{ReadbackMapStatus::DeviceLost, {}};
   }
 
-  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
+  if (std::chrono::steady_clock::now() >= deadline) {
+    return ReadbackMapResult{ReadbackMapStatus::TimedOut, {}};
+  }
+
+  geode::GeodeWgpuAdapterDevice& runtime = device.adapterDevice();
   gpu::Result<gpu::BufferMapping> mapping =
       runtime.mapBufferAsync(buffer, gpu::MapMode::Read, 0, mapSize);
   if (mapping.hasError()) {
@@ -7345,33 +7348,40 @@ ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     // device lost between the check above and here is reported as such rather than as a plain
     // failure, because the caller retries a failure and must not retry a lost device.
     return ReadbackMapResult{
-        device->isDeviceLost() ? ReadbackMapStatus::DeviceLost : ReadbackMapStatus::Failed, {}};
+        device.isDeviceLost() ? ReadbackMapStatus::DeviceLost : ReadbackMapStatus::Failed, {}};
   }
   gpu::BufferMapping liveMapping = std::move(mapping).result();
+  if (mapRequested) mapRequested();
 
   int pollIter = 0;
   bool cancelled = false;
   bool timedOut = false;
   gpu::MapWaitOutcome outcome = gpu::MapWaitOutcome::TimedOut;
   const auto readbackWaitStart = std::chrono::steady_clock::now();
-  const auto readbackDeadline = readbackWaitStart + geode::kReadbackMapTimeout;
   while (true) {
     if (shouldCancel && shouldCancel()) {
       cancelled = true;
       break;
     }
-    if (std::chrono::steady_clock::now() >= readbackDeadline) {
+    if (std::chrono::steady_clock::now() >= deadline) {
       timedOut = true;
       break;
     }
+    const double remainingSeconds =
+        std::chrono::duration<double>(deadline - std::chrono::steady_clock::now()).count();
+    if (remainingSeconds <= 0.0) {
+      timedOut = true;
+      break;
+    }
+    const double sliceSeconds = std::min(kReadbackWaitSliceSeconds, remainingSeconds);
     // Counted after the two checks above, so a wait that was cancelled or already past its
     // deadline reports zero slices - the signal a caller uses to tell "gave up immediately"
     // from "waited and then gave up".
     ++pollIter;
 
-    const gpu::Result<gpu::MapWaitOutcome> slice = runtime.waitForMapping(
-        liveMapping, gpu::MapWaitParams{kReadbackWaitSliceSeconds, kReadbackWaitSliceSeconds},
-        /*shouldCancel=*/{});
+    const gpu::Result<gpu::MapWaitOutcome> slice =
+        runtime.waitForMapping(liveMapping, gpu::MapWaitParams{sliceSeconds, sliceSeconds},
+                               /*shouldCancel=*/{});
     if (slice.hasError()) {
       outcome = gpu::MapWaitOutcome::Failed;
       break;
@@ -7384,15 +7394,14 @@ ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     }
   }
 
-  device->recordReadback(runtime.mappingUsedTimedWaitAny(liveMapping), pollIter);
+  device.recordReadback(runtime.mappingUsedTimedWaitAny(liveMapping), pollIter);
 
   if (cancelled || timedOut) {
     if (timedOut) {
-      device->markDeviceLostAfterWaitTimeout(
-          geode::GpuWaitSite::ReadbackMap,
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                readbackWaitStart),
-          "snapshot readback map did not complete within the readback deadline");
+      std::fprintf(
+          stderr, "[Geode] snapshot map reached the capture deadline after %.3f seconds waiting\n",
+          std::chrono::duration<double>(std::chrono::steady_clock::now() - readbackWaitStart)
+              .count());
     }
     // Abandoning a pending map leaves the buffer unusable for anything else, so it is destroyed
     // here rather than returned to a pool that would hand it out again.
@@ -7415,167 +7424,94 @@ ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
                            {}};
 }
 
-/// GPU-side snapshot readback for premultiplied RGBA8Unorm render targets: a
-/// compute pass unpremultiplies the target into a straight-alpha RGBA8
-/// staging texture, which is then copied into a map-readable buffer. The
-/// output bytes are identical to the CPU reference loop in
-/// ReadGeodeTextureSnapshot. Returns an empty bitmap on any failure so the
-/// caller can fall back to the CPU copy path.
-///
-/// wgpu-native forbids combining MAP_READ with STORAGE on a single buffer, so
-/// the compute output cannot be mapped directly; the staging-texture copy is
-/// the standard readback shape.
-RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDevice>& device,
-                                           const gpu::Texture& texture, uint32_t width,
-                                           uint32_t height,
-                                           const std::function<bool()>& shouldCancel,
-                                           bool& outTimedOut) {
-  RendererBitmap bitmap;
-  outTimedOut = false;
-  const geode::GeodeSnapshotReadbackPipeline& readbackPipeline = device->snapshotReadbackPipeline();
-  if (!readbackPipeline.valid()) {
-    return bitmap;
+/// Convert one mapped row to tightly packed straight-alpha RGBA.
+void CopyReadbackRow(uint8_t* destination, const uint8_t* source, uint32_t width, bool sourceIsBgra,
+                     AlphaType alphaType) {
+  if (!sourceIsBgra && alphaType == AlphaType::Unpremultiplied) {
+    std::memcpy(destination, source, static_cast<size_t>(width) * 4u);
+    return;
   }
-
-  // Pooled staging texture + readback buffer, keyed by size. Repeat snapshots
-  // at the same dimensions reuse the entry, so steady-state readback
-  // allocates nothing.
-  geode::SnapshotReadbackResources resources =
-      device->acquireSnapshotReadbackResources(width, height);
-  if (resources.empty()) {
-    return bitmap;
+  for (uint32_t x = 0; x < width; ++x) {
+    const uint8_t red = source[x * 4 + (sourceIsBgra ? 2 : 0)];
+    const uint8_t green = source[x * 4 + 1];
+    const uint8_t blue = source[x * 4 + (sourceIsBgra ? 0 : 2)];
+    const uint8_t alpha = source[x * 4 + 3];
+    uint8_t* pixel = destination + x * 4;
+    if (alphaType == AlphaType::Unpremultiplied) {
+      pixel[0] = red;
+      pixel[1] = green;
+      pixel[2] = blue;
+    } else if (alpha == 0) {
+      pixel[0] = pixel[1] = pixel[2] = 0;
+    } else if (alpha == 255) {
+      pixel[0] = red;
+      pixel[1] = green;
+      pixel[2] = blue;
+    } else {
+      const unsigned half = static_cast<unsigned>(alpha) >> 1u;
+      pixel[0] = static_cast<uint8_t>(std::min(255u, (red * 255u + half) / alpha));
+      pixel[1] = static_cast<uint8_t>(std::min(255u, (green * 255u + half) / alpha));
+      pixel[2] = static_cast<uint8_t>(std::min(255u, (blue * 255u + half) / alpha));
+    }
+    pixel[3] = alpha;
   }
-  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
-  const uint64_t mapSize = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
+}
 
-  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
-
-  gpu::Result<gpu::TextureView> importedView = runtime.createTextureView(
+/// Submit unpremultiplication and staging-copy work through the isolated runtime.
+bool RecordGpuReadback(geode::GeodeDevice& context,
+                       const geode::GeodeSnapshotReadbackPipeline& pipeline,
+                       const gpu::Texture& texture,
+                       const geode::SnapshotReadbackResources& resources, uint32_t width,
+                       uint32_t height) {
+  geode::GeodeWgpuAdapterDevice& runtime = context.adapterDevice();
+  auto createdView = runtime.createTextureView(
       texture, gpu::TextureViewDescriptor{"RendererGeodeReadbackInputView"});
-  if (importedView.hasError()) {
-    return bitmap;
-  }
-  const gpu::TextureView inputView = std::move(importedView).result();
-
-  using ReadbackBinding = gpu::shader::programs::SnapshotUnpremultiplyBinding;
-  gpu::Result<gpu::BindGroup> bindGroup = runtime.createBindGroup(gpu::BindGroupDescriptor{
+  if (createdView.hasError()) return false;
+  const gpu::TextureView inputView = std::move(createdView).result();
+  using Binding = gpu::shader::programs::SnapshotUnpremultiplyBinding;
+  auto bindGroup = runtime.createBindGroup(gpu::BindGroupDescriptor{
       "RendererGeodeReadbackBG",
-      readbackPipeline.bindGroupLayout(),
-      {gpu::BindGroupEntry{static_cast<uint32_t>(ReadbackBinding::InputTexture),
+      pipeline.bindGroupLayout(),
+      {gpu::BindGroupEntry{static_cast<uint32_t>(Binding::InputTexture),
                            gpu::TextureViewBinding{inputView}},
-       gpu::BindGroupEntry{static_cast<uint32_t>(ReadbackBinding::OutputTexture),
+       gpu::BindGroupEntry{static_cast<uint32_t>(Binding::OutputTexture),
                            gpu::TextureViewBinding{resources.stagingView}}}});
-  if (bindGroup.hasError()) {
-    return bitmap;
-  }
-
-  // Record the unpremultiply compute pass and the staging-texture copy into one command buffer.
-  gpu::Result<std::unique_ptr<gpu::CommandEncoder>> encoderResult = runtime.createCommandEncoder();
-  if (encoderResult.hasError()) {
-    return bitmap;
-  }
-  const std::unique_ptr<gpu::CommandEncoder> encoder = std::move(encoderResult).result();
-
-  gpu::Result<gpu::ComputePassEncoder*> passResult =
+  if (bindGroup.hasError()) return false;
+  auto createdEncoder = runtime.createCommandEncoder();
+  if (createdEncoder.hasError()) return false;
+  const std::unique_ptr<gpu::CommandEncoder> encoder = std::move(createdEncoder).result();
+  auto createdPass =
       encoder->beginComputePass(gpu::ComputePassDescriptor{"RendererGeodeReadbackPass"});
-  if (passResult.hasError()) {
-    return bitmap;
-  }
-  gpu::ComputePassEncoder* pass = passResult.result();
-  // The dispatch is sized from the same generated constants the pipeline declares, so the grid
-  // cannot disagree with the size compiled into the shader. A stale larger copy here would
-  // under-dispatch and leave the tail of the destination unwritten.
+  if (createdPass.hasError()) return false;
+  gpu::ComputePassEncoder* pass = createdPass.result();
   constexpr uint32_t kWorkgroupX = gpu::shader::programs::kSnapshotUnpremultiplyWorkgroupSize;
   constexpr uint32_t kWorkgroupY = gpu::shader::programs::kSnapshotUnpremultiplyWorkgroupSize;
-  if (pass->setPipeline(readbackPipeline.pipeline()).hasError() ||
+  if (pass->setPipeline(pipeline.pipeline()).hasError() ||
       pass->setBindGroup(0, bindGroup.result()).hasError() ||
       pass->dispatchWorkgroups((width + kWorkgroupX - 1) / kWorkgroupX,
                                (height + kWorkgroupY - 1) / kWorkgroupY, 1)
           .hasError() ||
-      pass->end().hasError()) {
-    return bitmap;
-  }
-
+      pass->end().hasError())
+    return false;
   if (encoder
           ->copyTextureToBuffer(gpu::TexelCopyTextureInfo{resources.staging}, resources.readback,
-                                gpu::TexelCopyBufferLayout{0, bytesPerRow, height},
+                                gpu::TexelCopyBufferLayout{0, alignBytesPerRow(width * 4u), height},
                                 gpu::Extent2d{width, height})
-          .hasError()) {
-    return bitmap;
-  }
-
-  gpu::Result<gpu::CommandBuffer> commands = encoder->finish();
-  if (commands.hasError()) {
-    return bitmap;
-  }
-  // Standalone, not the frame's encoder: this readback has its own map to wait on, and a
-  // snapshot is routinely asked for while another renderer's frame is open. Its sources were
-  // submitted before it was asked for and its only writes are its own staging texture and
-  // readback buffer, so it shares nothing with the spans that frame is still recording.
-  //
-  // The runtime counts its own submit, so there is no explicit tick here; a second one would
-  // double-count every snapshot against the per-frame submission ceilings.
-  if (runtime.submitStandalone(std::move(commands).result()).hasError()) {
-    return bitmap;
-  }
-
-  ReadbackMapResult mapResult =
-      MapAndWaitReadback(device, resources.readback, mapSize, shouldCancel);
-  const ReadbackMapStatus mapStatus = mapResult.status;
-  if (mapStatus != ReadbackMapStatus::Success) {
-    // Cancelled, timed out, lost, or failed: on cancellation and timeout the
-    // helper already unmapped and destroyed the readback buffer, and on a
-    // lost device the map was never requested; either way the entry cannot
-    // be pooled. The caller uses outTimedOut to avoid a second full-deadline
-    // wait against an unresponsive device.
-    outTimedOut =
-        mapStatus == ReadbackMapStatus::TimedOut || mapStatus == ReadbackMapStatus::DeviceLost;
-    return bitmap;
-  }
-
-  const gpu::Result<std::span<const uint8_t>> mappedBytes =
-      device->adapterDevice().mappedBytes(mapResult.mapping);
-  if (mappedBytes.hasError()) {
-    // A mapped-range/buffer-size mismatch is reported here rather than raising a validation
-    // error. Unmap and drop the entry (do not pool a buffer whose sizing math disagreed with
-    // ours) and let the CPU path take over.
-    (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
-    return bitmap;
-  }
-  const uint8_t* mapped = mappedBytes.result().data();
-
-  // The staging texture already holds straight-alpha RGBA, so the CPU only
-  // strips row padding.
-  bitmap.dimensions = Vector2i(static_cast<int>(width), static_cast<int>(height));
-  bitmap.rowBytes = static_cast<size_t>(width) * 4u;
-  bitmap.alphaType = AlphaType::Unpremultiplied;
-  bitmap.pixels.resize(bitmap.rowBytes * height);
-  for (uint32_t y = 0; y < height; ++y) {
-    if (shouldCancel && shouldCancel()) {
-      (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
-      return {};
-    }
-    std::memcpy(bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes,
-                mapped + static_cast<size_t>(y) * bytesPerRow, bitmap.rowBytes);
-  }
-  (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
-  device->releaseSnapshotReadbackResources(std::move(resources));
-  return bitmap;
+          .hasError())
+    return false;
+  auto commands = encoder->finish();
+  if (commands.hasError()) return false;
+  return !runtime.submitStandalone(std::move(commands).result()).hasError();
 }
 
-}  // namespace
-
-namespace {
 bool CanReadSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
                      const wgpu::Texture& texture, Vector2i dimensions,
-                     const gpu::Texture* runtimeTexture) {
-  if (!device || !texture || !SnapshotExtentFits(dimensions, SnapshotAllocationExtent(texture))) {
-    return false;
-  }
-  return runtimeTexture == nullptr ||
-         (runtimeTexture->deviceId() == device->adapterDevice().deviceId() &&
-          static_cast<WGPUTexture>(device->adapterDevice().wgpuTextureOf(*runtimeTexture)) ==
-              static_cast<WGPUTexture>(texture));
+                     wgpu::TextureFormat format) {
+  return device && texture && SnapshotRuntimeFormat(format).has_value() &&
+         texture.getFormat() == format && texture.getSampleCount() == 1 &&
+         texture.getDepthOrArrayLayers() == 1 &&
+         texture.getDimension() == wgpu::TextureDimension::_2D &&
+         SnapshotExtentFits(dimensions, SnapshotAllocationExtent(texture));
 }
 
 bool CanUnpremultiplySnapshotOnGpu(const wgpu::Texture& texture, wgpu::TextureFormat format,
@@ -7585,185 +7521,190 @@ bool CanUnpremultiplySnapshotOnGpu(const wgpu::Texture& texture, wgpu::TextureFo
          (static_cast<WGPUTextureUsage>(texture.getUsage()) &
           static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) != 0u;
 }
+
+bool SnapshotHasReadbackRoute(const wgpu::Texture& texture, wgpu::TextureFormat format,
+                              AlphaType alphaType) {
+  const bool canCopy = (static_cast<WGPUTextureUsage>(texture.getUsage()) &
+                        static_cast<WGPUTextureUsage>(wgpu::TextureUsage::CopySrc)) != 0u;
+  return canCopy || CanUnpremultiplySnapshotOnGpu(texture, format, alphaType);
+}
 }  // namespace
 
-static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
-                                               const wgpu::Texture& texture, Vector2i dimensions,
-                                               wgpu::TextureFormat format,
-                                               AlphaType sourceAlphaType,
-                                               const std::function<bool()>& shouldCancel,
-                                               const gpu::Texture* runtimeTexture = nullptr) {
-  RendererBitmap bitmap;
-  // Close the traversal-to-snapshot race before allocating a readback buffer or submitting any GPU
-  // work. A main-document request may arrive immediately after the thumbnail finishes drawing.
-  if (shouldCancel && shouldCancel()) {
-    return bitmap;
-  }
-  if (!CanReadSnapshot(device, texture, dimensions, runtimeTexture)) {
-    return bitmap;
-  }
+struct RendererGeodeTextureSnapshot::ReadbackControl {
+  const std::function<bool()>& shouldCancel;
+  std::chrono::steady_clock::time_point deadline;
+  const std::function<void()>& mapRequested;
+  ReadbackMapStatus status = ReadbackMapStatus::Success;
 
-  const uint32_t width = static_cast<uint32_t>(dimensions.x);
-  const uint32_t height = static_cast<uint32_t>(dimensions.y);
-
-  const bool canCopySource = (static_cast<WGPUTextureUsage>(texture.getUsage()) &
-                              static_cast<WGPUTextureUsage>(wgpu::TextureUsage::CopySrc)) != 0u;
-  const bool gpuConversion = CanUnpremultiplySnapshotOnGpu(texture, format, sourceAlphaType);
-  if (!gpuConversion && !canCopySource) {
-    return bitmap;
-  }
-  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
-  gpu::Texture importedSource;
-  const gpu::Texture* sourceTexture = runtimeTexture;
-  if (sourceTexture == nullptr) {
-    const gpu::TextureUsage usage =
-        (canCopySource ? gpu::TextureUsage::CopySrc : gpu::TextureUsage::None) |
-        (gpuConversion ? gpu::TextureUsage::Sampled : gpu::TextureUsage::None);
-    auto imported = runtime.importExternalTexture(
-        texture, gpu::Extent2d{texture.getWidth(), texture.getHeight()},
-        geode::GpuTextureFormatFromWgpu(format), usage);
-    if (imported.hasError()) {
-      return bitmap;
+  bool stopped() {
+    if (status == ReadbackMapStatus::Cancelled || status == ReadbackMapStatus::TimedOut ||
+        status == ReadbackMapStatus::DeviceLost)
+      return true;
+    if (shouldCancel && shouldCancel()) {
+      status = ReadbackMapStatus::Cancelled;
+      return true;
     }
-    importedSource = std::move(imported).result();
-    sourceTexture = &importedSource;
-  }
-
-  // GPU unpremultiply path: premultiplied RGBA8Unorm render targets only. The
-  // compute shader produces straight RGBA regardless of the texture's memory
-  // layout, but BGRA targets keep the proven CPU path for now.
-  // Gate on the texture's REAL format as well as the caller-declared one:
-  // the compute pass binds a view that inherits the texture's actual format,
-  // so an sRGB surface declared as RGBA8Unorm would be silently linearized
-  // by textureLoad and re-quantized into wrong bytes with no validation
-  // error, where the CPU copy path degrades only to a channel-order bug.
-  if (gpuConversion) {
-    bool gpuTimedOut = false;
-    RendererBitmap gpuBitmap = ReadGeodeTextureSnapshotGpu(device, *sourceTexture, width, height,
-                                                           shouldCancel, gpuTimedOut);
-    if (!gpuBitmap.empty()) {
-      return gpuBitmap;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      status = ReadbackMapStatus::TimedOut;
+      return true;
     }
-    // The GPU path returned empty: cancelled, timed out, or failed. A
-    // cancellation must return here so a superseding request is not delayed
-    // by a second GPU round-trip. A timeout must also return: the device
-    // just spent the full deadline not delivering a map, and the CPU copy
-    // path would begin another full-deadline wait against the same
-    // unresponsive device, turning a 10 s stall into 20 s. Only a genuine
-    // map failure falls back to the CPU copy path below.
-    if ((shouldCancel && shouldCancel()) || gpuTimedOut) {
-      return bitmap;
-    }
+    return false;
   }
+};
 
-  if (!canCopySource) {
-    return bitmap;
-  }
-
-  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
-
-  // Allocate readback buffer. Created through the runtime, which counts the allocation itself,
-  // so there is no explicit tick here.
-  const uint64_t readbackSize = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
-  gpu::Result<gpu::Buffer> createdReadback = device->adapterDevice().createBuffer(
-      gpu::BufferDescriptor{"RendererGeodeReadback", readbackSize,
-                            gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead});
-  if (createdReadback.hasError()) {
-    return bitmap;
-  }
-  gpu::Buffer readback = std::move(createdReadback).result();
-
-  gpu::Result<std::unique_ptr<gpu::CommandEncoder>> encoderResult = runtime.createCommandEncoder();
-  if (encoderResult.hasError()) {
-    return bitmap;
-  }
-  const std::unique_ptr<gpu::CommandEncoder> encoder = std::move(encoderResult).result();
-  if (encoder
-          ->copyTextureToBuffer(gpu::TexelCopyTextureInfo{*sourceTexture}, readback,
-                                gpu::TexelCopyBufferLayout{0, bytesPerRow, height},
-                                gpu::Extent2d{width, height})
-          .hasError()) {
-    return bitmap;
-  }
-  gpu::Result<gpu::CommandBuffer> commands = encoder->finish();
-  if (commands.hasError()) {
-    return bitmap;
-  }
-  // Standalone for the same reason as the GPU path above, and the runtime counts its own submit.
-  if (runtime.submitStandalone(std::move(commands).result()).hasError()) {
-    return bitmap;
-  }
-
-  ReadbackMapResult mapResult = MapAndWaitReadback(device, readback, readbackSize, shouldCancel);
-  if (mapResult.status != ReadbackMapStatus::Success) {
-    return bitmap;
-  }
-
-  const gpu::Result<std::span<const uint8_t>> mappedBytes =
-      device->adapterDevice().mappedBytes(mapResult.mapping);
+RendererBitmap RendererGeodeTextureSnapshot::readMappedTexture(
+    geode::GeodeDevice& context, gpu::BufferMapping& mapping, uint32_t width, uint32_t height,
+    wgpu::TextureFormat format, AlphaType alphaType, ReadbackControl& control) {
+  auto mappedBytes = context.adapterDevice().mappedBytes(mapping);
   if (mappedBytes.hasError()) {
-    // A size mismatch between the map request and the buffer is reported here rather than
-    // raising a validation error; never memcpy from it.
-    (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
-    return bitmap;
+    (void)context.adapterDevice().unmapBuffer(std::move(mapping));
+    return {};
   }
-  const uint8_t* mapped = mappedBytes.result().data();
-
-  // Strip row padding and unpremultiply alpha so the consumer gets a tightly
-  // packed *straight-alpha* RGBA buffer. `GeoEncoder::fillPath` premultiplies
-  // paint RGB by alpha before upload to match the blend pipeline's
-  // premultiplied storage, but `RendererBitmap` - like Skia's and
-  // tiny-skia's `takeSnapshot()` outputs - is defined as straight RGBA.
-  // Returning raw texture bytes would darken semi-transparent content and
-  // break cross-backend parity.
+  RendererBitmap bitmap;
   bitmap.dimensions = Vector2i(static_cast<int>(width), static_cast<int>(height));
   bitmap.rowBytes = static_cast<size_t>(width) * 4u;
   bitmap.alphaType = AlphaType::Unpremultiplied;
   bitmap.pixels.resize(bitmap.rowBytes * height);
-  const bool sourceIsBgra = IsBgraTextureFormat(format);
+  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
   for (uint32_t y = 0; y < height; ++y) {
-    if (shouldCancel && shouldCancel()) {
-      (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
+    if (control.stopped()) {
+      (void)context.adapterDevice().unmapBuffer(std::move(mapping));
       return {};
     }
-    const uint8_t* srcRow = mapped + static_cast<size_t>(y) * bytesPerRow;
-    uint8_t* dstRow = bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes;
-    for (uint32_t x = 0; x < width; ++x) {
-      const uint8_t srcR = sourceIsBgra ? srcRow[x * 4 + 2] : srcRow[x * 4 + 0];
-      const uint8_t srcG = srcRow[x * 4 + 1];
-      const uint8_t srcB = sourceIsBgra ? srcRow[x * 4 + 0] : srcRow[x * 4 + 2];
-      const uint8_t srcA = srcRow[x * 4 + 3];
-      if (sourceAlphaType == AlphaType::Unpremultiplied) {
-        dstRow[x * 4 + 0] = srcR;
-        dstRow[x * 4 + 1] = srcG;
-        dstRow[x * 4 + 2] = srcB;
-        dstRow[x * 4 + 3] = srcA;
-        continue;
-      }
-      if (srcA == 0u) {
-        dstRow[x * 4 + 0] = 0u;
-        dstRow[x * 4 + 1] = 0u;
-        dstRow[x * 4 + 2] = 0u;
-        dstRow[x * 4 + 3] = 0u;
-        continue;
-      }
-      if (srcA == 255u) {
-        dstRow[x * 4 + 0] = srcR;
-        dstRow[x * 4 + 1] = srcG;
-        dstRow[x * 4 + 2] = srcB;
-        dstRow[x * 4 + 3] = 255u;
-        continue;
-      }
-      // Round-nearest unpremultiply: straight = (premul * 255 + alpha/2) / alpha.
-      const unsigned a = srcA;
-      const unsigned half = a >> 1u;
-      dstRow[x * 4 + 0] = static_cast<uint8_t>(std::min(255u, (srcR * 255u + half) / a));
-      dstRow[x * 4 + 1] = static_cast<uint8_t>(std::min(255u, (srcG * 255u + half) / a));
-      dstRow[x * 4 + 2] = static_cast<uint8_t>(std::min(255u, (srcB * 255u + half) / a));
-      dstRow[x * 4 + 3] = srcA;
-    }
+    CopyReadbackRow(bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes,
+                    mappedBytes.result().data() + static_cast<size_t>(y) * bytesPerRow, width,
+                    IsBgraTextureFormat(format), alphaType);
   }
-  (void)device->adapterDevice().unmapBuffer(std::move(mapResult.mapping));
+  (void)context.adapterDevice().unmapBuffer(std::move(mapping));
+  return bitmap;
+}
+
+RendererBitmap RendererGeodeTextureSnapshot::readTextureGpu(geode::GeodeDevice& context,
+                                                            const gpu::Texture& texture,
+                                                            uint32_t width, uint32_t height,
+                                                            ReadbackControl& control) {
+  if (control.stopped()) return {};
+  const geode::GeodeSnapshotReadbackPipeline& pipeline = context.snapshotReadbackPipeline();
+  if (!pipeline.valid()) return {};
+  if (control.stopped()) return {};
+  geode::SnapshotReadbackResources resources =
+      context.acquireSnapshotReadbackResources(width, height);
+  if (resources.empty()) return {};
+  if (control.stopped()) return {};
+  if (!RecordGpuReadback(context, pipeline, texture, resources, width, height)) return {};
+  const uint64_t mapSize = static_cast<uint64_t>(alignBytesPerRow(width * 4u)) * height;
+  ReadbackMapResult mapped =
+      MapAndWaitReadback(context, resources.readback, mapSize, control.shouldCancel,
+                         control.deadline, control.mapRequested);
+  control.status = mapped.status;
+  if (mapped.status != ReadbackMapStatus::Success) return {};
+  RendererBitmap bitmap =
+      readMappedTexture(context, mapped.mapping, width, height, wgpu::TextureFormat::RGBA8Unorm,
+                        AlphaType::Unpremultiplied, control);
+  if (bitmap.empty()) return {};
+  context.releaseSnapshotReadbackResources(std::move(resources));
+  return bitmap;
+}
+
+RendererBitmap RendererGeodeTextureSnapshot::readTextureCpu(
+    geode::GeodeDevice& context, const gpu::Texture& texture, uint32_t width, uint32_t height,
+    wgpu::TextureFormat format, AlphaType alphaType, ReadbackControl& control) {
+  if (control.stopped()) return {};
+  geode::GeodeWgpuAdapterDevice& runtime = context.adapterDevice();
+  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
+  const uint64_t mapSize = static_cast<uint64_t>(bytesPerRow) * height;
+  auto createdBuffer = runtime.createBuffer(gpu::BufferDescriptor{
+      "RendererGeodeReadback", mapSize, gpu::BufferUsage::CopyDst | gpu::BufferUsage::MapRead});
+  if (createdBuffer.hasError()) return {};
+  gpu::Buffer buffer = std::move(createdBuffer).result();
+  if (control.stopped()) return {};
+  auto createdEncoder = runtime.createCommandEncoder();
+  if (createdEncoder.hasError()) return {};
+  const std::unique_ptr<gpu::CommandEncoder> encoder = std::move(createdEncoder).result();
+  if (encoder
+          ->copyTextureToBuffer(gpu::TexelCopyTextureInfo{texture}, buffer,
+                                gpu::TexelCopyBufferLayout{0, bytesPerRow, height},
+                                gpu::Extent2d{width, height})
+          .hasError())
+    return {};
+  auto commands = encoder->finish();
+  if (commands.hasError()) return {};
+  if (control.stopped()) return {};
+  if (runtime.submitStandalone(std::move(commands).result()).hasError()) return {};
+  ReadbackMapResult mapped = MapAndWaitReadback(context, buffer, mapSize, control.shouldCancel,
+                                                control.deadline, control.mapRequested);
+  control.status = mapped.status;
+  if (mapped.status != ReadbackMapStatus::Success) return {};
+  return readMappedTexture(context, mapped.mapping, width, height, format, alphaType, control);
+}
+
+RendererBitmap RendererGeodeTextureSnapshot::readTextureWithContext(
+    geode::GeodeDevice& context, wgpu::Texture texture, Vector2i dimensions,
+    wgpu::TextureFormat format, AlphaType alphaType, ReadbackControl& control) {
+  if (control.stopped()) return {};
+  if (context.isDeviceLost()) {
+    control.status = ReadbackMapStatus::DeviceLost;
+    return {};
+  }
+  auto imported = context.adapterDevice().importExternalTexture(
+      texture, {texture.getWidth(), texture.getHeight()}, geode::GpuTextureFormatFromWgpu(format),
+      geode::GpuTextureUsageFromWgpu(texture.getUsage()));
+  if (imported.hasError()) return {};
+  const gpu::Texture source = std::move(imported).result();
+  const uint32_t width = static_cast<uint32_t>(dimensions.x);
+  const uint32_t height = static_cast<uint32_t>(dimensions.y);
+  if (CanUnpremultiplySnapshotOnGpu(texture, format, alphaType)) {
+    RendererBitmap bitmap = readTextureGpu(context, source, width, height, control);
+    if (!bitmap.empty()) return bitmap;
+  }
+  if (control.stopped()) return {};
+  if (context.isDeviceLost()) {
+    control.status = ReadbackMapStatus::DeviceLost;
+    return {};
+  }
+  const bool canCopy = (static_cast<WGPUTextureUsage>(texture.getUsage()) &
+                        static_cast<WGPUTextureUsage>(wgpu::TextureUsage::CopySrc)) != 0u;
+  if (!canCopy) return {};
+  return readTextureCpu(context, source, width, height, format, alphaType, control);
+}
+
+RendererBitmap RendererGeodeTextureSnapshot::readTexture(std::shared_ptr<geode::GeodeDevice> device,
+                                                         wgpu::Texture texture, Vector2i dimensions,
+                                                         wgpu::TextureFormat format,
+                                                         AlphaType alphaType,
+                                                         const std::function<bool()>& shouldCancel,
+                                                         std::shared_ptr<Backing> backing) {
+  (void)backing;  // Keep the source allocation leased through context-local resource teardown.
+  const auto captureStart = std::chrono::steady_clock::now();
+  if (!device) return {};
+  const auto deadline =
+      captureStart +
+      std::chrono::milliseconds(device->snapshotReadbackBudgetMs_.load(std::memory_order_relaxed));
+  const std::function<void()> mapRequested = [&device] {
+    device->notifySnapshotReadbackPhaseForTesting(
+        geode::GeodeDevice::SnapshotReadbackPhase::MapRequested);
+  };
+  ReadbackControl control{shouldCancel, deadline, mapRequested};
+  if (control.stopped()) {
+    if (control.status == ReadbackMapStatus::Cancelled) {
+      device->readbackCaptureCancellations_.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      device->recordSnapshotCaptureTimeout();
+    }
+    return {};
+  }
+  if (!CanReadSnapshot(device, texture, dimensions, format)) return {};
+  if (!SnapshotHasReadbackRoute(texture, format, alphaType)) return {};
+  if (device->isDeviceLost()) return {};
+  auto capture = device->acquireSnapshotCapture(shouldCancel, deadline);
+  if (capture.status != geode::GeodeDevice::SnapshotCaptureStatus::Ready) return {};
+  RendererBitmap bitmap =
+      readTextureWithContext(*capture.context, texture, dimensions, format, alphaType, control);
+  if (control.status == ReadbackMapStatus::Cancelled) {
+    device->readbackCaptureCancellations_.fetch_add(1, std::memory_order_relaxed);
+  } else if (control.status == ReadbackMapStatus::TimedOut) {
+    device->recordSnapshotCaptureTimeout();
+  }
   return bitmap;
 }
 
@@ -7771,8 +7712,8 @@ RendererBitmap RendererGeodeTextureSnapshot::takeSnapshot() const {
   if (!isValid()) {
     return {};
   }
-  return ReadGeodeTextureSnapshot(device_, texture_, dimensions_, format_, alphaType_,
-                                  /*shouldCancel=*/{}, runtimeTexture());
+  return readTexture(device_, texture_, dimensions_, format_, alphaType_,
+                     /*shouldCancel=*/{}, backing_);
 }
 
 RendererBitmap RendererGeode::takeSnapshotInterruptibly(
@@ -7780,11 +7721,9 @@ RendererBitmap RendererGeode::takeSnapshotInterruptibly(
   if (!impl_->device || !impl_->target || impl_->pixelWidth <= 0 || impl_->pixelHeight <= 0) {
     return RendererBitmap{};
   }
-  return ReadGeodeTextureSnapshot(
+  return RendererGeodeTextureSnapshot::readTexture(
       impl_->device, impl_->target, Vector2i(impl_->pixelWidth, impl_->pixelHeight),
-      impl_->textureFormat, AlphaType::Premultiplied, shouldCancel,
-      impl_->targetHandleTexture == static_cast<WGPUTexture>(impl_->target) ? impl_->targetHandle
-                                                                            : nullptr);
+      impl_->textureFormat, AlphaType::Premultiplied, shouldCancel);
 }
 
 bool RendererGeode::deviceLost() const {
@@ -7825,6 +7764,15 @@ RendererReadbackStats RendererGeode::consumeReadbackStats() {
       .deviceLost = stats.deviceLost,
       .timedOutWaitSite = NeutralWaitSite(stats.timedOutWaitSite),
       .timedOutWaitMs = stats.timedOutWaitMs,
+      .captureCancellations = stats.captureCancellations,
+      .captureTimeouts = stats.captureTimeouts,
+      .contextCreates = stats.contextCreates,
+      .bufferCreates = stats.bufferCreates,
+      .textureCreates = stats.textureCreates,
+      .bindgroupCreates = stats.bindgroupCreates,
+      .submits = stats.submits,
+      .poolEntries = stats.poolEntries,
+      .poolBytes = stats.poolBytes,
   };
 }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -14,6 +14,7 @@
 #include <optional>
 #include <span>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -105,7 +106,7 @@ struct RendererGeodeTextureSnapshot::Backing {
       hostTexture.destroyBackingAndReset();
     }
     if (runtimeTexture.isValid() && device) {
-      (void)device->adapterDevice().destroyTextureBacking(std::move(runtimeTexture));
+      UTILS_RELEASE_ASSERT(device->deferDestroyTextureBacking(std::move(runtimeTexture)));
     }
   }
 };
@@ -114,14 +115,24 @@ RendererGeodeTextureSnapshot::RendererGeodeTextureSnapshot(
     std::shared_ptr<geode::GeodeDevice> device, wgpu::Texture texture, Vector2i dimensions,
     wgpu::TextureFormat format, AlphaType alphaType)
     : device_(std::move(device)), format_(format), alphaType_(alphaType) {
+  if (device_) {
+    runtimeDeviceId_ = device_->adapterDevice().deviceId();
+    nativeDevice_ = static_cast<WGPUDevice>(device_->device());
+    nativeQueue_ = static_cast<WGPUQueue>(device_->queue());
+  }
   if (texture) {
     backing_ = std::make_shared<Backing>();
     backing_->device = device_;
     backing_->hostTexture.reset(texture);
+    textureUsage_ = texture.getUsage();
   }
   texture_ = texture;
   allocationDimensions_ = SnapshotAllocationExtent(texture_);
   runtimeFormat_ = texture_ ? SnapshotRuntimeFormat(texture_.getFormat()) : std::nullopt;
+  if (texture && (texture.getSampleCount() != 1 || texture.getDepthOrArrayLayers() != 1 ||
+                  texture.getDimension() != wgpu::TextureDimension::_2D)) {
+    allocationDimensions_ = Vector2i::Zero();
+  }
   (void)setDimensions(dimensions);
 }
 
@@ -147,6 +158,10 @@ RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
     return result;
   }
   result.device_ = std::move(device);
+  result.runtimeDeviceId_ = texture.deviceId();
+  result.nativeDevice_ = static_cast<WGPUDevice>(result.device_->device());
+  result.nativeQueue_ = static_cast<WGPUQueue>(result.device_->queue());
+  result.textureUsage_ = backend.getUsage();
   result.backing_ = std::make_shared<Backing>();
   result.backing_->device = result.device_;
   result.backing_->runtimeTexture = std::move(texture);
@@ -177,8 +192,7 @@ const gpu::Texture* RendererGeodeTextureSnapshot::runtimeTexture() const {
 }
 
 uint64_t RendererGeodeTextureSnapshot::deviceId() const {
-  const gpu::Texture* runtime = runtimeTexture();
-  return runtime ? runtime->deviceId() : (device_ ? device_->adapterDevice().deviceId() : 0);
+  return runtimeDeviceId_;
 }
 
 bool RendererGeodeTextureSnapshot::setDimensions(Vector2i dimensions) {
@@ -201,6 +215,10 @@ RendererGeodeTextureSnapshot& RendererGeodeTextureSnapshot::operator=(
 
   destroyOwnedBacking();
   device_ = std::move(other.device_);
+  runtimeDeviceId_ = std::exchange(other.runtimeDeviceId_, 0);
+  nativeDevice_ = std::exchange(other.nativeDevice_, nullptr);
+  nativeQueue_ = std::exchange(other.nativeQueue_, nullptr);
+  textureUsage_ = std::exchange(other.textureUsage_, wgpu::TextureUsage::None);
   backing_ = std::move(other.backing_);
   borrowedGpuTexture_ = std::move(other.borrowedGpuTexture_);
   allocationDimensions_ = std::exchange(other.allocationDimensions_, Vector2i::Zero());
@@ -220,6 +238,10 @@ void RendererGeodeTextureSnapshot::destroyOwnedBacking() noexcept {
   allocationDimensions_ = Vector2i::Zero();
   runtimeFormat_.reset();
   texture_ = wgpu::Texture();
+  runtimeDeviceId_ = 0;
+  nativeDevice_ = nullptr;
+  nativeQueue_ = nullptr;
+  textureUsage_ = wgpu::TextureUsage::None;
 }
 
 RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::BorrowCurrentFrame(
@@ -227,6 +249,8 @@ RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::BorrowCurrentFrame(
     wgpu::TextureFormat format) {
   RendererGeodeTextureSnapshot result(nullptr, {}, Vector2i::Zero(), format);
   result.texture_ = texture;
+  result.runtimeDeviceId_ = runtimeTexture.deviceId();
+  result.textureUsage_ = texture.getUsage();
   result.borrowedGpuTexture_ = gpu::Texture::CreateForBackend(
       runtimeTexture.slotIndex(), runtimeTexture.generation(), runtimeTexture.deviceId());
   result.allocationDimensions_ = SnapshotAllocationExtent(texture);
@@ -1592,6 +1616,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   std::deque<gpu::Texture> frameImportedTextures;
   std::deque<gpu::TextureView> frameImportedTextureViews;
   std::unordered_set<std::shared_ptr<RendererGeodeTextureSnapshot::Backing>> frameSnapshotBackings;
+  /// Consumer-local borrowed registrations; the retained backing owns the source texture.
+  std::unordered_map<const RendererGeodeTextureSnapshot::Backing*, gpu::Texture>
+      frameSnapshotImports;
 
   /// Names a backend-owned texture as a runtime texture handle valid for the rest of the frame.
   /// The extent comes from the texture itself, so a caller can never describe it wrongly.
@@ -1733,7 +1760,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frameGpuEncoders.clear();
     frameGpuEncoder = nullptr;
     frameCommandEncoder.reset();
+    frameSnapshotImports.clear();
     frameSnapshotBackings.clear();
+    if (device) {
+      device->drainDeferredTextureBackings();
+    }
   }
 
   std::unique_ptr<geode::GeoEncoder> encoder;
@@ -5246,7 +5277,9 @@ void RendererGeode::endFrame() {
     // about to be recycled, so drop them before any of them can be handed out again.
     impl_->frameImportedTextureViews.clear();
     impl_->frameImportedTextures.clear();
+    impl_->frameSnapshotImports.clear();
     impl_->frameSnapshotBackings.clear();
+    impl_->device->drainDeferredTextureBackings();
   }
 
   // The frame's work is submitted, so nothing it recorded can still be waiting
@@ -6454,19 +6487,22 @@ void RendererGeode::drawImage(const ImageResource& image, const ImageParams& par
   impl_->encoder->drawImage(image, params.targetRect, combinedOpacity, imageRendering);
 }
 
-namespace {
-bool CanSampleSnapshot(const RendererGeodeTextureSnapshot& snapshot, geode::GeodeDevice& device) {
-  if (!snapshot.isValid() || snapshot.deviceId() != device.adapterDevice().deviceId() ||
-      (static_cast<WGPUTextureUsage>(snapshot.texture().getUsage()) &
+bool RendererGeodeTextureSnapshot::canSampleWith(const geode::GeodeDevice& device) const {
+  if (!isValid() || !runtimeFormat_ || SnapshotRuntimeFormat(format_) != runtimeFormat_ ||
+      (static_cast<WGPUTextureUsage>(textureUsage_) &
        static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) == 0u) {
     return false;
   }
-  const gpu::Texture* runtimeTexture = snapshot.runtimeTexture();
-  return runtimeTexture == nullptr ||
-         static_cast<WGPUTexture>(device.adapterDevice().wgpuTextureOf(*runtimeTexture)) ==
-             static_cast<WGPUTexture>(snapshot.texture());
+  if (runtimeDeviceId_ == device.adapterDevice().deviceId()) {
+    const gpu::Texture* runtime = runtimeTexture();
+    return runtime == nullptr ||
+           static_cast<WGPUTexture>(device.adapterDevice().wgpuTextureOf(*runtime)) ==
+               static_cast<WGPUTexture>(texture_);
+  }
+  return backing_ && nativeDevice_ != nullptr && nativeQueue_ != nullptr &&
+         nativeDevice_ == static_cast<WGPUDevice>(device.device()) &&
+         nativeQueue_ == static_cast<WGPUQueue>(device.queue());
 }
-}  // namespace
 
 bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
                                         const Box2d& targetRect, double opacity, bool pixelated) {
@@ -6478,7 +6514,7 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
     return false;
   }
   const auto* geodeTexture = static_cast<const RendererGeodeTextureSnapshot*>(&texture);
-  if (!CanSampleSnapshot(*geodeTexture, *impl_->device)) {
+  if (!geodeTexture->canSampleWith(*impl_->device)) {
     return false;
   }
 
@@ -6501,9 +6537,22 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
     impl_->frameSnapshotBackings.insert(geodeTexture->backing_);
   }
   const gpu::Texture* source = geodeTexture->runtimeTexture();
-  if (source == nullptr) {
-    source = &impl_->importTexture(geodeTexture->texture(), geodeTexture->format(),
-                                   wgpu::TextureUsage::TextureBinding);
+  if (source == nullptr || source->deviceId() != impl_->device->adapterDevice().deviceId()) {
+    const auto key = geodeTexture->backing_.get();
+    auto found = impl_->frameSnapshotImports.find(key);
+    if (found == impl_->frameSnapshotImports.end()) {
+      auto imported = impl_->device->adapterDevice().importExternalTexture(
+          geodeTexture->texture(),
+          {static_cast<uint32_t>(geodeTexture->allocationDimensions().x),
+           static_cast<uint32_t>(geodeTexture->allocationDimensions().y)},
+          *geodeTexture->runtimeFormat(),
+          geode::GpuTextureUsageFromWgpu(geodeTexture->textureUsage_));
+      if (imported.hasError()) {
+        return false;
+      }
+      found = impl_->frameSnapshotImports.emplace(key, std::move(imported).result()).first;
+    }
+    source = &found->second;
   }
   impl_->encoder->drawTexture(*source, targetRect, sourceUv, opacity, pixelated,
                               geodeTexture->alphaType() == AlphaType::Premultiplied);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -14,6 +14,7 @@
 #include <optional>
 #include <span>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 #include <webgpu/webgpu.hpp>
@@ -94,14 +95,31 @@ Vector2i SnapshotAllocationExtent(const wgpu::Texture& texture) {
 }
 }  // namespace
 
+struct RendererGeodeTextureSnapshot::Backing {
+  std::shared_ptr<geode::GeodeDevice> device;
+  gpu::Texture runtimeTexture;
+  geode::ScopedWgpuHandle<wgpu::Texture> hostTexture;
+
+  ~Backing() {
+    if (hostTexture) {
+      hostTexture.destroyBackingAndReset();
+    }
+    if (runtimeTexture.isValid() && device) {
+      (void)device->adapterDevice().destroyTextureBacking(std::move(runtimeTexture));
+    }
+  }
+};
+
 RendererGeodeTextureSnapshot::RendererGeodeTextureSnapshot(
     std::shared_ptr<geode::GeodeDevice> device, wgpu::Texture texture, Vector2i dimensions,
     wgpu::TextureFormat format, AlphaType alphaType)
-    : device_(std::move(device)),
-      ownedTexture_(std::move(texture)),
-      format_(format),
-      alphaType_(alphaType) {
-  texture_ = ownedTexture_.get();
+    : device_(std::move(device)), format_(format), alphaType_(alphaType) {
+  if (texture) {
+    backing_ = std::make_shared<Backing>();
+    backing_->device = device_;
+    backing_->hostTexture.reset(texture);
+  }
+  texture_ = texture;
   allocationDimensions_ = SnapshotAllocationExtent(texture_);
   runtimeFormat_ = texture_ ? SnapshotRuntimeFormat(texture_.getFormat()) : std::nullopt;
   (void)setDimensions(dimensions);
@@ -129,7 +147,9 @@ RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
     return result;
   }
   result.device_ = std::move(device);
-  result.ownedGpuTexture_ = std::move(texture);
+  result.backing_ = std::make_shared<Backing>();
+  result.backing_->device = result.device_;
+  result.backing_->runtimeTexture = std::move(texture);
   result.texture_ = backend;
   result.allocationDimensions_ = allocation;
   result.runtimeFormat_ = runtimeFormat;
@@ -150,8 +170,8 @@ bool RendererGeodeTextureSnapshot::isValid() const {
 }
 
 const gpu::Texture* RendererGeodeTextureSnapshot::runtimeTexture() const {
-  if (ownedGpuTexture_.isValid()) {
-    return &ownedGpuTexture_;
+  if (backing_ && backing_->runtimeTexture.isValid()) {
+    return &backing_->runtimeTexture;
   }
   return borrowedGpuTexture_.isValid() ? &borrowedGpuTexture_ : nullptr;
 }
@@ -181,11 +201,10 @@ RendererGeodeTextureSnapshot& RendererGeodeTextureSnapshot::operator=(
 
   destroyOwnedBacking();
   device_ = std::move(other.device_);
-  ownedGpuTexture_ = std::move(other.ownedGpuTexture_);
+  backing_ = std::move(other.backing_);
   borrowedGpuTexture_ = std::move(other.borrowedGpuTexture_);
   allocationDimensions_ = std::exchange(other.allocationDimensions_, Vector2i::Zero());
   runtimeFormat_ = std::exchange(other.runtimeFormat_, std::nullopt);
-  ownedTexture_ = std::move(other.ownedTexture_);
   texture_ = std::exchange(other.texture_, wgpu::Texture());
   textureView_ = std::move(other.textureView_);
   dimensions_ = std::exchange(other.dimensions_, Vector2i::Zero());
@@ -196,15 +215,7 @@ RendererGeodeTextureSnapshot& RendererGeodeTextureSnapshot::operator=(
 
 void RendererGeodeTextureSnapshot::destroyOwnedBacking() noexcept {
   textureView_.reset();
-  if (ownedTexture_) {
-    ownedTexture_.destroyBackingAndReset();
-  }
-  if (ownedGpuTexture_.isValid() && device_) {
-    // Destroy the backend object explicitly rather than only releasing the handle: a succession
-    // of presentation snapshots otherwise stays resident until the host runtime collects it.
-    (void)device_->adapterDevice().destroyTextureBacking(std::move(ownedGpuTexture_));
-  }
-  ownedGpuTexture_ = gpu::Texture();
+  backing_.reset();
   borrowedGpuTexture_ = {};
   allocationDimensions_ = Vector2i::Zero();
   runtimeFormat_.reset();
@@ -1580,6 +1591,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   // handle.
   std::deque<gpu::Texture> frameImportedTextures;
   std::deque<gpu::TextureView> frameImportedTextureViews;
+  std::unordered_set<std::shared_ptr<RendererGeodeTextureSnapshot::Backing>> frameSnapshotBackings;
 
   /// Names a backend-owned texture as a runtime texture handle valid for the rest of the frame.
   /// The extent comes from the texture itself, so a caller can never describe it wrongly.
@@ -1721,6 +1733,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     frameGpuEncoders.clear();
     frameGpuEncoder = nullptr;
     frameCommandEncoder.reset();
+    frameSnapshotBackings.clear();
   }
 
   std::unique_ptr<geode::GeoEncoder> encoder;
@@ -5233,6 +5246,7 @@ void RendererGeode::endFrame() {
     // about to be recycled, so drop them before any of them can be handed out again.
     impl_->frameImportedTextureViews.clear();
     impl_->frameImportedTextures.clear();
+    impl_->frameSnapshotBackings.clear();
   }
 
   // The frame's work is submitted, so nothing it recorded can still be waiting
@@ -6483,6 +6497,9 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
 
   impl_->flushPendingBatch();
   impl_->syncTransform();
+  if (geodeTexture->backing_) {
+    impl_->frameSnapshotBackings.insert(geodeTexture->backing_);
+  }
   const gpu::Texture* source = geodeTexture->runtimeTexture();
   if (source == nullptr) {
     source = &impl_->importTexture(geodeTexture->texture(), geodeTexture->format(),

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -70,30 +70,103 @@ namespace donner::svg {
 // GeodeWgpuUtil.h for the helper rationale.
 using ::donner::geode::wgpuLabel;
 
+namespace {
+std::optional<gpu::TextureFormat> SnapshotRuntimeFormat(wgpu::TextureFormat format) {
+  if (format == wgpu::TextureFormat::RGBA8Unorm) {
+    return gpu::TextureFormat::RGBA8Unorm;
+  }
+  if (format == wgpu::TextureFormat::BGRA8Unorm) {
+    return gpu::TextureFormat::BGRA8Unorm;
+  }
+  return std::nullopt;
+}
+
+bool SnapshotExtentFits(Vector2i content, Vector2i allocation) {
+  return content.x > 0 && content.y > 0 && content.x <= allocation.x && content.y <= allocation.y;
+}
+
+Vector2i SnapshotAllocationExtent(const wgpu::Texture& texture) {
+  if (!texture || texture.getWidth() > uint32_t(std::numeric_limits<int>::max()) ||
+      texture.getHeight() > uint32_t(std::numeric_limits<int>::max())) {
+    return Vector2i::Zero();
+  }
+  return {static_cast<int>(texture.getWidth()), static_cast<int>(texture.getHeight())};
+}
+}  // namespace
+
 RendererGeodeTextureSnapshot::RendererGeodeTextureSnapshot(
     std::shared_ptr<geode::GeodeDevice> device, wgpu::Texture texture, Vector2i dimensions,
     wgpu::TextureFormat format, AlphaType alphaType)
     : device_(std::move(device)),
       ownedTexture_(std::move(texture)),
-      dimensions_(dimensions),
       format_(format),
       alphaType_(alphaType) {
   texture_ = ownedTexture_.get();
+  allocationDimensions_ = SnapshotAllocationExtent(texture_);
+  runtimeFormat_ = texture_ ? SnapshotRuntimeFormat(texture_.getFormat()) : std::nullopt;
+  (void)setDimensions(dimensions);
 }
 
 RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
-    std::shared_ptr<geode::GeodeDevice> device, gpu::Texture texture, Vector2i dimensions,
+    std::shared_ptr<geode::GeodeDevice> device, gpu::Texture&& texture, Vector2i dimensions,
     wgpu::TextureFormat format, AlphaType alphaType) {
-  // The runtime handle is what owns the texture here. The backend alias beside it is only what
-  // the readback path still names it by; it borrows, and holding it does not extend the
-  // texture's life beyond the handle's.
-  wgpu::Texture backendAlias =
-      device ? device->adapterDevice().wgpuTextureOf(texture) : wgpu::Texture();
-  RendererGeodeTextureSnapshot result(std::move(device), wgpu::Texture(), dimensions, format,
-                                      alphaType);
+  RendererGeodeTextureSnapshot result(nullptr, {}, Vector2i::Zero(),
+                                      wgpu::TextureFormat::Undefined);
+  if (!device || !device->adapterDevice().ownsTextureBacking(texture)) {
+    return result;
+  }
+  const wgpu::Texture backend = device->adapterDevice().wgpuTextureOf(texture);
+  const auto runtimeFormat = SnapshotRuntimeFormat(format);
+  const Vector2i allocation = SnapshotAllocationExtent(backend);
+  const auto usableCapabilities =
+      static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding) |
+      static_cast<WGPUTextureUsage>(wgpu::TextureUsage::CopySrc);
+  if (!backend || !runtimeFormat || backend.getFormat() != format ||
+      backend.getSampleCount() != 1 || backend.getDepthOrArrayLayers() != 1 ||
+      backend.getDimension() != wgpu::TextureDimension::_2D ||
+      (static_cast<WGPUTextureUsage>(backend.getUsage()) & usableCapabilities) == 0u ||
+      !SnapshotExtentFits(dimensions, allocation)) {
+    return result;
+  }
+  result.device_ = std::move(device);
   result.ownedGpuTexture_ = std::move(texture);
-  result.texture_ = std::move(backendAlias);
+  result.texture_ = backend;
+  result.allocationDimensions_ = allocation;
+  result.runtimeFormat_ = runtimeFormat;
+  result.dimensions_ = dimensions;
+  result.format_ = format;
+  result.alphaType_ = alphaType;
   return result;
+}
+
+RendererGeodeTextureSnapshot::RendererGeodeTextureSnapshot(
+    RendererGeodeTextureSnapshot&& other) noexcept
+    : RendererGeodeTextureSnapshot(nullptr, {}, Vector2i::Zero(), wgpu::TextureFormat::Undefined) {
+  *this = std::move(other);
+}
+
+bool RendererGeodeTextureSnapshot::isValid() const {
+  return texture_ && SnapshotExtentFits(dimensions_, allocationDimensions_);
+}
+
+const gpu::Texture* RendererGeodeTextureSnapshot::runtimeTexture() const {
+  if (ownedGpuTexture_.isValid()) {
+    return &ownedGpuTexture_;
+  }
+  return borrowedGpuTexture_.isValid() ? &borrowedGpuTexture_ : nullptr;
+}
+
+uint64_t RendererGeodeTextureSnapshot::deviceId() const {
+  const gpu::Texture* runtime = runtimeTexture();
+  return runtime ? runtime->deviceId() : (device_ ? device_->adapterDevice().deviceId() : 0);
+}
+
+bool RendererGeodeTextureSnapshot::setDimensions(Vector2i dimensions) {
+  if (!SnapshotExtentFits(dimensions, allocationDimensions_)) {
+    return false;
+  }
+  dimensions_ = dimensions;
+  return true;
 }
 
 RendererGeodeTextureSnapshot::~RendererGeodeTextureSnapshot() {
@@ -109,6 +182,9 @@ RendererGeodeTextureSnapshot& RendererGeodeTextureSnapshot::operator=(
   destroyOwnedBacking();
   device_ = std::move(other.device_);
   ownedGpuTexture_ = std::move(other.ownedGpuTexture_);
+  borrowedGpuTexture_ = std::move(other.borrowedGpuTexture_);
+  allocationDimensions_ = std::exchange(other.allocationDimensions_, Vector2i::Zero());
+  runtimeFormat_ = std::exchange(other.runtimeFormat_, std::nullopt);
   ownedTexture_ = std::move(other.ownedTexture_);
   texture_ = std::exchange(other.texture_, wgpu::Texture());
   textureView_ = std::move(other.textureView_);
@@ -129,13 +205,22 @@ void RendererGeodeTextureSnapshot::destroyOwnedBacking() noexcept {
     (void)device_->adapterDevice().destroyTextureBacking(std::move(ownedGpuTexture_));
   }
   ownedGpuTexture_ = gpu::Texture();
+  borrowedGpuTexture_ = {};
+  allocationDimensions_ = Vector2i::Zero();
+  runtimeFormat_.reset();
   texture_ = wgpu::Texture();
 }
 
 RendererGeodeTextureSnapshot RendererGeodeTextureSnapshot::BorrowCurrentFrame(
-    wgpu::Texture texture, Vector2i dimensions, wgpu::TextureFormat format) {
-  RendererGeodeTextureSnapshot result(nullptr, wgpu::Texture(), dimensions, format);
+    const gpu::Texture& runtimeTexture, wgpu::Texture texture, Vector2i dimensions,
+    wgpu::TextureFormat format) {
+  RendererGeodeTextureSnapshot result(nullptr, {}, Vector2i::Zero(), format);
   result.texture_ = texture;
+  result.borrowedGpuTexture_ = gpu::Texture::CreateForBackend(
+      runtimeTexture.slotIndex(), runtimeTexture.generation(), runtimeTexture.deviceId());
+  result.allocationDimensions_ = SnapshotAllocationExtent(texture);
+  result.runtimeFormat_ = SnapshotRuntimeFormat(format);
+  (void)result.setDimensions(dimensions);
   return result;
 }
 
@@ -6355,10 +6440,23 @@ void RendererGeode::drawImage(const ImageResource& image, const ImageParams& par
   impl_->encoder->drawImage(image, params.targetRect, combinedOpacity, imageRendering);
 }
 
+namespace {
+bool CanSampleSnapshot(const RendererGeodeTextureSnapshot& snapshot, geode::GeodeDevice& device) {
+  if (!snapshot.isValid() || snapshot.deviceId() != device.adapterDevice().deviceId() ||
+      (static_cast<WGPUTextureUsage>(snapshot.texture().getUsage()) &
+       static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) == 0u) {
+    return false;
+  }
+  const gpu::Texture* runtimeTexture = snapshot.runtimeTexture();
+  return runtimeTexture == nullptr ||
+         static_cast<WGPUTexture>(device.adapterDevice().wgpuTextureOf(*runtimeTexture)) ==
+             static_cast<WGPUTexture>(snapshot.texture());
+}
+}  // namespace
+
 bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
                                         const Box2d& targetRect, double opacity, bool pixelated) {
-  impl_->flushPendingBatch();
-  if (!impl_->encoder || opacity <= 0.0) {
+  if (!impl_->encoder || !impl_->device || opacity <= 0.0) {
     return false;
   }
 
@@ -6366,7 +6464,7 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
     return false;
   }
   const auto* geodeTexture = static_cast<const RendererGeodeTextureSnapshot*>(&texture);
-  if (geodeTexture == nullptr || !geodeTexture->texture()) {
+  if (!CanSampleSnapshot(*geodeTexture, *impl_->device)) {
     return false;
   }
 
@@ -6375,24 +6473,23 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
   // that region, otherwise the unused remainder is squeezed into `targetRect` and every
   // tile edge lands in the wrong place.
   const Vector2i contentDimensions = geodeTexture->dimensions();
-  const uint32_t textureWidth = geodeTexture->texture().getWidth();
-  const uint32_t textureHeight = geodeTexture->texture().getHeight();
-  if (contentDimensions.x <= 0 || contentDimensions.y <= 0 || textureWidth == 0 ||
-      textureHeight == 0) {
-    return false;
-  }
+  const uint32_t textureWidth = static_cast<uint32_t>(geodeTexture->allocationDimensions().x);
+  const uint32_t textureHeight = static_cast<uint32_t>(geodeTexture->allocationDimensions().y);
   const Box2d sourceUv(Vector2d::Zero(),
                        Vector2d(std::min(1.0, static_cast<double>(contentDimensions.x) /
                                                   static_cast<double>(textureWidth)),
                                 std::min(1.0, static_cast<double>(contentDimensions.y) /
                                                   static_cast<double>(textureHeight))));
 
+  impl_->flushPendingBatch();
   impl_->syncTransform();
-  impl_->encoder->drawTexture(
-      impl_->importTexture(geodeTexture->texture(), geodeTexture->format(),
-                           wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst),
-      targetRect, sourceUv, opacity, pixelated,
-      geodeTexture->alphaType() == AlphaType::Premultiplied);
+  const gpu::Texture* source = geodeTexture->runtimeTexture();
+  if (source == nullptr) {
+    source = &impl_->importTexture(geodeTexture->texture(), geodeTexture->format(),
+                                   wgpu::TextureUsage::TextureBinding);
+  }
+  impl_->encoder->drawTexture(*source, targetRect, sourceUv, opacity, pixelated,
+                              geodeTexture->alphaType() == AlphaType::Premultiplied);
   return true;
 }
 
@@ -7067,19 +7164,19 @@ std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapsho
     return nullptr;
   }
 
-  gpu::Texture texture = std::move(impl_->ownedTarget);
-  impl_->ownedTarget = gpu::Texture();
   const Vector2i dimensions(impl_->pixelWidth, impl_->pixelHeight);
+  auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      impl_->device, std::move(impl_->ownedTarget), dimensions, impl_->textureFormat,
+      AlphaType::Premultiplied);
+  if (!snapshot.isValid()) {
+    return nullptr;
+  }
   impl_->target = wgpu::Texture();
   impl_->targetHandle = nullptr;
   impl_->targetHandleTexture = nullptr;
   impl_->targetWidth = 0;
   impl_->targetHeight = 0;
-
-  return std::make_shared<RendererGeodeTextureSnapshot>(
-      RendererGeodeTextureSnapshot::AdoptRuntimeTexture(impl_->device, std::move(texture),
-                                                        dimensions, impl_->textureFormat,
-                                                        AlphaType::Premultiplied));
+  return std::make_shared<RendererGeodeTextureSnapshot>(std::move(snapshot));
 }
 
 const RendererTextureSnapshot* RendererGeode::borrowTextureSnapshot() {
@@ -7090,8 +7187,12 @@ const RendererTextureSnapshot* RendererGeode::borrowTextureSnapshot() {
   }
 
   impl_->borrowedTargetSnapshot.emplace(RendererGeodeTextureSnapshot::BorrowCurrentFrame(
-      impl_->device->adapterDevice().wgpuTextureOf(impl_->ownedTarget),
+      impl_->ownedTarget, impl_->device->adapterDevice().wgpuTextureOf(impl_->ownedTarget),
       Vector2i(impl_->pixelWidth, impl_->pixelHeight), impl_->textureFormat));
+  if (!impl_->borrowedTargetSnapshot->isValid()) {
+    impl_->borrowedTargetSnapshot.reset();
+    return nullptr;
+  }
   return &*impl_->borrowedTargetSnapshot;
 }
 
@@ -7259,7 +7360,7 @@ ReadbackMapResult MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
 /// the compute output cannot be mapped directly; the staging-texture copy is
 /// the standard readback shape.
 RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDevice>& device,
-                                           const wgpu::Texture& texture, uint32_t width,
+                                           const gpu::Texture& texture, uint32_t width,
                                            uint32_t height,
                                            const std::function<bool()>& shouldCancel,
                                            bool& outTimedOut) {
@@ -7283,17 +7384,8 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
 
   geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
 
-  // The source is the caller's own render target, which the runtime has not named; it is
-  // borrowed for this one submission and the caller keeps ownership.
-  gpu::Result<gpu::Texture> importedInput =
-      runtime.importExternalTexture(texture, gpu::Extent2d{width, height},
-                                    gpu::TextureFormat::RGBA8Unorm, gpu::TextureUsage::Sampled);
-  if (importedInput.hasError()) {
-    return bitmap;
-  }
-  const gpu::Texture inputTexture = std::move(importedInput).result();
   gpu::Result<gpu::TextureView> importedView = runtime.createTextureView(
-      inputTexture, gpu::TextureViewDescriptor{"RendererGeodeReadbackInputView"});
+      texture, gpu::TextureViewDescriptor{"RendererGeodeReadbackInputView"});
   if (importedView.hasError()) {
     return bitmap;
   }
@@ -7407,23 +7499,69 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
 
 }  // namespace
 
+namespace {
+bool CanReadSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
+                     const wgpu::Texture& texture, Vector2i dimensions,
+                     const gpu::Texture* runtimeTexture) {
+  if (!device || !texture || !SnapshotExtentFits(dimensions, SnapshotAllocationExtent(texture))) {
+    return false;
+  }
+  return runtimeTexture == nullptr ||
+         (runtimeTexture->deviceId() == device->adapterDevice().deviceId() &&
+          static_cast<WGPUTexture>(device->adapterDevice().wgpuTextureOf(*runtimeTexture)) ==
+              static_cast<WGPUTexture>(texture));
+}
+
+bool CanUnpremultiplySnapshotOnGpu(const wgpu::Texture& texture, wgpu::TextureFormat format,
+                                   AlphaType alphaType) {
+  return alphaType == AlphaType::Premultiplied && format == wgpu::TextureFormat::RGBA8Unorm &&
+         texture.getFormat() == format &&
+         (static_cast<WGPUTextureUsage>(texture.getUsage()) &
+          static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) != 0u;
+}
+}  // namespace
+
 static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
                                                const wgpu::Texture& texture, Vector2i dimensions,
                                                wgpu::TextureFormat format,
                                                AlphaType sourceAlphaType,
-                                               const std::function<bool()>& shouldCancel) {
+                                               const std::function<bool()>& shouldCancel,
+                                               const gpu::Texture* runtimeTexture = nullptr) {
   RendererBitmap bitmap;
   // Close the traversal-to-snapshot race before allocating a readback buffer or submitting any GPU
   // work. A main-document request may arrive immediately after the thumbnail finishes drawing.
   if (shouldCancel && shouldCancel()) {
     return bitmap;
   }
-  if (!device || !texture || dimensions.x <= 0 || dimensions.y <= 0) {
+  if (!CanReadSnapshot(device, texture, dimensions, runtimeTexture)) {
     return bitmap;
   }
 
   const uint32_t width = static_cast<uint32_t>(dimensions.x);
   const uint32_t height = static_cast<uint32_t>(dimensions.y);
+
+  const bool canCopySource = (static_cast<WGPUTextureUsage>(texture.getUsage()) &
+                              static_cast<WGPUTextureUsage>(wgpu::TextureUsage::CopySrc)) != 0u;
+  const bool gpuConversion = CanUnpremultiplySnapshotOnGpu(texture, format, sourceAlphaType);
+  if (!gpuConversion && !canCopySource) {
+    return bitmap;
+  }
+  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
+  gpu::Texture importedSource;
+  const gpu::Texture* sourceTexture = runtimeTexture;
+  if (sourceTexture == nullptr) {
+    const gpu::TextureUsage usage =
+        (canCopySource ? gpu::TextureUsage::CopySrc : gpu::TextureUsage::None) |
+        (gpuConversion ? gpu::TextureUsage::Sampled : gpu::TextureUsage::None);
+    auto imported = runtime.importExternalTexture(
+        texture, gpu::Extent2d{texture.getWidth(), texture.getHeight()},
+        geode::GpuTextureFormatFromWgpu(format), usage);
+    if (imported.hasError()) {
+      return bitmap;
+    }
+    importedSource = std::move(imported).result();
+    sourceTexture = &importedSource;
+  }
 
   // GPU unpremultiply path: premultiplied RGBA8Unorm render targets only. The
   // compute shader produces straight RGBA regardless of the texture's memory
@@ -7433,13 +7571,10 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   // so an sRGB surface declared as RGBA8Unorm would be silently linearized
   // by textureLoad and re-quantized into wrong bytes with no validation
   // error, where the CPU copy path degrades only to a channel-order bug.
-  if (sourceAlphaType == AlphaType::Premultiplied && format == wgpu::TextureFormat::RGBA8Unorm &&
-      texture.getFormat() == format &&
-      (static_cast<WGPUTextureUsage>(texture.getUsage()) &
-       static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) != 0u) {
+  if (gpuConversion) {
     bool gpuTimedOut = false;
-    RendererBitmap gpuBitmap =
-        ReadGeodeTextureSnapshotGpu(device, texture, width, height, shouldCancel, gpuTimedOut);
+    RendererBitmap gpuBitmap = ReadGeodeTextureSnapshotGpu(device, *sourceTexture, width, height,
+                                                           shouldCancel, gpuTimedOut);
     if (!gpuBitmap.empty()) {
       return gpuBitmap;
     }
@@ -7455,6 +7590,10 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
     }
   }
 
+  if (!canCopySource) {
+    return bitmap;
+  }
+
   const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
 
   // Allocate readback buffer. Created through the runtime, which counts the allocation itself,
@@ -7468,24 +7607,13 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   }
   gpu::Buffer readback = std::move(createdReadback).result();
 
-  // Copy texture -> readback buffer. The source is the caller's own render target, borrowed for
-  // this one submission; the caller keeps ownership.
-  geode::GeodeWgpuAdapterDevice& runtime = device->adapterDevice();
-  gpu::Result<gpu::Texture> importedSource = runtime.importExternalTexture(
-      texture, gpu::Extent2d{width, height}, geode::GpuTextureFormatFromWgpu(format),
-      gpu::TextureUsage::CopySrc);
-  if (importedSource.hasError()) {
-    return bitmap;
-  }
-  const gpu::Texture sourceTexture = std::move(importedSource).result();
-
   gpu::Result<std::unique_ptr<gpu::CommandEncoder>> encoderResult = runtime.createCommandEncoder();
   if (encoderResult.hasError()) {
     return bitmap;
   }
   const std::unique_ptr<gpu::CommandEncoder> encoder = std::move(encoderResult).result();
   if (encoder
-          ->copyTextureToBuffer(gpu::TexelCopyTextureInfo{sourceTexture}, readback,
+          ->copyTextureToBuffer(gpu::TexelCopyTextureInfo{*sourceTexture}, readback,
                                 gpu::TexelCopyBufferLayout{0, bytesPerRow, height},
                                 gpu::Extent2d{width, height})
           .hasError()) {
@@ -7574,8 +7702,11 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
 }
 
 RendererBitmap RendererGeodeTextureSnapshot::takeSnapshot() const {
+  if (!isValid()) {
+    return {};
+  }
   return ReadGeodeTextureSnapshot(device_, texture_, dimensions_, format_, alphaType_,
-                                  /*shouldCancel=*/{});
+                                  /*shouldCancel=*/{}, runtimeTexture());
 }
 
 RendererBitmap RendererGeode::takeSnapshotInterruptibly(
@@ -7583,9 +7714,11 @@ RendererBitmap RendererGeode::takeSnapshotInterruptibly(
   if (!impl_->device || !impl_->target || impl_->pixelWidth <= 0 || impl_->pixelHeight <= 0) {
     return RendererBitmap{};
   }
-  return ReadGeodeTextureSnapshot(impl_->device, impl_->target,
-                                  Vector2i(impl_->pixelWidth, impl_->pixelHeight),
-                                  impl_->textureFormat, AlphaType::Premultiplied, shouldCancel);
+  return ReadGeodeTextureSnapshot(
+      impl_->device, impl_->target, Vector2i(impl_->pixelWidth, impl_->pixelHeight),
+      impl_->textureFormat, AlphaType::Premultiplied, shouldCancel,
+      impl_->targetHandleTexture == static_cast<WGPUTexture>(impl_->target) ? impl_->targetHandle
+                                                                            : nullptr);
 }
 
 bool RendererGeode::deviceLost() const {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -7,6 +7,7 @@
 /// **headless** (creating its own device) or **embedded** inside a host
 /// application that provides an existing WebGPU device and render target.
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -145,6 +146,24 @@ private:
   [[nodiscard]] bool canSampleWith(const geode::GeodeDevice& device) const;
 
   struct Backing;
+  struct ReadbackControl;
+  static RendererBitmap readTexture(std::shared_ptr<geode::GeodeDevice> device,
+                                    wgpu::Texture texture, Vector2i dimensions,
+                                    wgpu::TextureFormat format, AlphaType alphaType,
+                                    const std::function<bool()>& shouldCancel,
+                                    std::shared_ptr<Backing> backing = {});
+  static RendererBitmap readTextureWithContext(geode::GeodeDevice& context, wgpu::Texture texture,
+                                               Vector2i dimensions, wgpu::TextureFormat format,
+                                               AlphaType alphaType, ReadbackControl& control);
+  static RendererBitmap readTextureGpu(geode::GeodeDevice& context, const gpu::Texture& texture,
+                                       uint32_t width, uint32_t height, ReadbackControl& control);
+  static RendererBitmap readTextureCpu(geode::GeodeDevice& context, const gpu::Texture& texture,
+                                       uint32_t width, uint32_t height, wgpu::TextureFormat format,
+                                       AlphaType alphaType, ReadbackControl& control);
+  static RendererBitmap readMappedTexture(geode::GeodeDevice& context, gpu::BufferMapping& mapping,
+                                          uint32_t width, uint32_t height,
+                                          wgpu::TextureFormat format, AlphaType alphaType,
+                                          ReadbackControl& control);
   std::shared_ptr<geode::GeodeDevice> device_;
   /// Origin-side stamps avoid reading producer context state during shared-backend presentation.
   uint64_t runtimeDeviceId_ = 0;

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -143,14 +143,13 @@ private:
 
   void destroyOwnedBacking() noexcept;
 
+  struct Backing;
   std::shared_ptr<geode::GeodeDevice> device_;
-  /// Runtime handle when this snapshot took over a target the runtime allocated. Its slot is
-  /// released when the snapshot dies, which is what frees the texture in that case.
-  gpu::Texture ownedGpuTexture_;
+  /// Shared with consuming frames until their recorded draws have been submitted.
+  std::shared_ptr<Backing> backing_;
   gpu::Texture borrowedGpuTexture_;  //!< Identity-only handle; never owns the renderer target.
   Vector2i allocationDimensions_ = Vector2i::Zero();
   std::optional<gpu::TextureFormat> runtimeFormat_;
-  geode::ScopedWgpuHandle<wgpu::Texture> ownedTexture_;
   wgpu::Texture texture_;
   mutable geode::ScopedWgpuHandle<wgpu::TextureView> textureView_;
   Vector2i dimensions_ = Vector2i::Zero();

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -16,6 +16,8 @@
 
 #include "donner/base/Box.h"
 #include "donner/base/Transform.h"
+#include "donner/base/Utils.h"
+#include "donner/gpu/Descriptors.h"
 #include "donner/gpu/Handles.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/renderer/RendererInterface.h"
@@ -68,26 +70,41 @@ public:
    * Takes over a target the runtime allocated, so the snapshot keeps it alive after the renderer
    * has let go of it.
    *
+   * Failure returns an empty snapshot (`isValid() == false`) and leaves the caller's handle
+   * unchanged. Validation uses the owning device and the texture's actual backing descriptor.
+   * External registrations are rejected because they do not own their backing allocation.
+   *
    * @param device Device the texture belongs to.
-   * @param texture Runtime texture handle to take ownership of.
+   * @param texture Runtime texture handle, consumed only after validation succeeds.
    * @param dimensions Texture dimensions in pixels.
    * @param format Texel format.
    * @param alphaType Alpha interpretation of the stored pixels.
    */
   static RendererGeodeTextureSnapshot AdoptRuntimeTexture(
-      std::shared_ptr<geode::GeodeDevice> device, gpu::Texture texture, Vector2i dimensions,
+      std::shared_ptr<geode::GeodeDevice> device, gpu::Texture&& texture, Vector2i dimensions,
       wgpu::TextureFormat format, AlphaType alphaType);
 
   ~RendererGeodeTextureSnapshot() override;
 
   RendererGeodeTextureSnapshot(const RendererGeodeTextureSnapshot&) = delete;
   RendererGeodeTextureSnapshot& operator=(const RendererGeodeTextureSnapshot&) = delete;
-  RendererGeodeTextureSnapshot(RendererGeodeTextureSnapshot&&) noexcept = default;
+  RendererGeodeTextureSnapshot(RendererGeodeTextureSnapshot&& other) noexcept;
   RendererGeodeTextureSnapshot& operator=(RendererGeodeTextureSnapshot&& other) noexcept;
 
   [[nodiscard]] RendererTextureSnapshotBackend backend() const override {
     return RendererTextureSnapshotBackend::Geode;
   }
+  /// Whether the snapshot names valid content in a backing allocation.
+  [[nodiscard]] bool isValid() const;
+  /// Runtime identity when owned or borrowed from the renderer, otherwise null for legacy uploads.
+  /// The returned handle borrows this snapshot's lifetime and must never be consumed.
+  [[nodiscard]] const gpu::Texture* runtimeTexture() const UTILS_LIFETIME_BOUND;
+  /// Device identity used to reject cross-device presentation before recording.
+  [[nodiscard]] uint64_t deviceId() const;
+  /// Actual allocation extent; content may use a smaller prefix.
+  [[nodiscard]] Vector2i allocationDimensions() const { return allocationDimensions_; }
+  /// Runtime format, if the backend format has a supported runtime representation.
+  [[nodiscard]] std::optional<gpu::TextureFormat> runtimeFormat() const { return runtimeFormat_; }
   /// Valid content extent in device pixels, anchored at the texture origin. Sampling and
   /// readback are confined to this region even when the backing texture is larger.
   [[nodiscard]] Vector2i dimensions() const override { return dimensions_; }
@@ -102,8 +119,9 @@ public:
    * backing texture.
    *
    * @param dimensions Valid content dimensions in device pixels.
+   * @return True if accepted; an invalid extent leaves the previous content unchanged.
    */
-  void setDimensions(Vector2i dimensions) { dimensions_ = dimensions; }
+  bool setDimensions(Vector2i dimensions);
 
   /// Resolved single-sample WebGPU texture.
   [[nodiscard]] const wgpu::Texture& texture() const { return texture_; }
@@ -117,8 +135,10 @@ public:
 private:
   friend class RendererGeode;
 
-  /// Construct a frame-local view that does not retain or release the texture.
-  static RendererGeodeTextureSnapshot BorrowCurrentFrame(wgpu::Texture texture, Vector2i dimensions,
+  /// Construct a frame-local view that does not retain or release the texture backing.
+  /// The renderer destroys this view before replacing, detaching, or releasing its target.
+  static RendererGeodeTextureSnapshot BorrowCurrentFrame(const gpu::Texture& runtimeTexture,
+                                                         wgpu::Texture texture, Vector2i dimensions,
                                                          wgpu::TextureFormat format);
 
   void destroyOwnedBacking() noexcept;
@@ -127,6 +147,9 @@ private:
   /// Runtime handle when this snapshot took over a target the runtime allocated. Its slot is
   /// released when the snapshot dies, which is what frees the texture in that case.
   gpu::Texture ownedGpuTexture_;
+  gpu::Texture borrowedGpuTexture_;  //!< Identity-only handle; never owns the renderer target.
+  Vector2i allocationDimensions_ = Vector2i::Zero();
+  std::optional<gpu::TextureFormat> runtimeFormat_;
   geode::ScopedWgpuHandle<wgpu::Texture> ownedTexture_;
   wgpu::Texture texture_;
   mutable geode::ScopedWgpuHandle<wgpu::TextureView> textureView_;

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -142,9 +142,15 @@ private:
                                                          wgpu::TextureFormat format);
 
   void destroyOwnedBacking() noexcept;
+  [[nodiscard]] bool canSampleWith(const geode::GeodeDevice& device) const;
 
   struct Backing;
   std::shared_ptr<geode::GeodeDevice> device_;
+  /// Origin-side stamps avoid reading producer context state during shared-backend presentation.
+  uint64_t runtimeDeviceId_ = 0;
+  WGPUDevice nativeDevice_ = nullptr;
+  WGPUQueue nativeQueue_ = nullptr;
+  wgpu::TextureUsage textureUsage_ = wgpu::TextureUsage::None;
   /// Shared with consuming frames until their recorded draws have been submitted.
   std::shared_ptr<Backing> backing_;
   gpu::Texture borrowedGpuTexture_;  //!< Identity-only handle; never owns the renderer target.

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -121,6 +121,18 @@ struct RendererReadbackStats {
   /// Wall time that wait spent before giving up, in milliseconds. Zero while
   /// \ref timedOutWaitSite is \ref GpuWaitTimeoutSite::None.
   int timedOutWaitMs = 0;
+  /// Capture cancellation and total-budget expiry, independent of device loss.
+  std::uint64_t captureCancellations = 0;
+  std::uint64_t captureTimeouts = 0;
+  /// Readback-only contexts and the allocation/submission work they performed.
+  std::uint64_t contextCreates = 0;
+  std::uint64_t bufferCreates = 0;
+  std::uint64_t textureCreates = 0;
+  std::uint64_t bindgroupCreates = 0;
+  std::uint64_t submits = 0;
+  /// Idle pooled readback sets and their logical backing bytes.
+  std::uint64_t poolEntries = 0;
+  std::uint64_t poolBytes = 0;
 };
 
 /** Aggregate budget for render targets, layers, masks, clips, and pattern tiles. */

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -344,16 +344,12 @@ struct GeodeDevice::Impl {
     SnapshotReadbackResources resources;
     uint64_t lastUsedTick = 0;
   };
-  std::mutex snapshotReadbackPoolMutex;
   std::map<std::pair<uint32_t, uint32_t>, SnapshotReadbackPoolEntry> snapshotReadbackPool;
   uint64_t snapshotReadbackPoolTick = 0;
 
-  /// Guards the lazy snapshotReadbackPipeline construction: the device is
-  /// documented as shareable between the main thread and the async-render
-  /// worker, and both can take a first snapshot concurrently. A plain
-  /// null-check would let both construct, and the second assignment would
-  /// destroy the pipeline the first thread already holds a reference to.
-  std::once_flag snapshotReadbackPipelineOnce;
+  std::timed_mutex snapshotCaptureMutex;
+  std::unique_ptr<GeodeDevice> snapshotCaptureContext;
+  std::function<void(SnapshotReadbackPhase)> snapshotCaptureHook;
 };
 
 /// Distinct snapshot sizes retained by the readback pool: covers the main
@@ -379,6 +375,12 @@ GeodeDevice::GeodeDevice()
     : impl_(std::make_unique<Impl>()),
       deviceId_(g_nextDeviceId.fetch_add(1, std::memory_order_relaxed) + 1),
       lostState_(std::make_shared<GeodeDeviceLostState>()) {}
+
+GeodeDevice::SnapshotCaptureLease::~SnapshotCaptureLease() {
+  if (lock.owns_lock() && owner && context) {
+    owner->finishSnapshotCapture(*context);
+  }
+}
 
 GeodeDevice::~GeodeDevice() {
   // Release all resources that were created from the device before releasing the
@@ -525,7 +527,131 @@ GeodeDevice::ReadbackStats GeodeDevice::consumeReadbackStats() {
       // guarantees the elapsed time written before it is visible too.
       .timedOutWaitSite = lostState_->timedOutSite.load(std::memory_order_acquire),
       .timedOutWaitMs = lostState_->timedOutElapsedMs.load(std::memory_order_relaxed),
+      .captureCancellations = readbackCaptureCancellations_.exchange(0, std::memory_order_relaxed),
+      .captureTimeouts = readbackCaptureTimeouts_.exchange(0, std::memory_order_relaxed),
+      .contextCreates = readbackContextCreates_.exchange(0, std::memory_order_relaxed),
+      .bufferCreates = readbackBufferCreates_.exchange(0, std::memory_order_relaxed),
+      .textureCreates = readbackTextureCreates_.exchange(0, std::memory_order_relaxed),
+      .bindgroupCreates = readbackBindgroupCreates_.exchange(0, std::memory_order_relaxed),
+      .submits = readbackSubmits_.exchange(0, std::memory_order_relaxed),
+      .poolEntries = readbackPoolEntries_.load(std::memory_order_relaxed),
+      .poolBytes = readbackPoolBytes_.load(std::memory_order_relaxed),
   };
+}
+
+void GeodeDevice::setSnapshotReadbackHookForTesting(
+    std::function<void(SnapshotReadbackPhase)> hook) {
+  std::lock_guard lock(impl_->snapshotCaptureMutex);
+  impl_->snapshotCaptureHook = std::move(hook);
+}
+
+void GeodeDevice::notifySnapshotReadbackPhaseForTesting(SnapshotReadbackPhase phase) const {
+  if (impl_->snapshotCaptureHook) {
+    impl_->snapshotCaptureHook(phase);
+  }
+}
+
+void GeodeDevice::recordSnapshotCaptureTimeout() {
+  readbackCaptureTimeouts_.fetch_add(1, std::memory_order_relaxed);
+  std::fprintf(stderr, "[Geode] snapshot capture deadline expired\n");
+}
+
+GeodeDevice::SnapshotCaptureStatus GeodeDevice::waitForSnapshotCapture(
+    std::unique_lock<std::timed_mutex>& lock, const std::function<bool()>& shouldCancel,
+    std::chrono::steady_clock::time_point deadline) {
+  while (true) {
+    if (shouldCancel && shouldCancel()) {
+      readbackCaptureCancellations_.fetch_add(1, std::memory_order_relaxed);
+      return SnapshotCaptureStatus::Cancelled;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
+      recordSnapshotCaptureTimeout();
+      return SnapshotCaptureStatus::TimedOut;
+    }
+    if (lock.try_lock_until(std::min(deadline, now + kGpuWaitPollInterval))) {
+      return SnapshotCaptureStatus::Ready;
+    }
+    notifySnapshotReadbackPhaseForTesting(SnapshotReadbackPhase::WaitingForContext);
+  }
+}
+
+GeodeDevice::SnapshotCaptureLease GeodeDevice::acquireSnapshotCapture(
+    const std::function<bool()>& shouldCancel, std::chrono::steady_clock::time_point deadline) {
+  UTILS_RELEASE_ASSERT(!readbackOnly_);
+  SnapshotCaptureLease lease;
+  lease.owner = this;
+  lease.lock = std::unique_lock<std::timed_mutex>(impl_->snapshotCaptureMutex, std::defer_lock);
+  lease.status = waitForSnapshotCapture(lease.lock, shouldCancel, deadline);
+  if (lease.status != SnapshotCaptureStatus::Ready) {
+    return lease;
+  }
+  lease.status = SnapshotCaptureStatus::TimedOut;
+  if (shouldCancel && shouldCancel()) {
+    readbackCaptureCancellations_.fetch_add(1, std::memory_order_relaxed);
+    lease.status = SnapshotCaptureStatus::Cancelled;
+    return lease;
+  }
+  if (std::chrono::steady_clock::now() >= deadline) {
+    recordSnapshotCaptureTimeout();
+    return lease;
+  }
+  if (!impl_->snapshotCaptureContext) {
+    auto context = std::unique_ptr<GeodeDevice>(new GeodeDevice());
+    context->external_ = true;
+    context->readbackOnly_ = true;
+    context->device_ = device_;
+    context->queue_ = queue_;
+    context->adapter_ = adapter_;
+    context->textureFormat_ = textureFormat_;
+    context->maxTextureDimension2D_ = maxTextureDimension2D_;
+    context->isVulkan_ = isVulkan_;
+    context->lostState_ = lostState_;
+    context->impl_->instance = instance();
+    context->impl_->adapterDevice = std::make_unique<GeodeWgpuAdapterDevice>(*context);
+    context->impl_->runtimeDeviceId = context->impl_->adapterDevice->deviceId();
+    context->counters_ = &context->isolatedReadbackCounters_;
+    impl_->snapshotCaptureContext = std::move(context);
+    readbackContextCreates_.fetch_add(1, std::memory_order_relaxed);
+  }
+  lease.context = impl_->snapshotCaptureContext.get();
+  lease.context->isolatedReadbackCounters_.reset();
+  notifySnapshotReadbackPhaseForTesting(SnapshotReadbackPhase::ContextAcquired);
+  if (shouldCancel && shouldCancel()) {
+    readbackCaptureCancellations_.fetch_add(1, std::memory_order_relaxed);
+    lease.status = SnapshotCaptureStatus::Cancelled;
+  } else if (std::chrono::steady_clock::now() >= deadline) {
+    recordSnapshotCaptureTimeout();
+  } else {
+    lease.status = SnapshotCaptureStatus::Ready;
+  }
+  return lease;
+}
+
+void GeodeDevice::finishSnapshotCapture(GeodeDevice& context) {
+  const ReadbackStats stats = context.consumeReadbackStats();
+  readbackCount_.fetch_add(stats.count, std::memory_order_relaxed);
+  readbackPollIterations_.fetch_add(stats.pollIterations, std::memory_order_relaxed);
+  if (stats.usedTimedWaitAny) {
+    readbackUsedTimedWaitAny_.store(true, std::memory_order_relaxed);
+  }
+  const GeodeCounters& counters = context.isolatedReadbackCounters_;
+  readbackBufferCreates_.fetch_add(counters.bufferCreates, std::memory_order_relaxed);
+  readbackTextureCreates_.fetch_add(counters.textureCreates, std::memory_order_relaxed);
+  readbackBindgroupCreates_.fetch_add(counters.bindgroupCreates, std::memory_order_relaxed);
+  readbackSubmits_.fetch_add(counters.submits, std::memory_order_relaxed);
+  readbackLifetimeBufferCreates_.fetch_add(counters.bufferCreates, std::memory_order_relaxed);
+  readbackLifetimeTextureCreates_.fetch_add(counters.textureCreates, std::memory_order_relaxed);
+  uint64_t poolBytes = 0;
+  for (const auto& [unusedSize, entry] : context.impl_->snapshotReadbackPool) {
+    (void)unusedSize;
+    const auto& resources = entry.resources;
+    poolBytes +=
+        static_cast<uint64_t>(resources.height) * (static_cast<uint64_t>(resources.width) * 4u +
+                                                   AlignReadbackBytesPerRow(resources.width * 4u));
+  }
+  readbackPoolEntries_.store(context.impl_->snapshotReadbackPool.size(), std::memory_order_relaxed);
+  readbackPoolBytes_.store(poolBytes, std::memory_order_relaxed);
 }
 
 namespace {
@@ -812,21 +938,19 @@ GeodeFilterEngine& GeodeDevice::filterEngine() const {
   return *impl_->filterEngine;
 }
 GeodeSnapshotReadbackPipeline& GeodeDevice::snapshotReadbackPipeline() const {
-  // Lazy: only snapshot readback consumes this pipeline, so renderers that
-  // never call takeSnapshot() avoid the compile cost. call_once, not a plain
-  // null-check: see Impl::snapshotReadbackPipelineOnce.
-  std::call_once(impl_->snapshotReadbackPipelineOnce, [this] {
+  UTILS_RELEASE_ASSERT(readbackOnly_);
+  if (!impl_->snapshotReadbackPipeline) {
     impl_->snapshotReadbackPipeline =
         std::make_unique<GeodeSnapshotReadbackPipeline>(adapterDevice());
-  });
+  }
   return *impl_->snapshotReadbackPipeline;
 }
 
 SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t width,
                                                                         uint32_t height) {
+  UTILS_RELEASE_ASSERT(readbackOnly_);
   const std::pair<uint32_t, uint32_t> key(width, height);
   {
-    std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
     auto it = impl_->snapshotReadbackPool.find(key);
     if (it != impl_->snapshotReadbackPool.end()) {
       SnapshotReadbackResources result = std::move(it->second.resources);
@@ -875,11 +999,11 @@ SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t
 }
 
 void GeodeDevice::releaseSnapshotReadbackResources(SnapshotReadbackResources resources) {
+  UTILS_RELEASE_ASSERT(readbackOnly_);
   if (resources.empty()) {
     return;
   }
   const std::pair<uint32_t, uint32_t> key(resources.width, resources.height);
-  std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
   Impl::SnapshotReadbackPoolEntry entry;
   entry.resources = std::move(resources);
   entry.lastUsedTick = ++impl_->snapshotReadbackPoolTick;

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -293,6 +293,9 @@ struct GeodeDevice::Impl {
   // whose destructors release through the adapter, so the adapter must destruct after them
   // (reverse-declaration order).
   std::unique_ptr<GeodeWgpuAdapterDevice> adapterDevice;
+  uint64_t runtimeDeviceId = 0;
+  std::mutex textureBackingRetirementMutex;
+  std::vector<gpu::Texture> textureBackingsAwaitingRetirement;
 
   // Shared bind-slot resources used by every encoder's bind groups: 1x1 identity fills for the
   // pattern and clip-mask slots of draws that do not use them, one identity instance record,
@@ -1155,6 +1158,7 @@ void GeodeDevice::initSharedPipelines() {
   const gpu::TextureFormat fmt = GpuTextureFormatFromWgpu(textureFormat_);
 
   impl_->adapterDevice = std::make_unique<GeodeWgpuAdapterDevice>(*this);
+  impl_->runtimeDeviceId = impl_->adapterDevice->deviceId();
   initSharedBindSlotResources();
   impl_->pipeline = std::make_unique<GeodePipeline>(*impl_->adapterDevice, fmt);
   impl_->gradientPipeline = std::make_unique<GeodeGradientPipeline>(*impl_->adapterDevice, fmt);
@@ -1231,7 +1235,37 @@ void GeodeDevice::deferDestroy(gpu::Texture texture) {
   }
 }
 
+bool GeodeDevice::deferDestroyTextureBacking(gpu::Texture&& texture) {
+  if (!texture.isValid() || !impl_ || texture.deviceId() != impl_->runtimeDeviceId) {
+    return false;
+  }
+  std::lock_guard lock(impl_->textureBackingRetirementMutex);
+  impl_->textureBackingsAwaitingRetirement.push_back(std::move(texture));
+  return true;
+}
+
+void GeodeDevice::drainDeferredTextureBackings() {
+  if (!impl_) {
+    return;
+  }
+  std::vector<gpu::Texture> retired;
+  {
+    std::lock_guard lock(impl_->textureBackingRetirementMutex);
+    retired.swap(impl_->textureBackingsAwaitingRetirement);
+  }
+  for (gpu::Texture& texture : retired) {
+    (void)impl_->adapterDevice->destroyTextureBacking(std::move(texture));
+  }
+}
+
+std::size_t GeodeDevice::deferredTextureDestroyCountForTesting() const {
+  std::lock_guard lock(impl_->textureBackingRetirementMutex);
+  return pendingTextures_.size() + pendingGpuTextures_.size() +
+         impl_->textureBackingsAwaitingRetirement.size();
+}
+
 void GeodeDevice::drainDeferredDestroys() {
+  drainDeferredTextureBackings();
   pendingBuffers_.clear();
   pendingTextures_.clear();
   pendingBindGroups_.clear();

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -354,6 +354,20 @@ public:
   void deferDestroy(gpu::Texture texture);
 
   /**
+   * Transfer owned texture backing to this context's thread-safe retirement mailbox.
+   *
+   * Enqueuing checks only immutable device identity and never touches the resource table.
+   * The owning rendering context or exclusive teardown must drain the mailbox.
+   *
+   * @param texture Handle consumed on success; unchanged for a null or foreign handle.
+   * @return Whether the handle was accepted.
+   */
+  [[nodiscard]] bool deferDestroyTextureBacking(gpu::Texture&& texture);
+
+  /// Destroy queued texture backing on the owning rendering context or during exclusive teardown.
+  void drainDeferredTextureBackings();
+
+  /**
    * Drop all deferred-destroy handles, releasing their GPU resources.
    *
    * Called at the top of each frame (before new allocations) so resources
@@ -366,9 +380,7 @@ public:
 
   /// Number of textures waiting for the next frame-boundary destroy pass.
   /// Exposed to pin resource-retirement behavior in renderer regression tests.
-  [[nodiscard]] std::size_t deferredTextureDestroyCountForTesting() const {
-    return pendingTextures_.size() + pendingGpuTextures_.size();
-  }
+  [[nodiscard]] std::size_t deferredTextureDestroyCountForTesting() const;
 
   /**
    * Key identifying a scene-batch bind group by its exact buffer bindings:

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -4,10 +4,13 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <tuple>
 #include <vector>
 #include <webgpu/webgpu.hpp>
@@ -18,6 +21,10 @@
 #include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+
+namespace donner::svg {
+class RendererGeodeTextureSnapshot;
+}
 
 namespace donner::geode {
 
@@ -309,7 +316,36 @@ public:
     GpuWaitSite timedOutWaitSite = GpuWaitSite::None;
     /// Wall time that wait spent before giving up, in milliseconds.
     int timedOutWaitMs = 0;
+    /// Captures cancelled while acquiring the context, mapping, or copying pixels.
+    uint64_t captureCancellations = 0;
+    /// Captures whose total deadline expired.
+    uint64_t captureTimeouts = 0;
+    /// Lazily created readback-only contexts; independent of rendering pipelines.
+    uint64_t contextCreates = 0;
+    /// GPU allocation and submission work performed by isolated captures.
+    uint64_t bufferCreates = 0;
+    uint64_t textureCreates = 0;
+    uint64_t bindgroupCreates = 0;
+    uint64_t submits = 0;
+    /// Idle pooled resource sets and their logical backing bytes after the latest capture.
+    uint64_t poolEntries = 0;
+    uint64_t poolBytes = 0;
   };
+
+  /// Override the total capture budget for deterministic cancellation/deadline tests.
+  /// @param budget Includes context acquisition and GPU mapping.
+  void setSnapshotReadbackBudgetForTesting(std::chrono::milliseconds budget) {
+    snapshotReadbackBudgetMs_.store(
+        std::clamp<int64_t>(budget.count(), 0, kReadbackMapTimeout.count()),
+        std::memory_order_relaxed);
+  }
+
+  /// Explicit capture phases exposed only for deterministic protocol tests.
+  enum class SnapshotReadbackPhase { WaitingForContext, ContextAcquired, MapRequested };
+
+  /// Install a capture-phase test hook; it may be called concurrently by capture waiters.
+  /// @param hook Hook to install; empty removes it. Set only while captures are quiescent.
+  void setSnapshotReadbackHookForTesting(std::function<void(SnapshotReadbackPhase)> hook);
 
   /// Record one completed CPU readback from a renderer sharing this device.
   void recordReadback(bool usedTimedWaitAny, int pollIterations);
@@ -517,10 +553,15 @@ public:
   /// Cumulative number of `countTexture()` calls since this `GeodeDevice`
   /// was created. Does not account for textures released back into a
   /// pool - it is an allocation-site counter, not a live-count.
-  uint64_t lifetimeTextureCreates() const { return lifetimeTextureCreates_; }
+  uint64_t lifetimeTextureCreates() const {
+    return lifetimeTextureCreates_ +
+           readbackLifetimeTextureCreates_.load(std::memory_order_relaxed);
+  }
   /// Cumulative number of `countBuffer()` calls since this `GeodeDevice`
   /// was created. Same caveat as `lifetimeTextureCreates()`.
-  uint64_t lifetimeBufferCreates() const { return lifetimeBufferCreates_; }
+  uint64_t lifetimeBufferCreates() const {
+    return lifetimeBufferCreates_ + readbackLifetimeBufferCreates_.load(std::memory_order_relaxed);
+  }
   void countSubmit() const {
     if (counters_) ++counters_->submits;
   }
@@ -703,35 +744,6 @@ public:
   /// GPU filter-graph executor. Owns ~15 compute pipelines for SVG
   /// filter primitives.
   GeodeFilterEngine& filterEngine() const;
-  /// Snapshot-unpremultiply compute pipeline. Built lazily (thread-safe,
-  /// once-only) on first access so consumers that never read back a snapshot
-  /// avoid the compile cost.
-  GeodeSnapshotReadbackPipeline& snapshotReadbackPipeline() const;
-
-  /**
-   * Acquire the pooled readback resource set for a GPU snapshot readback at
-   * the given size, allocating it on first use. Repeated snapshots at the
-   * same dimensions reuse the pooled entry, so steady-state snapshot readback
-   * allocates nothing.
-   *
-   * The caller owns the returned set until `releaseSnapshotReadbackResources`
-   * returns it to the pool, or until the set is destroyed unpooled. An empty
-   * set means allocation failed.
-   */
-  SnapshotReadbackResources acquireSnapshotReadbackResources(uint32_t width, uint32_t height);
-
-  /**
-   * Return a readback resource set acquired from
-   * `acquireSnapshotReadbackResources` to the device pool for reuse. The
-   * returned set must be unmapped. Do not call this after the readback map
-   * was cancelled and the buffer destroyed; drop the set instead.
-   *
-   * The pool holds at most a small fixed number of size buckets; when a
-   * release would exceed that, the least-recently-used entry's backing
-   * resources are destroyed (pooled entries are idle, so eager destroy is
-   * safe).
-   */
-  void releaseSnapshotReadbackResources(SnapshotReadbackResources resources);
   /// Framebuffer checkerboard underlay pipeline used by the editor's direct
   /// presentation path. Built lazily on first access - only the editor draws
   /// it, so headless/WASM consumers never pay the compile cost.
@@ -754,6 +766,32 @@ public:
   const GeodeGpuContext& gpuContext() const UTILS_LIFETIME_BOUND;
 
 private:
+  friend class svg::RendererGeodeTextureSnapshot;
+
+  enum class SnapshotCaptureStatus { Ready, Cancelled, TimedOut };
+  struct SnapshotCaptureLease {
+    SnapshotCaptureLease() = default;
+    SnapshotCaptureLease(SnapshotCaptureLease&&) = default;
+    SnapshotCaptureLease& operator=(SnapshotCaptureLease&&) = delete;
+    ~SnapshotCaptureLease();
+    GeodeDevice* owner = nullptr;
+    GeodeDevice* context = nullptr;
+    std::unique_lock<std::timed_mutex> lock;
+    SnapshotCaptureStatus status = SnapshotCaptureStatus::TimedOut;
+  };
+
+  SnapshotCaptureLease acquireSnapshotCapture(const std::function<bool()>& shouldCancel,
+                                              std::chrono::steady_clock::time_point deadline);
+  SnapshotCaptureStatus waitForSnapshotCapture(std::unique_lock<std::timed_mutex>& lock,
+                                               const std::function<bool()>& shouldCancel,
+                                               std::chrono::steady_clock::time_point deadline);
+  void finishSnapshotCapture(GeodeDevice& context);
+  void recordSnapshotCaptureTimeout();
+  void notifySnapshotReadbackPhaseForTesting(SnapshotReadbackPhase phase) const;
+  GeodeSnapshotReadbackPipeline& snapshotReadbackPipeline() const;
+  SnapshotReadbackResources acquireSnapshotReadbackResources(uint32_t width, uint32_t height);
+  void releaseSnapshotReadbackResources(SnapshotReadbackResources resources);
+
   GeodeDevice();
 
   /// Allocate the shared pipelines and filter engine after `device_`,
@@ -789,6 +827,8 @@ private:
   /// True when this device was created via CreateFromExternal(). The destructor
   /// skips releasing the instance/adapter since the host owns them.
   bool external_ = false;
+  bool readbackOnly_ = false;
+  GeodeCounters isolatedReadbackCounters_;
 
   /// Process-unique identity assigned at construction. See `deviceId()`.
   const uint64_t deviceId_ = 0;
@@ -822,6 +862,18 @@ private:
   std::atomic<int> readbackCount_{0};
   std::atomic<int> readbackPollIterations_{0};
   std::atomic<bool> readbackUsedTimedWaitAny_{false};
+  std::atomic<int64_t> snapshotReadbackBudgetMs_{kReadbackMapTimeout.count()};
+  std::atomic<uint64_t> readbackCaptureCancellations_{0};
+  std::atomic<uint64_t> readbackCaptureTimeouts_{0};
+  std::atomic<uint64_t> readbackContextCreates_{0};
+  std::atomic<uint64_t> readbackBufferCreates_{0};
+  std::atomic<uint64_t> readbackTextureCreates_{0};
+  std::atomic<uint64_t> readbackBindgroupCreates_{0};
+  std::atomic<uint64_t> readbackSubmits_{0};
+  std::atomic<uint64_t> readbackPoolEntries_{0};
+  std::atomic<uint64_t> readbackPoolBytes_{0};
+  std::atomic<uint64_t> readbackLifetimeBufferCreates_{0};
+  std::atomic<uint64_t> readbackLifetimeTextureCreates_{0};
 
   // Shared live-resident-bytes gauge. Mutable +
   // lazily created so `residentBytesGauge()` stays const like the other

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -300,6 +300,12 @@ bool GeodeWgpuAdapterDevice::waitForSerial(uint64_t serial, double timeoutSecond
   return completedSerial() >= serial;
 }
 
+bool GeodeWgpuAdapterDevice::ownsTextureBacking(const gpu::Texture& texture) const {
+  return !validateTextureHandleForBackend(texture).hasError() &&
+         texture.slotIndex() < slotTextures_.size() &&
+         static_cast<bool>(slotTextures_[texture.slotIndex()].ownedTexture);
+}
+
 gpu::Status GeodeWgpuAdapterDevice::destroyTextureBacking(gpu::Texture&& texture) {
   // Validate before touching the slot so a stale or foreign handle cannot destroy whatever
   // occupies that slot now.

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -103,6 +103,10 @@ public:
    */
   gpu::Status destroyTextureBacking(gpu::Texture&& texture);
 
+  /// Whether a live handle owns adapter-allocated backing, rather than an external registration.
+  /// @param texture Handle whose device and generation are validated before inspecting ownership.
+  [[nodiscard]] bool ownsTextureBacking(const gpu::Texture& texture) const;
+
   /**
    * Destroys the backend object behind \p buffer explicitly, then releases its slot.
    *

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -118,8 +118,32 @@ void printCounters(const char* label, const geode::GeodeCounters& c) {
                c.bufferWriteBytes, c.textureWriteBytes);
 }
 
+/// Render one frame and include its isolated snapshot cost in the returned test sample.
+geode::GeodeCounters renderAndCaptureCounters(RendererGeode& renderer, SVGDocument& document) {
+  (void)renderer.consumeReadbackStats();
+  renderer.draw(document);
+
+  // Capture has its own context and counters. Include its work in these
+  // aggregate ceilings without attributing it to the producer's frame.
+  EXPECT_FALSE(renderer.takeSnapshot().empty());
+  const RendererReadbackStats readback = renderer.consumeReadbackStats();
+  EXPECT_EQ(readback.count, 1);
+  EXPECT_EQ(readback.captureCancellations, 0u);
+  EXPECT_EQ(readback.captureTimeouts, 0u);
+  EXPECT_FALSE(readback.deviceLost);
+  EXPECT_EQ(readback.submits, 1u);
+  EXPECT_EQ(readback.bindgroupCreates, 1u);
+
+  geode::GeodeCounters counters = renderer.lastFrameTimings().counters;
+  counters.bufferCreates += readback.bufferCreates;
+  counters.textureCreates += readback.textureCreates;
+  counters.bindgroupCreates += readback.bindgroupCreates;
+  counters.submits += readback.submits;
+  return counters;
+}
+
 /// Fully render `svgSource` through a RendererGeode backed by a shared
-/// device, then return the per-frame counters.
+/// device, then return the combined frame and snapshot-readback counters.
 ///
 /// `RendererGeode::draw()` internally drives its own `beginFrame` →
 /// traversal → `endFrame` cycle using the SVG's own viewBox dimensions,
@@ -136,13 +160,7 @@ geode::GeodeCounters renderAndGetCounters(std::string_view svgSource,
   SVGDocument document = std::move(parsed.result());
 
   RendererGeode renderer(device);
-  renderer.draw(document);
-
-  // `takeSnapshot()` allocates a readback buffer + issues its own submit.
-  // Include it so steady-state cost isn't hidden.
-  (void)renderer.takeSnapshot();
-
-  return renderer.lastFrameTimings().counters;
+  return renderAndCaptureCounters(renderer, document);
 }
 
 class GeodePerfTest : public ::testing::Test {
@@ -596,20 +614,14 @@ TEST_F(GeodePerfTest, CountersResetBetweenFrames) {
 
   // First frame. `draw()` internally manages beginFrame/endFrame using
   // the document's viewBox dimensions (200×200 for kSimpleShapesSvg).
-  renderer.draw(document);
-  (void)renderer.takeSnapshot();
-
-  const auto firstCounters = renderer.lastFrameTimings().counters;
+  const auto firstCounters = renderAndCaptureCounters(renderer, document);
   EXPECT_GT(firstCounters.pathEncodes, 0u);  // Sanity: something happened.
 
   // Second frame: same document, same size. Counters reset in beginFrame
   // and should accumulate only this frame's work. Render targets are
   // reused across same-size frames, so the second
   // frame's textureCreates should be strictly smaller.
-  renderer.draw(document);
-  (void)renderer.takeSnapshot();
-
-  const auto secondCounters = renderer.lastFrameTimings().counters;
+  const auto secondCounters = renderAndCaptureCounters(renderer, document);
 
   // Second-frame counters are strictly this-frame only (beginFrame
   // resets). With `GeodePathCacheComponent` in place, an unchanged
@@ -639,7 +651,7 @@ TEST_F(GeodePerfTest, CountersResetBetweenFrames) {
 // ---------------------------------------------------------------------------
 
 /// Helper: two consecutive renders of the same document, returning only
-/// the SECOND frame's counters. Used by the zero-encode assertions.
+/// the SECOND frame's combined render/capture counters. Used by the zero-encode assertions.
 geode::GeodeCounters countersForSecondRender(std::string_view svgSource,
                                              const std::shared_ptr<geode::GeodeDevice>& device) {
   ParseWarningSink sink = ParseWarningSink::Disabled();
@@ -651,14 +663,11 @@ geode::GeodeCounters countersForSecondRender(std::string_view svgSource,
   SVGDocument document = std::move(parsed.result());
 
   RendererGeode renderer(device);
-  renderer.draw(document);
-  (void)renderer.takeSnapshot();
+  (void)renderAndCaptureCounters(renderer, document);
   // First-frame counters intentionally discarded - we only care about the
   // steady-state second frame.
 
-  renderer.draw(document);
-  (void)renderer.takeSnapshot();
-  return renderer.lastFrameTimings().counters;
+  return renderAndCaptureCounters(renderer, document);
 }
 
 TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -102,7 +102,6 @@ protected:
 TEST_F(GeodeSnapshotReadbackTest, GpuAndCpuPathsAreByteIdentical) {
   auto device = sharedDevice();
   ASSERT_NE(device, nullptr);
-  ASSERT_TRUE(device->snapshotReadbackPipeline().valid());
 
   wgpu::Texture gpuTex = createTestTexture(device->device(), wgpu::TextureUsage::TextureBinding);
   wgpu::Texture cpuTex = createTestTexture(device->device(), wgpu::TextureUsage::CopySrc);
@@ -132,7 +131,6 @@ TEST_F(GeodeSnapshotReadbackTest, GpuAndCpuPathsAreByteIdentical) {
 TEST_F(GeodeSnapshotReadbackTest, ACompletedReadbackAccountsForTheSlicesItRan) {
   auto device = sharedDevice();
   ASSERT_NE(device, nullptr);
-  ASSERT_TRUE(device->snapshotReadbackPipeline().valid());
 
   wgpu::Texture texture = createTestTexture(device->device(), wgpu::TextureUsage::TextureBinding);
   const Vector2i dimensions(static_cast<int>(kWidth), static_cast<int>(kHeight));

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4455,5 +4455,23 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotCannotAdoptABorrowedHostRegistration) {
   (void)runtime.destroyTextureBacking(std::move(owner));
 }
 
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsUnusableCapabilitiesWithoutConsumption) {
+  auto& runtime = sharedDevice()->adapterDevice();
+  auto created = runtime.createTexture(
+      {"upload only", {4, 4}, gpu::TextureFormat::RGBA8Unorm, gpu::TextureUsage::CopyDst});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  {
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(texture), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+    EXPECT_THAT(texture.isValid(), testing::IsTrue());
+  }
+  if (texture.isValid()) {
+    (void)runtime.destroyTextureBacking(std::move(texture));
+  }
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4757,7 +4757,10 @@ TEST_F(RendererGeodeTest, UploadedSnapshotBackingSurvivesUntilConsumerSubmission
   beginFrame(consumer);
   {
     wgpu::TextureDescriptor descriptor{};
+    descriptor.dimension = wgpu::TextureDimension::_2D;
     descriptor.size = {4, 4, 1};
+    descriptor.mipLevelCount = 1;
+    descriptor.sampleCount = 1;
     descriptor.format = wgpu::TextureFormat::RGBA8Unorm;
     descriptor.usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::TextureBinding;
     wgpu::Texture texture = sharedDevice()->device().createTexture(descriptor);

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4722,5 +4722,25 @@ TEST_F(RendererGeodeTest, BorrowedRuntimeSnapshotCanBeDrawnWithoutReleasingThePr
                              "borrowed_runtime_snapshot_next_frame");
 }
 
+TEST_F(RendererGeodeTest, RuntimeSnapshotBackingSurvivesUntilConsumerSubmission) {
+  RendererGeode consumer = createRenderer();
+  beginFrame(consumer);
+  {
+    RendererGeode producer = createRenderer();
+    beginFrame(producer);
+    producer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+    producer.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+    producer.endFrame();
+    const auto snapshot = producer.takeTextureSnapshot();
+    ASSERT_THAT(snapshot, testing::NotNull());
+    EXPECT_THAT(consumer.drawTextureSnapshot(
+                    *snapshot, Box2d({0, 0}, {kViewportSize, kViewportSize}), 1, true),
+                testing::IsTrue());
+  }
+  consumer.endFrame();
+  ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "runtime_snapshot_pending_submission");
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4955,5 +4955,25 @@ TEST_F(RendererGeodeTest, SharedBackendPresentationRequiresAnOwningSnapshotLease
                              "shared_backend_owned_snapshot_accepted");
 }
 
+TEST_F(RendererGeodeTest, DetachedSnapshotReadbackDoesNotMutateProducerFrameCounters) {
+  RendererGeode producer = createRenderer();
+  beginFrame(producer);
+  producer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  producer.drawRect(Box2d({0, 0}, {64, 64}), StrokeParams{});
+  producer.endFrame();
+  const auto snapshot = producer.takeTextureSnapshot();
+  ASSERT_THAT(snapshot, testing::NotNull());
+  beginFrame(producer);
+  const geode::GeodeCounters before = producer.lastFrameTimings().counters;
+  ExpectSolidRuntimeSnapshot(snapshot->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "isolated_snapshot_readback");
+  const geode::GeodeCounters after = producer.lastFrameTimings().counters;
+  EXPECT_THAT(after.bufferCreates, testing::Eq(before.bufferCreates));
+  EXPECT_THAT(after.textureCreates, testing::Eq(before.textureCreates));
+  EXPECT_THAT(after.bindgroupCreates, testing::Eq(before.bindgroupCreates));
+  EXPECT_THAT(after.submits, testing::Eq(before.submits));
+  producer.endFrame();
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4789,5 +4789,31 @@ TEST_F(RendererGeodeTest, UploadedSnapshotBackingSurvivesUntilConsumerSubmission
                              "uploaded_snapshot_pending_submission");
 }
 
+TEST_F(RendererGeodeTest, RuntimeSnapshotBackingIsReleasedWhenConsumerFrameIsDiscarded) {
+  auto& runtime = sharedDevice()->adapterDevice();
+  RendererGeode consumer = createRenderer();
+  beginFrame(consumer);
+  gpu::Texture sourceIdentity;
+  {
+    auto created = runtime.createTexture(
+        {"snapshot", {4, 4}, gpu::TextureFormat::RGBA8Unorm, gpu::TextureUsage::Sampled});
+    ASSERT_FALSE(created.hasError()) << created.error();
+    gpu::Texture source = std::move(created).result();
+    sourceIdentity =
+        gpu::Texture::CreateForBackend(source.slotIndex(), source.generation(), source.deviceId());
+    const auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(source), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(consumer.drawTextureSnapshot(snapshot, Box2d({0, 0}, {4, 4}), 1, true),
+                testing::IsTrue());
+  }
+  EXPECT_THAT(runtime.ownsTextureBacking(sourceIdentity), testing::IsTrue());
+  beginFrame(consumer);
+  EXPECT_THAT(runtime.ownsTextureBacking(sourceIdentity), testing::IsFalse());
+  consumer.endFrame();
+  ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {0, 0, 0, 0},
+                             "runtime_snapshot_discarded_frame");
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <thread>
 #include <utility>
 
 #include "donner/base/Box.h"
@@ -4816,6 +4817,109 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotBackingIsReleasedWhenConsumerFrameIsDis
   consumer.endFrame();
   ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {0, 0, 0, 0},
                              "runtime_snapshot_discarded_frame");
+}
+
+std::shared_ptr<geode::GeodeDevice> CreateSharedBackendContext(
+    const std::shared_ptr<geode::GeodeDevice>& device) {
+  geode::GeodeEmbedConfig config;
+  config.device = device->device();
+  config.queue = device->queue();
+  config.adapter = device->adapter();
+  config.textureFormat = device->textureFormat();
+  return geode::GeodeDevice::CreateFromExternal(config);
+}
+
+TEST_F(RendererGeodeTest, SharedBackendSnapshotPreservesIdentityAndCroppedContent) {
+  auto producer = CreateSharedBackendContext(sharedDevice());
+  auto consumer = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(producer, testing::NotNull());
+  ASSERT_THAT(consumer, testing::NotNull());
+  EXPECT_THAT(producer->adapterDevice().deviceId(),
+              testing::Ne(consumer->adapterDevice().deviceId()));
+  auto created = producer->adapterDevice().createTexture(
+      {"shared snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc | gpu::TextureUsage::CopyDst});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture source = std::move(created).result();
+  const uint32_t slot = source.slotIndex();
+  const uint32_t generation = source.generation();
+  std::array<uint8_t, 1024> pixels{};
+  for (size_t y = 0; y < 4; ++y) {
+    for (size_t x = 0; x < 4; ++x) {
+      pixels[y * 256 + x * 4 + (x < 2 && y < 3 ? 0 : 1)] = 255;
+      pixels[y * 256 + x * 4 + 3] = 255;
+    }
+  }
+  ASSERT_FALSE(
+      producer->adapterDevice().writeTexture(source, pixels, {0, 256, 4}, {4, 4}).hasError());
+  auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      producer, std::move(source), {2, 3}, wgpu::TextureFormat::RGBA8Unorm,
+      AlphaType::Premultiplied);
+  RendererGeode renderer(consumer);
+  beginFrame(renderer);
+  for (int draw = 0; draw < 100; ++draw) {
+    EXPECT_THAT(renderer.drawTextureSnapshot(snapshot, Box2d({0, 0}, {64, 64}), 1, true),
+                testing::IsTrue());
+  }
+  ASSERT_THAT(snapshot.runtimeTexture(), testing::NotNull());
+  EXPECT_THAT(snapshot.runtimeTexture()->slotIndex(), testing::Eq(slot));
+  EXPECT_THAT(snapshot.runtimeTexture()->generation(), testing::Eq(generation));
+  EXPECT_THAT(snapshot.deviceId(), testing::Eq(producer->adapterDevice().deviceId()));
+  renderer.endFrame();
+  ExpectSolidRuntimeSnapshot(renderer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "shared_backend_snapshot_cropped_content");
+}
+
+TEST_F(RendererGeodeTest, SharedBackendSnapshotSurvivesProducerScopeUntilConsumerSubmission) {
+  auto producer = CreateSharedBackendContext(sharedDevice());
+  auto consumer = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(producer, testing::NotNull());
+  ASSERT_THAT(consumer, testing::NotNull());
+  std::weak_ptr<geode::GeodeDevice> producerLifetime = producer;
+  RendererGeode renderer(consumer);
+  beginFrame(renderer);
+  {
+    RendererGeode sourceRenderer(producer);
+    beginFrame(sourceRenderer);
+    sourceRenderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+    sourceRenderer.drawRect(Box2d({0, 0}, {64, 64}), StrokeParams{});
+    sourceRenderer.endFrame();
+    const auto snapshot = sourceRenderer.takeTextureSnapshot();
+    ASSERT_THAT(snapshot, testing::NotNull());
+    EXPECT_THAT(renderer.drawTextureSnapshot(*snapshot, Box2d({0, 0}, {64, 64}), 1, true),
+                testing::IsTrue());
+  }
+  producer.reset();
+  EXPECT_THAT(producerLifetime.expired(), testing::IsFalse());
+  renderer.endFrame();
+  EXPECT_THAT(producerLifetime.expired(), testing::IsTrue());
+  ExpectSolidRuntimeSnapshot(renderer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "shared_backend_snapshot_producer_scope");
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotReleaseOnAnotherThreadDefersOwnerSlotRetirement) {
+  auto owner = sharedDevice();
+  owner->drainDeferredDestroys();
+  const size_t pendingBefore = owner->deferredTextureDestroyCountForTesting();
+  auto created = owner->adapterDevice().createTexture(
+      {"threaded snapshot", {4, 4}, gpu::TextureFormat::RGBA8Unorm, gpu::TextureUsage::Sampled});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture source = std::move(created).result();
+  gpu::Texture identity =
+      gpu::Texture::CreateForBackend(source.slotIndex(), source.generation(), source.deviceId());
+  auto snapshot = std::make_shared<RendererGeodeTextureSnapshot>(
+      RendererGeodeTextureSnapshot::AdoptRuntimeTexture(owner, std::move(source), {4, 4},
+                                                        wgpu::TextureFormat::RGBA8Unorm,
+                                                        AlphaType::Premultiplied));
+  std::thread releaser([snapshot = std::move(snapshot)]() mutable { snapshot.reset(); });
+  releaser.join();
+  EXPECT_THAT(owner->adapterDevice().ownsTextureBacking(identity), testing::IsTrue());
+  EXPECT_THAT(owner->deferredTextureDestroyCountForTesting(), testing::Eq(pendingBefore + 1));
+  owner->drainDeferredDestroys();
+  EXPECT_THAT(owner->adapterDevice().ownsTextureBacking(identity), testing::IsFalse());
+  EXPECT_THAT(owner->deferredTextureDestroyCountForTesting(), testing::Eq(pendingBefore));
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4725,6 +4725,7 @@ TEST_F(RendererGeodeTest, BorrowedRuntimeSnapshotCanBeDrawnWithoutReleasingThePr
 TEST_F(RendererGeodeTest, RuntimeSnapshotBackingSurvivesUntilConsumerSubmission) {
   RendererGeode consumer = createRenderer();
   beginFrame(consumer);
+  gpu::Texture sourceIdentity;
   {
     RendererGeode producer = createRenderer();
     beginFrame(producer);
@@ -4733,13 +4734,59 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotBackingSurvivesUntilConsumerSubmission)
     producer.endFrame();
     const auto snapshot = producer.takeTextureSnapshot();
     ASSERT_THAT(snapshot, testing::NotNull());
+    const auto* runtime =
+        static_cast<const RendererGeodeTextureSnapshot&>(*snapshot).runtimeTexture();
+    ASSERT_THAT(runtime, testing::NotNull());
+    sourceIdentity = gpu::Texture::CreateForBackend(runtime->slotIndex(), runtime->generation(),
+                                                    runtime->deviceId());
     EXPECT_THAT(consumer.drawTextureSnapshot(
                     *snapshot, Box2d({0, 0}, {kViewportSize, kViewportSize}), 1, true),
                 testing::IsTrue());
   }
+  EXPECT_THAT(sharedDevice()->adapterDevice().ownsTextureBacking(sourceIdentity),
+              testing::IsTrue());
   consumer.endFrame();
+  EXPECT_THAT(sharedDevice()->adapterDevice().ownsTextureBacking(sourceIdentity),
+              testing::IsFalse());
   ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
                              "runtime_snapshot_pending_submission");
+}
+
+TEST_F(RendererGeodeTest, UploadedSnapshotBackingSurvivesUntilConsumerSubmission) {
+  RendererGeode consumer = createRenderer();
+  beginFrame(consumer);
+  {
+    wgpu::TextureDescriptor descriptor{};
+    descriptor.size = {4, 4, 1};
+    descriptor.format = wgpu::TextureFormat::RGBA8Unorm;
+    descriptor.usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::TextureBinding;
+    wgpu::Texture texture = sharedDevice()->device().createTexture(descriptor);
+    ASSERT_THAT(static_cast<bool>(texture), testing::IsTrue());
+    std::array<uint8_t, 64> pixels;
+    for (size_t i = 0; i < pixels.size(); i += 4) {
+      pixels[i] = 255;
+      pixels[i + 1] = 0;
+      pixels[i + 2] = 0;
+      pixels[i + 3] = 255;
+    }
+    wgpu::TexelCopyTextureInfo destination{};
+    destination.texture = texture;
+    wgpu::TexelCopyBufferLayout layout{};
+    layout.bytesPerRow = 16;
+    layout.rowsPerImage = 4;
+    const wgpu::Extent3D size{4, 4, 1};
+    sharedDevice()->queue().writeTexture(destination, pixels.data(), pixels.size(), layout, size);
+    RendererGeodeTextureSnapshot snapshot(sharedDevice(), texture, {4, 4},
+                                          wgpu::TextureFormat::RGBA8Unorm);
+    for (int draw = 0; draw < 100; ++draw) {
+      EXPECT_THAT(consumer.drawTextureSnapshot(
+                      snapshot, Box2d({0, 0}, {kViewportSize, kViewportSize}), 1, true),
+                  testing::IsTrue());
+    }
+  }
+  consumer.endFrame();
+  ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "uploaded_snapshot_pending_submission");
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -1150,7 +1150,7 @@ TEST_F(RendererGeodeTest, TakeTextureSnapshotReturnsTextureAndDetachesTarget) {
   EXPECT_EQ(secondTexture->dimensions(), texture->dimensions());
 }
 
-TEST_F(RendererGeodeTest, OwnedTextureSnapshotExplicitlyDestroysBackingOnRelease) {
+TEST_F(RendererGeodeTest, OwnedTextureSnapshotExplicitlyDestroysBackingWhenOwnerDrains) {
   ASSERT_TRUE(sharedDevice() != nullptr);
   RendererGeode renderer = createRenderer();
   beginFrame(renderer);
@@ -1163,8 +1163,12 @@ TEST_F(RendererGeodeTest, OwnedTextureSnapshotExplicitlyDestroysBackingOnRelease
   snapshot.reset();
 
   EXPECT_EQ(geode::ScopedWgpuHandle<wgpu::Texture>::backingDestroyCountForTesting(),
+            destroysBefore);
+  EXPECT_THAT(sharedDevice()->deferredTextureDestroyCountForTesting(), testing::Eq(1u));
+  sharedDevice()->drainDeferredTextureBackings();
+  EXPECT_EQ(geode::ScopedWgpuHandle<wgpu::Texture>::backingDestroyCountForTesting(),
             destroysBefore + 1u)
-      << "Dropping an owned presentation snapshot must explicitly destroy its GPU backing";
+      << "The owner-context drain must explicitly destroy released snapshot backing";
 }
 
 TEST_F(RendererGeodeTest, BorrowedTextureSnapshotNeverDestroysBacking) {
@@ -4688,6 +4692,8 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotMoveAssignmentReleasesThePreviousBackin
       AlphaType::Premultiplied);
   destination = std::move(source);
   EXPECT_THAT(source.isValid(), testing::IsFalse());
+  EXPECT_THAT(static_cast<bool>(runtime.wgpuTextureOf(oldIdentity)), testing::IsTrue());
+  sharedDevice()->drainDeferredTextureBackings();
   EXPECT_THAT(static_cast<bool>(runtime.wgpuTextureOf(oldIdentity)), testing::IsFalse());
   ASSERT_THAT(destination.runtimeTexture(), testing::NotNull());
   EXPECT_THAT(runtime.ownsTextureBacking(*destination.runtimeTexture()), testing::IsTrue());
@@ -4920,6 +4926,33 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotReleaseOnAnotherThreadDefersOwnerSlotRe
   owner->drainDeferredDestroys();
   EXPECT_THAT(owner->adapterDevice().ownsTextureBacking(identity), testing::IsFalse());
   EXPECT_THAT(owner->deferredTextureDestroyCountForTesting(), testing::Eq(pendingBefore));
+}
+
+TEST_F(RendererGeodeTest, SharedBackendPresentationRequiresAnOwningSnapshotLease) {
+  RendererGeode producer = createRenderer();
+  beginFrame(producer);
+  producer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  producer.drawRect(Box2d({0, 0}, {64, 64}), StrokeParams{});
+  producer.endFrame();
+  const auto* borrowed = producer.borrowTextureSnapshot();
+  ASSERT_THAT(borrowed, testing::NotNull());
+  auto consumerDevice = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(consumerDevice, testing::NotNull());
+  RendererGeode consumer(consumerDevice);
+  beginFrame(consumer);
+  EXPECT_THAT(consumer.drawTextureSnapshot(*borrowed, Box2d({0, 0}, {64, 64}), 1, true),
+              testing::IsFalse());
+  consumer.endFrame();
+  ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {0, 0, 0, 0},
+                             "shared_backend_borrowed_snapshot_refused");
+  const auto owned = producer.takeTextureSnapshot();
+  ASSERT_THAT(owned, testing::NotNull());
+  beginFrame(consumer);
+  EXPECT_THAT(consumer.drawTextureSnapshot(*owned, Box2d({0, 0}, {64, 64}), 1, true),
+              testing::IsTrue());
+  consumer.endFrame();
+  ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "shared_backend_owned_snapshot_accepted");
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <latch>
 #include <limits>
 #include <optional>
 #include <thread>
@@ -767,26 +768,20 @@ TEST_F(RendererGeodeTest, DeviceLostWhileTheMapIsPendingIsReportedWithinASlice) 
   renderer.endFrame();
   (void)renderer.consumeReadbackStats();
 
-  // The cancellation predicate is polled once before the readback is set up at all, and then
-  // once per wait slice, before the slice itself. The second call is therefore the one place a
-  // test can stand between the map request and the first slice: the readback's own fast-fail on
-  // an already-lost device is behind us, no poll has run since the map was requested, so the
-  // slice cannot find the map already complete and must reach its lost-device check.
-  //
-  // If that call sequence ever changes, this lands on the fast-fail route instead, where no
-  // statistics are recorded - which the assertions below fail on rather than pass silently.
-  int predicateCalls = 0;
-  const auto start = std::chrono::steady_clock::now();
-  const RendererBitmap snapshot = renderer.takeSnapshotInterruptibly([&] {
-    if (++predicateCalls == 2) {
+  bool mapRequested = false;
+  device->setSnapshotReadbackHookForTesting([&](geode::GeodeDevice::SnapshotReadbackPhase phase) {
+    if (phase == geode::GeodeDevice::SnapshotReadbackPhase::MapRequested) {
+      mapRequested = true;
       device->markDeviceLost("test-injected loss while the map was pending");
     }
-    return false;  // Never cancel: the loss, not the caller, must end this wait.
   });
+  const auto start = std::chrono::steady_clock::now();
+  const RendererBitmap snapshot = renderer.takeSnapshot();
+  device->setSnapshotReadbackHookForTesting({});
   const auto elapsed = std::chrono::steady_clock::now() - start;
 
   EXPECT_TRUE(snapshot.empty());
-  EXPECT_GE(predicateCalls, 2) << "the wait must have reached at least one slice";
+  EXPECT_THAT(mapRequested, testing::IsTrue());
   // Well under the ten-second readback deadline: the slice reports the loss rather than the
   // deadline discovering it.
   EXPECT_LT(elapsed, std::chrono::seconds(2));
@@ -811,10 +806,17 @@ TEST_F(RendererGeodeTest, InterruptibleSnapshotCancelsPromptlyAfterGpuSubmit) {
   renderer.endFrame();
   (void)renderer.consumeReadbackStats();
 
-  std::atomic<int> cancellationChecks{0};
+  std::atomic<bool> cancel{false};
+  sharedDevice()->setSnapshotReadbackHookForTesting(
+      [&](geode::GeodeDevice::SnapshotReadbackPhase phase) {
+        if (phase == geode::GeodeDevice::SnapshotReadbackPhase::MapRequested) {
+          cancel.store(true, std::memory_order_relaxed);
+        }
+      });
   const auto start = std::chrono::steady_clock::now();
-  const RendererBitmap snapshot = renderer.takeSnapshotInterruptibly(
-      [&] { return cancellationChecks.fetch_add(1, std::memory_order_relaxed) >= 1; });
+  const RendererBitmap snapshot =
+      renderer.takeSnapshotInterruptibly([&] { return cancel.load(std::memory_order_relaxed); });
+  sharedDevice()->setSnapshotReadbackHookForTesting({});
   const auto elapsed = std::chrono::steady_clock::now() - start;
 
   EXPECT_TRUE(snapshot.empty());
@@ -4973,6 +4975,142 @@ TEST_F(RendererGeodeTest, DetachedSnapshotReadbackDoesNotMutateProducerFrameCoun
   EXPECT_THAT(after.bindgroupCreates, testing::Eq(before.bindgroupCreates));
   EXPECT_THAT(after.submits, testing::Eq(before.submits));
   producer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, IsolatedReadbackReusesOneContextAndAccountsForItsPool) {
+  auto device = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode producer(device);
+  beginFrame(producer);
+  producer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  producer.drawRect(Box2d({0, 0}, {64, 64}), StrokeParams{});
+  producer.endFrame();
+  const auto snapshot = producer.takeTextureSnapshot();
+  ASSERT_THAT(snapshot, testing::NotNull());
+  const uint64_t buffersBefore = device->lifetimeBufferCreates();
+  const uint64_t texturesBefore = device->lifetimeTextureCreates();
+  ExpectSolidRuntimeSnapshot(snapshot->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "isolated_readback_cold");
+  const auto cold = device->consumeReadbackStats();
+  EXPECT_THAT(cold.contextCreates, testing::Eq(1u));
+  EXPECT_THAT(cold.bufferCreates, testing::Eq(1u));
+  EXPECT_THAT(cold.textureCreates, testing::Eq(1u));
+  EXPECT_THAT(cold.count, testing::Eq(1));
+  EXPECT_THAT(cold.submits, testing::Eq(1u));
+  EXPECT_THAT(cold.poolEntries, testing::Eq(1u));
+  EXPECT_THAT(cold.poolBytes, testing::Eq(32768u));
+  EXPECT_THAT(device->lifetimeBufferCreates(), testing::Eq(buffersBefore + 1));
+  EXPECT_THAT(device->lifetimeTextureCreates(), testing::Eq(texturesBefore + 1));
+  ExpectSolidRuntimeSnapshot(snapshot->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "isolated_readback_warm");
+  const auto warm = device->consumeReadbackStats();
+  EXPECT_THAT(warm.contextCreates, testing::Eq(0u));
+  EXPECT_THAT(warm.bufferCreates, testing::Eq(0u));
+  EXPECT_THAT(warm.textureCreates, testing::Eq(0u));
+  EXPECT_THAT(warm.count, testing::Eq(1));
+  EXPECT_THAT(warm.poolBytes, testing::Eq(cold.poolBytes));
+}
+
+TEST_F(RendererGeodeTest, IsolatedReadbackDeadlineBeforeAcquisitionAllocatesNothing) {
+  auto device = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode renderer(device);
+  beginFrame(renderer);
+  renderer.endFrame();
+  const uint64_t buffersBefore = device->lifetimeBufferCreates();
+  const uint64_t texturesBefore = device->lifetimeTextureCreates();
+  device->setSnapshotReadbackBudgetForTesting(std::chrono::milliseconds(0));
+  EXPECT_THAT(renderer.takeSnapshot().empty(), testing::IsTrue());
+  const auto stats = renderer.consumeReadbackStats();
+  EXPECT_THAT(stats.captureTimeouts, testing::Eq(1u));
+  EXPECT_THAT(stats.contextCreates, testing::Eq(0u));
+  EXPECT_THAT(stats.bufferCreates, testing::Eq(0u));
+  EXPECT_THAT(stats.textureCreates, testing::Eq(0u));
+  EXPECT_THAT(stats.count, testing::Eq(0));
+  EXPECT_THAT(stats.deviceLost, testing::IsFalse());
+  EXPECT_THAT(device->lifetimeBufferCreates(), testing::Eq(buffersBefore));
+  EXPECT_THAT(device->lifetimeTextureCreates(), testing::Eq(texturesBefore));
+}
+
+TEST_F(RendererGeodeTest, IsolatedReadbackWaitHonorsCancellationAndDeadlineWithoutDeviceLoss) {
+  auto device = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode renderer(device);
+  beginFrame(renderer);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawRect(Box2d({0, 0}, {64, 64}), StrokeParams{});
+  renderer.endFrame();
+  const auto snapshot = renderer.takeTextureSnapshot();
+  ASSERT_THAT(snapshot, testing::NotNull());
+  beginFrame(renderer);
+  renderer.endFrame();
+  std::latch acquired(1);
+  std::latch release(1);
+  std::atomic<bool> first{true};
+  std::atomic<bool> cancelWaiter{false};
+  device->setSnapshotReadbackHookForTesting([&](geode::GeodeDevice::SnapshotReadbackPhase phase) {
+    if (phase == geode::GeodeDevice::SnapshotReadbackPhase::ContextAcquired &&
+        first.exchange(false)) {
+      acquired.count_down();
+      release.wait();
+    } else if (phase == geode::GeodeDevice::SnapshotReadbackPhase::WaitingForContext) {
+      cancelWaiter.store(true, std::memory_order_relaxed);
+    }
+  });
+  RendererBitmap captured;
+  std::thread worker([&] { captured = snapshot->takeSnapshot(); });
+  acquired.wait();
+  device->setSnapshotReadbackBudgetForTesting(std::chrono::milliseconds(1));
+  EXPECT_THAT(renderer.takeSnapshot().empty(), testing::IsTrue());
+  device->setSnapshotReadbackBudgetForTesting(geode::kReadbackMapTimeout);
+  cancelWaiter.store(false, std::memory_order_relaxed);
+  EXPECT_THAT(
+      renderer
+          .takeSnapshotInterruptibly([&] { return cancelWaiter.load(std::memory_order_relaxed); })
+          .empty(),
+      testing::IsTrue());
+  const auto blocked = renderer.consumeReadbackStats();
+  EXPECT_THAT(blocked.captureTimeouts, testing::Eq(1u));
+  EXPECT_THAT(blocked.captureCancellations, testing::Eq(1u));
+  EXPECT_THAT(blocked.contextCreates, testing::Eq(1u));
+  EXPECT_THAT(blocked.bufferCreates, testing::Eq(0u));
+  EXPECT_THAT(blocked.textureCreates, testing::Eq(0u));
+  EXPECT_THAT(blocked.deviceLost, testing::IsFalse());
+  release.count_down();
+  for (int frame = 0; frame < 4; ++frame) {
+    beginFrame(renderer);
+    renderer.endFrame();
+    EXPECT_THAT(renderer.lastFrameTimings().counters.submits, testing::Eq(1u));
+  }
+  worker.join();
+  device->setSnapshotReadbackHookForTesting({});
+  ExpectSolidRuntimeSnapshot(captured, {64, 64}, {255, 0, 0, 255},
+                             "isolated_readback_with_active_producer");
+  EXPECT_THAT(device->consumeReadbackStats().count, testing::Eq(1));
+  ExpectSolidRuntimeSnapshot(snapshot->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "isolated_readback_after_contention_timeout");
+  EXPECT_THAT(device->isDeviceLost(), testing::IsFalse());
+}
+
+TEST_F(RendererGeodeTest, IsolatedReadbackPoolRemainsBoundedAcrossSizes) {
+  auto device = CreateSharedBackendContext(sharedDevice());
+  ASSERT_THAT(device, testing::NotNull());
+  RendererGeode renderer(device);
+  for (int size : {8, 16, 24, 32, 40}) {
+    RenderViewport viewport;
+    viewport.size = Vector2d(size, size);
+    viewport.devicePixelRatio = 1;
+    renderer.beginFrame(viewport);
+    renderer.endFrame();
+    ExpectSolidRuntimeSnapshot(renderer.takeSnapshot(), {size, size}, {0, 0, 0, 0},
+                               "isolated_readback_pool_sizes");
+    const auto stats = device->consumeReadbackStats();
+    EXPECT_THAT(stats.poolEntries, testing::Le(4u));
+    EXPECT_THAT(stats.poolBytes, testing::Gt(0u));
+  }
+  const auto retained = device->consumeReadbackStats();
+  EXPECT_THAT(retained.poolEntries, testing::Eq(4u));
+  EXPECT_THAT(retained.poolBytes, testing::Eq(42496u));
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4299,5 +4299,161 @@ TEST_F(RendererGeodeTest, ClippedVerticalOnlyFillWithEmptyVerticalBandsRenders) 
       << "A clipped fill with no vertical bands must not invalidate the frame it is drawn in.";
 }
 
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsWrongFormatWithoutConsumingTheTexture) {
+  auto created = sharedDevice()->adapterDevice().createTexture(
+      {"snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  {
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(texture), {4, 4}, wgpu::TextureFormat::BGRA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+    EXPECT_THAT(texture.isValid(), testing::IsTrue());
+  }
+  if (texture.isValid()) {
+    (void)sharedDevice()->adapterDevice().destroyTextureBacking(std::move(texture));
+  }
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsInvalidContentBeforeTakingOwnership) {
+  for (const Vector2i dimensions :
+       {Vector2i(0, 4), Vector2i(-1, 4), Vector2i(5, 4), Vector2i(4, 5)}) {
+    SCOPED_TRACE(dimensions);
+    auto created = sharedDevice()->adapterDevice().createTexture(
+        {"snapshot",
+         {4, 4},
+         gpu::TextureFormat::RGBA8Unorm,
+         gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+    ASSERT_FALSE(created.hasError()) << created.error();
+    gpu::Texture texture = std::move(created).result();
+    {
+      auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+          sharedDevice(), std::move(texture), dimensions, wgpu::TextureFormat::RGBA8Unorm,
+          AlphaType::Premultiplied);
+      EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+      EXPECT_THAT(texture.isValid(), testing::IsTrue());
+    }
+    if (texture.isValid()) {
+      (void)sharedDevice()->adapterDevice().destroyTextureBacking(std::move(texture));
+    }
+  }
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsForeignOwnerWithoutConsumingTheTexture) {
+  auto other = std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+  ASSERT_THAT(other, testing::NotNull());
+  auto created = sharedDevice()->adapterDevice().createTexture(
+      {"snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  {
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        other, std::move(texture), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+    EXPECT_THAT(texture.isValid(), testing::IsTrue());
+  }
+  if (texture.isValid()) {
+    (void)sharedDevice()->adapterDevice().destroyTextureBacking(std::move(texture));
+  }
+}
+
+TEST_F(RendererGeodeTest, SnapshotContentCannotGrowBeyondItsBacking) {
+  auto created = sharedDevice()->adapterDevice().createTexture(
+      {"snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      sharedDevice(), std::move(texture), {2, 3}, wgpu::TextureFormat::RGBA8Unorm,
+      AlphaType::Premultiplied);
+  snapshot.setDimensions({5, 3});
+  EXPECT_THAT(snapshot.dimensions(), testing::Eq(Vector2i(2, 3)));
+  snapshot.setDimensions({2, -1});
+  EXPECT_THAT(snapshot.dimensions(), testing::Eq(Vector2i(2, 3)));
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsNullOwnerAndUnsupportedFormatWithoutConsumption) {
+  for (const bool missingOwner : {false, true}) {
+    SCOPED_TRACE(missingOwner);
+    const auto format = missingOwner ? gpu::TextureFormat::RGBA8Unorm : gpu::TextureFormat::R8Unorm;
+    auto created = sharedDevice()->adapterDevice().createTexture(
+        {"snapshot", {4, 4}, format, gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+    ASSERT_FALSE(created.hasError()) << created.error();
+    gpu::Texture texture = std::move(created).result();
+    {
+      auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+          missingOwner ? nullptr : sharedDevice(), std::move(texture), {4, 4},
+          missingOwner ? wgpu::TextureFormat::RGBA8Unorm : wgpu::TextureFormat::R8Unorm,
+          AlphaType::Premultiplied);
+      EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+      EXPECT_THAT(texture.isValid(), testing::IsTrue());
+    }
+    if (texture.isValid()) {
+      (void)sharedDevice()->adapterDevice().destroyTextureBacking(std::move(texture));
+    }
+  }
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsStaleIdentityWithoutTouchingItsReplacement) {
+  auto& runtime = sharedDevice()->adapterDevice();
+  const gpu::TextureDescriptor descriptor{"snapshot",
+                                          {4, 4},
+                                          gpu::TextureFormat::RGBA8Unorm,
+                                          gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc};
+  auto first = runtime.createTexture(descriptor);
+  ASSERT_FALSE(first.hasError()) << first.error();
+  gpu::Texture texture = std::move(first).result();
+  gpu::Texture stale =
+      gpu::Texture::CreateForBackend(texture.slotIndex(), texture.generation(), texture.deviceId());
+  ASSERT_FALSE(runtime.destroyTextureBacking(std::move(texture)).hasError());
+  auto replacement = runtime.createTexture(descriptor);
+  ASSERT_FALSE(replacement.hasError()) << replacement.error();
+  gpu::Texture live = std::move(replacement).result();
+  {
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(stale), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+    EXPECT_THAT(stale.isValid(), testing::IsTrue());
+  }
+  EXPECT_THAT(static_cast<bool>(runtime.wgpuTextureOf(live)), testing::IsTrue());
+  (void)runtime.destroyTextureBacking(std::move(live));
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotCannotAdoptABorrowedHostRegistration) {
+  auto& runtime = sharedDevice()->adapterDevice();
+  auto created = runtime.createTexture({"host owner",
+                                        {4, 4},
+                                        gpu::TextureFormat::RGBA8Unorm,
+                                        gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture owner = std::move(created).result();
+  auto imported = runtime.importExternalTexture(
+      runtime.wgpuTextureOf(owner), {4, 4}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc);
+  ASSERT_FALSE(imported.hasError()) << imported.error();
+  gpu::Texture registration = std::move(imported).result();
+  {
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(registration), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    EXPECT_THAT(static_cast<bool>(snapshot.texture()), testing::IsFalse());
+    EXPECT_THAT(registration.isValid(), testing::IsTrue());
+  }
+  EXPECT_THAT(static_cast<bool>(runtime.wgpuTextureOf(owner)), testing::IsTrue());
+  registration = {};
+  (void)runtime.destroyTextureBacking(std::move(owner));
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -4455,6 +4455,202 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotCannotAdoptABorrowedHostRegistration) {
   (void)runtime.destroyTextureBacking(std::move(owner));
 }
 
+void ExpectSolidRuntimeSnapshot(const RendererBitmap& actual, Vector2i dimensions,
+                                const std::array<uint8_t, 4>& color, const char* label) {
+  ASSERT_THAT(actual.dimensions, testing::Eq(dimensions));
+  RendererBitmap expected;
+  expected.dimensions = dimensions;
+  expected.rowBytes = actual.rowBytes;
+  expected.alphaType = actual.alphaType;
+  expected.pixels.resize(expected.rowBytes * dimensions.y);
+  for (int y = 0; y < dimensions.y; ++y) {
+    for (int x = 0; x < dimensions.x; ++x) {
+      std::copy(color.begin(), color.end(),
+                expected.pixels.begin() + y * expected.rowBytes + x * 4);
+    }
+  }
+  editor::tests::CompareBitmapToBitmap(actual, expected, label,
+                                       editor::tests::PixelmatchIdentityParams());
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotMovesPreserveTheResourceIdentity) {
+  auto created = sharedDevice()->adapterDevice().createTexture(
+      {"snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  const uint32_t slot = texture.slotIndex(), generation = texture.generation();
+  auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      sharedDevice(), std::move(texture), {2, 3}, wgpu::TextureFormat::RGBA8Unorm,
+      AlphaType::Premultiplied);
+  ASSERT_THAT(snapshot.isValid(), testing::IsTrue());
+  EXPECT_THAT(texture.isValid(), testing::IsFalse());
+  EXPECT_THAT(snapshot.allocationDimensions(), testing::Eq(Vector2i(4, 4)));
+  EXPECT_THAT(snapshot.runtimeFormat(), testing::Optional(gpu::TextureFormat::RGBA8Unorm));
+  RendererGeodeTextureSnapshot moved(std::move(snapshot));
+  EXPECT_THAT(snapshot.isValid(), testing::IsFalse());
+  ASSERT_THAT(moved.runtimeTexture(), testing::NotNull());
+  EXPECT_THAT(moved.runtimeTexture()->slotIndex(), testing::Eq(slot));
+  EXPECT_THAT(moved.runtimeTexture()->generation(), testing::Eq(generation));
+  EXPECT_THAT(moved.deviceId(), testing::Eq(sharedDevice()->adapterDevice().deviceId()));
+  RendererGeodeTextureSnapshot assigned(nullptr, {}, Vector2i::Zero(),
+                                        wgpu::TextureFormat::Undefined);
+  assigned = std::move(moved);
+  EXPECT_THAT(moved.isValid(), testing::IsFalse());
+  ASSERT_THAT(assigned.runtimeTexture(), testing::NotNull());
+  EXPECT_THAT(assigned.runtimeTexture()->slotIndex(), testing::Eq(slot));
+  EXPECT_THAT(assigned.setDimensions({4, 4}), testing::IsTrue());
+  EXPECT_THAT(assigned.dimensions(), testing::Eq(Vector2i(4, 4)));
+}
+
+TEST_F(RendererGeodeTest, BorrowedSnapshotNamesTheSameRuntimeTargetThatDetachmentTransfers) {
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+  renderer.endFrame();
+  const auto* base = renderer.borrowTextureSnapshot();
+  ASSERT_THAT(base, testing::NotNull());
+  const auto* borrowed = static_cast<const RendererGeodeTextureSnapshot*>(base);
+  ASSERT_THAT(borrowed->runtimeTexture(), testing::NotNull());
+  const uint32_t slot = borrowed->runtimeTexture()->slotIndex(),
+                 generation = borrowed->runtimeTexture()->generation();
+  const auto detached = renderer.takeTextureSnapshot();
+  ASSERT_THAT(detached, testing::NotNull());
+  const auto* owned = static_cast<const RendererGeodeTextureSnapshot*>(detached.get());
+  ASSERT_THAT(owned->runtimeTexture(), testing::NotNull());
+  EXPECT_THAT(owned->runtimeTexture()->slotIndex(), testing::Eq(slot));
+  EXPECT_THAT(owned->runtimeTexture()->generation(), testing::Eq(generation));
+  EXPECT_THAT(renderer.borrowTextureSnapshot(), testing::IsNull());
+}
+
+TEST(RuntimeSnapshotLifetime, DetachedContentAndDeviceOutliveTheProducer) {
+  auto owner = std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+  ASSERT_THAT(owner, testing::NotNull());
+  std::weak_ptr<geode::GeodeDevice> lifetime = owner;
+  std::shared_ptr<const RendererTextureSnapshot> snapshot;
+  {
+    RendererGeode renderer(owner);
+    RenderViewport viewport;
+    viewport.size = {8, 8};
+    viewport.devicePixelRatio = 1;
+    renderer.beginFrame(viewport);
+    renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+    renderer.drawRect(Box2d({0, 0}, {8, 8}), StrokeParams{});
+    renderer.endFrame();
+    snapshot = renderer.takeTextureSnapshot();
+    ASSERT_THAT(snapshot, testing::NotNull());
+    renderer.beginFrame(viewport);
+    renderer.setPaint(solidFill(css::RGBA(0, 0, 255, 255)));
+    renderer.drawRect(Box2d({0, 0}, {8, 8}), StrokeParams{});
+    renderer.endFrame();
+  }
+  owner.reset();
+  EXPECT_THAT(lifetime.expired(), testing::IsFalse());
+  ExpectSolidRuntimeSnapshot(snapshot->takeSnapshot(), {8, 8}, {255, 0, 0, 255},
+                             "runtime_snapshot_retained_content");
+  snapshot.reset();
+  EXPECT_THAT(lifetime.expired(), testing::IsTrue());
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotContentAlphaAndBothByteFormatsRemainExact) {
+  for (bool bgra : {false, true}) {
+    for (bool straight : {false, true}) {
+      SCOPED_TRACE(testing::Message() << "bgra=" << bgra << " straight=" << straight);
+      auto& runtime = sharedDevice()->adapterDevice();
+      auto created = runtime.createTexture(
+          {"snapshot",
+           {4, 4},
+           bgra ? gpu::TextureFormat::BGRA8Unorm : gpu::TextureFormat::RGBA8Unorm,
+           gpu::TextureUsage::CopyDst | gpu::TextureUsage::CopySrc | gpu::TextureUsage::Sampled});
+      ASSERT_FALSE(created.hasError()) << created.error();
+      gpu::Texture texture = std::move(created).result();
+      std::array<uint8_t, 1024> pixels{};
+      for (size_t y = 0; y < 4; ++y) {
+        for (size_t x = 0; x < 4; ++x) {
+          const bool content = x < 2 && y < 3;
+          const uint8_t red = straight ? 128 : 64;
+          const std::array<uint8_t, 4> color = content
+                                                   ? (bgra ? std::array<uint8_t, 4>{0, 0, red, 128}
+                                                           : std::array<uint8_t, 4>{red, 0, 0, 128})
+                                                   : std::array<uint8_t, 4>{0, 255, 0, 255};
+          std::copy(color.begin(), color.end(), pixels.begin() + y * 256 + x * 4);
+        }
+      }
+      ASSERT_FALSE(runtime.writeTexture(texture, pixels, {0, 256, 4}, {4, 4}).hasError());
+      auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+          sharedDevice(), std::move(texture), {2, 3},
+          bgra ? wgpu::TextureFormat::BGRA8Unorm : wgpu::TextureFormat::RGBA8Unorm,
+          straight ? AlphaType::Unpremultiplied : AlphaType::Premultiplied);
+      ASSERT_THAT(snapshot.isValid(), testing::IsTrue());
+      ExpectSolidRuntimeSnapshot(snapshot.takeSnapshot(), {2, 3}, {128, 0, 0, 128},
+                                 "runtime_snapshot_readback_formats");
+      RendererGeode renderer = createRenderer();
+      beginFrame(renderer);
+      EXPECT_THAT(renderer.drawTextureSnapshot(
+                      snapshot, Box2d({0, 0}, {kViewportSize, kViewportSize}), 1, true),
+                  testing::IsTrue());
+      renderer.endFrame();
+      ExpectSolidRuntimeSnapshot(renderer.takeSnapshot(), {64, 64}, {128, 0, 0, 128},
+                                 "runtime_snapshot_content_sampling");
+    }
+  }
+}
+
+TEST_F(RendererGeodeTest, ForeignRuntimeSnapshotIsRejectedBeforeRecording) {
+  auto owner = std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+  ASSERT_THAT(owner, testing::NotNull());
+  auto created = owner->adapterDevice().createTexture(
+      {"snapshot",
+       {4, 4},
+       gpu::TextureFormat::RGBA8Unorm,
+       gpu::TextureUsage::Sampled | gpu::TextureUsage::CopySrc});
+  ASSERT_FALSE(created.hasError()) << created.error();
+  gpu::Texture texture = std::move(created).result();
+  auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      owner, std::move(texture), {4, 4}, wgpu::TextureFormat::RGBA8Unorm, AlphaType::Premultiplied);
+  ASSERT_THAT(snapshot.isValid(), testing::IsTrue());
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+  EXPECT_THAT(renderer.drawTextureSnapshot(snapshot, Box2d({0, 0}, {4, 4}), 1, true),
+              testing::IsFalse());
+  renderer.endFrame();
+}
+
+TEST_F(RendererGeodeTest, RuntimeReadbackPreservesSampledOnlyAndCopyOnlyRoutes) {
+  for (bool sampled : {false, true}) {
+    SCOPED_TRACE(sampled);
+    auto& runtime = sharedDevice()->adapterDevice();
+    auto created = runtime.createTexture(
+        {"snapshot capability",
+         {4, 4},
+         gpu::TextureFormat::RGBA8Unorm,
+         gpu::TextureUsage::CopyDst |
+             (sampled ? gpu::TextureUsage::Sampled : gpu::TextureUsage::CopySrc)});
+    ASSERT_FALSE(created.hasError()) << created.error();
+    gpu::Texture texture = std::move(created).result();
+    std::array<uint8_t, 1024> pixels{};
+    for (size_t y = 0; y < 4; ++y) {
+      for (size_t x = 0; x < 4; ++x) {
+        pixels[y * 256 + x * 4 + 1] = 255;
+        pixels[y * 256 + x * 4 + 3] = 255;
+      }
+    }
+    ASSERT_FALSE(runtime.writeTexture(texture, pixels, {0, 256, 4}, {4, 4}).hasError());
+    auto snapshot = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+        sharedDevice(), std::move(texture), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+        AlphaType::Premultiplied);
+    ASSERT_THAT(snapshot.isValid(), testing::IsTrue());
+    ExpectSolidRuntimeSnapshot(snapshot.takeSnapshot(), {4, 4}, {0, 255, 0, 255},
+                               "runtime_snapshot_capability_routes");
+    RendererGeode renderer = createRenderer();
+    beginFrame(renderer);
+    EXPECT_THAT(renderer.drawTextureSnapshot(snapshot, Box2d({0, 0}, {4, 4}), 1, true),
+                testing::Eq(sampled));
+    renderer.endFrame();
+  }
+}
+
 TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsUnusableCapabilitiesWithoutConsumption) {
   auto& runtime = sharedDevice()->adapterDevice();
   auto created = runtime.createTexture(
@@ -4471,6 +4667,59 @@ TEST_F(RendererGeodeTest, RuntimeSnapshotRejectsUnusableCapabilitiesWithoutConsu
   if (texture.isValid()) {
     (void)runtime.destroyTextureBacking(std::move(texture));
   }
+}
+
+TEST_F(RendererGeodeTest, RuntimeSnapshotMoveAssignmentReleasesThePreviousBacking) {
+  auto& runtime = sharedDevice()->adapterDevice();
+  const gpu::TextureDescriptor descriptor{
+      "snapshot", {4, 4}, gpu::TextureFormat::RGBA8Unorm, gpu::TextureUsage::Sampled};
+  auto first = runtime.createTexture(descriptor);
+  auto second = runtime.createTexture(descriptor);
+  ASSERT_FALSE(first.hasError()) << first.error();
+  ASSERT_FALSE(second.hasError()) << second.error();
+  gpu::Texture oldIdentity = gpu::Texture::CreateForBackend(
+      first.result().slotIndex(), first.result().generation(), first.result().deviceId());
+  auto destination = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      sharedDevice(), std::move(first).result(), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+      AlphaType::Premultiplied);
+  auto source = RendererGeodeTextureSnapshot::AdoptRuntimeTexture(
+      sharedDevice(), std::move(second).result(), {4, 4}, wgpu::TextureFormat::RGBA8Unorm,
+      AlphaType::Premultiplied);
+  destination = std::move(source);
+  EXPECT_THAT(source.isValid(), testing::IsFalse());
+  EXPECT_THAT(static_cast<bool>(runtime.wgpuTextureOf(oldIdentity)), testing::IsFalse());
+  ASSERT_THAT(destination.runtimeTexture(), testing::NotNull());
+  EXPECT_THAT(runtime.ownsTextureBacking(*destination.runtimeTexture()), testing::IsTrue());
+}
+
+TEST_F(RendererGeodeTest, BorrowedRuntimeSnapshotCanBeDrawnWithoutReleasingTheProducerTarget) {
+  RendererGeode producer = createRenderer();
+  beginFrame(producer);
+  producer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  producer.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+  producer.endFrame();
+  const auto* borrowed = producer.borrowTextureSnapshot();
+  ASSERT_THAT(borrowed, testing::NotNull());
+  {
+    RendererGeode consumer = createRenderer();
+    beginFrame(consumer);
+    EXPECT_THAT(consumer.drawTextureSnapshot(
+                    *borrowed, Box2d({0, 0}, {kViewportSize, kViewportSize}), 1, true),
+                testing::IsTrue());
+    consumer.endFrame();
+    ExpectSolidRuntimeSnapshot(consumer.takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                               "borrowed_runtime_snapshot_drawing");
+  }
+  const auto detached = producer.takeTextureSnapshot();
+  ASSERT_THAT(detached, testing::NotNull());
+  EXPECT_THAT(producer.borrowTextureSnapshot(), testing::IsNull());
+  ExpectSolidRuntimeSnapshot(detached->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "borrowed_runtime_snapshot_preserves_owner");
+  beginFrame(producer);
+  producer.endFrame();
+  ASSERT_THAT(producer.borrowTextureSnapshot(), testing::NotNull());
+  ExpectSolidRuntimeSnapshot(detached->takeSnapshot(), {64, 64}, {255, 0, 0, 255},
+                             "borrowed_runtime_snapshot_next_frame");
 }
 
 }  // namespace

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -1182,11 +1182,22 @@
     },
     "donner/svg/renderer/tests/RendererGeode_tests.cc": {
       "operations": [
-        "draw"
+        "createTexture",
+        "draw",
+        "writeTexture"
+      ],
+      "wgpuCFunctions": [
+        "wgpuTextureOf"
       ],
       "wgpuCppTokens": [
+        "Extent3D",
+        "TexelCopyBufferLayout",
+        "TexelCopyTextureInfo",
         "Texture",
-        "TextureFormat"
+        "TextureDescriptor",
+        "TextureDimension",
+        "TextureFormat",
+        "TextureUsage"
       ]
     },
     "donner/svg/renderer/tests/RendererTestBackendGeode.cc": {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -484,6 +484,8 @@
         "wgpuTextureOf"
       ],
       "wgpuCTypes": [
+        "WGPUDevice",
+        "WGPUQueue",
         "WGPUTexture",
         "WGPUTextureFormat",
         "WGPUTextureFormat_BGRA8Unorm",
@@ -502,6 +504,10 @@
       ]
     },
     "donner/svg/renderer/RendererGeode.h": {
+      "wgpuCTypes": [
+        "WGPUDevice",
+        "WGPUQueue"
+      ],
       "wgpuCppTokens": [
         "Texture",
         "TextureFormat",


### PR DESCRIPTION
Keep GPU snapshot backing alive until presentation and capture finish, and validate runtime adoption before consuming the caller's texture. Rejected adoption leaves the caller's handle untouched.

Snapshots retain their original owning runtime identity. Drawing within that context uses the handle directly; separate presentation contexts may create one borrowed registration per backing only when their native device and queue match. Runtime backing retirement returns to the owning context through a synchronized mailbox.

CPU capture uses one lazy readback-only context and bounded pool per producer. It serializes the complete capture operation without sharing mutable rendering state or creating another set of render pipelines. One total deadline covers context acquisition, mapping, and copying; cancellation and capture timeout remain distinct from device loss, with explicit diagnostics and allocation accounting.

Regression evidence covers ownership refusal, cropped RGBA/BGRA content, alpha, moves, borrowed-view refusal, scoped producer teardown, shared-backend presentation, foreign-thread retirement, producer-state isolation, cancellation, deadlines, pool bounds, and reuse. Existing failing tests were observed before their fixes; bitmap acceptance uses strict pixelmatch.

Performance fixtures continue to measure combined rendering and capture cost through isolated counters, preserving every existing ceiling. The fixtures explicitly check the expected GPU capture work so it cannot hide a rendering regression.

Validation completed: macOS full suite (496 targets passed, 33 configuration/platform skips), all five explicit Geode editor targets, scoped renderer/readback/shared-frame tests, all 35 performance cases, inventory freshness, lint, CMake static validation, and independent review. A Geode Wasm package from the identical pre-rebase source tree passed all nine size/content checks; its original embedded revision and artifact hashes were verified. Browser smoke and presentation regression targets also pass through the full suite.
