### PR TITLE
Document parallel implementation and early PR delivery

### DIFF
--- a/.claude/skills/donner-bugfix-discipline/SKILL.md
+++ b/.claude/skills/donner-bugfix-discipline/SKILL.md
@@ -26,7 +26,9 @@ sections "Debugging Discipline" and "Bug-Fix Commit Discipline".
    same failure the user reported (see the model message below); pasting raw stdout is optional.
 3. **Commit the red test on its own commit** so CI records a red-to-green transition on the branch.
 4. Fix the bug in a follow-up commit; the test now passes.
-5. `bazel test //...` must be fully green before pushing (see donner-build-test skill).
+5. `bazel test //...` must be fully green before merge readiness (see donner-build-test skill).
+   It remains the default pre-push gate; requested early delivery follows the narrower publication
+   gate in `AGENTS.md` and schedules full qualification without skipping it.
 6. `clang-format -i` every modified C/C++ file (or `git clang-format` for staged changes).
 
 If you cannot make the test fail at HEAD, **the test is wrong — not the bug**. Rework the test;
@@ -116,7 +118,7 @@ and the donner-editor-debugging skill.
 | "Glyph outline differences"                                                     | Same lazy-excuse family; hides wrong glyph position / transform / coverage bugs.                                                                                                                                                                                                                                             |
 | Percentage thresholds in pixel diffs                                            | They mask regressions smaller than the threshold. A private 5% comparator hid bug #582 for weeks. Diff is zero or the test fails with PNGs for inspection.                                                                                                                                                                   |
 | Private "boutique" comparators (`composeOver`, `CountDifferingPixelsInRect`, …) | Use / extend `bitmap_golden_compare` instead — see donner-pixel-diff skill.                                                                                                                                                                                                                                                  |
-| "Preexisting failure, not mine"                                                 | There is no such thing on this repo. A red test found while doing other work is now in scope: fix it or open + link a tracking issue explicitly.                                                                                                                                                                             |
+| "Preexisting failure, not mine"                                                 | A red test remains blocking. Fix it when it is in the unit's scope; otherwise report it to the coordinator for one assigned repair owner and linked repair. Never dismiss it or duplicate the repair across workers.                                                                                                        |
 
 ## 6. Diagnosable tests (the ToTT standard)
 

--- a/.claude/skills/donner-build-test/SKILL.md
+++ b/.claude/skills/donner-build-test/SKILL.md
@@ -19,7 +19,7 @@ beyond this how-to: `docs/building.md` (setup + FAQ), `build_defs/rules.bzl` (ma
 ## 1. TL;DR command card
 
 ```sh
-bazel test //...                      # THE single local gate before any push — nothing else
+bazel test //...                      # full local qualification gate
 bazel test //donner/base/...         # scope while iterating (renderer tests are slow)
 bazel build //donner/...             # build everything
 bazel test --test_tag_filters=lint //...           # just the banned-pattern lint tests
@@ -44,16 +44,20 @@ terminal previews. Missing diagnostics means quiet mode, not a broken harness �
 
 ## 2. Presubmit ritual (exact order)
 
-1. `git fetch origin main && git rebase origin/main`
+1. Update the owned branch against its actual PR base. Independent PRs normally use `origin/main`;
+   genuine dependencies use the supported stacked-PR workflow and retain the reviewed parent base.
+   Do not rebase another worker's branch or run Git commands in another worker's checkout.
 2. Format changed files (clang-format 18 and 19 produce identical output under the project
    `.clang-format`; bare `git clang-format` only covers uncommitted changes, so pass the branch
    base for already-committed work):
    ```sh
-   git-clang-format origin/main                                        # C/C++, whole branch
-   git diff --name-only origin/main | grep -E '(BUILD|\.bzl)$' | xargs -r buildifier
+   git-clang-format <base-ref>                                        # C/C++, whole branch
+   git diff --name-only <base-ref> | grep -E '(BUILD|\.bzl)$' | xargs -r buildifier
    ```
-3. `bazel test //...` — must be fully green. There is no "preexisting failure": any red test is
-   now in scope to fix (CLAUDE.md §"Always-Green Main").
+3. `bazel test //...` — must be fully green before merge readiness. It remains the default pre-push
+   gate; the requested early-delivery policy in `AGENTS.md` permits earlier publication only after
+   its narrower review and affected-check gates, with full qualification scheduled and completed.
+   Commands here describe test scope and do not authorize execution in an undesignated venue.
 4. If you touched `tools/cmake/` or the dependency graph:
    `python3 tools/cmake/gen_cmakelists.py --check --build` — plain `--check` is static-only and
    misses real compile breaks; `--build` is the local compile gate (`--build` requires `--check`).
@@ -277,7 +281,8 @@ standalone consumer project for the exported `donner` target.
 
 ## 11. Hard rules
 
-- Any red in `bazel test //...` is in scope to fix now (§2 step 3).
+- Any red in `bazel test //...` remains blocking. In coordinated delivery, route an unrelated base
+  failure to the coordinator for one assigned repair owner rather than duplicating the repair.
 - Never add `--jobs` / `--local_test_jobs` to the `ci` config in `.bazelrc`: self-hosted runners
   cap concurrency in `/etc/bazel.bazelrc`, and overriding it flooded the remote-execution worker
   (2026-06-30 hang; see the comment above `build:ci`).

--- a/.claude/skills/donner-editor-debugging/SKILL.md
+++ b/.claude/skills/donner-editor-debugging/SKILL.md
@@ -263,9 +263,9 @@ Traps:
   wait with a deadline.
 - Content-only capture is a readback-only presenter mode — it must not clear overlay textures or
   skip overlay rasterization, or the next non-capture frame is perturbed.
-- `GlRnrReplay_tests.cc` is timing-sensitive; under `--config=geode` on a
-  remote-exec-by-default setup run it with `--strategy=TestRunner=local` (see the comment in
-  `donner/editor/tests/BUILD.bazel`).
+- `GlRnrReplay_tests.cc` is timing-sensitive. Run it only in the designated test environment and
+  use that environment's prescribed execution strategy; commands in this skill do not authorize a
+  different venue or local browser execution.
 - Mirror the exact request-posting sequence the real editor fires — do not fabricate a prewarm
   phase that production never runs, or the test verifies a fictional pipeline.
 

--- a/.claude/skills/donner-pr-ci/SKILL.md
+++ b/.claude/skills/donner-pr-ci/SKILL.md
@@ -2,7 +2,7 @@
 name: donner-pr-ci
 description: >
   PR lifecycle and CI triage playbook for Donner: the pre-push gate, PR hygiene rules
-  (🤖 comment convention, no agent branding), the ~7-minute monitoring loop, merge rules,
+  (🤖 comment convention, no agent branding), bounded monitoring, merge rules,
   main.yml anatomy, and the transient-vs-real failure decision tree with artifact-driven
   diagnosis. Use when opening, updating, rebasing, or monitoring any PR; when responding to
   review comments; when a GitHub Actions check is red, hanging, or selected the wrong Bazel
@@ -11,11 +11,13 @@ description: >
 
 # Donner PR & CI Playbook
 
-## 1. Pre-push gate (run in this order, every time)
+## 1. Pre-push gate
 
-1. `git fetch origin main && git rebase origin/main` — stale bases hide merge conflicts and let
-   bazel-diff pick the wrong targets.
-2. `bazel test //...` — the single source of truth for local validation. It already includes the
+1. Update against the actual PR base. Independent PRs normally target `origin/main`; genuine
+   dependent PRs retain their reviewed parent through the supported stacked-PR workflow. Rebase
+   only a branch you own, and never run Git commands in another worker's checkout. Stale bases hide
+   merge conflicts and let bazel-diff pick the wrong targets.
+2. `bazel test //...` — the default single source of truth for full local validation. It includes the
    `*_tiny` / `*_text_full` / `*_geode` variant wrappers and the `*_lint` banned-pattern tests.
    See the `donner-build-test` skill for flags and variant details.
 3. `python3 tools/cmake/gen_cmakelists.py --check` — validates the generated CMake mirror. If your
@@ -31,18 +33,28 @@ description: >
    config is mandatory for fuzzers — Apple Clang lacks `libclang_rt.fuzzer_osx.a`, so without it
    fuzzers silently never link/run locally and the bug escapes to Linux CI. See `donner-fuzzing`.
 
-There is no "preexisting failure" escape hatch: any red test found during this gate is now in
-scope to fix (see the Always-Green Main policy in `CLAUDE.md`).
+There is no "preexisting failure" escape hatch: every red remains blocking. Fix failures within the
+unit's scope. Route an unrelated base failure to the coordinator for one assigned repair owner and
+linked repair; do not silently dismiss it or duplicate the fix across workers.
+
+When the operator requests early delivery, a coherent unit may be pushed and opened as a normal PR
+after affected tests, applicable formatting/generator checks, independent non-implementing review
+of the exact diff, and a full security/privacy review bound to the exact candidate pass. Mark an
+irrelevant review surface not applicable only with a reviewable rationale; the focused code review
+does not replace this gate. Schedule the full gate and existing
+applicable Geode editor integration matrix, then drive every required and advisory CI/review/conflict
+gate green before merge readiness. New source changes invalidate affected evidence. Outside that
+mode, complete the full gate before pushing.
 
 ## 2. Opening the PR
 
 ```sh
 git push -u origin <branch>
-gh pr create --title "..." --body "..."   # add --draft if you expect more CI-iteration commits
+gh pr create --title "..." --body "..."
 ```
 
-Use `--draft` when you still expect to iterate before review (Codex review fires when the PR
-leaves draft); publish with `gh pr ready <N>` once the pre-push gate is green.
+Do not use draft PRs. Open a normal PR only when the unit is coherent and reviewable under the
+default gate or the requested early-delivery gate above.
 
 - **Title**: plain project-style description of the change. No agent branding — `[codex]`,
   `[claude]`, or tool-name prefixes are banned.
@@ -62,11 +74,11 @@ leaves draft); publish with `gh pr ready <N>` once the pre-push gate is green.
   `full_test` output — which also fans the run out to the GitHub-hosted lanes even when the
   self-hosted runners are active (see §5).
 
-## 3. Monitoring loop (default for every PR you create)
+## 3. Monitoring (default for every PR you create)
 
-Poll every ~7 minutes until the PR is green AND reviewed — do not wait for a user prompt.
-Long foreground sleeps are blocked in the harness: implement the wait with the `loop` skill
-(e.g. `/loop 7m <check the PR>`) or a background command that sleeps between passes. Each pass:
+Use supported event waits when available. Otherwise poll at a bounded cadence only while the owning
+task is active. Do not use a persistent loop, background shell sleep, or fixed polling interval.
+Treat wake data as a prompt to confirm the real state through GitHub. Each pass:
 
 ```sh
 gh pr checks <N>                                      # CI status
@@ -79,11 +91,10 @@ gh api repos/jwmcglynn/donner/pulls/<N>/reviews       # review state + top-level
 - The `/comments` endpoint only shows inline diff comments. Approval state (`APPROVED` vs
   `COMMENTED`) and top-level review summaries (e.g. the Codex review body) live in `/reviews` —
   that is where you check whether `jwmcglynn` has actually approved.
-- Expect an automated Codex review within minutes of the PR leaving draft. Address feedback with
+- Expect an automated code review within minutes of the PR opening. Address feedback with
   follow-up commits; reply to comments with a leading 🤖 (every AI-posted GitHub comment starts
   with 🤖 so humans can tell AI activity apart on the shared account).
 - A Codex approval is NEVER sufficient — a `jwmcglynn` review is always required.
-- Draft PRs: monitor CI and mergeability only; review comments arrive after publishing.
 
 ## 4. Merge gate (hard rules)
 
@@ -160,8 +171,9 @@ network failure that exhausted its automatic retries — or that never had any (
 installs).
 
 **Test, compile, linker, and pixel-diff failures are NEVER transient.** Root-cause them; never
-blind-rerun. There is no "preexisting failure" category — a red test found on the branch is now
-your job (open a tracking issue and link it if genuinely out of scope, never silently reroute).
+blind-rerun. An unrelated base failure remains blocking: route it to the coordinator, who assigns
+one repair owner and links the repair. Do not silently dismiss it or expand every parallel worker's
+scope into the same fix.
 
 Failure signatures and what they mean:
 

--- a/.claude/skills/donner-web-editor/SKILL.md
+++ b/.claude/skills/donner-web-editor/SKILL.md
@@ -16,7 +16,8 @@ the production backend and TinySkia as a tested fallback, not as an interchangea
 
 ## Route the request
 
-- For a local build or preview, stop after the local browser suite passes.
+- For a build or preview request, use the designated preview and test venue. Stop after the
+  Bazel-owned browser suite passes there.
 - For a deployment, read `references/hosting-contract.md` before changing hosting configuration or
   publishing any artifact.
 - For a browser editor bug, apply `donner-editor-debugging` and `donner-bugfix-discipline` first.
@@ -41,33 +42,27 @@ bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package
 
 The editor Wasm package is Geode-only; there is no software-fallback package.
 
-## 2. Serve and verify locally
+## 2. Preview and verify in the designated venue
 
-Serve Geode on localhost in one terminal:
+For an operator-requested manual preview, serve Geode in the designated preview venue:
 
 ```sh
 bazel run --config=editor-wasm //donner/editor/wasm:serve_http -- \
   --no-https --host 127.0.0.1
 ```
 
-Install the pinned browser-test dependency and run the headed Geode suite:
+This command starts a manual preview only; it is not browser-test validation. Use the Bazel-owned
+test targets below for validation in the designated test venue.
 
-```sh
-cd donner/editor/wasm/tests
-npm ci
-npx playwright install chromium
-cd ../../../..
-DONNER_WASM_BASE_URL=http://127.0.0.1:8000 \
-DONNER_WASM_BACKEND=geode \
-  bash donner/editor/wasm/tests/run_tests.sh --headed
-```
+Run browser coverage through the current Bazel-owned targets
+`//donner/editor/wasm/tests:chromium_remote_smoke` and
+`//donner/editor/wasm/tests:browser_presentation_regression_test`, using the prescribed test venue
+and strategy. Confirm the names in `donner/editor/wasm/tests/BUILD.bazel` before running them; this
+skill does not authorize local browser execution.
 
-Use the URL printed by the server if port 8000 was occupied.
-
-To reproduce the full CI browser job instead of one suite, run `tools/run-browser-ci.sh`. It builds
-the package, serves a private copy on a free port, verifies the served `editor.wasm` hash, and runs
-every CI lane in CI order with `CI=true`. That script is the single source of truth for the lane
-sequence in `.github/workflows/editor_wasm.yml`; change lanes there, not in the workflow.
+Use the repository's Bazel targets as the source of truth for dependency installation, serving,
+artifact verification, and lane selection. Do not invoke removed helper scripts or recreate their
+behavior with direct npm, Playwright, or ad-hoc local server commands.
 
 Require all of the following before packaging:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,28 @@ Stages transform components through the ECS:
 
 **NEVER merge a PR without explicit operator approval.** Agents open, update, monitor, and review PRs — but `gh pr merge` (any flavor) is operator-gated: the operator must approve merging that specific PR in the current conversation. Green CI, passing reviews, or "obviously safe" changes do not substitute for approval.
 
+### Coordinated delivery
+
+When parallel delivery is requested, the controller divides the project into independent,
+outcome-oriented units that can become coherent pull requests, and assigns explicit file, branch,
+and integration ownership. Specialist profiles describe expertise; they do not grant exclusive
+editing rights. Overlapping files have one writer, shared Git operations have one owner, and an
+occupied checkout is preserved unless its owner releases it. A user-designated existing checkout
+may be used as a staging lane only after verifying its path, base, branch, dirty state, and owner;
+that designation does not authorize cleanup.
+
+Pipeline reviewable units through independent review and CI repair as soon as each qualifies. When
+reviewable work remains unpublished, prioritize publishing or repairing it before starting another
+unit. Each unit remains independently understandable and testable; coordination must not weaken
+quality gates or cause every worker to repair the same unrelated failure.
+
 When creating a pull request:
 
-1. **Rebase on latest `origin/main`** before pushing — `git fetch origin main && git rebase origin/main`.
-2. **Run `bazel test //...`** before opening the PR. This is the single source of truth for local validation — it covers:
+1. **Update against the actual PR base** before pushing. Independent PRs normally target
+   `origin/main`; genuine dependent PRs use the supported stacked-PR workflow and retain their
+   reviewed parent base. Rebase only a branch you own, and never run Git commands in another
+   worker's checkout.
+2. **Run `bazel test //...`** before opening the PR by default. This is the single source of truth for full local validation — it covers:
    - Unit tests across the default config AND the `tiny` / `text_full` / `geode` variant lanes (auto-emitted as `*_tiny` / `*_text_full` / `*_geode` wrappers by `donner_cc_test(variants=…)`).
      On Intel Arc Xe hosts the Geode lane needs `--test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp` to fall back to llvmpipe.
      Also run, separately:
@@ -103,14 +121,27 @@ When creating a pull request:
    - **`clang-format -i` on every modified C/C++ file** before committing — `git clang-format` covers staged changes. The project `.clang-format` is tuned so clang-format 18 and 19 produce identical output, so any locally-installed clang-format works.
 3. **For fuzzer-sensitive changes**, run `bazel test --config=asan-fuzzer <fuzzer target>`. macOS needs this config because Apple Clang lacks `libclang_rt.fuzzer_osx.a`; `--config=asan-fuzzer` activates the LLVM 21 toolchain which provides it.
 4. **Do not publish draft diffs** — agents must not open draft pull requests. Keep unfinished
-   work local; once the change is validated and ready for review, open a normal reviewable PR.
-5. **Monitor CI and code review by default for every created PR** — whenever you create or open a PR, automatically keep monitoring CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed; do not wait for a separate user prompt. For PR monitoring, the policy is to check both comments and CI/status checks on each ~7-minute pass until the PR has stabilized. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments` when `gh` is authenticated, or the GitHub connector equivalents when `gh` is unavailable.
-6. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
-7. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
+   work local; once the change is coherent and reviewable, open a normal PR.
+5. **Requested early-delivery mode:** a coherent unit may be pushed and opened as a normal PR
+   after its affected tests, applicable formatting and generator checks, an independent
+   non-implementing review of the exact diff, and a full security/privacy review bound to the exact
+   candidate pass. Mark an irrelevant review surface not applicable only with a reviewable
+   rationale. Schedule full qualification immediately and drive the PR green; do not skip it. New
+   source changes invalidate affected evidence. Before declaring merge readiness, require a green
+   `bazel test //...`, the existing Geode editor integration matrix where applicable, every required
+   and advisory CI check, no unaddressed actionable review comments or unresolved review threads,
+   and no merge conflict. Outside requested early-delivery mode, the full pre-push gate remains the
+   default.
+6. **Monitor CI and code review by default for every created PR** — use supported event waits when
+   available; otherwise use bounded polling only while the owning task is active. Confirm all wake
+   data against GitHub. Do not use a persistent loop, background shell sleep, or fixed polling
+   interval.
+7. **No agent branding in PR titles** — do not prefix pull request titles with agent names or other tool branding. Use a plain project-style title that describes the change.
+8. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
    summary, so start with the summary content directly instead of adding a redundant heading.
-8. **Expect a Codex code review** within the first few minutes after the PR is opened — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
-9. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
-10. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
+9. **Expect an automated code review** within the first few minutes after the PR is opened — address feedback promptly by pushing follow-up commits. An automated approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
+10. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
+11. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
    screenshots, undeclared outputs, pixel diffs, artifacts, or job summaries are missing or
    inaccessible, treat that as a CI bug and fix the workflow/test harness to expose the missing
    evidence. Do not leave failures opaque or rely on blind reruns when better GitHub Actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@
   summary, so start directly with the summary content.
 - **Do not publish draft diffs.** Agents must not open draft PRs. Keep unfinished work local; once
   the change is validated and ready for review, open a normal reviewable PR.
+- **Requested early delivery.** When the operator requests parallel or early delivery, a coherent
+  unit may open as a normal reviewable PR after affected tests, applicable format/generator checks,
+  independent non-implementing exact-diff review, and a full security/privacy review bound to the
+  exact candidate pass. Mark an irrelevant review surface not applicable only with a reviewable
+  rationale; the focused code review does not replace this gate.
+  Full `bazel test //...`, the existing applicable Geode editor integration matrix, and every
+  required and advisory CI/review/conflict gate remain mandatory before merge readiness. Schedule
+  that qualification and drive failures green; new source changes invalidate affected evidence.
+  The ordinary default remains the full pre-push gate.
 
 ## AI Comment Convention
 
@@ -30,11 +39,19 @@
 ## Always-Green Main
 
 - **`main` is always green.** There is no such thing as a "preexisting test failure" — any red test blocks merge, full stop. If something on `main` breaks, the next PR is fixing it, not routing around it.
-- **No preexisting issues, ever. We fix every issue we encounter.** "This test was already red at the base commit / before my change / on another branch" is NOT an exemption — it is the next thing to fix, not a footnote to route around. Discovering a base-red test, a latent crash, a segfault, or any other defect while doing other work means that defect is now in scope: root-cause and fix it (or, if it is genuinely too large for the current change, open a tracking issue, link it, and say so explicitly — never silently leave it red or label it "preexisting, not mine"). A branch is allowed to carry red tests *transiently while actively being driven to green*, but the bar for "done" is always a fully-green `bazel test //...` with real fixes and zero disabled/skipped tests. Agents must not downgrade a red test to "preexisting" to declare success.
-- **Run `bazel test //...` before pushing any PR.** This is the single source of truth for local validation. Our goal is that `bazel test //...` catches every regression that CI would — if CI catches something local didn't, that's a gap to fix in the test surface, not a reason to skip the local check.
+- **No preexisting-failure exemption.** A base-red test, latent crash, segfault, or other defect
+  remains blocking. Fix failures within the unit's scope. In coordinated delivery, report an
+  unrelated failure to the coordinator, who assigns one repair owner and links that repair; do not
+  silently leave it red or expand every worker's scope into the same fix. A branch may carry red
+  tests transiently while being driven green, but merge readiness always requires a fully green
+  `bazel test //...` with real fixes and zero disabled or skipped tests.
+- **Run `bazel test //...` before pushing by default.** This is the single source of truth for full local validation. The requested early-delivery exception above changes when full qualification completes, not whether it completes. If CI catches something the full local gate did not, fix the test-surface gap.
 - **If `main.yml`'s bazel-diff target determinator looks wrong on a PR, add the `ci:full-test` label** to force the workflow back to full `bazel test //...` coverage for that PR.
 - **When touching the CMake mirror or `gen_cmakelists.py`, also run `python3 tools/cmake/gen_cmakelists.py --check --build`.** Plain `--check` is intentionally fast and static; `--build` is the opt-in local compile gate that catches real CMake drift before CI does.
-- The `tiny`, `text-full`, and `geode` variant lanes now run as `*_tiny` / `*_text_full` / `*_geode` wrappers under default `bazel test //...` (see `donner_cc_test(variants=…)` in `build_defs/rules.bzl`). The transitional `tools/presubmit.sh` wrapper has been retired — `bazel test //...` is the single command that gates a PR.
+- The `tiny`, `text-full`, and `geode` variant lanes run as `*_tiny` / `*_text_full` / `*_geode`
+  wrappers under default `bazel test //...` (see `donner_cc_test(variants=…)` in
+  `build_defs/rules.bzl`). The transitional `tools/presubmit.sh` wrapper has been retired;
+  `bazel test //...` is the full qualification command required before merge readiness.
 
 ## Transform Naming
 

--- a/docs/design_docs/AGENTS.md
+++ b/docs/design_docs/AGENTS.md
@@ -34,7 +34,12 @@ All design documents live under `docs/design_docs/`.
 
 1. **Goals first.** Write a design doc driven by user/requester goals. Capture scope, constraints, open questions. **Non-goals matter as much as goals** — explicitly state what's out of scope to prevent scope creep, anchor review discussions, and give future readers a clear boundary. Iterate until user confirms ready before planning implementation.
 2. **Implementation plan.** Detailed plan + Markdown TODO checklist (`- [ ] Implement X`). Start with high-level milestones, expand into indented checkboxes when kicking off each milestone.
-3. **Iterative implementation.** Complete TODOs one at a time, gather feedback, update plan and check boxes to reflect progress. Always state the next planned step in summaries.
+3. **Iterative implementation.** Complete dependent TODOs in dependency order; independent items
+   may run in parallel. Update the implementation checklist at each completed unit, publication,
+   validation, and merge so it states current status with a short evidence link. Keep it concise:
+   replace stale state instead of appending a chronological work log. A shared checklist has one
+   editor; workers report a concise status and evidence update to that editor. Always state the next
+   planned step in summaries.
 4. **Finalization.** When a design ships, write the present-tense developer
    documentation it earned — either a new explainer via `developer_template.md`
    or folded into `../developer_docs.md`. **Never delete the design doc or free


### PR DESCRIPTION
Requested parallel implementation currently has conflicting guidance about work ownership, draft PRs, and when a full test run must finish. Define independent work units and checkout ownership, allow reviewed coherent PRs to open after affected checks in requested early-delivery mode, and keep full qualification plus every CI, review, and conflict gate mandatory before merge readiness.

Align the PR and debugging skills with that workflow, use the current Bazel browser targets in the designated test venue, and keep design implementation checklists focused on current state. Full security/privacy review and separate merge approval remain required.

Validation: independent exact-diff code/security/privacy review, skill structure validation, Markdown whitespace checks, and source inspection of the named browser targets. Documentation only; no product code, build configuration, dependencies, or runtime behavior changed.
