### PR TITLE
Parallelize sharded GPU tests in remote CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -460,8 +460,7 @@ build:ci --skip_incompatible_explicit_targets
 # that overrides this). Opt-in tests use `manual`, while wall-clock targets also
 # use `perf`. Filtering both tags protects affected-target lists and full `//...`
 # fallbacks even when a runner bazelrc changes wildcard expansion or config
-# precedence. See CLAUDE.md ("wall-clock budgets move to nightly perf targets")
-# and 0030.
+# precedence. See CLAUDE.md ("wall-clock budgets move to nightly perf targets").
 test:ci --test_tag_filters=-manual,-perf,-ci-remote-gpu
 
 # Allow `bazel run` on sharded test targets (sharding only applies to `bazel test`).

--- a/.bazelrc
+++ b/.bazelrc
@@ -308,7 +308,7 @@ build --test_env=DONNER_RENDERER_TEST_VERBOSE
 coverage --config=coverage
 coverage --combined_report=lcov
 coverage --instrumentation_filter="-test_utils$,//donner[:/]"
-coverage --test_tag_filters=-fuzz_target,-lint,-manual,-perf
+coverage --test_tag_filters=-fuzz_target,-lint,-manual,-perf,-ci-remote-gpu
 # Continue past build/analysis failures so coverage is collected from all tests
 # that can run.
 coverage --keep_going
@@ -416,6 +416,10 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 
 # Outputs test failures from failing tests instead just linking to test.log.
 test --test_output=errors
+# CI-only remote wrappers have a `no-local` execution requirement and mirror
+# an ordinary locally isolated target. Exclude them unless a remote lane
+# explicitly selects them in place of that target.
+test --test_tag_filters=-ci-remote-gpu
 
 # CI-specific optimizations — use `--config=ci` in GitHub Actions workflows.
 # NOTE: do NOT set --jobs / --local_test_jobs here. Trusted self-hosted Linux
@@ -458,7 +462,7 @@ build:ci --skip_incompatible_explicit_targets
 # fallbacks even when a runner bazelrc changes wildcard expansion or config
 # precedence. See CLAUDE.md ("wall-clock budgets move to nightly perf targets")
 # and 0030.
-test:ci --test_tag_filters=-manual,-perf
+test:ci --test_tag_filters=-manual,-perf,-ci-remote-gpu
 
 # Allow `bazel run` on sharded test targets (sharding only applies to `bazel test`).
 run --test_sharding_strategy=disabled

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1006,7 +1006,15 @@ jobs:
           export DONNER_CI_DIAGNOSTICS_DIR="$RUNNER_TEMP/donner-ci-diagnostics"
           echo "DONNER_CI_DIAGNOSTICS_DIR=$DONNER_CI_DIAGNOSTICS_DIR" >> "$GITHUB_ENV"
           read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
-          mapfile -t TARGETS < <(python3 tools/ci_remote_gpu_targets.py "${TARGETS[@]}" --one-per-line)
+          if ! mapped_targets="$(python3 tools/ci_remote_gpu_targets.py "${TARGETS[@]}")"; then
+            echo "::error::Failed to select remote GPU coverage targets."
+            exit 1
+          fi
+          if [[ -z "${mapped_targets// /}" ]]; then
+            echo "::error::Remote GPU coverage target selection is empty."
+            exit 1
+          fi
+          read -r -a TARGETS <<< "$mapped_targets"
           echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
           tools/coverage.sh --quiet --no-html "${TARGETS[@]}"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -585,7 +585,8 @@ jobs:
           # tests, so test_suite expansion and rule kinds this workflow does not
           # enumerate are handled by definition rather than by a name heuristic,
           # and subtract the tags the coverage command filters out
-          # (--test_tag_filters=-fuzz_target,-lint,-manual,-perf in .bazelrc),
+          # (--test_tag_filters=-fuzz_target,-lint,-manual,-perf,-ci-remote-gpu
+          # in .bazelrc),
           # because a subset whose only tests carry those tags leaves the
           # coverage run with the very empty test set this narrowing exists to
           # keep it out of. `attr` matches its pattern against the string form
@@ -595,7 +596,7 @@ jobs:
           # and the coverage run.
           if [[ "$kind_query_ok" == "true" ]]; then
             test_query_file="$work_dir/affected-tests-query.txt"
-            printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint|manual|perf)[,\]]", tests(%s))\n' \
+            printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint|manual|perf|ci-remote-gpu)[,\]]", tests(%s))\n' \
               "$resolved_expr" "$resolved_expr" > "$test_query_file"
             affected_tests_file="$work_dir/affected-tests.txt"
             if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
@@ -933,13 +934,13 @@ jobs:
       # >5s to accept large coverage uploads under a multi-job burst (observed
       # 2026-07-02 as DEADLINE_EXCEEDED upload failures); 60s fails fast enough
       # on a dead endpoint while tolerating a loaded one.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--strategy=TestRunner=remote --remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
       # The runner-owned Bazel rc already maps the `coverage` command to
       # `--config=ci`. Do not repeat that config here: a repeated expansion
       # duplicates its remote execution properties and Bazel rejects the
       # command before analysis. The `fetch` command below still needs its
       # explicit config because it does not inherit `coverage` options.
-      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
+      DONNER_COVERAGE_BAZEL_FLAGS: "--strategy=TestRunner=remote --remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s --test_tag_filters=-fuzz_target,-lint,-manual,-perf,-local-gpu-isolated"
 
     steps:
       - uses: actions/checkout@v7
@@ -1005,6 +1006,7 @@ jobs:
           export DONNER_CI_DIAGNOSTICS_DIR="$RUNNER_TEMP/donner-ci-diagnostics"
           echo "DONNER_CI_DIAGNOSTICS_DIR=$DONNER_CI_DIAGNOSTICS_DIR" >> "$GITHUB_ENV"
           read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
+          mapfile -t TARGETS < <(python3 tools/ci_remote_gpu_targets.py "${TARGETS[@]}" --one-per-line)
           echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
           tools/coverage.sh --quiet --no-html "${TARGETS[@]}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -557,7 +557,7 @@ jobs:
           # workspace), which `bazel test` reports as exit 4. The wrapper
           # maps only that status to success; every other failure still fails.
           tools/ci_bazel_test.sh bazelisk test --config=ci --test_output=errors \
-            --test_tag_filters=-manual,-perf \
+            --test_tag_filters=-manual,-perf,-ci-remote-gpu \
             $TARGETS
 
       - name: Upload Bazel test failure artifacts
@@ -698,7 +698,7 @@ jobs:
       # 2026-07-11, twice in a row on organic load; same signature as the
       # 2026-07-02 coverage-lane incident that motivated coverage.yml's 60s).
       # 60s still fast-fails a genuinely dead endpoint.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--strategy=TestRunner=remote --remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
       # Every self-hosted run uploads Bazel profiles + BEP + compact execution
       # logs so slow runs can be attributed to targets/actions without live
       # SSH. Keep artifacts small; retention is 3 days. DIAG_DIR is exported
@@ -952,11 +952,17 @@ jobs:
             echo "::error::Empty target selection reached the test step."
             exit 1
           fi
+          # The paired targets share the same transitioned implementation and
+          # shard count. Their no-local requirement fails closed if remote
+          # execution is unavailable.
+          # Intentional word splitting: each Bazel label is one argument.
+          # shellcheck disable=SC2086
+          TARGETS="$(python3 tools/ci_remote_gpu_targets.py $TARGETS)"
           tools/ci_bazel_test.sh "$DIAG_DIR/run_bazel_with_heartbeat.sh" "$DIAG_DIR/test/console.log" \
             bazelisk test --config=ci --config=latest_llvm --test_output=errors \
             $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS \
             $DIAG_TEST_FLAGS \
-            --test_tag_filters=-manual,-perf \
+            --test_tag_filters=-manual,-perf,-local-gpu-isolated \
             --profile="$DIAG_DIR/test/profile.gz" \
             --build_event_json_file="$DIAG_DIR/test/bep.json" \
             --nobuild_event_json_file_path_conversion \
@@ -1069,7 +1075,7 @@ jobs:
           # toolchain runs it.
           echo "::notice::Excluding requires_metal_toolchain targets: the hosted macOS image has no offline Metal compiler."
           tools/ci_bazel_test.sh bazelisk test --config=ci --test_output=errors \
-            --test_tag_filters=-manual,-perf,-requires_metal_toolchain \
+            --test_tag_filters=-manual,-perf,-requires_metal_toolchain,-ci-remote-gpu \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS
         # Deterministic fuzzer corpus replay remains in this Bazel suite. Sanitizer-backed mutation
         # runs nightly or on demand in `.github/workflows/fuzz.yml`.
@@ -1167,7 +1173,7 @@ jobs:
             exit 1
           fi
           tools/ci_bazel_test.sh bazelisk --nohome_rc test --config=ci --test_output=errors \
-            --test_tag_filters=-manual,-perf \
+            --test_tag_filters=-manual,-perf,-ci-remote-gpu \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS
         # Deterministic fuzzer corpus replay remains in this Bazel suite. Sanitizer-backed mutation
         # runs nightly or on demand in `.github/workflows/fuzz.yml`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -957,7 +957,15 @@ jobs:
           # execution is unavailable.
           # Intentional word splitting: each Bazel label is one argument.
           # shellcheck disable=SC2086
-          TARGETS="$(python3 tools/ci_remote_gpu_targets.py $TARGETS)"
+          if ! mapped_targets="$(python3 tools/ci_remote_gpu_targets.py $TARGETS)"; then
+            echo "::error::Failed to select remote GPU test targets."
+            exit 1
+          fi
+          if [[ -z "${mapped_targets// /}" ]]; then
+            echo "::error::Remote GPU target selection became empty."
+            exit 1
+          fi
+          TARGETS="$mapped_targets"
           tools/ci_bazel_test.sh "$DIAG_DIR/run_bazel_with_heartbeat.sh" "$DIAG_DIR/test/console.log" \
             bazelisk test --config=ci --config=latest_llvm --test_output=errors \
             $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS \

--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -32,6 +32,8 @@ py_test(
     data = [
         ":rules.bzl",
         "//:.bazelrc",
+        "//:.github/workflows/coverage.yml",
+        "//:.github/workflows/main.yml",
     ],
 )
 

--- a/build_defs/geode_test_scheduling_tests.py
+++ b/build_defs/geode_test_scheduling_tests.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+import subprocess
+import textwrap
 import unittest
 
 
@@ -84,6 +86,61 @@ class GeodeTestSchedulingTest(unittest.TestCase):
         )
         self.assertEqual(2, remote_job.count('if [[ -z "${'))
         self.assertIn('if [[ -z "${mapped_targets// /}" ]]; then', self.coverage_workflow)
+
+    def test_remote_target_mapping_blocks_propagate_failure_and_empty_output(self):
+        remote_job = self.main_workflow.split("  linux-self-hosted:\n", 1)[1]
+        remote_job = remote_job.split("\n  macos:\n", 1)[0]
+        cases = [
+            (
+                "test",
+                remote_job,
+                'TARGETS="$mapped_targets"',
+                'TARGETS="//donner/editor/tests:rnr_replay_tests_geode"',
+                'printf "%s\\n" "$TARGETS"',
+            ),
+            (
+                "coverage",
+                self.coverage_workflow,
+                'read -r -a TARGETS <<< "$mapped_targets"',
+                'TARGETS=("//donner/editor/tests:rnr_replay_tests_geode")',
+                'printf "%s\\n" "${TARGETS[@]}"',
+            ),
+        ]
+        fake_mapper = r"""
+        python3() {
+          case "$MAPPER_MODE" in
+            fail) return 23 ;;
+            empty) return 0 ;;
+            ok) printf '%s\n' "$MAPPED_TARGETS" ;;
+          esac
+        }
+        """
+        expected = "//donner/editor/tests:rnr_replay_tests_geode_ci_remote"
+        for name, workflow, final_line, setup, print_line in cases:
+            start = workflow.index('          if ! mapped_targets="$(python3')
+            end = workflow.index(final_line, start) + len(final_line)
+            block = textwrap.dedent(workflow[start:end])
+            script = "set -euo pipefail\n" + textwrap.dedent(fake_mapper) + setup + "\n" + block
+            for mode in ("fail", "empty"):
+                with self.subTest(route=name, mode=mode):
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env={**os.environ, "MAPPER_MODE": mode, "MAPPED_TARGETS": expected},
+                    )
+                    self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+            with self.subTest(route=name, mode="ok"):
+                result = subprocess.run(
+                    ["bash", "-c", script + "\n" + print_line],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env={**os.environ, "MAPPER_MODE": "ok", "MAPPED_TARGETS": expected},
+                )
+                self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+                self.assertEqual(expected, result.stdout.strip())
 
     def test_variant_specs_cannot_pin_a_remote_execution_platform_property(self):
         """Variant specs must not carry `exec_properties`.

--- a/build_defs/geode_test_scheduling_tests.py
+++ b/build_defs/geode_test_scheduling_tests.py
@@ -9,6 +9,8 @@ class GeodeTestSchedulingTest(unittest.TestCase):
         runfiles = Path(os.environ["TEST_SRCDIR"]) / os.environ["TEST_WORKSPACE"]
         cls.bazelrc = (runfiles / ".bazelrc").read_text()
         cls.rules = (runfiles / "build_defs/rules.bzl").read_text()
+        cls.main_workflow = (runfiles / ".github/workflows/main.yml").read_text()
+        cls.coverage_workflow = (runfiles / ".github/workflows/coverage.yml").read_text()
 
     def test_linux_suite_keeps_hardware_adapter_enabled(self):
         self.assertNotIn(
@@ -39,6 +41,37 @@ class GeodeTestSchedulingTest(unittest.TestCase):
             "geode backend alone",
         )
         self.assertIn("opens_gpu_device = False", self.rules)
+
+    def test_remote_ci_can_parallelize_opted_in_gpu_tests_without_weakening_local_isolation(self):
+        """Remote copies bypass Bazel's pre-spawn exclusive queue only in the RE lane.
+
+        Bazel 8.7 partitions `exclusive-if-local` targets into its exclusive
+        top-level queue before the TestRunner spawn selects a remote strategy.
+        The inner spawn is remote, but the shards still drain one at a time.
+        Opted-in tests therefore need a separately tagged wrapper with the same
+        transitioned executable and no exclusive tag. Local and hosted lanes
+        must keep selecting the original isolated wrapper.
+        """
+        self.assertIn("remote_parallel_ci = False", self.rules)
+        self.assertIn('name = name + "_ci_remote"', self.rules)
+        self.assertIn('"ci-remote-gpu"', self.rules)
+        self.assertIn('"no-local"', self.rules)
+        self.assertIn('"local-gpu-isolated"', self.rules)
+        self.assertIn(
+            "test --test_tag_filters=-ci-remote-gpu",
+            self.bazelrc,
+        )
+        remote_job = self.main_workflow.split("  linux-self-hosted:\n", 1)[1]
+        remote_job = remote_job.split("\n  macos:\n", 1)[0]
+        self.assertIn("--strategy=TestRunner=remote", remote_job)
+        self.assertIn("--remote_local_fallback=false", remote_job)
+        self.assertIn(
+            "--test_tag_filters=-manual,-perf,-local-gpu-isolated",
+            remote_job,
+        )
+        self.assertIn("--strategy=TestRunner=remote", self.coverage_workflow)
+        self.assertIn("--remote_local_fallback=false", self.coverage_workflow)
+        self.assertIn("-local-gpu-isolated", self.coverage_workflow)
 
     def test_variant_specs_cannot_pin_a_remote_execution_platform_property(self):
         """Variant specs must not carry `exec_properties`.

--- a/build_defs/geode_test_scheduling_tests.py
+++ b/build_defs/geode_test_scheduling_tests.py
@@ -72,6 +72,18 @@ class GeodeTestSchedulingTest(unittest.TestCase):
         self.assertIn("--strategy=TestRunner=remote", self.coverage_workflow)
         self.assertIn("--remote_local_fallback=false", self.coverage_workflow)
         self.assertIn("-local-gpu-isolated", self.coverage_workflow)
+        self.assertNotIn("mapfile -t TARGETS", remote_job)
+        self.assertNotIn("mapfile -t TARGETS", self.coverage_workflow)
+        self.assertIn(
+            'if ! mapped_targets="$(python3 tools/ci_remote_gpu_targets.py',
+            remote_job,
+        )
+        self.assertIn(
+            'if ! mapped_targets="$(python3 tools/ci_remote_gpu_targets.py',
+            self.coverage_workflow,
+        )
+        self.assertEqual(2, remote_job.count('if [[ -z "${'))
+        self.assertIn('if [[ -z "${mapped_targets// /}" ]]; then', self.coverage_workflow)
 
     def test_variant_specs_cannot_pin_a_remote_execution_platform_property(self):
         """Variant specs must not carry `exec_properties`.

--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -374,7 +374,13 @@ _donner_multi_transitioned_test = rule(
     } | _TRANSITIONED_TEST_COVERAGE_ATTRS,
 )
 
-def donner_multi_transitioned_test(name, dep, renderer_backend, opens_gpu_device = False, **kwargs):
+def donner_multi_transitioned_test(
+        name,
+        dep,
+        renderer_backend,
+        opens_gpu_device = False,
+        remote_parallel_ci = False,
+        **kwargs):
     """Create a transitioned test with an honest short-runtime default.
 
     Args:
@@ -390,14 +396,21 @@ def donner_multi_transitioned_test(name, dep, renderer_backend, opens_gpu_device
         parsing/ECS/CSS/text-shaping), and tagging those serialized every
         geode-configured target in the repo into a single-file queue at the
         end of the test phase.
+      remote_parallel_ci: Emit a second `no-local` wrapper for remote CI. The
+        ordinary wrapper keeps local device-loss isolation; the remote wrapper
+        shares its transitioned executable and test attributes but does not
+        enter Bazel's pre-spawn exclusive queue.
       **kwargs: Additional arguments for the underlying test rule.
     """
     if "size" not in kwargs and "timeout" not in kwargs:
         kwargs["size"] = "small"
     if renderer_backend == "geode" and opens_gpu_device:
         tags = kwargs.get("tags", [])
+        if remote_parallel_ci and "local-gpu-isolated" not in tags:
+            tags = tags + ["local-gpu-isolated"]
         if "exclusive-if-local" not in tags:
-            kwargs["tags"] = tags + ["exclusive-if-local"]
+            tags = tags + ["exclusive-if-local"]
+        kwargs["tags"] = tags
 
     _donner_multi_transitioned_test(
         name = name,
@@ -405,6 +418,21 @@ def donner_multi_transitioned_test(name, dep, renderer_backend, opens_gpu_device
         renderer_backend = renderer_backend,
         **kwargs
     )
+
+    if renderer_backend == "geode" and opens_gpu_device and remote_parallel_ci:
+        remote_kwargs = dict(kwargs)
+        remote_tags = [
+            tag
+            for tag in remote_kwargs.get("tags", [])
+            if tag not in ["exclusive-if-local", "local-gpu-isolated"]
+        ]
+        remote_kwargs["tags"] = remote_tags + ["ci-remote-gpu", "no-local"]
+        _donner_multi_transitioned_test(
+            name = name + "_ci_remote",
+            dep = dep,
+            renderer_backend = renderer_backend,
+            **remote_kwargs
+        )
 
 donner_multi_transitioned_binary = rule(
     implementation = _donner_transitioned_executable_impl,
@@ -430,7 +458,14 @@ donner_multi_transitioned_binary = rule(
     },
 )
 
-def donner_variant_cc_test(name, dep, variants = None, named_variants = None, opens_gpu_device = False, **kwargs):
+def donner_variant_cc_test(
+        name,
+        dep,
+        variants = None,
+        named_variants = None,
+        opens_gpu_device = False,
+        remote_parallel_ci = False,
+        **kwargs):
     """
     Generate test targets for variant configurations, plus a default alias
     that inherits the active command-line config.
@@ -447,6 +482,7 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, op
       variants: (legacy) List of variant axis lists.
       named_variants: List of dicts describing each variant explicitly.
       opens_gpu_device: Forwarded to donner_multi_transitioned_test; see there.
+      remote_parallel_ci: Forwarded to donner_multi_transitioned_test; see there.
       **kwargs: Additional arguments passed to the generated test rules.
 
     Generated targets:
@@ -474,6 +510,7 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, op
                 text = v.get("text", "false"),
                 text_full = v.get("text_full", "false"),
                 opens_gpu_device = opens_gpu_device,
+                remote_parallel_ci = remote_parallel_ci,
                 testonly = 1,
                 **variant_kwargs
             )
@@ -495,6 +532,7 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, op
                     text = text_val,
                     text_full = text_full_val,
                     opens_gpu_device = opens_gpu_device,
+                    remote_parallel_ci = remote_parallel_ci,
                     testonly = 1,
                     **kwargs
                 )
@@ -582,6 +620,7 @@ def donner_cc_test(
         tags = [],
         variants = None,
         opens_gpu_device = False,
+        remote_parallel_ci = False,
         **kwargs):
     """
     Create a cc_test with donner-specific defaults.
@@ -602,6 +641,8 @@ def donner_cc_test(
         device/adapter, so its geode-backed variants must be drained serially.
         Forwarded to donner_multi_transitioned_test; see there for why it is
         opt-in rather than implied by the geode backend.
+      remote_parallel_ci: Forwarded to donner_multi_transitioned_test for
+        opted-in Geode variants.
       **kwargs: Additional arguments, matching the implementation of cc_test.
     """
     if "size" not in kwargs and "timeout" not in kwargs:
@@ -642,6 +683,7 @@ def donner_cc_test(
                 dep = ":" + name,
                 renderer_backend = spec["backend"],
                 opens_gpu_device = opens_gpu_device,
+                remote_parallel_ci = remote_parallel_ci,
                 text = spec["text"],
                 text_full = spec["text_full"],
                 tags = tags + ["variant_" + variant_name],

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -1051,6 +1051,7 @@ donner_cc_test(
         "//:donner_splash.svg",
     ],
     opens_gpu_device = True,
+    remote_parallel_ci = True,
     # One shard per scenario caps the target at its slowest single replay.
     shard_count = 4,
     variants = ["geode"],

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -788,6 +788,7 @@ donner_variant_cc_test(
         },
     ],
     opens_gpu_device = True,
+    remote_parallel_ci = True,
     # Hundreds of independent image comparisons per variant. Unsharded, the
     # geode variant alone ran ~267 s on the self-hosted RE lane
     # (CI baseline, 2026-07-01) and sat on the test-step critical path. 8 shards

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -146,6 +146,15 @@ py_test(
 )
 
 py_test(
+    name = "ci_remote_gpu_targets_tests",
+    size = "small",
+    srcs = [
+        "ci_remote_gpu_targets.py",
+        "ci_remote_gpu_targets_tests.py",
+    ],
+)
+
+py_test(
     name = "ci_runtime_workflow_tests",
     size = "small",
     srcs = ["ci_runtime_workflow_tests.py"],

--- a/tools/ci_remote_gpu_targets.py
+++ b/tools/ci_remote_gpu_targets.py
@@ -29,8 +29,11 @@ def main():
     parser.add_argument("labels", nargs="*")
     parser.add_argument("--one-per-line", action="store_true")
     args = parser.parse_args()
+    selected = select_remote_targets(args.labels)
+    if not selected:
+        return
     separator = "\n" if args.one_per_line else " "
-    print(separator.join(select_remote_targets(args.labels)))
+    print(separator.join(selected))
 
 
 if __name__ == "__main__":

--- a/tools/ci_remote_gpu_targets.py
+++ b/tools/ci_remote_gpu_targets.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Select fail-closed remote wrappers for CI-parallel GPU test suites."""
+
+import argparse
+
+
+REMOTE_TARGETS = {
+    "//donner/editor/tests:rnr_replay_tests_geode":
+        "//donner/editor/tests:rnr_replay_tests_geode_ci_remote",
+    "//donner/svg/renderer/tests:resvg_test_suite_geode":
+        "//donner/svg/renderer/tests:resvg_test_suite_geode_ci_remote",
+}
+
+
+def select_remote_targets(labels):
+    """Replace opted-in local-isolation wrappers and preserve stable order."""
+    result = []
+    seen = set()
+    for label in labels:
+        selected = REMOTE_TARGETS.get(label, label)
+        if selected not in seen:
+            result.append(selected)
+            seen.add(selected)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("labels", nargs="*")
+    parser.add_argument("--one-per-line", action="store_true")
+    args = parser.parse_args()
+    separator = "\n" if args.one_per_line else " "
+    print(separator.join(select_remote_targets(args.labels)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_remote_gpu_targets_tests.py
+++ b/tools/ci_remote_gpu_targets_tests.py
@@ -1,0 +1,57 @@
+"""Tests for exact remote GPU wrapper selection."""
+
+import unittest
+
+from tools.ci_remote_gpu_targets import REMOTE_TARGETS, select_remote_targets
+
+
+class CiRemoteGpuTargetsTest(unittest.TestCase):
+    def test_mapping_is_limited_to_measured_sharded_suites(self):
+        self.assertEqual(
+            {
+                "//donner/editor/tests:rnr_replay_tests_geode":
+                    "//donner/editor/tests:rnr_replay_tests_geode_ci_remote",
+                "//donner/svg/renderer/tests:resvg_test_suite_geode":
+                    "//donner/svg/renderer/tests:resvg_test_suite_geode_ci_remote",
+            },
+            REMOTE_TARGETS,
+        )
+
+    def test_empty_selection_stays_empty(self):
+        self.assertEqual([], select_remote_targets([]))
+
+    def test_full_fallback_pattern_is_left_for_bazel_tag_selection(self):
+        self.assertEqual(["//..."], select_remote_targets(["//..."]))
+
+    def test_only_exact_opted_in_variants_are_replaced(self):
+        self.assertEqual(
+            [
+                "//donner/editor/tests:rnr_replay_tests_geode_ci_remote",
+                "//donner/editor/tests:rnr_replay_tests",
+                "//other:rnr_replay_tests_geode",
+            ],
+            select_remote_targets(
+                [
+                    "//donner/editor/tests:rnr_replay_tests_geode",
+                    "//donner/editor/tests:rnr_replay_tests",
+                    "//other:rnr_replay_tests_geode",
+                ]
+            ),
+        )
+
+    def test_already_expanded_targets_are_deduplicated(self):
+        remote = "//donner/svg/renderer/tests:resvg_test_suite_geode_ci_remote"
+        self.assertEqual(
+            [remote, "//tools:ci_runtime_workflow_tests"],
+            select_remote_targets(
+                [
+                    "//donner/svg/renderer/tests:resvg_test_suite_geode",
+                    remote,
+                    "//tools:ci_runtime_workflow_tests",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci_remote_gpu_targets_tests.py
+++ b/tools/ci_remote_gpu_targets_tests.py
@@ -1,5 +1,8 @@
 """Tests for exact remote GPU wrapper selection."""
 
+from pathlib import Path
+import subprocess
+import sys
 import unittest
 
 from tools.ci_remote_gpu_targets import REMOTE_TARGETS, select_remote_targets
@@ -20,8 +23,53 @@ class CiRemoteGpuTargetsTest(unittest.TestCase):
     def test_empty_selection_stays_empty(self):
         self.assertEqual([], select_remote_targets([]))
 
+    def test_empty_cli_selection_emits_no_array_element(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                Path(__file__).with_name("ci_remote_gpu_targets.py"),
+                "--one-per-line",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+
     def test_full_fallback_pattern_is_left_for_bazel_tag_selection(self):
         self.assertEqual(["//..."], select_remote_targets(["//..."]))
+
+    def test_invalid_cli_option_fails(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                Path(__file__).with_name("ci_remote_gpu_targets.py"),
+                "--invalid",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(0, result.returncode)
+
+    def test_nonempty_cli_selection_is_exact(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                Path(__file__).with_name("ci_remote_gpu_targets.py"),
+                "//donner/editor/tests:rnr_replay_tests_geode",
+                "//other:test",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            "//donner/editor/tests:rnr_replay_tests_geode_ci_remote //other:test\n",
+            result.stdout,
+        )
 
     def test_only_exact_opted_in_variants_are_replaced(self):
         self.assertEqual(

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -164,7 +164,7 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         )
         self.assertIsNotNone(match)
         self.assertEqual(
-            {"-fuzz_target", "-lint", "-manual", "-perf"},
+            {"-fuzz_target", "-lint", "-manual", "-perf", "-ci-remote-gpu"},
             set(match.group(1).split(",")),
         )
         query_match = re.search(


### PR DESCRIPTION
Remote CI now runs the sharded Geode replay and resvg suites through fail-closed remote-only wrappers, allowing their shards to overlap while preserving serial GPU-device isolation for local, hosted, and macOS execution.

Bazel 8.7 partitions `exclusive-if-local` tests into an exclusive top-level queue before the `TestRunner` spawn chooses its execution strategy. The affected CI actions were already remote, so pinning `TestRunner=remote` alone could not remove the serial queue. Each opted-in suite now has a `no-local` CI wrapper over the same transitioned test implementation and shard count. Exact target mapping and complementary tag filters select one wrapper per suite in remote Linux test and coverage lanes; mapper failures or empty mapped selections stop before Bazel runs. Ordinary routes continue selecting the original wrapper.

This changes scheduling only. It does not claim to fix remote input-fetch latency; it prevents that per-action latency from accumulating serially across these shards.

## Validation

- Preserved a red contract commit before the implementation commit.
- Passed the focused workflow, coverage-routing, tag-selection, target-mapping, and security-policy test set (10 targets).
- Verified by query that the original and CI wrappers share their dep, backend/text transition, args, size/timeout, and shard count.
- Verified by aquery that all 4 replay and 16 resvg CI TestRunner actions carry `no-local`.
- Compared uncached remote replay actions at the same source/configuration: maximum overlap increased from 1 to 4 and the TestRunner block fell from 8.458 s to 4.913 s.
- `tools/lint.sh` (1,435 files) and `python3 tools/cmake/gen_cmakelists.py --check` pass.
