### PR TITLE
Skip coverage admission for documentation-only changes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,11 @@ name: Coverage
 # the reason resolves to a FULL //... target set: running that on a PR is exactly
 # the 21-min re-run we are eliminating, so the PR coverage jobs SKIP instead --
 # the main-push baseline already covers those lines. Only the affected subset
-# (fallback_reason == bazel_diff), the cheap smoke subset (coverage_smoke), and
-# the explicit ci:full-test opt-in still produce PR coverage.
+# (fallback_reason == bazel_diff), the cheap smoke subset for coverage/reporting
+# tooling changes (coverage_smoke), and the explicit ci:full-test opt-in still
+# produce PR coverage. A documentation-only PR uses the established
+# no-instrumentable route because no changed file can contribute executable
+# lines to an LCOV report.
 #
 # Two more skips, both about a genuine incremental subset that has nothing a
 # coverage run could measure. Running anyway builds an empty or absent LCOV
@@ -37,16 +40,19 @@ name: Coverage
 #     target_compatible_with a platform this lane does not run, which
 #     `coverage --skip_incompatible_explicit_targets` silently drops.
 #
-# Both are decided from Bazel's own answers (target KINDS from a query, host
-# compatibility from a cquery), never from file extensions, and both fail
+# Documentation-only changes are identified before graph analysis from the
+# repository's docs tree and Markdown files. Mixed documentation/tooling
+# changes retain smoke coverage, and any source change proceeds to bazel-diff.
+# Every other no-test/no-instrumentable decision comes from Bazel's own answers
+# (target KINDS from a query, host compatibility from a cquery) and fails
 # closed: any query, filtering, or classifier error runs coverage with the
-# guard intact. The instrumentability decision is taken exactly once, on the
-# FINAL target list after every narrowing step, because three separate
-# production failures came from guards that each judged a different,
+# guard intact. The graph-based instrumentability decision is taken exactly
+# once, on the FINAL target list after every narrowing step, because three
+# separate production failures came from guards that each judged a different,
 # wider set than the one coverage actually ran; see the block in
 # determine-targets for that history. Future readers: do not silently re-add a
-# full instrumented PR coverage run, and do not add a fourth guard at a fourth
-# pipeline stage -- extend the single decision instead.
+# full instrumented PR coverage run, and do not add a fourth graph guard at a
+# fourth pipeline stage -- extend the single decision instead.
 on:
   push:
     branches: [main]
@@ -359,6 +365,7 @@ jobs:
 
           should_fallback=false
           fallback_reason=""
+          docs_only=true
           smoke_only=true
           while IFS= read -r path; do
             [[ -z "$path" ]] && continue
@@ -393,6 +400,14 @@ jobs:
             esac
 
             case "$path" in
+              docs/*|*.md)
+                ;;
+              *)
+                docs_only=false
+                ;;
+            esac
+
+            case "$path" in
               .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py|tools/coverage_variant_trim.py|tools/coverage_variant_trim_tests.py|tools/coverage_selection_decision_tests.py)
                 ;;
               *)
@@ -403,6 +418,12 @@ jobs:
 
           if [[ "$should_fallback" == "true" ]]; then
             emit_targets true "$fallback_reason" "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if [[ "$docs_only" == "true" ]]; then
+            echo "Documentation-only change; skipping coverage because no changed file is instrumentable."
+            emit_targets true no_instrumentable_targets ""
             exit 0
           fi
 

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -15,7 +15,10 @@ These tests hold the routing to one shape:
     justified list.
 """
 
+import os
 import re
+import subprocess
+import textwrap
 import unittest
 
 from python.runfiles import runfiles
@@ -153,6 +156,52 @@ class CoverageLaneRoutingTest(unittest.TestCase):
         rest = self.text.split(marker, 1)[1]
         end = re.search(r"^  [A-Za-z0-9_-]+:\s*$", rest, re.MULTILINE)
         return rest[: end.start()] if end else rest
+
+    def _classify_changed_files(self, *paths):
+        """Execute the workflow's early changed-file routing verbatim."""
+        start = self.text.index("          should_fallback=false\n")
+        end = self.text.index('          work_dir="$(mktemp -d)"', start)
+        fragment = textwrap.dedent(self.text[start:end])
+        harness = textwrap.dedent(
+            """
+            set -euo pipefail
+            SMOKE_COVERAGE_TARGETS="//donner/base/..."
+            changed_files="$CHANGED_FILES"
+            emit_targets() {
+              printf '%s|%s|%s\n' "$1" "$2" "$3"
+            }
+            """
+        )
+        result = subprocess.run(
+            ["bash", "-c", harness + fragment + '\nprintf "affected\\n"\n'],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CHANGED_FILES": "\n".join(paths)},
+        )
+        return result.stdout.strip().splitlines()[-1]
+
+    def test_docs_only_changes_skip_smoke_coverage_admission(self):
+        self.assertEqual(
+            "true|no_instrumentable_targets|",
+            self._classify_changed_files("docs/design_docs/0053-native_gpu_hal.md"),
+        )
+
+    def test_docs_plus_coverage_tooling_retains_smoke_coverage(self):
+        self.assertEqual(
+            "true|coverage_smoke|//donner/base/...",
+            self._classify_changed_files(
+                "docs/design_docs/0053-native_gpu_hal.md", "tools/coverage.sh"
+            ),
+        )
+
+    def test_markdown_plus_source_reaches_affected_target_analysis(self):
+        self.assertEqual(
+            "affected",
+            self._classify_changed_files(
+                "docs/design_docs/0053-native_gpu_hal.md", "donner/base/MathUtils.cc"
+            ),
+        )
 
     def test_every_coverage_job_gates_on_runs_coverage(self):
         """All three lanes, including the hosted one.

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -162,7 +162,7 @@ class CoverageLaneRoutingTest(unittest.TestCase):
         start = self.text.index("          should_fallback=false\n")
         end = self.text.index('          work_dir="$(mktemp -d)"', start)
         fragment = textwrap.dedent(self.text[start:end])
-        harness = textwrap.dedent(
+        shell_prefix = textwrap.dedent(
             """
             set -euo pipefail
             SMOKE_COVERAGE_TARGETS="//donner/base/..."
@@ -173,7 +173,7 @@ class CoverageLaneRoutingTest(unittest.TestCase):
             """
         )
         result = subprocess.run(
-            ["bash", "-c", harness + fragment + '\nprintf "affected\\n"\n'],
+            ["bash", "-c", shell_prefix + fragment + '\nprintf "affected\\n"\n'],
             check=True,
             capture_output=True,
             text=True,
@@ -182,25 +182,23 @@ class CoverageLaneRoutingTest(unittest.TestCase):
         return result.stdout.strip().splitlines()[-1]
 
     def test_docs_only_changes_skip_smoke_coverage_admission(self):
-        self.assertEqual(
-            "true|no_instrumentable_targets|",
-            self._classify_changed_files("docs/design_docs/0053-native_gpu_hal.md"),
-        )
+        for path in ("docs/guide.md", "README.md", "AGENTS.md"):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    "true|no_instrumentable_targets|",
+                    self._classify_changed_files(path),
+                )
 
     def test_docs_plus_coverage_tooling_retains_smoke_coverage(self):
         self.assertEqual(
             "true|coverage_smoke|//donner/base/...",
-            self._classify_changed_files(
-                "docs/design_docs/0053-native_gpu_hal.md", "tools/coverage.sh"
-            ),
+            self._classify_changed_files("docs/guide.md", "tools/coverage.sh"),
         )
 
     def test_markdown_plus_source_reaches_affected_target_analysis(self):
         self.assertEqual(
             "affected",
-            self._classify_changed_files(
-                "docs/design_docs/0053-native_gpu_hal.md", "donner/base/MathUtils.cc"
-            ),
+            self._classify_changed_files("README.md", "donner/base/MathUtils.cc"),
         )
 
     def test_every_coverage_job_gates_on_runs_coverage(self):


### PR DESCRIPTION
Documentation-only pull requests now complete coverage target determination without reserving a coverage runner for a smoke target that cannot measure any changed line.

- Route changes containing only `docs/*` and Markdown files through the existing no-instrumentable coverage decision.
- Keep smoke coverage for mixed documentation and coverage/reporting tooling changes.
- Keep bazel-diff affected-target analysis for any mixed product source change.
- Execute the workflow's own routing block in regression tests so the emitted reason, target set, and job-admission decision stay coupled.

Validation:

- `//tools:coverage_lane_routing_tests`
- `actionlint .github/workflows/coverage.yml`
- `tools/lint.sh`

Full repository qualification follows these affected gates.
