### PR TITLE
Guard canvas initialization before the first frame

### DIFF
--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -99,3 +99,37 @@ playwright_bin.playwright_test(
         "@platforms//os:macos",
     ],
 )
+
+playwright_bin.playwright_test(
+    name = "boot_presentation_test",
+    size = "large",
+    timeout = "moderate",
+    args = [
+        "test",
+        "$(rootpath :boot-presentation.spec.ts)",
+        "--config=$(rootpath :playwright.boot-presentation.bazel.config.js)",
+    ],
+    copy_data_to_bin = False,
+    data = [
+        "boot-presentation.spec.ts",
+        "package.json",
+        "playwright.bazel.config.js",
+        "playwright.boot-presentation.bazel.config.js",
+        "playwright.config.js",
+        "remote-webserver.mjs",
+        ":node_modules/@playwright/test",
+        "//donner/editor/wasm:_wasm_web_package_for_serve",
+        "@playwright//:chromium",
+    ],
+    env = {
+        "CI": "1",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
+        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+        "NODE_OPTIONS": "",
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
+)

--- a/donner/editor/wasm/tests/boot-presentation.spec.ts
+++ b/donner/editor/wasm/tests/boot-presentation.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+
+const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
+
+type BootSample = {
+  firstFrame: boolean;
+  covered: boolean;
+  canvasCount: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  expectedWidth: number;
+  expectedHeight: number;
+};
+type BootWindow = Window & {
+  __donnerFirstFramePresented?: boolean;
+  __bootPresentationProbe: { running: boolean; samples: BootSample[] };
+};
+
+test("delayed startup never exposes an unconfigured canvas", async ({ page }, testInfo) => {
+  test.setTimeout(60000);
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  let releaseStartup!: () => void;
+  const startupGate = new Promise<void>((resolve) => {
+    releaseStartup = resolve;
+  });
+  await page.route("**/editor.js", async (route) => {
+    await startupGate;
+    await route.continue();
+  });
+  await page.addInitScript(() => {
+    const state = window as BootWindow;
+    state.__bootPresentationProbe = { running: true, samples: [] };
+    const sample = () => {
+      if (!state.__bootPresentationProbe.running) return;
+      const canvas = document.querySelector("canvas");
+      const loader = document.getElementById("loading-screen");
+      if (canvas && loader) {
+        const style = getComputedStyle(loader);
+        const bounds = loader.getBoundingClientRect();
+        state.__bootPresentationProbe.samples.push({
+          firstFrame: state.__donnerFirstFramePresented === true,
+          covered: !loader.hidden && style.display !== "none" && style.visibility === "visible"
+            && Number(style.opacity) === 1 && bounds.left <= 0 && bounds.top <= 0
+            && bounds.right >= innerWidth && bounds.bottom >= innerHeight,
+          canvasCount: document.querySelectorAll("canvas").length,
+          width: canvas.width,
+          height: canvas.height,
+          viewportWidth: innerWidth,
+          viewportHeight: innerHeight,
+          expectedWidth: Math.max(1, Math.floor(innerWidth * devicePixelRatio)),
+          expectedHeight: Math.max(1, Math.floor(innerHeight * devicePixelRatio)),
+        });
+      }
+      requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+
+  try {
+    try {
+      await page.goto(`${baseUrl}/index.html`, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("#loading-screen")).toBeVisible();
+      await expect(page.locator("canvas")).toHaveCount(1);
+      await page.setViewportSize({ width: 1390, height: 1121 });
+      await expect.poll(() =>
+        page.evaluate(() =>
+          (window as BootWindow).__bootPresentationProbe.samples.filter((sample) =>
+            sample.viewportWidth === 1390 && sample.viewportHeight === 1121
+          ).length
+        )
+      ).toBeGreaterThanOrEqual(5);
+      expect(await page.evaluate(() => (window as BootWindow).__donnerFirstFramePresented === true))
+        .toBe(false);
+    } finally {
+      releaseStartup();
+    }
+
+    await expect(page.locator("#loading-screen")).toBeHidden({ timeout: 45000 });
+    await page.evaluate(() =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+    );
+    const samples = await page.evaluate(() =>
+      (window as BootWindow).__bootPresentationProbe.samples
+    );
+    expect(samples.some((sample) => !sample.firstFrame && sample.covered)).toBe(true);
+    expect(samples.some((sample) => !sample.covered)).toBe(true);
+    expect(samples.filter((sample) => sample.canvasCount !== 1)).toEqual([]);
+    expect(samples.filter((sample) =>
+      !sample.covered && (
+        !sample.firstFrame || sample.width !== sample.expectedWidth
+        || sample.height !== sample.expectedHeight
+      )
+    )).toEqual([]);
+    expect(errors).toEqual([]);
+  } finally {
+    releaseStartup();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const diagnostics = await Promise.race([
+      page.evaluate(() => {
+        const probe = (window as BootWindow).__bootPresentationProbe;
+        if (probe) probe.running = false;
+        return {
+          samples: probe?.samples ?? [],
+          loader: document.getElementById("loading-screen")?.outerHTML,
+          canvas: document.querySelector("canvas")?.outerHTML,
+        };
+      }).catch((error) => ({ error: String(error) })),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve({ error: "diagnostic capture timed out" }), 5000);
+      }),
+    ]).finally(() => clearTimeout(timer));
+    await testInfo.attach("boot-presentation-samples", {
+      body: JSON.stringify({ diagnostics, errors }, null, 2),
+      contentType: "application/json",
+    });
+  }
+});

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -96,10 +96,10 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   // runfiles tree that is missing them.
   const lanes = [...buildFile.matchAll(/playwright_bin\.playwright_test\(([\s\S]*?)\n\)\n/g)]
     .map(([, body]) => body);
-  assert.equal(
-    lanes.length,
-    2,
-    "every playwright_test lane must be checkable; update this contract when one is added",
+  assert.deepEqual(
+    lanes.map((lane) => /name = "([^"]+)"/.exec(lane)?.[1]).sort(),
+    ["boot_presentation_test", "browser_presentation_regression_test", "chromium_remote_smoke"],
+    "every playwright_test lane must be named and checked; update this contract when one is added",
   );
   for (const lane of lanes) {
     const laneName = /name = "([^"]+)"/.exec(lane)?.[1];

--- a/donner/editor/wasm/tests/playwright.boot-presentation.bazel.config.js
+++ b/donner/editor/wasm/tests/playwright.boot-presentation.bazel.config.js
@@ -1,0 +1,14 @@
+const baseConfig = require("./playwright.bazel.config.js");
+
+module.exports = {
+  ...baseConfig,
+  globalTimeout: 75000,
+  timeout: 60000,
+  use: {
+    ...baseConfig.use,
+    launchOptions: {
+      ...baseConfig.use.launchOptions,
+      timeout: 15000,
+    },
+  },
+};


### PR DESCRIPTION
Guard the single-canvas startup fix from #923 with a delayed-initialization browser regression. The test resizes the viewport before releasing startup, then verifies the loading surface covers unconfigured frames and the exposed canvas backing matches the viewport and device scale.

Browser launch and suite deadlines are bounded, and failures retain the sampled startup state. This checks startup ordering and canvas configuration; it complements the existing rendered-pixel smoke coverage.

Validation: the dedicated browser test passes, and the full Bazel suite passes all 498 applicable targets with 34 existing configuration exclusions. All 35 selector-contract checks, formatting, and independent review pass.

Closes #926.
