### PR TITLE
Keep WebGPU readbacks responsive in Firefox

### DIFF
--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@npm//donner/editor/wasm/tests:@playwright/test/package_json.bzl", playwright_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//donner/editor/wasm/tests:@playwright/test/package_json.bzl", playwright_bin = "bin")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -94,6 +94,45 @@ playwright_bin.playwright_test(
         "NODE_OPTIONS": "",
         "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
     },
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
+)
+
+playwright_bin.playwright_test(
+    name = "browser_responsiveness_perf_test",
+    size = "large",
+    timeout = "long",
+    args = [
+        "test",
+        "$(rootpath :browser-responsiveness.perf.ts)",
+        "--config=$(rootpath :playwright.responsiveness.bazel.config.js)",
+    ],
+    copy_data_to_bin = False,
+    data = [
+        "browser-responsiveness.perf.ts",
+        "package.json",
+        "playwright.bazel.config.js",
+        "playwright.config.js",
+        "playwright.responsiveness.bazel.config.js",
+        "remote-webserver.mjs",
+        ":node_modules/@playwright/test",
+        "//donner/editor/wasm:_wasm_web_package_for_serve",
+        "@playwright//:chromium",
+        "@playwright//:firefox",
+    ],
+    env = {
+        "CI": "1",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
+        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+        "NODE_OPTIONS": "",
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+    },
+    tags = [
+        "manual",
+        "perf",
+    ],
     target_compatible_with = [
         "@platforms//cpu:aarch64",
         "@platforms//os:macos",

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -55,7 +55,7 @@ test("Playwright version stays synchronized across package locks and browser met
   );
 });
 
-test("Bazel owns a hermetic no-window Chromium browser lane", () => {
+test("Bazel owns hermetic browser regression and manual performance lanes", () => {
   const moduleFile = readFileSync(path.join(repositoryRoot, "MODULE.bazel"), "utf8");
   assert.match(
     moduleFile,
@@ -98,14 +98,36 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
     .map(([, body]) => body);
   assert.deepEqual(
     lanes.map((lane) => /name = "([^"]+)"/.exec(lane)?.[1]).sort(),
-    ["boot_presentation_test", "browser_presentation_regression_test", "chromium_remote_smoke"],
+    [
+      "boot_presentation_test",
+      "browser_presentation_regression_test",
+      "browser_responsiveness_perf_test",
+      "chromium_remote_smoke",
+    ],
     "every playwright_test lane must be named and checked; update this contract when one is added",
   );
   for (const lane of lanes) {
     const laneName = /name = "([^"]+)"/.exec(lane)?.[1];
     assert.ok(laneName, "every browser lane must be named");
-    const specFile = /\$\(rootpath :([^)]+\.spec\.ts)\)/.exec(lane)?.[1];
+    const performanceLane = laneName === "browser_responsiveness_perf_test";
+    const tags = [...(/tags = \[([\s\S]*?)\]/.exec(lane)?.[1] ?? "").matchAll(/"([^"]+)"/g)]
+      .map(([, tag]) => tag);
+    if (performanceLane) {
+      assert.deepEqual(tags.sort(), ["manual", "perf"], "responsiveness timing must remain opt-in");
+      assert.match(lane, /--config=\$\(rootpath :playwright\.responsiveness\.bazel\.config\.js\)/);
+      assert.ok(lane.includes("\"playwright.responsiveness.bazel.config.js\""));
+    } else {
+      assert.ok(
+        !tags.includes("manual") && !tags.includes("perf"),
+        `${laneName} must remain a regression gate`,
+      );
+    }
+    const specPattern = performanceLane
+      ? /\$\(rootpath :([^)]+\.perf\.ts)\)/
+      : /\$\(rootpath :([^)]+\.spec\.ts)\)/;
+    const specFile = specPattern.exec(lane)?.[1];
     assert.ok(specFile, `${laneName} must run a named spec`);
+    if (performanceLane) assert.equal(specFile, "browser-responsiveness.perf.ts");
     assert.ok(
       lane.includes(`"${specFile}"`),
       `${laneName} must list ${specFile} in its data`,
@@ -138,7 +160,7 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
     assert.match(
       lane,
       /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?"@platforms\/\/os:macos"[\s\S]*?\]/,
-      "every headless browser lane must allow only macOS ARM64 execution",
+      "every browser lane must allow only macOS ARM64 execution",
     );
   }
   // Linux is excluded deliberately, not by omission: headless Chromium there

--- a/donner/editor/wasm/tests/browser-responsiveness.perf.ts
+++ b/donner/editor/wasm/tests/browser-responsiveness.perf.ts
@@ -242,6 +242,10 @@ test(
           }).toEqual(
             expect.objectContaining({ pending: false, active: false, resultReady: false }),
           );
+          await expect.poll(async () => (await snapshot(page)).layerThumbnails?.deferredCount, {
+            timeout: 15000,
+            message: "warm input must start after layer previews settle",
+          }).toBe(0);
         }
         const before = await snapshot(page);
         const latencies: number[] = [];

--- a/donner/editor/wasm/tests/browser-responsiveness.perf.ts
+++ b/donner/editor/wasm/tests/browser-responsiveness.perf.ts
@@ -205,7 +205,7 @@ test(
       await expect(canvas).toHaveAttribute("data-active-sample-id", "donner-splash");
       await expect.poll(async () => {
         const state = await snapshot(page);
-        return state.worker?.completedResults! > (beforeSample.worker?.completedResults ?? 0)
+        return (state.worker?.completedResults ?? 0) > (beforeSample.worker?.completedResults ?? 0)
           && state.worker?.presentedAtMs !== undefined;
       }, { timeout: 20000, message: "the clicked sample must reach a presenting frame" }).toBe(
         true,

--- a/donner/editor/wasm/tests/browser-responsiveness.perf.ts
+++ b/donner/editor/wasm/tests/browser-responsiveness.perf.ts
@@ -7,6 +7,7 @@ interface Diagnostics extends Window {
     renderedFrames: number;
     uiFrameMsSamples: number[];
     lastFrameAtMs: number;
+    phaseTotalsMs?: Record<string, number>;
   };
   __donnerHostFrameTiming?: { frames: number; sums: Record<string, number> };
   __donnerAsyncifySuspendStats?: {
@@ -43,6 +44,12 @@ interface Diagnostics extends Window {
     [name: string]: unknown;
   };
   __donnerSampleThumbnailStats?: { pending: boolean; active: boolean; resultReady: boolean };
+  __donnerLayerThumbnailStats?: {
+    rowCount: number;
+    renderedCount: number;
+    deferredCount: number;
+    snapshotRebuildCount: number;
+  };
   __donnerFrameTickStats?: unknown;
   __donnerMemoryStats?: unknown;
   __donnerImGuiDrawStats?: unknown;
@@ -61,6 +68,7 @@ async function snapshot(page: Page, detailed = false) {
       viewport: state.__donnerViewportStats,
       worker: state.__donnerWorkerStats,
       thumbnails: state.__donnerSampleThumbnailStats,
+      layerThumbnails: state.__donnerLayerThumbnailStats,
       ticks: state.__donnerFrameTickStats,
       memory: detailed ? state.__donnerMemoryStats : undefined,
       draw: state.__donnerImGuiDrawStats,
@@ -90,6 +98,13 @@ function phaseReport(before: Snapshot, after: Snapshot, inputToFrameMs: number[]
     uiFrameMs: distribution(
       after.frameLoop?.uiFrameMsSamples.slice(before.frameLoop?.uiFrameMsSamples.length ?? 0) ?? [],
     ),
+    uiPhaseMeanMs: Object.fromEntries(
+      Object.entries(after.frameLoop?.phaseTotalsMs ?? {}).map(([name, total]) => [
+        name,
+        (total - (before.frameLoop?.phaseTotalsMs?.[name] ?? 0)) / Math.max(frames, 1),
+      ]),
+    ),
+    layerThumbnails: after.layerThumbnails,
     hostMeanMs: Object.fromEntries(
       Object.entries(after.host?.sums ?? {}).map(([name, total]) => [
         name,

--- a/donner/editor/wasm/tests/browser-responsiveness.perf.ts
+++ b/donner/editor/wasm/tests/browser-responsiveness.perf.ts
@@ -1,0 +1,297 @@
+import { expect, type Page, test } from "@playwright/test";
+
+interface Diagnostics extends Window {
+  __donnerBackend?: string;
+  __donnerFirstFramePresented?: boolean;
+  __donnerFrameLoopStats?: {
+    renderedFrames: number;
+    uiFrameMsSamples: number[];
+    lastFrameAtMs: number;
+  };
+  __donnerHostFrameTiming?: { frames: number; sums: Record<string, number> };
+  __donnerAsyncifySuspendStats?: {
+    frames: number;
+    suspends: number;
+    totalMs: number;
+    tileYieldMs: number;
+    gpuReadbackMs: number;
+    deviceWaitMs: number;
+    startupMs: number;
+  };
+  __donnerInteractionStats?: {
+    pointerX: number;
+    pointerY: number;
+    pendingClick: boolean;
+    workerBusy: boolean;
+  };
+  __donnerViewportStats?: {
+    paneX: number;
+    paneY: number;
+    paneWidth: number;
+    paneHeight: number;
+    zoom: number;
+  };
+  __donnerWorkerStats?: {
+    completedResults: number;
+    publishedAtMs: number;
+    presentedAtMs?: number;
+    workerMs: number;
+    queueWaitMs: number;
+    dequeueToStartMs: number;
+    pollDelayMs: number;
+    deviceLost: boolean;
+    [name: string]: unknown;
+  };
+  __donnerSampleThumbnailStats?: { pending: boolean; active: boolean; resultReady: boolean };
+  __donnerFrameTickStats?: unknown;
+  __donnerMemoryStats?: unknown;
+  __donnerImGuiDrawStats?: unknown;
+  __donnerResponsivenessInput?: { type: string; atMs: number; x: number; y: number };
+}
+
+async function snapshot(page: Page, detailed = false) {
+  return page.evaluate((detailed) => {
+    const state = window as Diagnostics;
+    return {
+      backend: state.__donnerBackend,
+      frameLoop: state.__donnerFrameLoopStats,
+      host: state.__donnerHostFrameTiming,
+      suspend: state.__donnerAsyncifySuspendStats,
+      interaction: state.__donnerInteractionStats,
+      viewport: state.__donnerViewportStats,
+      worker: state.__donnerWorkerStats,
+      thumbnails: state.__donnerSampleThumbnailStats,
+      ticks: state.__donnerFrameTickStats,
+      memory: detailed ? state.__donnerMemoryStats : undefined,
+      draw: state.__donnerImGuiDrawStats,
+      input: state.__donnerResponsivenessInput,
+    };
+  }, detailed);
+}
+
+type Snapshot = Awaited<ReturnType<typeof snapshot>>;
+
+function distribution(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const percentile = (fraction: number) =>
+    sorted[
+      Math.min(
+        sorted.length - 1,
+        Math.floor(sorted.length * fraction),
+      )
+    ] ?? null;
+  return { count: sorted.length, p50: percentile(0.5), p95: percentile(0.95), max: sorted.at(-1) };
+}
+
+function phaseReport(before: Snapshot, after: Snapshot, inputToFrameMs: number[]) {
+  const frames = (after.host?.frames ?? 0) - (before.host?.frames ?? 0);
+  return {
+    inputToFrameMs: distribution(inputToFrameMs),
+    uiFrameMs: distribution(
+      after.frameLoop?.uiFrameMsSamples.slice(before.frameLoop?.uiFrameMsSamples.length ?? 0) ?? [],
+    ),
+    hostMeanMs: Object.fromEntries(
+      Object.entries(after.host?.sums ?? {}).map(([name, total]) => [
+        name,
+        (total - (before.host?.sums[name] ?? 0)) / Math.max(frames, 1),
+      ]),
+    ),
+    suspendDelta: Object.fromEntries(
+      ([
+        "frames",
+        "suspends",
+        "totalMs",
+        "tileYieldMs",
+        "gpuReadbackMs",
+        "deviceWaitMs",
+        "startupMs",
+      ] as const).flatMap((name) => {
+        const total = after.suspend?.[name];
+        return typeof total === "number" ? [[name, total - (before.suspend?.[name] ?? 0)]] : [];
+      }),
+    ),
+    frames,
+    workerResults: (after.worker?.completedResults ?? 0) - (before.worker?.completedResults ?? 0),
+    lastWorker: after.worker,
+    ticks: after.ticks,
+  };
+}
+
+async function waitForIdle(page: Page) {
+  await expect.poll(async () => (await snapshot(page)).interaction, {
+    message: "the editor must consume pending input and finish its foreground render",
+    timeout: 15000,
+  }).toEqual(expect.objectContaining({ pendingClick: false, workerBusy: false }));
+}
+
+// This manual lane measures production frame telemetry. Pixel reads, screenshots and traces
+// serialize the GPU in Firefox and must stay outside the measured interaction windows.
+test(
+  "reports input-to-frame latency with matching raster load",
+  async ({ page, browser }, info) => {
+    const failures: string[] = [];
+    page.on("pageerror", (error) => failures.push(error.message));
+    page.on("console", (message) => {
+      if (/Aborted|RuntimeError|UTILS_RELEASE_ASSERT|device lost/i.test(message.text())) {
+        failures.push(message.text());
+      }
+    });
+    await page.addInitScript(() => {
+      for (const type of ["mousemove", "mousedown", "wheel"]) {
+        window.addEventListener(type, (event) => {
+          const pointer = event as MouseEvent;
+          (window as Diagnostics).__donnerResponsivenessInput = {
+            type,
+            atMs: performance.now(),
+            x: pointer.clientX,
+            y: pointer.clientY,
+          };
+        }, { capture: true, passive: true });
+      }
+    });
+    const report: Record<string, unknown> = {
+      browser: info.project.name,
+      version: browser.version(),
+      headless: info.project.use.headless,
+    };
+    try {
+      await page.goto(process.env.DONNER_WASM_BASE_URL!, { waitUntil: "domcontentloaded" });
+      await expect.poll(
+        () => page.evaluate(() => (window as Diagnostics).__donnerFirstFramePresented),
+        {
+          timeout: 30000,
+          message: "WebGPU must present the production editor before timing interactions",
+        },
+      ).toBe(true);
+      const raster = await page.evaluate(() => {
+        const canvas = document.querySelector<HTMLCanvasElement>("canvas#canvas")!;
+        return {
+          dpr: devicePixelRatio,
+          backingWidth: canvas.width,
+          backingHeight: canvas.height,
+          cssWidth: canvas.clientWidth,
+          cssHeight: canvas.clientHeight,
+        };
+      });
+      report.raster = raster;
+      console.log(`responsiveness raster ${info.project.name} ${JSON.stringify(raster)}`);
+      expect(raster).toEqual({
+        dpr: 2,
+        backingWidth: 2560,
+        backingHeight: 1800,
+        cssWidth: 1280,
+        cssHeight: 900,
+      });
+      const beforeSample = await snapshot(page);
+      const canvas = page.locator("canvas#canvas");
+      const bounds = await canvas.boundingBox();
+      expect(bounds).not.toBeNull();
+      await page.mouse.click(bounds!.x + bounds!.width * 0.24, bounds!.y + 282);
+      await expect(canvas).toHaveAttribute("data-active-sample-id", "donner-splash");
+      await expect.poll(async () => {
+        const state = await snapshot(page);
+        return state.worker?.completedResults! > (beforeSample.worker?.completedResults ?? 0)
+          && state.worker?.presentedAtMs !== undefined;
+      }, { timeout: 20000, message: "the clicked sample must reach a presenting frame" }).toBe(
+        true,
+      );
+      const loaded = await snapshot(page);
+      const worker = loaded.worker!;
+      const inputAtMs = loaded.input!.atMs;
+      report.sample = {
+        ...phaseReport(beforeSample, loaded, [worker.presentedAtMs! - inputAtMs]),
+        workerQueueMs: worker.queueWaitMs,
+        dequeueToStartMs: worker.dequeueToStartMs,
+        workerMs: worker.workerMs,
+        completionToPollMs: worker.pollDelayMs,
+        pollToFrameMs: worker.presentedAtMs! - worker.publishedAtMs,
+      };
+      await waitForIdle(page);
+      const viewport = (await snapshot(page)).viewport!;
+      const center = {
+        x: Math.round(viewport.paneX + viewport.paneWidth * 0.5),
+        y: Math.round(viewport.paneY + viewport.paneHeight * 0.5),
+      };
+      for (
+        const { phase, kind } of [
+          { phase: "cold-pointer", kind: "pointer" },
+          { phase: "cold-zoom", kind: "zoom" },
+          { phase: "warm-pointer", kind: "pointer" },
+          { phase: "warm-zoom", kind: "zoom" },
+        ] as const
+      ) {
+        if (phase.startsWith("warm-")) {
+          await expect.poll(async () => (await snapshot(page)).thumbnails, {
+            timeout: 15000,
+            message: "warm input must start after thumbnail work settles",
+          }).toEqual(
+            expect.objectContaining({ pending: false, active: false, resultReady: false }),
+          );
+        }
+        const before = await snapshot(page);
+        const latencies: number[] = [];
+        for (let step = 0; step < 12; ++step) {
+          const prior = await snapshot(page);
+          const point = { x: center.x + step * 3, y: center.y + step * 2 };
+          if (kind === "pointer") {
+            await page.mouse.move(point.x, point.y);
+          } else {
+            await page.evaluate(({ x, y, deltaY }) => {
+              document.querySelector("canvas#canvas")!.dispatchEvent(
+                new WheelEvent("wheel", {
+                  bubbles: true,
+                  cancelable: true,
+                  clientX: x,
+                  clientY: y,
+                  ctrlKey: true,
+                  deltaMode: 0,
+                  deltaY,
+                }),
+              );
+            }, { ...center, deltaY: step % 2 === 0 ? -42 : 42 });
+          }
+          let presented: Snapshot | undefined;
+          await expect.poll(async () => {
+            const current = await snapshot(page);
+            const changed = kind === "pointer"
+              ? current.interaction?.pointerX === point.x
+                && current.interaction?.pointerY === point.y
+              : current.viewport?.zoom !== prior.viewport?.zoom;
+            const ready = changed
+              && (current.frameLoop?.renderedFrames ?? 0) > (prior.frameLoop?.renderedFrames ?? 0)
+              && (current.frameLoop?.lastFrameAtMs ?? 0) >= (current.input?.atMs ?? Infinity);
+            if (ready) presented = current;
+            return ready;
+          }, {
+            timeout: 10000,
+            intervals: [8, 16, 32],
+            message: `${phase} step ${step} must present`,
+          })
+            .toBe(true);
+          latencies.push(presented!.frameLoop!.lastFrameAtMs - presented!.input!.atMs);
+        }
+        report[phase] = phaseReport(before, await snapshot(page), latencies);
+        console.log(
+          `responsiveness ${phase} ${info.project.name} ${JSON.stringify(report[phase])}`,
+        );
+        await waitForIdle(page);
+      }
+      expect(failures).toEqual([]);
+    } finally {
+      let deadline: ReturnType<typeof setTimeout> | undefined;
+      report.last = await Promise.race([
+        snapshot(page, true),
+        new Promise((resolve) => {
+          deadline = setTimeout(() => resolve({ diagnosticTimedOut: true }), 5000);
+        }),
+      ]).catch(() => null);
+      clearTimeout(deadline);
+      report.failures = failures;
+      console.log(`responsiveness ${JSON.stringify(report)}`);
+      await info.attach("responsiveness.json", {
+        body: JSON.stringify(report, null, 2),
+        contentType: "application/json",
+      });
+    }
+  },
+);

--- a/donner/editor/wasm/tests/playwright.responsiveness.bazel.config.js
+++ b/donner/editor/wasm/tests/playwright.responsiveness.bazel.config.js
@@ -1,0 +1,44 @@
+const baseConfig = require("./playwright.bazel.config.js");
+
+const sharedUse = {
+  headless: false,
+  ignoreHTTPSErrors: true,
+  viewport: { width: 1280, height: 900 },
+  deviceScaleFactor: 2,
+  screenshot: "off",
+  trace: "off",
+  video: "off",
+};
+
+module.exports = {
+  ...baseConfig,
+  testMatch: "browser-responsiveness.perf.ts",
+  timeout: 90000,
+  globalTimeout: 240000,
+  use: sharedUse,
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...baseConfig.use,
+        ...sharedUse,
+        browserName: "chromium",
+        launchOptions: { ...baseConfig.use.launchOptions, timeout: 15000 },
+      },
+    },
+    {
+      name: "firefox",
+      use: {
+        ...sharedUse,
+        browserName: "firefox",
+        launchOptions: {
+          timeout: 15000,
+          firefoxUserPrefs: {
+            "dom.webgpu.enabled": true,
+            "layout.css.devPixelsPerPx": "2.0",
+          },
+        },
+      },
+    },
+  ],
+};

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -733,8 +733,14 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
     (void)slice;
     return true;
   }
+  const MappingSlot::Completion* completion = slotMappings_[mappingSlotIndex].completion;
+  const wgpu::Future future = slotMappings_[mappingSlotIndex].mapFuture;
+  if (!future.id) {
+    return false;
+  }
   if (timedMapWaitForTest_) {
-    return finishMapWaitSlice(mappingSlotIndex, timedMapWaitForTest_());
+    const wgpu::WaitStatus status = timedMapWaitForTest_();
+    return finishMapWaitSlice(mappingSlotIndex, completion, future, status);
   }
 #ifdef __EMSCRIPTEN__
   // The browser instance is created asking for TimedWaitAny (see GeodeDevice::CreateHeadless)
@@ -748,14 +754,12 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
   // thread's relationship to the instance, not of one mapping: once a status other than
   // Success or TimedOut says this future cannot be time-waited here, every later wait polls.
   static std::atomic<bool> instanceWaitUsable{true};
-  MappingSlot& slot = slotMappings_[mappingSlotIndex];
-  if (!geodeDevice_.instance() || !slot.mapFuture.id ||
-      !instanceWaitUsable.load(std::memory_order_relaxed)) {
+  if (!geodeDevice_.instance() || !instanceWaitUsable.load(std::memory_order_relaxed)) {
     return false;
   }
 
   wgpu::FutureWaitInfo waitInfo{};
-  waitInfo.future = slot.mapFuture;
+  waitInfo.future = future;
   // The browser's timed wait keeps its own cadence rather than the caller's slice. Every wait
   // here is an asyncify suspend and rewind of the whole call stack, so slicing at the native
   // poll cadence would spend fifty of those per millisecond to learn the same thing; five
@@ -770,7 +774,7 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
     instanceWaitUsable.store(false, std::memory_order_relaxed);
     return false;
   }
-  return finishMapWaitSlice(mappingSlotIndex, waitStatus);
+  return finishMapWaitSlice(mappingSlotIndex, completion, future, waitStatus);
 #else
   (void)mappingSlotIndex;
   (void)slice;
@@ -778,12 +782,31 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
 #endif
 }
 
+bool GeodeWgpuAdapterDevice::mappingStillMatches(uint32_t mappingSlotIndex,
+                                                 const MappingSlot::Completion* completion,
+                                                 wgpu::Future future) const {
+  return mappingSlotIndex < slotMappings_.size() &&
+         slotMappings_[mappingSlotIndex].completion == completion &&
+         slotMappings_[mappingSlotIndex].mapFuture.id == future.id &&
+         !completion->abandoned.load(std::memory_order_acquire);
+}
+
 bool GeodeWgpuAdapterDevice::finishMapWaitSlice(uint32_t mappingSlotIndex,
-                                                wgpu::WaitStatus status) {
+                                                const MappingSlot::Completion* completion,
+                                                wgpu::Future future, wgpu::WaitStatus status) {
   if (status != wgpu::WaitStatus::Success && status != wgpu::WaitStatus::TimedOut) {
     return false;
   }
+  if (!mappingStillMatches(mappingSlotIndex, completion, future)) {
+    return true;
+  }
   slotMappings_[mappingSlotIndex].usedTimedWaitAny = true;
+  if (status == wgpu::WaitStatus::TimedOut && !completion->done.load(std::memory_order_acquire) &&
+      !geodeDevice_.isDeviceLost()) {
+    // A browser can defer pending map completion until another queue submission arrives.
+    geodeDevice_.queue().submit(0, nullptr);
+    geodeDevice_.countSubmit();
+  }
   return true;
 }
 
@@ -798,6 +821,13 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
     return sliceStateOf(completion);
   }
 
+  // Asyncify may run completion or abandonment callbacks before this stack resumes.
+  completion.references.fetch_add(1, std::memory_order_relaxed);
+  const auto releaseCompletion = [](MappingSlot::Completion* value) { value->release(); };
+  const std::unique_ptr<MappingSlot::Completion, decltype(releaseCompletion)> retainedCompletion(
+      &completion, releaseCompletion);
+  const wgpu::Future future = slotMappings_[mappingSlotIndex].mapFuture;
+
   // Wait out the slice the caller allowed rather than returning the moment one poll finds
   // nothing: the waiter's budget is wall time, so a slice that returns immediately turns a map
   // that is merely not ready yet into a burst of fast calls against that budget.
@@ -807,18 +837,24 @@ gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSl
   const auto slice = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::duration<double>(sliceSeconds));
 
-  if (waitOnMapFutureSlice(mappingSlotIndex, slice)) {
+  const bool usedEventWait = waitOnMapFutureSlice(mappingSlotIndex, slice);
+  if (!mappingStillMatches(mappingSlotIndex, &completion, future)) {
+    return gpu::MapSliceState::Failed;
+  }
+  if (usedEventWait) {
     return sliceStateOf(completion);
   }
 
   (void)BoundedGpuWait(
       [&] {
         (void)geodeDevice_.pollSuspending(false);
-        return completion.done.load(std::memory_order_acquire) || geodeDevice_.isDeviceLost();
+        return !mappingStillMatches(mappingSlotIndex, &completion, future) ||
+               completion.done.load(std::memory_order_acquire) || geodeDevice_.isDeviceLost();
       },
       std::max(slice, std::chrono::microseconds(1)));
 
-  return sliceStateOf(completion);
+  return mappingStillMatches(mappingSlotIndex, &completion, future) ? sliceStateOf(completion)
+                                                                    : gpu::MapSliceState::Failed;
 }
 
 bool GeodeWgpuAdapterDevice::mappingUsedTimedWaitAny(const gpu::BufferMapping& mapping) const {

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -733,6 +733,9 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
     (void)slice;
     return true;
   }
+  if (timedMapWaitForTest_) {
+    return finishMapWaitSlice(mappingSlotIndex, timedMapWaitForTest_());
+  }
 #ifdef __EMSCRIPTEN__
   // The browser instance is created asking for TimedWaitAny (see GeodeDevice::CreateHeadless)
   // exactly so this wait exists: on a worker thread the map completion is a browser-side event,
@@ -767,13 +770,21 @@ bool GeodeWgpuAdapterDevice::waitOnMapFutureSlice(uint32_t mappingSlotIndex,
     instanceWaitUsable.store(false, std::memory_order_relaxed);
     return false;
   }
-  slot.usedTimedWaitAny = true;
-  return true;
+  return finishMapWaitSlice(mappingSlotIndex, waitStatus);
 #else
   (void)mappingSlotIndex;
   (void)slice;
   return false;
 #endif
+}
+
+bool GeodeWgpuAdapterDevice::finishMapWaitSlice(uint32_t mappingSlotIndex,
+                                                wgpu::WaitStatus status) {
+  if (status != wgpu::WaitStatus::Success && status != wgpu::WaitStatus::TimedOut) {
+    return false;
+  }
+  slotMappings_[mappingSlotIndex].usedTimedWaitAny = true;
+  return true;
 }
 
 gpu::MapSliceState GeodeWgpuAdapterDevice::onWaitMappingSlice(uint32_t mappingSlotIndex,

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <span>
@@ -516,6 +517,12 @@ private:
   /// @return True if the slice was waited on the event (so the caller re-reads the completion
   ///   rather than polling), false if this platform or this thread cannot event-wait it.
   bool waitOnMapFutureSlice(uint32_t mappingSlotIndex, std::chrono::microseconds slice);
+
+  /// Applies a completed event-wait slice through the same path on browsers and in tests.
+  bool finishMapWaitSlice(uint32_t mappingSlotIndex, wgpu::WaitStatus status);
+
+  /// Test-only replacement for the suspending backend wait; may exercise reentrant slot changes.
+  std::function<wgpu::WaitStatus()> timedMapWaitForTest_;
 
   /// Makes \ref waitOnMapFutureSlice report that an event wait handled the slice without one
   /// having happened, so the browser arm's contract can be checked where that arm is compiled

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -519,7 +519,12 @@ private:
   bool waitOnMapFutureSlice(uint32_t mappingSlotIndex, std::chrono::microseconds slice);
 
   /// Applies a completed event-wait slice through the same path on browsers and in tests.
-  bool finishMapWaitSlice(uint32_t mappingSlotIndex, wgpu::WaitStatus status);
+  bool finishMapWaitSlice(uint32_t mappingSlotIndex, const MappingSlot::Completion* completion,
+                          wgpu::Future future, wgpu::WaitStatus status);
+
+  /// Revalidates a slot after a backend wait may have yielded to other work.
+  bool mappingStillMatches(uint32_t mappingSlotIndex, const MappingSlot::Completion* completion,
+                           wgpu::Future future) const;
 
   /// Test-only replacement for the suspending backend wait; may exercise reentrant slot changes.
   std::function<wgpu::WaitStatus()> timedMapWaitForTest_;

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -59,6 +59,18 @@ struct GeodeWgpuAdapterDeviceTestAccess {
     return adapter.onWaitMappingSlice(0, 0.000001);
   }
 
+  static void completeMap(GeodeWgpuAdapterDevice& adapter) {
+    auto* completion = adapter.slotMappings_[0].completion;
+    completion->ok.store(true, std::memory_order_relaxed);
+    completion->done.store(true, std::memory_order_release);
+  }
+
+  static void abandonMap(GeodeWgpuAdapterDevice& adapter) { adapter.onUnmapBuffer(0); }
+
+  static void setMapFuture(GeodeWgpuAdapterDevice& adapter, uint64_t id) {
+    adapter.slotMappings_[0].mapFuture.id = id;
+  }
+
   static void clearMaps(GeodeWgpuAdapterDevice& adapter) {
     adapter.timedMapWaitForTest_ = {};
     for (uint32_t index = 0; index < adapter.slotMappings_.size(); ++index) {
@@ -1030,6 +1042,103 @@ TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapTimeoutSubmitsQueueProgressWithoutAR
               testing::Eq(gpu::MapSliceState::Pending));
   EXPECT_THAT(probe.counters.submits, testing::Eq(1u));
   EXPECT_THAT(adapter_->lastSubmittedSerial(), testing::Eq(beforeSerial));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapCompletionDuringTimeoutNeedsNoQueueProgress) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    GeodeWgpuAdapterDeviceTestAccess::completeMap(*adapter_);
+    return wgpu::WaitStatus::TimedOut;
+  });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Ready));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapReadyOrMissingFutureDoesNotRequestQueueProgress) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  int waitCalls = 0;
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    ++waitCalls;
+    return wgpu::WaitStatus::TimedOut;
+  });
+  GeodeWgpuAdapterDeviceTestAccess::setMapFuture(*adapter_, 0);
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Pending));
+  GeodeWgpuAdapterDeviceTestAccess::completeMap(*adapter_);
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Ready));
+  EXPECT_THAT(waitCalls, testing::Eq(0));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapSuccessfulWaitDoesNotRequestQueueProgress) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_,
+                                                 [] { return wgpu::WaitStatus::Success; });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Pending));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapDeviceLossDuringWaitDoesNotSubmit) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    geodeDevice_->markDeviceLost("map-wait test");
+    return wgpu::WaitStatus::TimedOut;
+  });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::DeviceLost));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapAbandonmentDuringWaitRetainsCompletionUntilReturn) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    GeodeWgpuAdapterDeviceTestAccess::abandonMap(*adapter_);
+    return wgpu::WaitStatus::TimedOut;
+  });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Failed));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapSlotReuseDoesNotSubmitForTheReplacement) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    GeodeWgpuAdapterDeviceTestAccess::abandonMap(*adapter_);
+    GeodeWgpuAdapterDeviceTestAccess::installPendingMap(*adapter_);
+    GeodeWgpuAdapterDeviceTestAccess::setMapFuture(*adapter_, 2);
+    return wgpu::WaitStatus::TimedOut;
+  });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Failed));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(0u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapSlotGrowthReacquiresTheLiveMapping) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_, [&] {
+    GeodeWgpuAdapterDeviceTestAccess::installPendingMap(*adapter_, 1024);
+    return wgpu::WaitStatus::TimedOut;
+  });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Pending));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(1u));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapProgressDoesNotCompleteUnsubmittedHostWork) {
+  ScopedWgpuHandle<wgpu::CommandEncoder> host(geodeDevice_->device().createCommandEncoder());
+  const uint64_t pending = ReplayHostClear(*adapter_, host.get());
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_,
+                                                 [] { return wgpu::WaitStatus::TimedOut; });
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Pending));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(1u));
+  EXPECT_THAT(adapter_->lastSubmittedSerial(), testing::Eq(pending));
+  EXPECT_THAT(adapter_->completedSerial(), testing::Lt(pending));
+  adapter_->notifyHostDiscarded(host.get());
 }
 
 TEST_F(GeodeWgpuAdapterDeviceTests, AMappingReleasedBeforeItsCallbackStillUnmapsTheBuffer) {

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -40,9 +40,53 @@ namespace donner::geode {
 /// Exposes only the real completion state for deterministic callback-order tests.
 struct GeodeWgpuAdapterDeviceTestAccess {
   using CompletionState = GeodeWgpuAdapterDevice::CompletionState;
+
+  static void installPendingMap(GeodeWgpuAdapterDevice& adapter, uint32_t index = 0) {
+    if (adapter.slotMappings_.size() <= index) adapter.slotMappings_.resize(index + 1);
+    auto& slot = adapter.slotMappings_[index];
+    slot.completion = new GeodeWgpuAdapterDevice::MappingSlot::Completion();
+    // This controlled completion has no backend callback retaining a second reference.
+    slot.completion->references.store(1);
+    slot.mapFuture.id = index + 1;
+  }
+
+  static void setTimedWait(GeodeWgpuAdapterDevice& adapter,
+                           std::function<wgpu::WaitStatus()> wait) {
+    adapter.timedMapWaitForTest_ = std::move(wait);
+  }
+
+  static gpu::MapSliceState waitSlice(GeodeWgpuAdapterDevice& adapter) {
+    return adapter.onWaitMappingSlice(0, 0.000001);
+  }
+
+  static void clearMaps(GeodeWgpuAdapterDevice& adapter) {
+    adapter.timedMapWaitForTest_ = {};
+    for (uint32_t index = 0; index < adapter.slotMappings_.size(); ++index) {
+      adapter.onUnmapBuffer(index);
+    }
+  }
 };
 
 namespace {
+
+/// Owns controlled map completions while the real adapter handles the wait and queue decision.
+class TimedMapProbe {
+public:
+  TimedMapProbe(GeodeWgpuAdapterDevice& adapter, GeodeDevice& device)
+      : adapter_(adapter), device_(device) {
+    GeodeWgpuAdapterDeviceTestAccess::installPendingMap(adapter_);
+    device_.setCounters(&counters);
+  }
+  ~TimedMapProbe() {
+    GeodeWgpuAdapterDeviceTestAccess::clearMaps(adapter_);
+    device_.setCounters(nullptr);
+  }
+  GeodeCounters counters;
+
+private:
+  GeodeWgpuAdapterDevice& adapter_;
+  GeodeDevice& device_;
+};
 
 /// Minimal compute WGSL writing a constant color into a write-only storage texture, matching the
 /// compute pipeline the conformance and replay tests create.
@@ -975,6 +1019,17 @@ TEST_F(GeodeWgpuAdapterDeviceTests, MisalignedBindOffsetFailsClosedBeforeWgpu) {
       gpu::IsGpuErrorWithMessage(gpu::GpuErrorType::InvalidDescriptor,
                                  HasSubstr("offsetBytes 8 is not a multiple of the 256-byte "
                                            "binding offset alignment")));
+}
+
+TEST_F(GeodeWgpuAdapterDeviceTests, TimedMapTimeoutSubmitsQueueProgressWithoutARuntimeSerial) {
+  TimedMapProbe probe(*adapter_, *geodeDevice_);
+  GeodeWgpuAdapterDeviceTestAccess::setTimedWait(*adapter_,
+                                                 [] { return wgpu::WaitStatus::TimedOut; });
+  const uint64_t beforeSerial = adapter_->lastSubmittedSerial();
+  EXPECT_THAT(GeodeWgpuAdapterDeviceTestAccess::waitSlice(*adapter_),
+              testing::Eq(gpu::MapSliceState::Pending));
+  EXPECT_THAT(probe.counters.submits, testing::Eq(1u));
+  EXPECT_THAT(adapter_->lastSubmittedSerial(), testing::Eq(beforeSerial));
 }
 
 TEST_F(GeodeWgpuAdapterDeviceTests, AMappingReleasedBeforeItsCallbackStillUnmapsTheBuffer) {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -863,6 +863,7 @@
         "Extent3D",
         "FilterMode",
         "FragmentState",
+        "Future",
         "FutureWaitInfo",
         "IndexFormat",
         "LoadOp",
@@ -939,7 +940,8 @@
         "Texture",
         "TextureFormat",
         "TextureUsage",
-        "TextureView"
+        "TextureView",
+        "WaitStatus"
       ]
     },
     "donner/svg/renderer/geode/GeodeWgpuUtil.h": {
@@ -1229,7 +1231,8 @@
         "TextureDescriptor",
         "TextureDimension",
         "TextureFormat",
-        "TextureUsage"
+        "TextureUsage",
+        "WaitStatus"
       ]
     },
     "donner/svg/renderer/tests/RendererGeodeGolden_tests.cc": {


### PR DESCRIPTION
Firefox can delay each serial GPU tile readback until its periodic device poll. After a bounded browser map wait expires, submit an empty command list on the same queue while that mapping is still pending. This advances deferred callbacks while preserving the existing cancellation and timeout limits.

Retain completion state across Asyncify suspension and revalidate the mapping slot and future before resuming. Count the empty submission without advancing Donner's submission serials or completing unsubmitted host work. Addresses the general Firefox responsiveness investigated in #927.

The matched-raster benchmark uses the same sample, a 1280×900 viewport, DPR 2, and a 2560×1800 canvas in both browsers. Firefox sample presentation decreased from about 1.72 s to 0.65 s, and raster work from 1.36 s to 0.31 s; Chromium stayed near its baseline. These measurements describe the sample/readback workload; pointer and zoom timings remain diagnostic observations.

Validation:

- Regression fails before the fix; all 39 adapter tests pass afterward.
- All nine new mapping regressions pass with address and undefined-behavior sanitizers.
- Both pinned browser benchmark cases pass with matching raster and tile counts.
- Full repository gate: 505 tests passed, with 34 configuration exclusions.
- All five Geode editor integration targets, CMake generation validation, formatting, inventory freshness, and independent code/security review pass.
